### PR TITLE
dyninst: extend line-probe condition test coverage

### DIFF
--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
@@ -9,10 +9,10 @@ Probes:
       segments: ['ptr: ', {json: {ref: ptr}, dsl: ptr}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 76}
+        - subprogram: {subprogram: 78}
           events:
             - Kind: Entry
-              Type: 611 EventRootType Probe[main.PointerChainArg]
+              Type: 619 EventRootType Probe[main.PointerChainArg]
               InjectionPoints: [{PC: "0x4a6c4c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -32,10 +32,10 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 77}
+        - subprogram: {subprogram: 79}
           events:
             - Kind: Entry
-              Type: 612 EventRootType Probe[main.PointerSmallChainArg]
+              Type: 620 EventRootType Probe[main.PointerSmallChainArg]
               InjectionPoints: [{PC: "0x4a6c91", Frameless: false}]
               Condition: null
     - id: bigMapArg
@@ -50,11 +50,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 312 EventRootType Probe[main.bigMapArg]
-              InjectionPoints: [{PC: "0x4a9113", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9353", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 313 EventRootType Probe[main.bigMapArg]Return
-              InjectionPoints: [{PC: "0x4a919e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a93de", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 'm: {m}'
@@ -78,7 +78,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 358 EventRootType Probe[main.condBool]
-              InjectionPoints: [{PC: "0x4a99aa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9bea", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -95,7 +95,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 359 EventRootType Probe[main.condBool]Return
-              InjectionPoints: [{PC: "0x4a9a1a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9c5a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -119,7 +119,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 360 EventRootType Probe[main.condBool]
-              InjectionPoints: [{PC: "0x4a99aa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9bea", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -136,7 +136,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 361 EventRootType Probe[main.condBool]Return
-              InjectionPoints: [{PC: "0x4a9a1a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9c5a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -159,11 +159,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 362 EventRootType Probe[main.condBool]
-              InjectionPoints: [{PC: "0x4a99aa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9bea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 363 EventRootType Probe[main.condBool]Return
-              InjectionPoints: [{PC: "0x4a9a1a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9c5a", Frameless: false}]
               Condition: null
     - id: condCompound_and
       version: 0
@@ -188,7 +188,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 408 EventRootType Probe[main.condReturnAndLocal]
-              InjectionPoints: [{PC: "0x4a9e8a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4aa0ca", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -220,7 +220,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 409 EventRootType Probe[main.condReturnAndLocal]Return
-              InjectionPoints: [{PC: "0x4a9ef5", Frameless: false}]
+              InjectionPoints: [{PC: "0x4aa135", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: a == 1 && b == 1 [a={a}, b={b}]
@@ -262,7 +262,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 378 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0x4a9b2e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9d6e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -292,7 +292,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 379 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0x4a9c36", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9e76", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x.S == "world" && tag == "match" [x.S={x.S}, tag={tag}]
@@ -314,7 +314,7 @@ Probes:
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["519"]
+        lines: ["547"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -338,7 +338,7 @@ Probes:
           events:
             - Kind: Line
               Type: 418 EventRootType Probe[main.condLine]Line
-              InjectionPoints: [{PC: "0x4aa001", Frameless: false}]
+              InjectionPoints: [{PC: "0x4aa241", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -412,7 +412,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 380 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0x4a9b2e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9d6e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -460,7 +460,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 381 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0x4a9c36", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9e76", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: (x.I32 == 300 || x.I32 == 999) && !isEmpty(x.S) [x.I32={x.I32}, x.S={x.S}, tag={tag}]
@@ -502,7 +502,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 364 EventRootType Probe[main.condBool]
-              InjectionPoints: [{PC: "0x4a99aa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9bea", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -520,7 +520,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 365 EventRootType Probe[main.condBool]Return
-              InjectionPoints: [{PC: "0x4a9a1a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9c5a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '!x [x={x}, tag={tag}]'
@@ -559,7 +559,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 324 EventRootType Probe[main.condInt32]
-              InjectionPoints: [{PC: "0x4a93aa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a95ea", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -591,7 +591,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 325 EventRootType Probe[main.condInt32]Return
-              InjectionPoints: [{PC: "0x4a941a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a965a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x == 42 || x == 100 [x={x}, tag={tag}]
@@ -629,16 +629,16 @@ Probes:
         - ']'
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 431 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4aa993", Frameless: false}]
+              Type: 439 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4aae93", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 37, index: 1, name: tag}
+                      Variable: {subprogram: 39, index: 1, name: tag}
                       Offset: 0
                       ByteSize: 16
                     - __kind: ExprReadStringOp
@@ -650,7 +650,7 @@ Probes:
                       Cond: true
                       Target: 1
                     - __kind: LocationOp
-                      Variable: {subprogram: 37, index: 0, name: s}
+                      Variable: {subprogram: 39, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -664,8 +664,8 @@ Probes:
                       ID: 1
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 432 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4aaa85", Frameless: false}]
+              Type: 440 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4aaf85", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag == "match" || !isEmpty(s) [s={s}, tag={tag}]
@@ -703,20 +703,20 @@ Probes:
         - ']'
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 72}
+        - subprogram: {subprogram: 74}
           events:
             - Kind: Entry
-              Type: 603 EventRootType Probe[main.condMultiReturn]
-              InjectionPoints: [{PC: "0x4ac70e", Frameless: false}]
+              Type: 611 EventRootType Probe[main.condMultiReturn]
+              InjectionPoints: [{PC: "0x4acc0e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 604 EventRootType Probe[main.condMultiReturn]Return
-              InjectionPoints: [{PC: "0x4ac7ac", Frameless: false}]
+              Type: 612 EventRootType Probe[main.condMultiReturn]Return
+              InjectionPoints: [{PC: "0x4accac", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 72, index: 1, name: r0}
+                      Variable: {subprogram: 74, index: 1, name: r0}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -729,7 +729,7 @@ Probes:
                       Cond: false
                       Target: 1
                     - __kind: LocationOp
-                      Variable: {subprogram: 72, index: 2, name: r1}
+                      Variable: {subprogram: 74, index: 2, name: r1}
                       Offset: 0
                       ByteSize: 16
                     - __kind: ExprReadStringOp
@@ -777,7 +777,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 400 EventRootType Probe[main.condNilPtrStruct]
-              InjectionPoints: [{PC: "0x4a9dce", Frameless: false}]
+              InjectionPoints: [{PC: "0x4aa00e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -811,7 +811,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 401 EventRootType Probe[main.condNilPtrStruct]Return
-              InjectionPoints: [{PC: "0x4a9e4e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4aa08e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag == "nilptr" && x.I32 == 300 [tag={tag}]
@@ -845,7 +845,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 402 EventRootType Probe[main.condNilPtrStruct]
-              InjectionPoints: [{PC: "0x4a9dce", Frameless: false}]
+              InjectionPoints: [{PC: "0x4aa00e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -879,7 +879,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 403 EventRootType Probe[main.condNilPtrStruct]Return
-              InjectionPoints: [{PC: "0x4a9e4e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4aa08e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag == "nilptr" || x.I32 == 300 [tag={tag}]
@@ -903,11 +903,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 354 EventRootType Probe[main.condFloat32]
-              InjectionPoints: [{PC: "0x4a982e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9a6e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 355 EventRootType Probe[main.condFloat32]Return
-              InjectionPoints: [{PC: "0x4a98a5", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9ae5", Frameless: false}]
               Condition: null
     - id: condFloat64_nocond
       version: 0
@@ -922,11 +922,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 356 EventRootType Probe[main.condFloat64]
-              InjectionPoints: [{PC: "0x4a98ee", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9b2e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 357 EventRootType Probe[main.condFloat64]Return
-              InjectionPoints: [{PC: "0x4a9966", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9ba6", Frameless: false}]
               Condition: null
     - id: condInt16_cond
       version: 0
@@ -942,7 +942,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 320 EventRootType Probe[main.condInt16]
-              InjectionPoints: [{PC: "0x4a92ea", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a952a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -959,7 +959,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 321 EventRootType Probe[main.condInt16]Return
-              InjectionPoints: [{PC: "0x4a935a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a959a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -982,11 +982,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 322 EventRootType Probe[main.condInt16]
-              InjectionPoints: [{PC: "0x4a92ea", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a952a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 323 EventRootType Probe[main.condInt16]Return
-              InjectionPoints: [{PC: "0x4a935a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a959a", Frameless: false}]
               Condition: null
     - id: condInt32_cond
       version: 0
@@ -1002,7 +1002,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 326 EventRootType Probe[main.condInt32]
-              InjectionPoints: [{PC: "0x4a93aa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a95ea", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1019,7 +1019,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 327 EventRootType Probe[main.condInt32]Return
-              InjectionPoints: [{PC: "0x4a941a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a965a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1046,7 +1046,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 328 EventRootType Probe[main.condInt32]
-              InjectionPoints: [{PC: "0x4a93aa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a95ea", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1063,7 +1063,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 329 EventRootType Probe[main.condInt32]Return
-              InjectionPoints: [{PC: "0x4a941a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a965a", Frameless: false}]
               Condition: null
     - id: condInt32_nocond
       version: 0
@@ -1078,11 +1078,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 330 EventRootType Probe[main.condInt32]
-              InjectionPoints: [{PC: "0x4a93aa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a95ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 331 EventRootType Probe[main.condInt32]Return
-              InjectionPoints: [{PC: "0x4a941a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a965a", Frameless: false}]
               Condition: null
     - id: condInt64_cond
       version: 0
@@ -1098,7 +1098,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 332 EventRootType Probe[main.condInt64]
-              InjectionPoints: [{PC: "0x4a946a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a96aa", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1115,7 +1115,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 333 EventRootType Probe[main.condInt64]Return
-              InjectionPoints: [{PC: "0x4a94da", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a971a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1138,11 +1138,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 334 EventRootType Probe[main.condInt64]
-              InjectionPoints: [{PC: "0x4a946a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a96aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 335 EventRootType Probe[main.condInt64]Return
-              InjectionPoints: [{PC: "0x4a94da", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a971a", Frameless: false}]
               Condition: null
     - id: condInt8_cond
       version: 0
@@ -1158,7 +1158,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 316 EventRootType Probe[main.condInt8]
-              InjectionPoints: [{PC: "0x4a922a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a946a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1175,7 +1175,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 317 EventRootType Probe[main.condInt8]Return
-              InjectionPoints: [{PC: "0x4a929a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a94da", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1198,11 +1198,257 @@ Probes:
           events:
             - Kind: Entry
               Type: 318 EventRootType Probe[main.condInt8]
-              InjectionPoints: [{PC: "0x4a922a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a946a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 319 EventRootType Probe[main.condInt8]Return
-              InjectionPoints: [{PC: "0x4a929a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a94da", Frameless: false}]
+              Condition: null
+    - id: condLineMixed_cond_bool
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when: {dsl: b == true, json: {eq: [{ref: b}, true]}}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 422 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0x4aa371", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 1, name: b}
+                      Offset: 0
+                      ByteSize: 1
+                    - __kind: ExprPushOffsetOp
+                      ByteSize: 1
+                    - __kind: ExprLoadLiteralOp
+                      Data: AQ==
+                    - __kind: ExprCmpEqBaseOp
+                      ByteSize: 1
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_isEmpty_slice
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when: {dsl: isEmpty(ss), json: {isEmpty: {ref: ss}}}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 423 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0x4aa371", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 4, name: ss}
+                      Offset: 8
+                      ByteSize: 8
+                    - __kind: ExprPushOffsetOp
+                      ByteSize: 8
+                    - __kind: ExprLoadLiteralOp
+                      Data: AAAAAAAAAAA=
+                    - __kind: ExprCmpEqBaseOp
+                      ByteSize: 8
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_len_string
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when:
+        dsl: len(s) == 5
+        json: {eq: [{len: {ref: s}}, 5]}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 424 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0x4aa371", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 0, name: s}
+                      Offset: 8
+                      ByteSize: 8
+                    - __kind: ExprPushOffsetOp
+                      ByteSize: 8
+                    - __kind: ExprLoadLiteralOp
+                      Data: BQAAAAAAAAA=
+                    - __kind: ExprCmpEqBaseOp
+                      ByteSize: 8
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_ptrstruct_field
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when:
+        dsl: p.S == "world"
+        json: {eq: [{getmember: [{ref: p}, S]}, world]}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 425 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0x4aa371", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 3, name: p}
+                      Offset: 0
+                      ByteSize: 8
+                    - __kind: DereferenceOp
+                      Bias: 56
+                      ByteSize: 16
+                    - __kind: ExprReadStringOp
+                      MaxLen: 255
+                    - __kind: ExprLoadLiteralOp
+                      Data: BQAAAHdvcmxk
+                    - __kind: ExprCmpEqStringOp
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_string
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when:
+        dsl: s == "hello"
+        json: {eq: [{ref: s}, hello]}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 426 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0x4aa371", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 0, name: s}
+                      Offset: 0
+                      ByteSize: 16
+                    - __kind: ExprReadStringOp
+                      MaxLen: 255
+                    - __kind: ExprLoadLiteralOp
+                      Data: BQAAAGhlbGxv
+                    - __kind: ExprCmpEqStringOp
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_struct_field
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when:
+        dsl: x.I32 == 300
+        json: {eq: [{getmember: [{ref: x}, I32]}, 300]}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 427 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0x4aa371", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 2, name: x}
+                      Offset: 4
+                      ByteSize: 4
+                    - __kind: ExprPushOffsetOp
+                      ByteSize: 4
+                    - __kind: ExprLoadLiteralOp
+                      Data: LAEAAA==
+                    - __kind: ExprCmpEqBaseOp
+                      ByteSize: 4
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_nocond
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 428 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0x4aa371", Frameless: false}]
               Condition: null
     - id: condLine_cond
       version: 0
@@ -1210,7 +1456,7 @@ Probes:
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["519"]
+        lines: ["547"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -1227,7 +1473,7 @@ Probes:
           events:
             - Kind: Line
               Type: 419 EventRootType Probe[main.condLine]Line
-              InjectionPoints: [{PC: "0x4aa001", Frameless: false}]
+              InjectionPoints: [{PC: "0x4aa241", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1242,13 +1488,13 @@ Probes:
                     - __kind: ExprCmpEqBaseOp
                       ByteSize: 8
                     - __kind: ConditionCheckOp
-    - id: condLine_nocond
+    - id: condLine_local_nocond
       version: 0
       type: LOG_PROBE
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["519"]
+        lines: ["548"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -1261,7 +1507,28 @@ Probes:
           events:
             - Kind: Line
               Type: 420 EventRootType Probe[main.condLine]Line
-              InjectionPoints: [{PC: "0x4aa001", Frameless: false}]
+              InjectionPoints: [{PC: "0x4aa247", Frameless: false}]
+              Condition: null
+    - id: condLine_nocond
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLine
+        sourceFile: main.go
+        lines: ["547"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 28}
+          events:
+            - Kind: Line
+              Type: 421 EventRootType Probe[main.condLine]Line
+              InjectionPoints: [{PC: "0x4aa241", Frameless: false}]
               Condition: null
     - id: condNilPtr_cond
       version: 0
@@ -1279,7 +1546,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 404 EventRootType Probe[main.condNilPtrStruct]
-              InjectionPoints: [{PC: "0x4a9dce", Frameless: false}]
+              InjectionPoints: [{PC: "0x4aa00e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1299,7 +1566,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 405 EventRootType Probe[main.condNilPtrStruct]Return
-              InjectionPoints: [{PC: "0x4a9e4e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4aa08e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: condNilPtr {tag}
@@ -1322,11 +1589,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 406 EventRootType Probe[main.condNilPtrStruct]
-              InjectionPoints: [{PC: "0x4a9dce", Frameless: false}]
+              InjectionPoints: [{PC: "0x4aa00e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 407 EventRootType Probe[main.condNilPtrStruct]Return
-              InjectionPoints: [{PC: "0x4a9e4e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4aa08e", Frameless: false}]
               Condition: null
     - id: condNull_iface
       version: 0
@@ -1338,16 +1605,16 @@ Probes:
       segments: ['i == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 35}
+        - subprogram: {subprogram: 37}
           events:
             - Kind: Entry
-              Type: 427 EventRootType Probe[main.condNullIface]
-              InjectionPoints: [{PC: "0x4aa6ee", Frameless: false}]
+              Type: 435 EventRootType Probe[main.condNullIface]
+              InjectionPoints: [{PC: "0x4aabee", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 35, index: 0, name: i}
+                      Variable: {subprogram: 37, index: 0, name: i}
                       Offset: 0
                       ByteSize: 16
                     - __kind: ExprPushOffsetOp
@@ -1358,8 +1625,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 428 EventRootType Probe[main.condNullIface]Return
-              InjectionPoints: [{PC: "0x4aa7f6", Frameless: false}]
+              Type: 436 EventRootType Probe[main.condNullIface]Return
+              InjectionPoints: [{PC: "0x4aacf6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: i == nil [tag={tag}]
@@ -1380,16 +1647,16 @@ Probes:
       segments: ['m == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 34}
+        - subprogram: {subprogram: 36}
           events:
             - Kind: Entry
-              Type: 425 EventRootType Probe[main.condNullMap]
-              InjectionPoints: [{PC: "0x4aa5ce", Frameless: false}]
+              Type: 433 EventRootType Probe[main.condNullMap]
+              InjectionPoints: [{PC: "0x4aaace", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 34, index: 0, name: m}
+                      Variable: {subprogram: 36, index: 0, name: m}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -1400,8 +1667,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 426 EventRootType Probe[main.condNullMap]Return
-              InjectionPoints: [{PC: "0x4aa6a5", Frameless: false}]
+              Type: 434 EventRootType Probe[main.condNullMap]Return
+              InjectionPoints: [{PC: "0x4aaba5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: m == nil [tag={tag}]
@@ -1422,16 +1689,16 @@ Probes:
       segments: ['p == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 32}
+        - subprogram: {subprogram: 34}
           events:
             - Kind: Entry
-              Type: 421 EventRootType Probe[main.condNullPtr]
-              InjectionPoints: [{PC: "0x4aa32e", Frameless: false}]
+              Type: 429 EventRootType Probe[main.condNullPtr]
+              InjectionPoints: [{PC: "0x4aa82e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 32, index: 0, name: p}
+                      Variable: {subprogram: 34, index: 0, name: p}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -1442,8 +1709,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 422 EventRootType Probe[main.condNullPtr]Return
-              InjectionPoints: [{PC: "0x4aa405", Frameless: false}]
+              Type: 430 EventRootType Probe[main.condNullPtr]Return
+              InjectionPoints: [{PC: "0x4aa905", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p == nil [tag={tag}]
@@ -1464,16 +1731,16 @@ Probes:
       segments: ['s == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 33}
+        - subprogram: {subprogram: 35}
           events:
             - Kind: Entry
-              Type: 423 EventRootType Probe[main.condNullSlice]
-              InjectionPoints: [{PC: "0x4aa453", Frameless: false}]
+              Type: 431 EventRootType Probe[main.condNullSlice]
+              InjectionPoints: [{PC: "0x4aa953", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 33, index: 0, name: s}
+                      Variable: {subprogram: 35, index: 0, name: s}
                       Offset: 0
                       ByteSize: 24
                     - __kind: ExprPushOffsetOp
@@ -1484,8 +1751,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 424 EventRootType Probe[main.condNullSlice]Return
-              InjectionPoints: [{PC: "0x4aa56b", Frameless: false}]
+              Type: 432 EventRootType Probe[main.condNullSlice]Return
+              InjectionPoints: [{PC: "0x4aaa6b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: s == nil [tag={tag}]
@@ -1506,16 +1773,16 @@ Probes:
       segments: ['p == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 36}
+        - subprogram: {subprogram: 38}
           events:
             - Kind: Entry
-              Type: 429 EventRootType Probe[main.condNullUnsafePtr]
-              InjectionPoints: [{PC: "0x4aa84e", Frameless: false}]
+              Type: 437 EventRootType Probe[main.condNullUnsafePtr]
+              InjectionPoints: [{PC: "0x4aad4e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 36, index: 0, name: p}
+                      Variable: {subprogram: 38, index: 0, name: p}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -1526,8 +1793,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 430 EventRootType Probe[main.condNullUnsafePtr]Return
-              InjectionPoints: [{PC: "0x4aa925", Frameless: false}]
+              Type: 438 EventRootType Probe[main.condNullUnsafePtr]Return
+              InjectionPoints: [{PC: "0x4aae25", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p == nil [tag={tag}]
@@ -1552,7 +1819,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 414 EventRootType Probe[main.condOnly]
-              InjectionPoints: [{PC: "0x4a9f2a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4aa16a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1569,7 +1836,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 415 EventRootType Probe[main.condOnly]Return
-              InjectionPoints: [{PC: "0x4a9f9a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4aa1da", Frameless: false}]
               Condition: null
     - id: condOnly_nocond
       version: 0
@@ -1584,11 +1851,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 416 EventRootType Probe[main.condOnly]
-              InjectionPoints: [{PC: "0x4a9f2a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4aa16a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 417 EventRootType Probe[main.condOnly]Return
-              InjectionPoints: [{PC: "0x4a9f9a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4aa1da", Frameless: false}]
               Condition: null
     - id: condPtrStruct_field_i32
       version: 0
@@ -1606,7 +1873,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 394 EventRootType Probe[main.condPtrStructArg]
-              InjectionPoints: [{PC: "0x4a9c6e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9eae", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1626,7 +1893,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 395 EventRootType Probe[main.condPtrStructArg]Return
-              InjectionPoints: [{PC: "0x4a9d85", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9fc5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1652,7 +1919,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 396 EventRootType Probe[main.condPtrStructArg]
-              InjectionPoints: [{PC: "0x4a9c6e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9eae", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1671,7 +1938,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 397 EventRootType Probe[main.condPtrStructArg]Return
-              InjectionPoints: [{PC: "0x4a9d85", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9fc5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1694,11 +1961,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 398 EventRootType Probe[main.condPtrStructArg]
-              InjectionPoints: [{PC: "0x4a9c6e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9eae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 399 EventRootType Probe[main.condPtrStructArg]Return
-              InjectionPoints: [{PC: "0x4a9d85", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9fc5", Frameless: false}]
               Condition: null
     - id: condReturnAndLocal_cond_param
       version: 0
@@ -1714,7 +1981,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 410 EventRootType Probe[main.condReturnAndLocal]
-              InjectionPoints: [{PC: "0x4a9e8a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4aa0ca", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1731,7 +1998,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 411 EventRootType Probe[main.condReturnAndLocal]Return
-              InjectionPoints: [{PC: "0x4a9ef5", Frameless: false}]
+              InjectionPoints: [{PC: "0x4aa135", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: b={b}
@@ -1754,11 +2021,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 412 EventRootType Probe[main.condReturnAndLocal]
-              InjectionPoints: [{PC: "0x4a9e8a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4aa0ca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 413 EventRootType Probe[main.condReturnAndLocal]Return
-              InjectionPoints: [{PC: "0x4a9ef5", Frameless: false}]
+              InjectionPoints: [{PC: "0x4aa135", Frameless: false}]
               Condition: null
     - id: condString_cond
       version: 0
@@ -1776,7 +2043,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 366 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0x4a9a6a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9caa", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1792,7 +2059,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 367 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0x4a9adf", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9d1f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1816,7 +2083,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 368 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0x4a9a6a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9caa", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1832,7 +2099,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 369 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0x4a9adf", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9d1f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1860,11 +2127,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 370 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0x4a9a6a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9caa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 371 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0x4a9adf", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9d1f", Frameless: false}]
               Condition: null
     - id: condString_eq_template
       version: 0
@@ -1882,11 +2149,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 372 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0x4a9a6a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9caa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 373 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0x4a9adf", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9d1f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: eq={x == "hello"}
@@ -1909,11 +2176,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 374 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0x4a9a6a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9caa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 375 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0x4a9adf", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9d1f", Frameless: false}]
               Condition: null
     - id: condString_snapshot_with_cond
       version: 0
@@ -1931,7 +2198,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 376 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0x4a9a6a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9caa", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1947,7 +2214,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 377 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0x4a9adf", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9d1f", Frameless: false}]
               Condition: null
     - id: condStruct_cond_i32_capture_tag
       version: 0
@@ -1968,7 +2235,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 382 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0x4a9b2e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9d6e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1985,7 +2252,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 383 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0x4a9c36", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9e76", Frameless: false}]
               Condition: null
     - id: condStruct_field_bool
       version: 0
@@ -2003,7 +2270,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 384 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0x4a9b2e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9d6e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2020,7 +2287,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 385 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0x4a9c36", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9e76", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2046,7 +2313,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 386 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0x4a9b2e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9d6e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2063,7 +2330,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 387 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0x4a9c36", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9e76", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2089,7 +2356,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 388 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0x4a9b2e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9d6e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2106,7 +2373,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 389 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0x4a9c36", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9e76", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2132,7 +2399,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 390 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0x4a9b2e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9d6e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2148,7 +2415,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 391 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0x4a9c36", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9e76", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2171,11 +2438,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 392 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0x4a9b2e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9d6e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 393 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0x4a9c36", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9e76", Frameless: false}]
               Condition: null
     - id: condUint16_cond
       version: 0
@@ -2191,7 +2458,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 342 EventRootType Probe[main.condUint16]
-              InjectionPoints: [{PC: "0x4a95ea", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a982a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2208,7 +2475,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 343 EventRootType Probe[main.condUint16]Return
-              InjectionPoints: [{PC: "0x4a965a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a989a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2231,11 +2498,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 344 EventRootType Probe[main.condUint16]
-              InjectionPoints: [{PC: "0x4a95ea", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a982a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 345 EventRootType Probe[main.condUint16]Return
-              InjectionPoints: [{PC: "0x4a965a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a989a", Frameless: false}]
               Condition: null
     - id: condUint32_cond
       version: 0
@@ -2251,7 +2518,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 346 EventRootType Probe[main.condUint32]
-              InjectionPoints: [{PC: "0x4a96aa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a98ea", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2268,7 +2535,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 347 EventRootType Probe[main.condUint32]Return
-              InjectionPoints: [{PC: "0x4a971a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a995a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2291,11 +2558,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 348 EventRootType Probe[main.condUint32]
-              InjectionPoints: [{PC: "0x4a96aa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a98ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 349 EventRootType Probe[main.condUint32]Return
-              InjectionPoints: [{PC: "0x4a971a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a995a", Frameless: false}]
               Condition: null
     - id: condUint64_cond
       version: 0
@@ -2311,7 +2578,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 350 EventRootType Probe[main.condUint64]
-              InjectionPoints: [{PC: "0x4a976a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a99aa", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2328,7 +2595,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 351 EventRootType Probe[main.condUint64]Return
-              InjectionPoints: [{PC: "0x4a97da", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9a1a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2351,11 +2618,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 352 EventRootType Probe[main.condUint64]
-              InjectionPoints: [{PC: "0x4a976a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a99aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 353 EventRootType Probe[main.condUint64]Return
-              InjectionPoints: [{PC: "0x4a97da", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9a1a", Frameless: false}]
               Condition: null
     - id: condUint8_cond
       version: 0
@@ -2371,7 +2638,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 336 EventRootType Probe[main.condUint8]
-              InjectionPoints: [{PC: "0x4a952a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a976a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2388,7 +2655,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 337 EventRootType Probe[main.condUint8]Return
-              InjectionPoints: [{PC: "0x4a959a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a97da", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2412,7 +2679,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 338 EventRootType Probe[main.condUint8]
-              InjectionPoints: [{PC: "0x4a952a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a976a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2429,7 +2696,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 339 EventRootType Probe[main.condUint8]Return
-              InjectionPoints: [{PC: "0x4a959a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a97da", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2452,11 +2719,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 340 EventRootType Probe[main.condUint8]
-              InjectionPoints: [{PC: "0x4a952a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a976a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 341 EventRootType Probe[main.condUint8]Return
-              InjectionPoints: [{PC: "0x4a959a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a97da", Frameless: false}]
               Condition: null
     - id: genericIdentity
       version: 0
@@ -2466,25 +2733,25 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 73}
+        - subprogram: {subprogram: 75}
           events:
             - Kind: Entry
-              Type: 605 EventRootType Probe[main.genericIdentity[go.shape.string]]
-              InjectionPoints: [{PC: "0x4ac7ea", Frameless: false}]
+              Type: 613 EventRootType Probe[main.genericIdentity[go.shape.string]]
+              InjectionPoints: [{PC: "0x4accea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 606 EventRootType Probe[main.genericIdentity[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x4ac84f", Frameless: false}]
+              Type: 614 EventRootType Probe[main.genericIdentity[go.shape.string]]Return
+              InjectionPoints: [{PC: "0x4acd4f", Frameless: false}]
               Condition: null
-        - subprogram: {subprogram: 74}
+        - subprogram: {subprogram: 76}
           events:
             - Kind: Entry
-              Type: 607 EventRootType Probe[main.genericIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0x4ac88a", Frameless: false}]
+              Type: 615 EventRootType Probe[main.genericIdentity[go.shape.int]]
+              InjectionPoints: [{PC: "0x4acd8a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 608 EventRootType Probe[main.genericIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x4ac8dd", Frameless: false}]
+              Type: 616 EventRootType Probe[main.genericIdentity[go.shape.int]]Return
+              InjectionPoints: [{PC: "0x4acddd", Frameless: false}]
               Condition: null
     - id: indexBigArrayStruct_last
       version: 0
@@ -2500,15 +2767,15 @@ Probes:
             dsl: s.data[131071]
             json: {index: [{getmember: [{ref: s}, data]}, 131071]}
       instances:
-        - subprogram: {subprogram: 48}
+        - subprogram: {subprogram: 50}
           events:
             - Kind: Entry
-              Type: 529 EventRootType Probe[main.bigArrayStructArg]
-              InjectionPoints: [{PC: "0x4ab80a", Frameless: false}]
+              Type: 537 EventRootType Probe[main.bigArrayStructArg]
+              InjectionPoints: [{PC: "0x4abd0a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 530 EventRootType Probe[main.bigArrayStructArg]Return
-              InjectionPoints: [{PC: "0x4ab87a", Frameless: false}]
+              Type: 538 EventRootType Probe[main.bigArrayStructArg]Return
+              InjectionPoints: [{PC: "0x4abd7a", Frameless: false}]
               Condition: null
     - id: indexBigArray_first
       version: 0
@@ -2522,15 +2789,15 @@ Probes:
         - name: s_0
           expr: {dsl: 's[0]', json: {index: [{ref: s}, 0]}}
       instances:
-        - subprogram: {subprogram: 47}
+        - subprogram: {subprogram: 49}
           events:
             - Kind: Entry
-              Type: 525 EventRootType Probe[main.bigArrayArg]
-              InjectionPoints: [{PC: "0x4ab76a", Frameless: false}]
+              Type: 533 EventRootType Probe[main.bigArrayArg]
+              InjectionPoints: [{PC: "0x4abc6a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 526 EventRootType Probe[main.bigArrayArg]Return
-              InjectionPoints: [{PC: "0x4ab7d6", Frameless: false}]
+              Type: 534 EventRootType Probe[main.bigArrayArg]Return
+              InjectionPoints: [{PC: "0x4abcd6", Frameless: false}]
               Condition: null
     - id: indexBigArray_last
       version: 0
@@ -2544,15 +2811,15 @@ Probes:
         - name: s_131071
           expr: {dsl: 's[131071]', json: {index: [{ref: s}, 131071]}}
       instances:
-        - subprogram: {subprogram: 47}
+        - subprogram: {subprogram: 49}
           events:
             - Kind: Entry
-              Type: 527 EventRootType Probe[main.bigArrayArg]
-              InjectionPoints: [{PC: "0x4ab76a", Frameless: false}]
+              Type: 535 EventRootType Probe[main.bigArrayArg]
+              InjectionPoints: [{PC: "0x4abc6a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 528 EventRootType Probe[main.bigArrayArg]Return
-              InjectionPoints: [{PC: "0x4ab7d6", Frameless: false}]
+              Type: 536 EventRootType Probe[main.bigArrayArg]Return
+              InjectionPoints: [{PC: "0x4abcd6", Frameless: false}]
               Condition: null
     - id: indexErr_array_oob_capture
       version: 0
@@ -2570,11 +2837,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 291 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0x4a8e4a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a908a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 292 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0x4a8e96", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a90d6", Frameless: false}]
               Condition: null
     - id: indexErr_array_oob_template
       version: 0
@@ -2589,11 +2856,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 293 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0x4a8e4a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a908a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 294 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0x4a8e96", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a90d6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's[3]: {s[3]}'
@@ -2617,11 +2884,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 277 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0x4a8dca", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a900a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 278 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0x4a8e0f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a904f", Frameless: false}]
               Condition: null
     - id: indexErr_slice_oob_cond
       version: 0
@@ -2639,7 +2906,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 279 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0x4a8dca", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a900a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2661,7 +2928,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 280 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0x4a8e0f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a904f", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: matched, Segments: [matched]}
     - id: indexErr_slice_oob_template
@@ -2677,11 +2944,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 281 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0x4a8dca", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a900a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 282 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0x4a8e0f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a904f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's[5]: {s[5]}'
@@ -2707,11 +2974,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 295 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0x4a8e4a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a908a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 296 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0x4a8e96", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a90d6", Frameless: false}]
               Condition: null
     - id: indexIntArray_cond
       version: 0
@@ -2729,7 +2996,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 297 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0x4a8e4a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a908a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2746,7 +3013,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 298 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0x4a8e96", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a90d6", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: matched, Segments: [matched]}
     - id: indexIntSlice_capture
@@ -2765,11 +3032,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 283 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0x4a8dca", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a900a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 284 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0x4a8e0f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a904f", Frameless: false}]
               Condition: null
     - id: indexIntSlice_cond
       version: 0
@@ -2787,7 +3054,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 285 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0x4a8dca", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a900a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2809,7 +3076,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 286 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0x4a8e0f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a904f", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: matched, Segments: [matched]}
     - id: indexIntSlice_template
@@ -2825,11 +3092,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 287 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0x4a8dca", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a900a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 288 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0x4a8e0f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a904f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's[1]: {s[1]}'
@@ -2853,15 +3120,15 @@ Probes:
             dsl: s[0].Val
             json: {getmember: [{index: [{ref: s}, 0]}, Val]}
       instances:
-        - subprogram: {subprogram: 50}
+        - subprogram: {subprogram: 52}
           events:
             - Kind: Entry
-              Type: 539 EventRootType Probe[main.structArrayArg]
-              InjectionPoints: [{PC: "0x4ab98e", Frameless: false}]
+              Type: 547 EventRootType Probe[main.structArrayArg]
+              InjectionPoints: [{PC: "0x4abe8e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 540 EventRootType Probe[main.structArrayArg]Return
-              InjectionPoints: [{PC: "0x4aba10", Frameless: false}]
+              Type: 548 EventRootType Probe[main.structArrayArg]Return
+              InjectionPoints: [{PC: "0x4abf10", Frameless: false}]
               Condition: null
     - id: indexMember_arrayStruct_capture_string
       version: 0
@@ -2877,15 +3144,15 @@ Probes:
             dsl: s[1].Txt
             json: {getmember: [{index: [{ref: s}, 1]}, Txt]}
       instances:
-        - subprogram: {subprogram: 50}
+        - subprogram: {subprogram: 52}
           events:
             - Kind: Entry
-              Type: 541 EventRootType Probe[main.structArrayArg]
-              InjectionPoints: [{PC: "0x4ab98e", Frameless: false}]
+              Type: 549 EventRootType Probe[main.structArrayArg]
+              InjectionPoints: [{PC: "0x4abe8e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 542 EventRootType Probe[main.structArrayArg]Return
-              InjectionPoints: [{PC: "0x4aba10", Frameless: false}]
+              Type: 550 EventRootType Probe[main.structArrayArg]Return
+              InjectionPoints: [{PC: "0x4abf10", Frameless: false}]
               Condition: null
     - id: indexMember_ptrArrayStruct_capture_int
       version: 0
@@ -2901,15 +3168,15 @@ Probes:
             dsl: s[0].Val
             json: {getmember: [{index: [{ref: s}, 0]}, Val]}
       instances:
-        - subprogram: {subprogram: 52}
+        - subprogram: {subprogram: 54}
           events:
             - Kind: Entry
-              Type: 547 EventRootType Probe[main.ptrStructArrayArg]
-              InjectionPoints: [{PC: "0x4abb4e", Frameless: false}]
+              Type: 555 EventRootType Probe[main.ptrStructArrayArg]
+              InjectionPoints: [{PC: "0x4ac04e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 548 EventRootType Probe[main.ptrStructArrayArg]Return
-              InjectionPoints: [{PC: "0x4abbc7", Frameless: false}]
+              Type: 556 EventRootType Probe[main.ptrStructArrayArg]Return
+              InjectionPoints: [{PC: "0x4ac0c7", Frameless: false}]
               Condition: null
     - id: indexMember_ptrArrayStruct_capture_string
       version: 0
@@ -2925,15 +3192,15 @@ Probes:
             dsl: s[1].Txt
             json: {getmember: [{index: [{ref: s}, 1]}, Txt]}
       instances:
-        - subprogram: {subprogram: 52}
+        - subprogram: {subprogram: 54}
           events:
             - Kind: Entry
-              Type: 549 EventRootType Probe[main.ptrStructArrayArg]
-              InjectionPoints: [{PC: "0x4abb4e", Frameless: false}]
+              Type: 557 EventRootType Probe[main.ptrStructArrayArg]
+              InjectionPoints: [{PC: "0x4ac04e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 550 EventRootType Probe[main.ptrStructArrayArg]Return
-              InjectionPoints: [{PC: "0x4abbc7", Frameless: false}]
+              Type: 558 EventRootType Probe[main.ptrStructArrayArg]Return
+              InjectionPoints: [{PC: "0x4ac0c7", Frameless: false}]
               Condition: null
     - id: indexMember_ptrSliceStruct_capture_int
       version: 0
@@ -2949,15 +3216,15 @@ Probes:
             dsl: s[0].Val
             json: {getmember: [{index: [{ref: s}, 0]}, Val]}
       instances:
-        - subprogram: {subprogram: 51}
+        - subprogram: {subprogram: 53}
           events:
             - Kind: Entry
-              Type: 543 EventRootType Probe[main.ptrStructSliceArg]
-              InjectionPoints: [{PC: "0x4aba4e", Frameless: false}]
+              Type: 551 EventRootType Probe[main.ptrStructSliceArg]
+              InjectionPoints: [{PC: "0x4abf4e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 544 EventRootType Probe[main.ptrStructSliceArg]Return
-              InjectionPoints: [{PC: "0x4abad6", Frameless: false}]
+              Type: 552 EventRootType Probe[main.ptrStructSliceArg]Return
+              InjectionPoints: [{PC: "0x4abfd6", Frameless: false}]
               Condition: null
     - id: indexMember_ptrSliceStruct_capture_string
       version: 0
@@ -2973,15 +3240,15 @@ Probes:
             dsl: s[1].Txt
             json: {getmember: [{index: [{ref: s}, 1]}, Txt]}
       instances:
-        - subprogram: {subprogram: 51}
+        - subprogram: {subprogram: 53}
           events:
             - Kind: Entry
-              Type: 545 EventRootType Probe[main.ptrStructSliceArg]
-              InjectionPoints: [{PC: "0x4aba4e", Frameless: false}]
+              Type: 553 EventRootType Probe[main.ptrStructSliceArg]
+              InjectionPoints: [{PC: "0x4abf4e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 546 EventRootType Probe[main.ptrStructSliceArg]Return
-              InjectionPoints: [{PC: "0x4abad6", Frameless: false}]
+              Type: 554 EventRootType Probe[main.ptrStructSliceArg]Return
+              InjectionPoints: [{PC: "0x4abfd6", Frameless: false}]
               Condition: null
     - id: indexMember_sliceStruct_capture_int
       version: 0
@@ -2997,15 +3264,15 @@ Probes:
             dsl: s[0].Val
             json: {getmember: [{index: [{ref: s}, 0]}, Val]}
       instances:
-        - subprogram: {subprogram: 49}
+        - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 531 EventRootType Probe[main.structSliceArg]
-              InjectionPoints: [{PC: "0x4ab8ae", Frameless: false}]
+              Type: 539 EventRootType Probe[main.structSliceArg]
+              InjectionPoints: [{PC: "0x4abdae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 532 EventRootType Probe[main.structSliceArg]Return
-              InjectionPoints: [{PC: "0x4ab92f", Frameless: false}]
+              Type: 540 EventRootType Probe[main.structSliceArg]Return
+              InjectionPoints: [{PC: "0x4abe2f", Frameless: false}]
               Condition: null
     - id: indexMember_sliceStruct_capture_string
       version: 0
@@ -3021,15 +3288,15 @@ Probes:
             dsl: s[1].Txt
             json: {getmember: [{index: [{ref: s}, 1]}, Txt]}
       instances:
-        - subprogram: {subprogram: 49}
+        - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 533 EventRootType Probe[main.structSliceArg]
-              InjectionPoints: [{PC: "0x4ab8ae", Frameless: false}]
+              Type: 541 EventRootType Probe[main.structSliceArg]
+              InjectionPoints: [{PC: "0x4abdae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 534 EventRootType Probe[main.structSliceArg]Return
-              InjectionPoints: [{PC: "0x4ab92f", Frameless: false}]
+              Type: 542 EventRootType Probe[main.structSliceArg]Return
+              InjectionPoints: [{PC: "0x4abe2f", Frameless: false}]
               Condition: null
     - id: indexMember_sliceStruct_cond
       version: 0
@@ -3044,16 +3311,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 49}
+        - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 535 EventRootType Probe[main.structSliceArg]
-              InjectionPoints: [{PC: "0x4ab8ae", Frameless: false}]
+              Type: 543 EventRootType Probe[main.structSliceArg]
+              InjectionPoints: [{PC: "0x4abdae", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 49, index: 0, name: s}
+                      Variable: {subprogram: 51, index: 0, name: s}
                       Offset: 0
                       ByteSize: 16
                     - __kind: SliceBoundsCheckOp
@@ -3069,8 +3336,8 @@ Probes:
                       ByteSize: 4
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 536 EventRootType Probe[main.structSliceArg]Return
-              InjectionPoints: [{PC: "0x4ab92f", Frameless: false}]
+              Type: 544 EventRootType Probe[main.structSliceArg]Return
+              InjectionPoints: [{PC: "0x4abe2f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -3092,15 +3359,15 @@ Probes:
           dsl: s[0].Val
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 49}
+        - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 537 EventRootType Probe[main.structSliceArg]
-              InjectionPoints: [{PC: "0x4ab8ae", Frameless: false}]
+              Type: 545 EventRootType Probe[main.structSliceArg]
+              InjectionPoints: [{PC: "0x4abdae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 538 EventRootType Probe[main.structSliceArg]Return
-              InjectionPoints: [{PC: "0x4ab92f", Frameless: false}]
+              Type: 546 EventRootType Probe[main.structSliceArg]Return
+              InjectionPoints: [{PC: "0x4abe2f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: s[0].Val={s[0].Val}
@@ -3127,15 +3394,15 @@ Probes:
             json:
                 getmember: [{index: [{getmember: [{ref: s}, Arr]}, 0]}, Val]
       instances:
-        - subprogram: {subprogram: 53}
+        - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 551 EventRootType Probe[main.indexMemberWrapperArg]
-              InjectionPoints: [{PC: "0x4abc0e", Frameless: false}]
+              Type: 559 EventRootType Probe[main.indexMemberWrapperArg]
+              InjectionPoints: [{PC: "0x4ac10e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 552 EventRootType Probe[main.indexMemberWrapperArg]Return
-              InjectionPoints: [{PC: "0x4abcb6", Frameless: false}]
+              Type: 560 EventRootType Probe[main.indexMemberWrapperArg]Return
+              InjectionPoints: [{PC: "0x4ac1b6", Frameless: false}]
               Condition: null
     - id: indexMember_wrapper_arr_capture_1
       version: 0
@@ -3152,15 +3419,15 @@ Probes:
             json:
                 getmember: [{index: [{getmember: [{ref: s}, Arr]}, 1]}, Txt]
       instances:
-        - subprogram: {subprogram: 53}
+        - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 553 EventRootType Probe[main.indexMemberWrapperArg]
-              InjectionPoints: [{PC: "0x4abc0e", Frameless: false}]
+              Type: 561 EventRootType Probe[main.indexMemberWrapperArg]
+              InjectionPoints: [{PC: "0x4ac10e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 554 EventRootType Probe[main.indexMemberWrapperArg]Return
-              InjectionPoints: [{PC: "0x4abcb6", Frameless: false}]
+              Type: 562 EventRootType Probe[main.indexMemberWrapperArg]Return
+              InjectionPoints: [{PC: "0x4ac1b6", Frameless: false}]
               Condition: null
     - id: indexMember_wrapper_ptrArr_capture
       version: 0
@@ -3177,15 +3444,15 @@ Probes:
             json:
                 getmember: [{index: [{getmember: [{ref: s}, PtrArr]}, 0]}, Val]
       instances:
-        - subprogram: {subprogram: 53}
+        - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 555 EventRootType Probe[main.indexMemberWrapperArg]
-              InjectionPoints: [{PC: "0x4abc0e", Frameless: false}]
+              Type: 563 EventRootType Probe[main.indexMemberWrapperArg]
+              InjectionPoints: [{PC: "0x4ac10e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 556 EventRootType Probe[main.indexMemberWrapperArg]Return
-              InjectionPoints: [{PC: "0x4abcb6", Frameless: false}]
+              Type: 564 EventRootType Probe[main.indexMemberWrapperArg]Return
+              InjectionPoints: [{PC: "0x4ac1b6", Frameless: false}]
               Condition: null
     - id: indexMember_wrapper_ptrArr_capture_1
       version: 0
@@ -3202,15 +3469,15 @@ Probes:
             json:
                 getmember: [{index: [{getmember: [{ref: s}, PtrArr]}, 1]}, Txt]
       instances:
-        - subprogram: {subprogram: 53}
+        - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 557 EventRootType Probe[main.indexMemberWrapperArg]
-              InjectionPoints: [{PC: "0x4abc0e", Frameless: false}]
+              Type: 565 EventRootType Probe[main.indexMemberWrapperArg]
+              InjectionPoints: [{PC: "0x4ac10e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 558 EventRootType Probe[main.indexMemberWrapperArg]Return
-              InjectionPoints: [{PC: "0x4abcb6", Frameless: false}]
+              Type: 566 EventRootType Probe[main.indexMemberWrapperArg]Return
+              InjectionPoints: [{PC: "0x4ac1b6", Frameless: false}]
               Condition: null
     - id: indexNilPtr_capture
       version: 0
@@ -3226,15 +3493,15 @@ Probes:
             dsl: x.Items[0]
             json: {index: [{getmember: [{ref: x}, Items]}, 0]}
       instances:
-        - subprogram: {subprogram: 45}
+        - subprogram: {subprogram: 47}
           events:
             - Kind: Entry
-              Type: 517 EventRootType Probe[main.indexNilPtrSlice]
-              InjectionPoints: [{PC: "0x4ab4ae", Frameless: false}]
+              Type: 525 EventRootType Probe[main.indexNilPtrSlice]
+              InjectionPoints: [{PC: "0x4ab9ae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 518 EventRootType Probe[main.indexNilPtrSlice]Return
-              InjectionPoints: [{PC: "0x4ab52e", Frameless: false}]
+              Type: 526 EventRootType Probe[main.indexNilPtrSlice]Return
+              InjectionPoints: [{PC: "0x4aba2e", Frameless: false}]
               Condition: null
     - id: indexNilPtr_cond
       version: 0
@@ -3249,16 +3516,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 45}
+        - subprogram: {subprogram: 47}
           events:
             - Kind: Entry
-              Type: 519 EventRootType Probe[main.indexNilPtrSlice]
-              InjectionPoints: [{PC: "0x4ab4ae", Frameless: false}]
+              Type: 527 EventRootType Probe[main.indexNilPtrSlice]
+              InjectionPoints: [{PC: "0x4ab9ae", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 45, index: 0, name: x}
+                      Variable: {subprogram: 47, index: 0, name: x}
                       Offset: 0
                       ByteSize: 8
                     - __kind: DereferenceOp
@@ -3277,8 +3544,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 520 EventRootType Probe[main.indexNilPtrSlice]Return
-              InjectionPoints: [{PC: "0x4ab52e", Frameless: false}]
+              Type: 528 EventRootType Probe[main.indexNilPtrSlice]Return
+              InjectionPoints: [{PC: "0x4aba2e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -3300,15 +3567,15 @@ Probes:
           dsl: x.Items[0]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 45}
+        - subprogram: {subprogram: 47}
           events:
             - Kind: Entry
-              Type: 521 EventRootType Probe[main.indexNilPtrSlice]
-              InjectionPoints: [{PC: "0x4ab4ae", Frameless: false}]
+              Type: 529 EventRootType Probe[main.indexNilPtrSlice]
+              InjectionPoints: [{PC: "0x4ab9ae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 522 EventRootType Probe[main.indexNilPtrSlice]Return
-              InjectionPoints: [{PC: "0x4ab52e", Frameless: false}]
+              Type: 530 EventRootType Probe[main.indexNilPtrSlice]Return
+              InjectionPoints: [{PC: "0x4aba2e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 'items[0]: {x.Items[0]}'
@@ -3334,15 +3601,15 @@ Probes:
             dsl: x.Items[0]
             json: {index: [{getmember: [{ref: x}, Items]}, 0]}
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 499 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0x4ab093", Frameless: false}]
+              Type: 507 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0x4ab593", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 500 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0x4ab1dc", Frameless: false}]
+              Type: 508 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0x4ab6dc", Frameless: false}]
               Condition: null
     - id: indexStringArray_capture
       version: 0
@@ -3360,11 +3627,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 305 EventRootType Probe[main.stringArrayArg]
-              InjectionPoints: [{PC: "0x4a8f4a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a918a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 306 EventRootType Probe[main.stringArrayArg]Return
-              InjectionPoints: [{PC: "0x4a8f96", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a91d6", Frameless: false}]
               Condition: null
     - id: indexStringSlice_capture
       version: 0
@@ -3382,11 +3649,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 301 EventRootType Probe[main.stringSliceArg]
-              InjectionPoints: [{PC: "0x4a8eca", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a910a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 302 EventRootType Probe[main.stringSliceArg]Return
-              InjectionPoints: [{PC: "0x4a8f0f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a914f", Frameless: false}]
               Condition: null
     - id: indexStructSliceField_capture
       version: 0
@@ -3402,15 +3669,15 @@ Probes:
             dsl: x.Items[2]
             json: {index: [{getmember: [{ref: x}, Items]}, 2]}
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 479 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4aaeb3", Frameless: false}]
+              Type: 487 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4ab3b3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 480 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4ab048", Frameless: false}]
+              Type: 488 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4ab548", Frameless: false}]
               Condition: null
     - id: inlined
       version: 0
@@ -3421,19 +3688,19 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 75}
+        - subprogram: {subprogram: 77}
           events:
             - Kind: Entry
-              Type: 609 EventRootType Probe[main.inlined]
+              Type: 617 EventRootType Probe[main.inlined]
               InjectionPoints:
                 - PC: "0x4a69fb"
                   Frameless: false
-                - PC: "0x4a8fea"
+                - PC: "0x4a922a"
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 610 EventRootType Probe[main.inlined]Return
-              InjectionPoints: [{PC: "0x4a902a", Frameless: false}]
+              Type: 618 EventRootType Probe[main.inlined]Return
+              InjectionPoints: [{PC: "0x4a926a", Frameless: false}]
               Condition: null
     - id: inlinedMethod
       version: 0
@@ -3443,11 +3710,11 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 78}
+        - subprogram: {subprogram: 80}
           events:
             - Kind: Entry
-              Type: 613 EventRootType Probe[main.(*methodValueReceiver).inlinedMethod]
-              InjectionPoints: [{PC: "0x4ac90d", Frameless: true}]
+              Type: 621 EventRootType Probe[main.(*methodValueReceiver).inlinedMethod]
+              InjectionPoints: [{PC: "0x4ace0d", Frameless: true}]
               Condition: null
     - id: intArg
       version: 0
@@ -3461,11 +3728,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 269 EventRootType Probe[main.intArg]
-              InjectionPoints: [{PC: "0x4a8cca", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a8f0a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 270 EventRootType Probe[main.intArg]Return
-              InjectionPoints: [{PC: "0x4a8d0a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a8f4a", Frameless: false}]
               Condition: null
     - id: intArrayArg
       version: 0
@@ -3479,11 +3746,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 299 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0x4a8e4a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a908a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 300 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0x4a8e96", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a90d6", Frameless: false}]
               Condition: null
     - id: intArrayArgFrameless
       version: 0
@@ -3497,7 +3764,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 309 EventRootType Probe[main.stringArrayArgFrameless]
-              InjectionPoints: [{PC: "0x4a8fc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x4a9200", Frameless: true}]
               Condition: null
     - id: intSliceArg
       version: 0
@@ -3511,11 +3778,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 289 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0x4a8dca", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a900a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 290 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0x4a8e0f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a904f", Frameless: false}]
               Condition: null
     - id: lenErrInt_nocond
       version: 0
@@ -3526,15 +3793,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 43}
+        - subprogram: {subprogram: 45}
           events:
             - Kind: Entry
-              Type: 509 EventRootType Probe[main.lenErrInt]
-              InjectionPoints: [{PC: "0x4ab233", Frameless: false}]
+              Type: 517 EventRootType Probe[main.lenErrInt]
+              InjectionPoints: [{PC: "0x4ab733", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 510 EventRootType Probe[main.lenErrInt]Return
-              InjectionPoints: [{PC: "0x4ab31c", Frameless: false}]
+              Type: 518 EventRootType Probe[main.lenErrInt]Return
+              InjectionPoints: [{PC: "0x4ab81c", Frameless: false}]
               Condition: null
     - id: lenErrStruct_nocond
       version: 0
@@ -3545,15 +3812,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 44}
+        - subprogram: {subprogram: 46}
           events:
             - Kind: Entry
-              Type: 513 EventRootType Probe[main.lenErrStruct]
-              InjectionPoints: [{PC: "0x4ab373", Frameless: false}]
+              Type: 521 EventRootType Probe[main.lenErrStruct]
+              InjectionPoints: [{PC: "0x4ab873", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 514 EventRootType Probe[main.lenErrStruct]Return
-              InjectionPoints: [{PC: "0x4ab476", Frameless: false}]
+              Type: 522 EventRootType Probe[main.lenErrStruct]Return
+              InjectionPoints: [{PC: "0x4ab976", Frameless: false}]
               Condition: null
     - id: lenErr_int
       version: 0
@@ -3564,15 +3831,15 @@ Probes:
       segments: [len=, {json: {len: {ref: x}}, dsl: len(x)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 43}
+        - subprogram: {subprogram: 45}
           events:
             - Kind: Entry
-              Type: 511 EventRootType Probe[main.lenErrInt]
-              InjectionPoints: [{PC: "0x4ab233", Frameless: false}]
+              Type: 519 EventRootType Probe[main.lenErrInt]
+              InjectionPoints: [{PC: "0x4ab733", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 512 EventRootType Probe[main.lenErrInt]Return
-              InjectionPoints: [{PC: "0x4ab31c", Frameless: false}]
+              Type: 520 EventRootType Probe[main.lenErrInt]Return
+              InjectionPoints: [{PC: "0x4ab81c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x)}
@@ -3589,15 +3856,15 @@ Probes:
       segments: [len=, {json: {len: {ref: x}}, dsl: len(x)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 44}
+        - subprogram: {subprogram: 46}
           events:
             - Kind: Entry
-              Type: 515 EventRootType Probe[main.lenErrStruct]
-              InjectionPoints: [{PC: "0x4ab373", Frameless: false}]
+              Type: 523 EventRootType Probe[main.lenErrStruct]
+              InjectionPoints: [{PC: "0x4ab873", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 516 EventRootType Probe[main.lenErrStruct]Return
-              InjectionPoints: [{PC: "0x4ab476", Frameless: false}]
+              Type: 524 EventRootType Probe[main.lenErrStruct]Return
+              InjectionPoints: [{PC: "0x4ab976", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x)}
@@ -3615,16 +3882,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 463 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0x4aac4e", Frameless: false}]
+              Type: 471 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0x4ab14e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 39, index: 0, name: m}
+                      Variable: {subprogram: 41, index: 0, name: m}
                       Offset: 0
                       ByteSize: 8
                     - __kind: DereferenceOp
@@ -3638,8 +3905,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 464 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0x4aad3c", Frameless: false}]
+              Type: 472 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0x4ab23c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -3661,15 +3928,15 @@ Probes:
           dsl: isEmpty(m)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 465 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0x4aac4e", Frameless: false}]
+              Type: 473 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0x4ab14e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 466 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0x4aad3c", Frameless: false}]
+              Type: 474 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0x4ab23c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: empty={isEmpty(m)}
@@ -3691,15 +3958,15 @@ Probes:
         - name: m_len
           expr: {dsl: len(m), json: {len: {ref: m}}}
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 467 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0x4aac4e", Frameless: false}]
+              Type: 475 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0x4ab14e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 468 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0x4aad3c", Frameless: false}]
+              Type: 476 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0x4ab23c", Frameless: false}]
               Condition: null
     - id: lenMap_len_eq_cond
       version: 0
@@ -3713,16 +3980,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 469 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0x4aac4e", Frameless: false}]
+              Type: 477 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0x4ab14e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 39, index: 0, name: m}
+                      Variable: {subprogram: 41, index: 0, name: m}
                       Offset: 0
                       ByteSize: 8
                     - __kind: DereferenceOp
@@ -3736,8 +4003,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 470 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0x4aad3c", Frameless: false}]
+              Type: 478 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0x4ab23c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -3756,15 +4023,15 @@ Probes:
       segments: [len=, {json: {len: {ref: m}}, dsl: len(m)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 471 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0x4aac4e", Frameless: false}]
+              Type: 479 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0x4ab14e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 472 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0x4aad3c", Frameless: false}]
+              Type: 480 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0x4ab23c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(m)}
@@ -3783,15 +4050,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 473 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0x4aac4e", Frameless: false}]
+              Type: 481 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0x4ab14e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 474 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0x4aad3c", Frameless: false}]
+              Type: 482 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0x4ab23c", Frameless: false}]
               Condition: null
     - id: lenPtrString_len_template
       version: 0
@@ -3802,15 +4069,15 @@ Probes:
       segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 40}
+        - subprogram: {subprogram: 42}
           events:
             - Kind: Entry
-              Type: 475 EventRootType Probe[main.lenPtrString]
-              InjectionPoints: [{PC: "0x4aad8e", Frameless: false}]
+              Type: 483 EventRootType Probe[main.lenPtrString]
+              InjectionPoints: [{PC: "0x4ab28e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 476 EventRootType Probe[main.lenPtrString]Return
-              InjectionPoints: [{PC: "0x4aae65", Frameless: false}]
+              Type: 484 EventRootType Probe[main.lenPtrString]Return
+              InjectionPoints: [{PC: "0x4ab365", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(s)}
@@ -3829,15 +4096,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 40}
+        - subprogram: {subprogram: 42}
           events:
             - Kind: Entry
-              Type: 477 EventRootType Probe[main.lenPtrString]
-              InjectionPoints: [{PC: "0x4aad8e", Frameless: false}]
+              Type: 485 EventRootType Probe[main.lenPtrString]
+              InjectionPoints: [{PC: "0x4ab28e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 478 EventRootType Probe[main.lenPtrString]Return
-              InjectionPoints: [{PC: "0x4aae65", Frameless: false}]
+              Type: 486 EventRootType Probe[main.lenPtrString]Return
+              InjectionPoints: [{PC: "0x4ab365", Frameless: false}]
               Condition: null
     - id: lenPtrStructFields_nocond
       version: 0
@@ -3848,15 +4115,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 501 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0x4ab093", Frameless: false}]
+              Type: 509 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0x4ab593", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 502 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0x4ab1dc", Frameless: false}]
+              Type: 510 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0x4ab6dc", Frameless: false}]
               Condition: null
     - id: lenPtrStruct_field_map
       version: 0
@@ -3870,15 +4137,15 @@ Probes:
           dsl: len(x.Dict)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 503 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0x4ab093", Frameless: false}]
+              Type: 511 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0x4ab593", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 504 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0x4ab1dc", Frameless: false}]
+              Type: 512 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0x4ab6dc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.Dict)}
@@ -3900,15 +4167,15 @@ Probes:
           dsl: len(x.Items)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 505 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0x4ab093", Frameless: false}]
+              Type: 513 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0x4ab593", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 506 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0x4ab1dc", Frameless: false}]
+              Type: 514 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0x4ab6dc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.Items)}
@@ -3930,15 +4197,15 @@ Probes:
           dsl: len(x.S)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 507 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0x4ab093", Frameless: false}]
+              Type: 515 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0x4ab593", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 508 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0x4ab1dc", Frameless: false}]
+              Type: 516 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0x4ab6dc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.S)}
@@ -3958,16 +4225,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 451 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0x4aaaf3", Frameless: false}]
+              Type: 459 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0x4aaff3", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 38, index: 0, name: s}
+                      Variable: {subprogram: 40, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -3978,8 +4245,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 452 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0x4aabf6", Frameless: false}]
+              Type: 460 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0x4ab0f6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4001,15 +4268,15 @@ Probes:
           dsl: isEmpty(s)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 453 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0x4aaaf3", Frameless: false}]
+              Type: 461 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0x4aaff3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 454 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0x4aabf6", Frameless: false}]
+              Type: 462 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0x4ab0f6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: empty={isEmpty(s)}
@@ -4031,15 +4298,15 @@ Probes:
         - name: s_len
           expr: {dsl: len(s), json: {len: {ref: s}}}
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 455 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0x4aaaf3", Frameless: false}]
+              Type: 463 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0x4aaff3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 456 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0x4aabf6", Frameless: false}]
+              Type: 464 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0x4ab0f6", Frameless: false}]
               Condition: null
     - id: lenSlice_len_eq_cond
       version: 0
@@ -4053,16 +4320,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 457 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0x4aaaf3", Frameless: false}]
+              Type: 465 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0x4aaff3", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 38, index: 0, name: s}
+                      Variable: {subprogram: 40, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4073,8 +4340,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 458 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0x4aabf6", Frameless: false}]
+              Type: 466 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0x4ab0f6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4093,15 +4360,15 @@ Probes:
       segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 459 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0x4aaaf3", Frameless: false}]
+              Type: 467 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0x4aaff3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 460 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0x4aabf6", Frameless: false}]
+              Type: 468 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0x4ab0f6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(s)}
@@ -4120,15 +4387,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 461 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0x4aaaf3", Frameless: false}]
+              Type: 469 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0x4aaff3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 462 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0x4aabf6", Frameless: false}]
+              Type: 470 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0x4ab0f6", Frameless: false}]
               Condition: null
     - id: lenString_eq_capture
       version: 0
@@ -4144,15 +4411,15 @@ Probes:
             dsl: len(s) == 5
             json: {eq: [{len: {ref: s}}, 5]}
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 433 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4aa993", Frameless: false}]
+              Type: 441 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4aae93", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 434 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4aaa85", Frameless: false}]
+              Type: 442 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4aaf85", Frameless: false}]
               Condition: null
     - id: lenString_eq_template
       version: 0
@@ -4166,15 +4433,15 @@ Probes:
           dsl: len(s) == 5
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 435 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4aa993", Frameless: false}]
+              Type: 443 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4aae93", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 436 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4aaa85", Frameless: false}]
+              Type: 444 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4aaf85", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: eq={len(s) == 5}
@@ -4196,15 +4463,15 @@ Probes:
         - name: s_isEmpty
           expr: {dsl: isEmpty(s), json: {isEmpty: {ref: s}}}
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 437 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4aa993", Frameless: false}]
+              Type: 445 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4aae93", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 438 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4aaa85", Frameless: false}]
+              Type: 446 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4aaf85", Frameless: false}]
               Condition: null
     - id: lenString_isEmpty_cond
       version: 0
@@ -4216,16 +4483,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 439 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4aa993", Frameless: false}]
+              Type: 447 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4aae93", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 37, index: 0, name: s}
+                      Variable: {subprogram: 39, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4236,8 +4503,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 440 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4aaa85", Frameless: false}]
+              Type: 448 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4aaf85", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4259,15 +4526,15 @@ Probes:
           dsl: isEmpty(s)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 441 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4aa993", Frameless: false}]
+              Type: 449 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4aae93", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 442 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4aaa85", Frameless: false}]
+              Type: 450 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4aaf85", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: empty={isEmpty(s)}
@@ -4289,15 +4556,15 @@ Probes:
         - name: s_len
           expr: {dsl: len(s), json: {len: {ref: s}}}
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 443 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4aa993", Frameless: false}]
+              Type: 451 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4aae93", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 444 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4aaa85", Frameless: false}]
+              Type: 452 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4aaf85", Frameless: false}]
               Condition: null
     - id: lenString_len_eq_cond
       version: 0
@@ -4311,16 +4578,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 445 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4aa993", Frameless: false}]
+              Type: 453 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4aae93", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 37, index: 0, name: s}
+                      Variable: {subprogram: 39, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4331,8 +4598,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 446 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4aaa85", Frameless: false}]
+              Type: 454 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4aaf85", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4351,15 +4618,15 @@ Probes:
       segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 447 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4aa993", Frameless: false}]
+              Type: 455 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4aae93", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 448 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4aaa85", Frameless: false}]
+              Type: 456 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4aaf85", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(s)}
@@ -4378,15 +4645,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 449 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4aa993", Frameless: false}]
+              Type: 457 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4aae93", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 450 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4aaa85", Frameless: false}]
+              Type: 458 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4aaf85", Frameless: false}]
               Condition: null
     - id: lenStructFields_nocond
       version: 0
@@ -4397,15 +4664,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 481 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4aaeb3", Frameless: false}]
+              Type: 489 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4ab3b3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 482 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4ab048", Frameless: false}]
+              Type: 490 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4ab548", Frameless: false}]
               Condition: null
     - id: lenStruct_field_map
       version: 0
@@ -4419,15 +4686,15 @@ Probes:
           dsl: len(x.Dict)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 483 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4aaeb3", Frameless: false}]
+              Type: 491 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4ab3b3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 484 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4ab048", Frameless: false}]
+              Type: 492 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4ab548", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.Dict)}
@@ -4449,15 +4716,15 @@ Probes:
           dsl: len(x.PtrSlice)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 485 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4aaeb3", Frameless: false}]
+              Type: 493 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4ab3b3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 486 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4ab048", Frameless: false}]
+              Type: 494 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4ab548", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.PtrSlice)}
@@ -4479,15 +4746,15 @@ Probes:
           dsl: len(x.PtrStr)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 487 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4aaeb3", Frameless: false}]
+              Type: 495 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4ab3b3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 488 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4ab048", Frameless: false}]
+              Type: 496 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4ab548", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.PtrStr)}
@@ -4509,15 +4776,15 @@ Probes:
           dsl: len(x.Items)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 489 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4aaeb3", Frameless: false}]
+              Type: 497 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4ab3b3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 490 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4ab048", Frameless: false}]
+              Type: 498 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4ab548", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.Items)}
@@ -4539,15 +4806,15 @@ Probes:
           dsl: len(x.S)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 491 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4aaeb3", Frameless: false}]
+              Type: 499 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4ab3b3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 492 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4ab048", Frameless: false}]
+              Type: 500 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4ab548", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.S)}
@@ -4569,16 +4836,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 493 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4aaeb3", Frameless: false}]
+              Type: 501 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4ab3b3", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 41, index: 0, name: x}
+                      Variable: {subprogram: 43, index: 0, name: x}
                       Offset: 40
                       ByteSize: 8
                     - __kind: DereferenceOp
@@ -4592,8 +4859,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 494 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4ab048", Frameless: false}]
+              Type: 502 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4ab548", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4615,16 +4882,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 495 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4aaeb3", Frameless: false}]
+              Type: 503 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4ab3b3", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 41, index: 0, name: x}
+                      Variable: {subprogram: 43, index: 0, name: x}
                       Offset: 24
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4635,8 +4902,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 496 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4ab048", Frameless: false}]
+              Type: 504 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4ab548", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4658,16 +4925,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 497 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4aaeb3", Frameless: false}]
+              Type: 505 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4ab3b3", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 41, index: 0, name: x}
+                      Variable: {subprogram: 43, index: 0, name: x}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4678,8 +4945,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 498 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4ab048", Frameless: false}]
+              Type: 506 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4ab548", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4701,11 +4968,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 271 EventRootType Probe[main.stringArg]
-              InjectionPoints: [{PC: "0x4a8d4a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a8f8a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 272 EventRootType Probe[main.stringArg]Return
-              InjectionPoints: [{PC: "0x4a8d8f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a8fcf", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's: {s}'
@@ -4727,11 +4994,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 273 EventRootType Probe[main.stringArg]
-              InjectionPoints: [{PC: "0x4a8d4a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a8f8a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 274 EventRootType Probe[main.stringArg]Return
-              InjectionPoints: [{PC: "0x4a8d8f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a8fcf", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 'x: {x}'
@@ -4751,11 +5018,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 310 EventRootType Probe[main.mapArg]
-              InjectionPoints: [{PC: "0x4a90aa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a92ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 311 EventRootType Probe[main.mapArg]Return
-              InjectionPoints: [{PC: "0x4a90df", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a931f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 'm: {m}'
@@ -4780,15 +5047,15 @@ Probes:
         - name: false_val
           expr: {dsl: 'm[false]', json: {index: [{ref: m}, false]}}
       instances:
-        - subprogram: {subprogram: 68}
+        - subprogram: {subprogram: 70}
           events:
             - Kind: Entry
-              Type: 593 EventRootType Probe[main.mapIndexBoolKey]
-              InjectionPoints: [{PC: "0x4ac4ea", Frameless: false}]
+              Type: 601 EventRootType Probe[main.mapIndexBoolKey]
+              InjectionPoints: [{PC: "0x4ac9ea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 594 EventRootType Probe[main.mapIndexBoolKey]Return
-              InjectionPoints: [{PC: "0x4ac51f", Frameless: false}]
+              Type: 602 EventRootType Probe[main.mapIndexBoolKey]Return
+              InjectionPoints: [{PC: "0x4aca1f", Frameless: false}]
               Condition: null
     - id: mapIndex_boolKey_true
       version: 0
@@ -4805,15 +5072,15 @@ Probes:
         - name: true_val
           expr: {dsl: 'm[true]', json: {index: [{ref: m}, true]}}
       instances:
-        - subprogram: {subprogram: 68}
+        - subprogram: {subprogram: 70}
           events:
             - Kind: Entry
-              Type: 595 EventRootType Probe[main.mapIndexBoolKey]
-              InjectionPoints: [{PC: "0x4ac4ea", Frameless: false}]
+              Type: 603 EventRootType Probe[main.mapIndexBoolKey]
+              InjectionPoints: [{PC: "0x4ac9ea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 596 EventRootType Probe[main.mapIndexBoolKey]Return
-              InjectionPoints: [{PC: "0x4ac51f", Frameless: false}]
+              Type: 604 EventRootType Probe[main.mapIndexBoolKey]Return
+              InjectionPoints: [{PC: "0x4aca1f", Frameless: false}]
               Condition: null
     - id: mapIndex_emptyKey_capture
       version: 0
@@ -4830,15 +5097,15 @@ Probes:
         - name: empty_val
           expr: {dsl: 'm[""]', json: {index: [{ref: m}, ""]}}
       instances:
-        - subprogram: {subprogram: 65}
+        - subprogram: {subprogram: 67}
           events:
             - Kind: Entry
-              Type: 587 EventRootType Probe[main.mapIndexEmptyKey]
-              InjectionPoints: [{PC: "0x4ac36a", Frameless: false}]
+              Type: 595 EventRootType Probe[main.mapIndexEmptyKey]
+              InjectionPoints: [{PC: "0x4ac86a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 588 EventRootType Probe[main.mapIndexEmptyKey]Return
-              InjectionPoints: [{PC: "0x4ac3c5", Frameless: false}]
+              Type: 596 EventRootType Probe[main.mapIndexEmptyKey]Return
+              InjectionPoints: [{PC: "0x4ac8c5", Frameless: false}]
               Condition: null
     - id: mapIndex_intKey_capture
       version: 0
@@ -4855,15 +5122,15 @@ Probes:
         - name: m_2
           expr: {dsl: 'm[2]', json: {index: [{ref: m}, 2]}}
       instances:
-        - subprogram: {subprogram: 54}
+        - subprogram: {subprogram: 56}
           events:
             - Kind: Entry
-              Type: 559 EventRootType Probe[main.mapIndexIntKey]
-              InjectionPoints: [{PC: "0x4abd0a", Frameless: false}]
+              Type: 567 EventRootType Probe[main.mapIndexIntKey]
+              InjectionPoints: [{PC: "0x4ac20a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 560 EventRootType Probe[main.mapIndexIntKey]Return
-              InjectionPoints: [{PC: "0x4abd3f", Frameless: false}]
+              Type: 568 EventRootType Probe[main.mapIndexIntKey]Return
+              InjectionPoints: [{PC: "0x4ac23f", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen16
       version: 0
@@ -4882,15 +5149,15 @@ Probes:
             dsl: m["000000000000002a"]
             json: {index: [{ref: m}, 000000000000002a]}
       instances:
-        - subprogram: {subprogram: 66}
+        - subprogram: {subprogram: 68}
           events:
             - Kind: Entry
-              Type: 589 EventRootType Probe[main.mapIndexKeyLen16]
-              InjectionPoints: [{PC: "0x4ac3ea", Frameless: false}]
+              Type: 597 EventRootType Probe[main.mapIndexKeyLen16]
+              InjectionPoints: [{PC: "0x4ac8ea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 590 EventRootType Probe[main.mapIndexKeyLen16]Return
-              InjectionPoints: [{PC: "0x4ac439", Frameless: false}]
+              Type: 598 EventRootType Probe[main.mapIndexKeyLen16]Return
+              InjectionPoints: [{PC: "0x4ac939", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen17
       version: 0
@@ -4909,15 +5176,15 @@ Probes:
             dsl: m["0000000000000002a"]
             json: {index: [{ref: m}, 0000000000000002a]}
       instances:
-        - subprogram: {subprogram: 67}
+        - subprogram: {subprogram: 69}
           events:
             - Kind: Entry
-              Type: 591 EventRootType Probe[main.mapIndexKeyLen17]
-              InjectionPoints: [{PC: "0x4ac46a", Frameless: false}]
+              Type: 599 EventRootType Probe[main.mapIndexKeyLen17]
+              InjectionPoints: [{PC: "0x4ac96a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 592 EventRootType Probe[main.mapIndexKeyLen17]Return
-              InjectionPoints: [{PC: "0x4ac4b9", Frameless: false}]
+              Type: 600 EventRootType Probe[main.mapIndexKeyLen17]Return
+              InjectionPoints: [{PC: "0x4ac9b9", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen200
       version: 0
@@ -4939,15 +5206,15 @@ Probes:
                     - ref: m
                     - 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002a
       instances:
-        - subprogram: {subprogram: 62}
+        - subprogram: {subprogram: 64}
           events:
             - Kind: Entry
-              Type: 577 EventRootType Probe[main.mapIndexKeyLen200]
-              InjectionPoints: [{PC: "0x4ac1ca", Frameless: false}]
+              Type: 585 EventRootType Probe[main.mapIndexKeyLen200]
+              InjectionPoints: [{PC: "0x4ac6ca", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 578 EventRootType Probe[main.mapIndexKeyLen200]Return
-              InjectionPoints: [{PC: "0x4ac219", Frameless: false}]
+              Type: 586 EventRootType Probe[main.mapIndexKeyLen200]Return
+              InjectionPoints: [{PC: "0x4ac719", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen24
       version: 0
@@ -4966,15 +5233,15 @@ Probes:
             dsl: m["00000000000000000000002a"]
             json: {index: [{ref: m}, 00000000000000000000002a]}
       instances:
-        - subprogram: {subprogram: 59}
+        - subprogram: {subprogram: 61}
           events:
             - Kind: Entry
-              Type: 571 EventRootType Probe[main.mapIndexKeyLen24]
-              InjectionPoints: [{PC: "0x4ac04a", Frameless: false}]
+              Type: 579 EventRootType Probe[main.mapIndexKeyLen24]
+              InjectionPoints: [{PC: "0x4ac54a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 572 EventRootType Probe[main.mapIndexKeyLen24]Return
-              InjectionPoints: [{PC: "0x4ac099", Frameless: false}]
+              Type: 580 EventRootType Probe[main.mapIndexKeyLen24]Return
+              InjectionPoints: [{PC: "0x4ac599", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen48
       version: 0
@@ -4996,15 +5263,15 @@ Probes:
                     - ref: m
                     - 00000000000000000000000000000000000000000000002a
       instances:
-        - subprogram: {subprogram: 60}
+        - subprogram: {subprogram: 62}
           events:
             - Kind: Entry
-              Type: 573 EventRootType Probe[main.mapIndexKeyLen48]
-              InjectionPoints: [{PC: "0x4ac0ca", Frameless: false}]
+              Type: 581 EventRootType Probe[main.mapIndexKeyLen48]
+              InjectionPoints: [{PC: "0x4ac5ca", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 574 EventRootType Probe[main.mapIndexKeyLen48]Return
-              InjectionPoints: [{PC: "0x4ac119", Frameless: false}]
+              Type: 582 EventRootType Probe[main.mapIndexKeyLen48]Return
+              InjectionPoints: [{PC: "0x4ac619", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen8
       version: 0
@@ -5023,15 +5290,15 @@ Probes:
             dsl: m["0000002a"]
             json: {index: [{ref: m}, 0000002a]}
       instances:
-        - subprogram: {subprogram: 58}
+        - subprogram: {subprogram: 60}
           events:
             - Kind: Entry
-              Type: 569 EventRootType Probe[main.mapIndexKeyLen8]
-              InjectionPoints: [{PC: "0x4abfca", Frameless: false}]
+              Type: 577 EventRootType Probe[main.mapIndexKeyLen8]
+              InjectionPoints: [{PC: "0x4ac4ca", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 570 EventRootType Probe[main.mapIndexKeyLen8]Return
-              InjectionPoints: [{PC: "0x4ac019", Frameless: false}]
+              Type: 578 EventRootType Probe[main.mapIndexKeyLen8]Return
+              InjectionPoints: [{PC: "0x4ac519", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen96
       version: 0
@@ -5053,15 +5320,15 @@ Probes:
                     - ref: m
                     - 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002a
       instances:
-        - subprogram: {subprogram: 61}
+        - subprogram: {subprogram: 63}
           events:
             - Kind: Entry
-              Type: 575 EventRootType Probe[main.mapIndexKeyLen96]
-              InjectionPoints: [{PC: "0x4ac14a", Frameless: false}]
+              Type: 583 EventRootType Probe[main.mapIndexKeyLen96]
+              InjectionPoints: [{PC: "0x4ac64a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 576 EventRootType Probe[main.mapIndexKeyLen96]Return
-              InjectionPoints: [{PC: "0x4ac199", Frameless: false}]
+              Type: 584 EventRootType Probe[main.mapIndexKeyLen96]Return
+              InjectionPoints: [{PC: "0x4ac699", Frameless: false}]
               Condition: null
     - id: mapIndex_largeMap_capture
       version: 0
@@ -5080,15 +5347,15 @@ Probes:
             dsl: m["key42"]
             json: {index: [{ref: m}, key42]}
       instances:
-        - subprogram: {subprogram: 56}
+        - subprogram: {subprogram: 58}
           events:
             - Kind: Entry
-              Type: 565 EventRootType Probe[main.mapIndexLargeMap]
-              InjectionPoints: [{PC: "0x4abdca", Frameless: false}]
+              Type: 573 EventRootType Probe[main.mapIndexLargeMap]
+              InjectionPoints: [{PC: "0x4ac2ca", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 566 EventRootType Probe[main.mapIndexLargeMap]Return
-              InjectionPoints: [{PC: "0x4abe19", Frameless: false}]
+              Type: 574 EventRootType Probe[main.mapIndexLargeMap]Return
+              InjectionPoints: [{PC: "0x4ac319", Frameless: false}]
               Condition: null
     - id: mapIndex_largeValue_capture
       version: 0
@@ -5107,15 +5374,15 @@ Probes:
             dsl: m["k"].Val
             json: {getmember: [{index: [{ref: m}, k]}, Val]}
       instances:
-        - subprogram: {subprogram: 71}
+        - subprogram: {subprogram: 73}
           events:
             - Kind: Entry
-              Type: 601 EventRootType Probe[main.mapIndexLargeValue]
-              InjectionPoints: [{PC: "0x4ac60a", Frameless: false}]
+              Type: 609 EventRootType Probe[main.mapIndexLargeValue]
+              InjectionPoints: [{PC: "0x4acb0a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 602 EventRootType Probe[main.mapIndexLargeValue]Return
-              InjectionPoints: [{PC: "0x4ac667", Frameless: false}]
+              Type: 610 EventRootType Probe[main.mapIndexLargeValue]Return
+              InjectionPoints: [{PC: "0x4acb67", Frameless: false}]
               Condition: null
     - id: mapIndex_missing_capture
       version: 0
@@ -5134,15 +5401,15 @@ Probes:
             dsl: m["missing"]
             json: {index: [{ref: m}, missing]}
       instances:
-        - subprogram: {subprogram: 57}
+        - subprogram: {subprogram: 59}
           events:
             - Kind: Entry
-              Type: 567 EventRootType Probe[main.mapIndexMissing]
-              InjectionPoints: [{PC: "0x4abe4a", Frameless: false}]
+              Type: 575 EventRootType Probe[main.mapIndexMissing]
+              InjectionPoints: [{PC: "0x4ac34a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 568 EventRootType Probe[main.mapIndexMissing]Return
-              InjectionPoints: [{PC: "0x4abe7f", Frameless: false}]
+              Type: 576 EventRootType Probe[main.mapIndexMissing]Return
+              InjectionPoints: [{PC: "0x4ac37f", Frameless: false}]
               Condition: null
     - id: mapIndex_nilPtrVal_capture
       version: 0
@@ -5161,15 +5428,15 @@ Probes:
             dsl: m["nil_key"].Val
             json: {getmember: [{index: [{ref: m}, nil_key]}, Val]}
       instances:
-        - subprogram: {subprogram: 70}
+        - subprogram: {subprogram: 72}
           events:
             - Kind: Entry
-              Type: 599 EventRootType Probe[main.mapIndexNilPtrVal]
-              InjectionPoints: [{PC: "0x4ac5aa", Frameless: false}]
+              Type: 607 EventRootType Probe[main.mapIndexNilPtrVal]
+              InjectionPoints: [{PC: "0x4acaaa", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 600 EventRootType Probe[main.mapIndexNilPtrVal]Return
-              InjectionPoints: [{PC: "0x4ac5df", Frameless: false}]
+              Type: 608 EventRootType Probe[main.mapIndexNilPtrVal]Return
+              InjectionPoints: [{PC: "0x4acadf", Frameless: false}]
               Condition: null
     - id: mapIndex_ptrStructVal_capture_int
       version: 0
@@ -5188,15 +5455,15 @@ Probes:
             dsl: m["x"].Val
             json: {getmember: [{index: [{ref: m}, x]}, Val]}
       instances:
-        - subprogram: {subprogram: 64}
+        - subprogram: {subprogram: 66}
           events:
             - Kind: Entry
-              Type: 583 EventRootType Probe[main.mapIndexPtrStructVal]
-              InjectionPoints: [{PC: "0x4ac2ca", Frameless: false}]
+              Type: 591 EventRootType Probe[main.mapIndexPtrStructVal]
+              InjectionPoints: [{PC: "0x4ac7ca", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 584 EventRootType Probe[main.mapIndexPtrStructVal]Return
-              InjectionPoints: [{PC: "0x4ac32a", Frameless: false}]
+              Type: 592 EventRootType Probe[main.mapIndexPtrStructVal]Return
+              InjectionPoints: [{PC: "0x4ac82a", Frameless: false}]
               Condition: null
     - id: mapIndex_ptrStructVal_capture_string
       version: 0
@@ -5215,15 +5482,15 @@ Probes:
             dsl: m["y"].Txt
             json: {getmember: [{index: [{ref: m}, "y"]}, Txt]}
       instances:
-        - subprogram: {subprogram: 64}
+        - subprogram: {subprogram: 66}
           events:
             - Kind: Entry
-              Type: 585 EventRootType Probe[main.mapIndexPtrStructVal]
-              InjectionPoints: [{PC: "0x4ac2ca", Frameless: false}]
+              Type: 593 EventRootType Probe[main.mapIndexPtrStructVal]
+              InjectionPoints: [{PC: "0x4ac7ca", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 586 EventRootType Probe[main.mapIndexPtrStructVal]Return
-              InjectionPoints: [{PC: "0x4ac32a", Frameless: false}]
+              Type: 594 EventRootType Probe[main.mapIndexPtrStructVal]Return
+              InjectionPoints: [{PC: "0x4ac82a", Frameless: false}]
               Condition: null
     - id: mapIndex_stringKey_capture
       version: 0
@@ -5242,15 +5509,15 @@ Probes:
             dsl: m["beta"]
             json: {index: [{ref: m}, beta]}
       instances:
-        - subprogram: {subprogram: 55}
+        - subprogram: {subprogram: 57}
           events:
             - Kind: Entry
-              Type: 561 EventRootType Probe[main.mapIndexStringKey]
-              InjectionPoints: [{PC: "0x4abd6a", Frameless: false}]
+              Type: 569 EventRootType Probe[main.mapIndexStringKey]
+              InjectionPoints: [{PC: "0x4ac26a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 562 EventRootType Probe[main.mapIndexStringKey]Return
-              InjectionPoints: [{PC: "0x4abd9f", Frameless: false}]
+              Type: 570 EventRootType Probe[main.mapIndexStringKey]Return
+              InjectionPoints: [{PC: "0x4ac29f", Frameless: false}]
               Condition: null
     - id: mapIndex_stringKey_template
       version: 0
@@ -5267,15 +5534,15 @@ Probes:
           dsl: m["beta"]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 55}
+        - subprogram: {subprogram: 57}
           events:
             - Kind: Entry
-              Type: 563 EventRootType Probe[main.mapIndexStringKey]
-              InjectionPoints: [{PC: "0x4abd6a", Frameless: false}]
+              Type: 571 EventRootType Probe[main.mapIndexStringKey]
+              InjectionPoints: [{PC: "0x4ac26a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 564 EventRootType Probe[main.mapIndexStringKey]Return
-              InjectionPoints: [{PC: "0x4abd9f", Frameless: false}]
+              Type: 572 EventRootType Probe[main.mapIndexStringKey]Return
+              InjectionPoints: [{PC: "0x4ac29f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: beta={m["beta"]}
@@ -5300,15 +5567,15 @@ Probes:
             dsl: m["a"].Val
             json: {getmember: [{index: [{ref: m}, a]}, Val]}
       instances:
-        - subprogram: {subprogram: 63}
+        - subprogram: {subprogram: 65}
           events:
             - Kind: Entry
-              Type: 579 EventRootType Probe[main.mapIndexStructVal]
-              InjectionPoints: [{PC: "0x4ac24a", Frameless: false}]
+              Type: 587 EventRootType Probe[main.mapIndexStructVal]
+              InjectionPoints: [{PC: "0x4ac74a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 580 EventRootType Probe[main.mapIndexStructVal]Return
-              InjectionPoints: [{PC: "0x4ac2a7", Frameless: false}]
+              Type: 588 EventRootType Probe[main.mapIndexStructVal]Return
+              InjectionPoints: [{PC: "0x4ac7a7", Frameless: false}]
               Condition: null
     - id: mapIndex_structVal_capture_string
       version: 0
@@ -5327,15 +5594,15 @@ Probes:
             dsl: m["b"].Txt
             json: {getmember: [{index: [{ref: m}, b]}, Txt]}
       instances:
-        - subprogram: {subprogram: 63}
+        - subprogram: {subprogram: 65}
           events:
             - Kind: Entry
-              Type: 581 EventRootType Probe[main.mapIndexStructVal]
-              InjectionPoints: [{PC: "0x4ac24a", Frameless: false}]
+              Type: 589 EventRootType Probe[main.mapIndexStructVal]
+              InjectionPoints: [{PC: "0x4ac74a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 582 EventRootType Probe[main.mapIndexStructVal]Return
-              InjectionPoints: [{PC: "0x4ac2a7", Frameless: false}]
+              Type: 590 EventRootType Probe[main.mapIndexStructVal]Return
+              InjectionPoints: [{PC: "0x4ac7a7", Frameless: false}]
               Condition: null
     - id: mapIndex_zeroValue_capture
       version: 0
@@ -5354,15 +5621,15 @@ Probes:
             dsl: m["zero"]
             json: {index: [{ref: m}, zero]}
       instances:
-        - subprogram: {subprogram: 69}
+        - subprogram: {subprogram: 71}
           events:
             - Kind: Entry
-              Type: 597 EventRootType Probe[main.mapIndexZeroValue]
-              InjectionPoints: [{PC: "0x4ac54a", Frameless: false}]
+              Type: 605 EventRootType Probe[main.mapIndexZeroValue]
+              InjectionPoints: [{PC: "0x4aca4a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 598 EventRootType Probe[main.mapIndexZeroValue]Return
-              InjectionPoints: [{PC: "0x4ac57f", Frameless: false}]
+              Type: 606 EventRootType Probe[main.mapIndexZeroValue]Return
+              InjectionPoints: [{PC: "0x4aca7f", Frameless: false}]
               Condition: null
     - id: noArgs
       version: 0
@@ -5376,11 +5643,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 314 EventRootType Probe[main.noArgs]
-              InjectionPoints: [{PC: "0x4a91ca", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a940a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 315 EventRootType Probe[main.noArgs]Return
-              InjectionPoints: [{PC: "0x4a9206", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a9446", Frameless: false}]
               Condition: null
     - id: stringArg
       version: 0
@@ -5394,11 +5661,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 275 EventRootType Probe[main.stringArg]
-              InjectionPoints: [{PC: "0x4a8d4a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a8f8a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 276 EventRootType Probe[main.stringArg]Return
-              InjectionPoints: [{PC: "0x4a8d8f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a8fcf", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's: {s}'
@@ -5420,11 +5687,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 307 EventRootType Probe[main.stringArrayArg]
-              InjectionPoints: [{PC: "0x4a8f4a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a918a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 308 EventRootType Probe[main.stringArrayArg]Return
-              InjectionPoints: [{PC: "0x4a8f96", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a91d6", Frameless: false}]
               Condition: null
     - id: stringSliceArg
       version: 0
@@ -5438,11 +5705,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 303 EventRootType Probe[main.stringSliceArg]
-              InjectionPoints: [{PC: "0x4a8eca", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a910a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 304 EventRootType Probe[main.stringSliceArg]Return
-              InjectionPoints: [{PC: "0x4a8f0f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4a914f", Frameless: false}]
               Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
       version: 0
@@ -5453,39 +5720,39 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 46}
+        - subprogram: {subprogram: 48}
           events:
             - Kind: Entry
-              Type: 523 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
-              InjectionPoints: [{PC: "0x4ab576", Frameless: false}]
+              Type: 531 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+              InjectionPoints: [{PC: "0x4aba76", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 524 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
-              InjectionPoints: [{PC: "0x4ab72e", Frameless: false}]
+              Type: 532 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+              InjectionPoints: [{PC: "0x4abc2e", Frameless: false}]
               Condition: null
 Subprograms:
     - ID: 1
       Name: main.intArg
-      OutOfLinePCRanges: [0x4a8cc0..0x4a8d22]
+      OutOfLinePCRanges: [0x4a8f00..0x4a8f62]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x4a8cc0..0x4a8cd9
+            - Range: 0x4a8f00..0x4a8f19
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 2
       Name: main.stringArg
-      OutOfLinePCRanges: [0x4a8d40..0x4a8db1]
+      OutOfLinePCRanges: [0x4a8f80..0x4a8ff1]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a8d40..0x4a8d5e
+            - Range: 0x4a8f80..0x4a8f9e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -5496,13 +5763,13 @@ Subprograms:
       DictRegister: null
     - ID: 3
       Name: main.intSliceArg
-      OutOfLinePCRanges: [0x4a8dc0..0x4a8e3a]
+      OutOfLinePCRanges: [0x4a9000..0x4a907a]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 100 GoSliceHeaderType []int
           Locations:
-            - Range: 0x4a8dc0..0x4a8dde
+            - Range: 0x4a9000..0x4a901e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -5515,26 +5782,26 @@ Subprograms:
       DictRegister: null
     - ID: 4
       Name: main.intArrayArg
-      OutOfLinePCRanges: [0x4a8e40..0x4a8ea7]
+      OutOfLinePCRanges: [0x4a9080..0x4a90e7]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 101 ArrayType [3]int
           Locations:
-            - Range: 0x4a8e40..0x4a8ea7
+            - Range: 0x4a9080..0x4a90e7
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 5
       Name: main.stringSliceArg
-      OutOfLinePCRanges: [0x4a8ec0..0x4a8f3a]
+      OutOfLinePCRanges: [0x4a9100..0x4a917a]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 102 GoSliceHeaderType []string
           Locations:
-            - Range: 0x4a8ec0..0x4a8ede
+            - Range: 0x4a9100..0x4a911e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -5547,86 +5814,86 @@ Subprograms:
       DictRegister: null
     - ID: 6
       Name: main.stringArrayArg
-      OutOfLinePCRanges: [0x4a8f40..0x4a8fa7]
+      OutOfLinePCRanges: [0x4a9180..0x4a91e7]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 103 ArrayType [3]string
           Locations:
-            - Range: 0x4a8f40..0x4a8fa7
+            - Range: 0x4a9180..0x4a91e7
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 7
       Name: main.stringArrayArgFrameless
-      OutOfLinePCRanges: [0x4a8fc0..0x4a8fc1]
+      OutOfLinePCRanges: [0x4a9200..0x4a9201]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 103 ArrayType [3]string
           Locations:
-            - Range: 0x4a8fc0..0x4a8fc1
+            - Range: 0x4a9200..0x4a9201
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 8
       Name: main.mapArg
-      OutOfLinePCRanges: [0x4a90a0..0x4a90f6]
+      OutOfLinePCRanges: [0x4a92e0..0x4a9336]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 104 GoMapType map[string]int
           Locations:
-            - Range: 0x4a90a0..0x4a90cd
+            - Range: 0x4a92e0..0x4a930d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 9
       Name: main.bigMapArg
-      OutOfLinePCRanges: [0x4a9100..0x4a91bb]
+      OutOfLinePCRanges: [0x4a9340..0x4a93fb]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 111 GoMapType map[string]main.bigStruct
           Locations:
-            - Range: 0x4a9100..0x4a9133
+            - Range: 0x4a9340..0x4a9373
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4a9133..0x4a91bb
+            - Range: 0x4a9373..0x4a93fb
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 10
       Name: main.noArgs
-      OutOfLinePCRanges: [0x4a91c0..0x4a9213]
+      OutOfLinePCRanges: [0x4a9400..0x4a9453]
       InlinePCRanges: []
       Variables: []
       DictRegister: null
     - ID: 11
       Name: main.condInt8
-      OutOfLinePCRanges: [0x4a9220..0x4a92c8]
+      OutOfLinePCRanges: [0x4a9460..0x4a9508]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 BaseType int8
           Locations:
-            - Range: 0x4a9220..0x4a9261
+            - Range: 0x4a9460..0x4a94a1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a9220..0x4a9264
+            - Range: 0x4a9460..0x4a94a4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a9264..0x4a9269
+            - Range: 0x4a94a4..0x4a94a9
               Pieces:
                 - Size: 8
                   Op: null
@@ -5637,26 +5904,26 @@ Subprograms:
       DictRegister: null
     - ID: 12
       Name: main.condInt16
-      OutOfLinePCRanges: [0x4a92e0..0x4a9389]
+      OutOfLinePCRanges: [0x4a9520..0x4a95c9]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 96 BaseType int16
           Locations:
-            - Range: 0x4a92e0..0x4a9309
+            - Range: 0x4a9520..0x4a9549
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a92e0..0x4a9309
+            - Range: 0x4a9520..0x4a9549
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a9309..0x4a9389
+            - Range: 0x4a9549..0x4a95c9
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -5667,26 +5934,26 @@ Subprograms:
       DictRegister: null
     - ID: 13
       Name: main.condInt32
-      OutOfLinePCRanges: [0x4a93a0..0x4a9447]
+      OutOfLinePCRanges: [0x4a95e0..0x4a9687]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x4a93a0..0x4a93c9
+            - Range: 0x4a95e0..0x4a9609
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a93a0..0x4a93c9
+            - Range: 0x4a95e0..0x4a9609
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a93c9..0x4a9447
+            - Range: 0x4a9609..0x4a9687
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -5697,26 +5964,26 @@ Subprograms:
       DictRegister: null
     - ID: 14
       Name: main.condInt64
-      OutOfLinePCRanges: [0x4a9460..0x4a9509]
+      OutOfLinePCRanges: [0x4a96a0..0x4a9749]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType int64
           Locations:
-            - Range: 0x4a9460..0x4a9489
+            - Range: 0x4a96a0..0x4a96c9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a9460..0x4a9489
+            - Range: 0x4a96a0..0x4a96c9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a9489..0x4a9509
+            - Range: 0x4a96c9..0x4a9749
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -5727,26 +5994,26 @@ Subprograms:
       DictRegister: null
     - ID: 15
       Name: main.condUint8
-      OutOfLinePCRanges: [0x4a9520..0x4a95c8]
+      OutOfLinePCRanges: [0x4a9760..0x4a9808]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x4a9520..0x4a9561
+            - Range: 0x4a9760..0x4a97a1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a9520..0x4a9564
+            - Range: 0x4a9760..0x4a97a4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a9564..0x4a9569
+            - Range: 0x4a97a4..0x4a97a9
               Pieces:
                 - Size: 8
                   Op: null
@@ -5757,26 +6024,26 @@ Subprograms:
       DictRegister: null
     - ID: 16
       Name: main.condUint16
-      OutOfLinePCRanges: [0x4a95e0..0x4a9689]
+      OutOfLinePCRanges: [0x4a9820..0x4a98c9]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType uint16
           Locations:
-            - Range: 0x4a95e0..0x4a9609
+            - Range: 0x4a9820..0x4a9849
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a95e0..0x4a9609
+            - Range: 0x4a9820..0x4a9849
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a9609..0x4a9689
+            - Range: 0x4a9849..0x4a98c9
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -5787,26 +6054,26 @@ Subprograms:
       DictRegister: null
     - ID: 17
       Name: main.condUint32
-      OutOfLinePCRanges: [0x4a96a0..0x4a9747]
+      OutOfLinePCRanges: [0x4a98e0..0x4a9987]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x4a96a0..0x4a96c9
+            - Range: 0x4a98e0..0x4a9909
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a96a0..0x4a96c9
+            - Range: 0x4a98e0..0x4a9909
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a96c9..0x4a9747
+            - Range: 0x4a9909..0x4a9987
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -5817,26 +6084,26 @@ Subprograms:
       DictRegister: null
     - ID: 18
       Name: main.condUint64
-      OutOfLinePCRanges: [0x4a9760..0x4a9809]
+      OutOfLinePCRanges: [0x4a99a0..0x4a9a49]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 BaseType uint64
           Locations:
-            - Range: 0x4a9760..0x4a9789
+            - Range: 0x4a99a0..0x4a99c9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a9760..0x4a9789
+            - Range: 0x4a99a0..0x4a99c9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a9789..0x4a9809
+            - Range: 0x4a99c9..0x4a9a49
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -5847,32 +6114,32 @@ Subprograms:
       DictRegister: null
     - ID: 19
       Name: main.condFloat32
-      OutOfLinePCRanges: [0x4a9820..0x4a98da]
+      OutOfLinePCRanges: [0x4a9a60..0x4a9b1a]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 BaseType float32
           Locations:
-            - Range: 0x4a9820..0x4a9853
+            - Range: 0x4a9a60..0x4a9a93
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a9820..0x4a984e
+            - Range: 0x4a9a60..0x4a9a8e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4a984e..0x4a9853
+            - Range: 0x4a9a8e..0x4a9a93
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4a9853..0x4a98da
+            - Range: 0x4a9a93..0x4a9b1a
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -5883,32 +6150,32 @@ Subprograms:
       DictRegister: null
     - ID: 20
       Name: main.condFloat64
-      OutOfLinePCRanges: [0x4a98e0..0x4a999a]
+      OutOfLinePCRanges: [0x4a9b20..0x4a9bda]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType float64
           Locations:
-            - Range: 0x4a98e0..0x4a9915
+            - Range: 0x4a9b20..0x4a9b55
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a98e0..0x4a9910
+            - Range: 0x4a9b20..0x4a9b50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4a9910..0x4a9915
+            - Range: 0x4a9b50..0x4a9b55
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4a9915..0x4a999a
+            - Range: 0x4a9b55..0x4a9bda
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -5919,26 +6186,26 @@ Subprograms:
       DictRegister: null
     - ID: 21
       Name: main.condBool
-      OutOfLinePCRanges: [0x4a99a0..0x4a9a48]
+      OutOfLinePCRanges: [0x4a9be0..0x4a9c88]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x4a99a0..0x4a99e1
+            - Range: 0x4a9be0..0x4a9c21
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a99a0..0x4a99e4
+            - Range: 0x4a9be0..0x4a9c24
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a99e4..0x4a99e9
+            - Range: 0x4a9c24..0x4a9c29
               Pieces:
                 - Size: 8
                   Op: null
@@ -5949,13 +6216,13 @@ Subprograms:
       DictRegister: null
     - ID: 22
       Name: main.condString
-      OutOfLinePCRanges: [0x4a9a60..0x4a9b17]
+      OutOfLinePCRanges: [0x4a9ca0..0x4a9d57]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a9a60..0x4a9a8e
+            - Range: 0x4a9ca0..0x4a9cce
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -5966,13 +6233,13 @@ Subprograms:
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a9a60..0x4a9a8e
+            - Range: 0x4a9ca0..0x4a9cce
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x4a9a8e..0x4a9b17
+            - Range: 0x4a9cce..0x4a9d57
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -5983,32 +6250,32 @@ Subprograms:
       DictRegister: null
     - ID: 23
       Name: main.condStructArg
-      OutOfLinePCRanges: [0x4a9b20..0x4a9c5a]
+      OutOfLinePCRanges: [0x4a9d60..0x4a9e9a]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 116 StructureType main.condFields
           Locations:
-            - Range: 0x4a9b20..0x4a9c5a
+            - Range: 0x4a9d60..0x4a9e9a
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a9b20..0x4a9b67
+            - Range: 0x4a9d60..0x4a9da7
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4a9b67..0x4a9b6c
+            - Range: 0x4a9da7..0x4a9dac
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
                 - Size: 8
                   Op: {CfaOffset: 88}
-            - Range: 0x4a9b6c..0x4a9c5a
+            - Range: 0x4a9dac..0x4a9e9a
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
@@ -6019,28 +6286,28 @@ Subprograms:
       DictRegister: null
     - ID: 24
       Name: main.condPtrStructArg
-      OutOfLinePCRanges: [0x4a9c60..0x4a9db3]
+      OutOfLinePCRanges: [0x4a9ea0..0x4a9ff3]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 118 PointerType *main.condFields
           Locations:
-            - Range: 0x4a9c60..0x4a9cb8
+            - Range: 0x4a9ea0..0x4a9ef8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4a9cb8..0x4a9db3
+            - Range: 0x4a9ef8..0x4a9ff3
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a9c60..0x4a9cbd
+            - Range: 0x4a9ea0..0x4a9efd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a9cbd..0x4a9db3
+            - Range: 0x4a9efd..0x4a9ff3
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -6051,26 +6318,26 @@ Subprograms:
       DictRegister: null
     - ID: 25
       Name: main.condNilPtrStruct
-      OutOfLinePCRanges: [0x4a9dc0..0x4a9e7c]
+      OutOfLinePCRanges: [0x4aa000..0x4aa0bc]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 118 PointerType *main.condFields
           Locations:
-            - Range: 0x4a9dc0..0x4a9e15
+            - Range: 0x4aa000..0x4aa055
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a9dc0..0x4a9e18
+            - Range: 0x4aa000..0x4aa058
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a9e18..0x4a9e1d
+            - Range: 0x4aa058..0x4aa05d
               Pieces:
                 - Size: 8
                   Op: null
@@ -6081,66 +6348,66 @@ Subprograms:
       DictRegister: null
     - ID: 26
       Name: main.condReturnAndLocal
-      OutOfLinePCRanges: [0x4a9e80..0x4a9f19]
+      OutOfLinePCRanges: [0x4aa0c0..0x4aa159]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x4a9e80..0x4a9e91
+            - Range: 0x4aa0c0..0x4aa0d1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x4a9e80..0x4a9ebf
+            - Range: 0x4aa0c0..0x4aa0ff
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x4a9e80..0x4a9ef5
+            - Range: 0x4aa0c0..0x4aa135
               Pieces: []
-            - Range: 0x4a9ef5..0x4a9ef6
+            - Range: 0x4aa135..0x4aa136
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4a9ef6..0x4a9f19
+            - Range: 0x4aa136..0x4aa159
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: sum
           Type: 9 BaseType int
           Locations:
-            - Range: 0x4a9e91..0x4a9ebf
+            - Range: 0x4aa0d1..0x4aa0ff
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4a9ebf..0x4a9f19
+            - Range: 0x4aa0ff..0x4aa159
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 27
       Name: main.condOnly
-      OutOfLinePCRanges: [0x4a9f20..0x4a9fc9]
+      OutOfLinePCRanges: [0x4aa160..0x4aa209]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x4a9f20..0x4a9f49
+            - Range: 0x4aa160..0x4aa189
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a9f20..0x4a9f49
+            - Range: 0x4aa160..0x4aa189
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a9f49..0x4a9fc9
+            - Range: 0x4aa189..0x4aa209
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -6151,28 +6418,28 @@ Subprograms:
       DictRegister: null
     - ID: 28
       Name: main.condLine
-      OutOfLinePCRanges: [0x4a9fe0..0x4aa0c5]
+      OutOfLinePCRanges: [0x4aa220..0x4aa305]
       InlinePCRanges: []
       Variables:
         - Name: "n"
           Type: 9 BaseType int
           Locations:
-            - Range: 0x4a9fe0..0x4aa01c
+            - Range: 0x4aa220..0x4aa25c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4aa01c..0x4aa0c5
+            - Range: 0x4aa25c..0x4aa305
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a9fe0..0x4aa025
+            - Range: 0x4aa220..0x4aa265
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4aa025..0x4aa0c5
+            - Range: 0x4aa265..0x4aa305
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -6182,14 +6449,107 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 29
+      Name: main.condLineMixed
+      OutOfLinePCRanges: [0x4aa320..0x4aa549]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0x4aa320..0x4aa396
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x4aa396..0x4aa39b
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 80}
+                - Size: 8
+                  Op: {CfaOffset: 88}
+            - Range: 0x4aa39b..0x4aa549
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 80}
+                - Size: 8
+                  Op: {CfaOffset: 88}
+          Role: Parameter
+          DictIndex: -1
+        - Name: b
+          Type: 4 BaseType bool
+          Locations:
+            - Range: 0x4aa320..0x4aa39b
+              Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0x4aa39b..0x4aa549
+              Pieces: [{Size: 1, Op: {CfaOffset: 96}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: x
+          Type: 116 StructureType main.condFields
+          Locations:
+            - Range: 0x4aa320..0x4aa549
+              Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: p
+          Type: 118 PointerType *main.condFields
+          Locations:
+            - Range: 0x4aa320..0x4aa376
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+            - Range: 0x4aa376..0x4aa549
+              Pieces: [{Size: 8, Op: {CfaOffset: 104}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: ss
+          Type: 100 GoSliceHeaderType []int
+          Locations:
+            - Range: 0x4aa320..0x4aa39b
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+            - Range: 0x4aa39b..0x4aa549
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 112}
+                - Size: 8
+                  Op: {CfaOffset: 120}
+                - Size: 8
+                  Op: {CfaOffset: 128}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 30
+      Name: main.condLineReturn
+      OutOfLinePCRanges: [0x4aa560..0x4aa5d2]
+      InlinePCRanges: []
+      Variables:
+        - Name: "n"
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x4aa560..0x4aa571
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: ~r0
+          Type: 9 BaseType int
+          Locations: [{Range: 0x4aa560..0x4aa5d2, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 31
       Name: main.condSliceArg
-      OutOfLinePCRanges: [0x4aa0e0..0x4aa1a5]
+      OutOfLinePCRanges: [0x4aa5e0..0x4aa6a5]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 100 GoSliceHeaderType []int
           Locations:
-            - Range: 0x4aa0e0..0x4aa10e
+            - Range: 0x4aa5e0..0x4aa60e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6202,13 +6562,13 @@ Subprograms:
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4aa0e0..0x4aa10e
+            - Range: 0x4aa5e0..0x4aa60e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
-            - Range: 0x4aa10e..0x4aa1a5
+            - Range: 0x4aa60e..0x4aa6a5
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
@@ -6217,28 +6577,28 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 30
+    - ID: 32
       Name: main.condMapArg
-      OutOfLinePCRanges: [0x4aa1c0..0x4aa25a]
+      OutOfLinePCRanges: [0x4aa6c0..0x4aa75a]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 104 GoMapType map[string]int
           Locations:
-            - Range: 0x4aa1c0..0x4aa1f3
+            - Range: 0x4aa6c0..0x4aa6f3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4aa1c0..0x4aa1f6
+            - Range: 0x4aa6c0..0x4aa6f6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4aa1f6..0x4aa1fb
+            - Range: 0x4aa6f6..0x4aa6fb
               Pieces:
                 - Size: 8
                   Op: null
@@ -6247,34 +6607,34 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 31
+    - ID: 33
       Name: main.condStructDirect
-      OutOfLinePCRanges: [0x4aa260..0x4aa31a]
+      OutOfLinePCRanges: [0x4aa760..0x4aa81a]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 116 StructureType main.condFields
           Locations:
-            - Range: 0x4aa260..0x4aa31a
+            - Range: 0x4aa760..0x4aa81a
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4aa260..0x4aa295
+            - Range: 0x4aa760..0x4aa795
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4aa295..0x4aa29a
+            - Range: 0x4aa795..0x4aa79a
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
                 - Size: 8
                   Op: {CfaOffset: 88}
-            - Range: 0x4aa29a..0x4aa31a
+            - Range: 0x4aa79a..0x4aa81a
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
@@ -6283,134 +6643,36 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 32
+    - ID: 34
       Name: main.condNullPtr
-      OutOfLinePCRanges: [0x4aa320..0x4aa433]
+      OutOfLinePCRanges: [0x4aa820..0x4aa933]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 93 PointerType *int
           Locations:
-            - Range: 0x4aa320..0x4aa38c
+            - Range: 0x4aa820..0x4aa88c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4aa38c..0x4aa433
+            - Range: 0x4aa88c..0x4aa933
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4aa320..0x4aa391
+            - Range: 0x4aa820..0x4aa891
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4aa391..0x4aa394
+            - Range: 0x4aa891..0x4aa894
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4aa394..0x4aa433
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 33
-      Name: main.condNullSlice
-      OutOfLinePCRanges: [0x4aa440..0x4aa5b0]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 100 GoSliceHeaderType []int
-          Locations:
-            - Range: 0x4aa440..0x4aa4de
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4aa4de..0x4aa4e3
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 0}
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-            - Range: 0x4aa4e3..0x4aa4e6
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 0}
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-            - Range: 0x4aa4e6..0x4aa5b0
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 0}
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 10 GoStringHeaderType string
-          Locations:
-            - Range: 0x4aa440..0x4aa4eb
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-            - Range: 0x4aa4eb..0x4aa5b0
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 24}
-                - Size: 8
-                  Op: {CfaOffset: 32}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 34
-      Name: main.condNullMap
-      OutOfLinePCRanges: [0x4aa5c0..0x4aa6d3]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 104 GoMapType map[string]int
-          Locations:
-            - Range: 0x4aa5c0..0x4aa62c
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4aa62c..0x4aa6d3
-              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 10 GoStringHeaderType string
-          Locations:
-            - Range: 0x4aa5c0..0x4aa631
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4aa631..0x4aa634
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-            - Range: 0x4aa634..0x4aa6d3
+            - Range: 0x4aa894..0x4aa933
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -6420,87 +6682,95 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 35
-      Name: main.condNullIface
-      OutOfLinePCRanges: [0x4aa6e0..0x4aa82e]
+      Name: main.condNullSlice
+      OutOfLinePCRanges: [0x4aa940..0x4aaab0]
       InlinePCRanges: []
       Variables:
-        - Name: i
-          Type: 18 GoInterfaceType error
+        - Name: s
+          Type: 100 GoSliceHeaderType []int
           Locations:
-            - Range: 0x4aa6e0..0x4aa76c
+            - Range: 0x4aa940..0x4aa9de
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4aa76c..0x4aa771
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4aa9de..0x4aa9e3
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0x4aa771..0x4aa82e
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x4aa9e3..0x4aa9e6
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x4aa9e6..0x4aaab0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 0}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4aa6e0..0x4aa774
+            - Range: 0x4aa940..0x4aa9eb
               Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x4aa774..0x4aa779
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+            - Range: 0x4aa9eb..0x4aaab0
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 16}
-                - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0x4aa779..0x4aa82e
-              Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 16}
-                - Size: 8
-                  Op: {CfaOffset: 24}
+                  Op: {CfaOffset: 32}
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 36
-      Name: main.condNullUnsafePtr
-      OutOfLinePCRanges: [0x4aa840..0x4aa953]
+      Name: main.condNullMap
+      OutOfLinePCRanges: [0x4aaac0..0x4aabd3]
       InlinePCRanges: []
       Variables:
-        - Name: p
-          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: m
+          Type: 104 GoMapType map[string]int
           Locations:
-            - Range: 0x4aa840..0x4aa8ac
+            - Range: 0x4aaac0..0x4aab2c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4aa8ac..0x4aa953
+            - Range: 0x4aab2c..0x4aabd3
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4aa840..0x4aa8b1
+            - Range: 0x4aaac0..0x4aab31
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4aa8b1..0x4aa8b4
+            - Range: 0x4aab31..0x4aab34
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4aa8b4..0x4aa953
+            - Range: 0x4aab34..0x4aabd3
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -6510,41 +6780,49 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 37
-      Name: main.lenString
-      OutOfLinePCRanges: [0x4aa980..0x4aaac5]
+      Name: main.condNullIface
+      OutOfLinePCRanges: [0x4aabe0..0x4aad2e]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 10 GoStringHeaderType string
+        - Name: i
+          Type: 18 GoInterfaceType error
           Locations:
-            - Range: 0x4aa980..0x4aaa07
+            - Range: 0x4aabe0..0x4aac6c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4aaa07..0x4aaa0c
-              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x4aaa0c..0x4aaac5
-              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
+            - Range: 0x4aac6c..0x4aac71
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 0}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+            - Range: 0x4aac71..0x4aad2e
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 0}
+                - Size: 8
+                  Op: {CfaOffset: 8}
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4aa980..0x4aaa0f
+            - Range: 0x4aabe0..0x4aac74
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x4aaa0f..0x4aaa14
+            - Range: 0x4aac74..0x4aac79
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0x4aaa14..0x4aaac5
+            - Range: 0x4aac79..0x4aad2e
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -6554,14 +6832,96 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 38
+      Name: main.condNullUnsafePtr
+      OutOfLinePCRanges: [0x4aad40..0x4aae53]
+      InlinePCRanges: []
+      Variables:
+        - Name: p
+          Type: 19 VoidPointerType unsafe.Pointer
+          Locations:
+            - Range: 0x4aad40..0x4aadac
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4aadac..0x4aae53
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0x4aad40..0x4aadb1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4aadb1..0x4aadb4
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x4aadb4..0x4aae53
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 39
+      Name: main.lenString
+      OutOfLinePCRanges: [0x4aae80..0x4aafc5]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0x4aae80..0x4aaf07
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x4aaf07..0x4aaf0c
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
+            - Range: 0x4aaf0c..0x4aafc5
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0x4aae80..0x4aaf0f
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+            - Range: 0x4aaf0f..0x4aaf14
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0x4aaf14..0x4aafc5
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 40
       Name: main.lenSlice
-      OutOfLinePCRanges: [0x4aaae0..0x4aac3b]
+      OutOfLinePCRanges: [0x4aafe0..0x4ab13b]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 100 GoSliceHeaderType []int
           Locations:
-            - Range: 0x4aaae0..0x4aab76
+            - Range: 0x4aafe0..0x4ab076
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6569,7 +6929,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4aab76..0x4aab7b
+            - Range: 0x4ab076..0x4ab07b
               Pieces:
                 - Size: 8
                   Op: null
@@ -6577,7 +6937,7 @@ Subprograms:
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4aab7b..0x4aab7e
+            - Range: 0x4ab07b..0x4ab07e
               Pieces:
                 - Size: 8
                   Op: null
@@ -6585,7 +6945,7 @@ Subprograms:
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: null
-            - Range: 0x4aab7e..0x4aac3b
+            - Range: 0x4ab07e..0x4ab13b
               Pieces:
                 - Size: 8
                   Op: null
@@ -6598,13 +6958,13 @@ Subprograms:
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4aaae0..0x4aab85
+            - Range: 0x4aafe0..0x4ab085
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
-            - Range: 0x4aab85..0x4aac3b
+            - Range: 0x4ab085..0x4ab13b
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
@@ -6613,36 +6973,36 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 39
+    - ID: 41
       Name: main.lenMap
-      OutOfLinePCRanges: [0x4aac40..0x4aad6a]
+      OutOfLinePCRanges: [0x4ab140..0x4ab26a]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 104 GoMapType map[string]int
           Locations:
-            - Range: 0x4aac40..0x4aacac
+            - Range: 0x4ab140..0x4ab1ac
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4aacac..0x4aad6a
+            - Range: 0x4ab1ac..0x4ab26a
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4aac40..0x4aacb1
+            - Range: 0x4ab140..0x4ab1b1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4aacb1..0x4aacb4
+            - Range: 0x4ab1b1..0x4ab1b4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4aacb4..0x4aad6a
+            - Range: 0x4ab1b4..0x4ab26a
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -6651,110 +7011,36 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 40
+    - ID: 42
       Name: main.lenPtrString
-      OutOfLinePCRanges: [0x4aad80..0x4aae93]
+      OutOfLinePCRanges: [0x4ab280..0x4ab393]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 88 PointerType *string
           Locations:
-            - Range: 0x4aad80..0x4aadec
+            - Range: 0x4ab280..0x4ab2ec
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4aadec..0x4aae93
+            - Range: 0x4ab2ec..0x4ab393
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4aad80..0x4aadf1
+            - Range: 0x4ab280..0x4ab2f1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4aadf1..0x4aadf4
+            - Range: 0x4ab2f1..0x4ab2f4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4aadf4..0x4aae93
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 41
-      Name: main.lenStructFields
-      OutOfLinePCRanges: [0x4aaea0..0x4ab074]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 119 StructureType main.lenFields
-          Locations:
-            - Range: 0x4aaea0..0x4ab074
-              Pieces: [{Size: 72, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 10 GoStringHeaderType string
-          Locations:
-            - Range: 0x4aaea0..0x4aaf72
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4aaf72..0x4aaf75
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 72}
-                - Size: 8
-                  Op: {CfaOffset: 80}
-            - Range: 0x4aaf75..0x4ab074
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 72}
-                - Size: 8
-                  Op: {CfaOffset: 80}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 42
-      Name: main.lenPtrStructFields
-      OutOfLinePCRanges: [0x4ab080..0x4ab20d]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 121 PointerType *main.lenFields
-          Locations:
-            - Range: 0x4ab080..0x4ab0fd
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4ab0fd..0x4ab20d
-              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 10 GoStringHeaderType string
-          Locations:
-            - Range: 0x4ab080..0x4ab102
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4ab102..0x4ab105
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-            - Range: 0x4ab105..0x4ab20d
+            - Range: 0x4ab2f4..0x4ab393
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -6764,35 +7050,71 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 43
-      Name: main.lenErrInt
-      OutOfLinePCRanges: [0x4ab220..0x4ab34a]
+      Name: main.lenStructFields
+      OutOfLinePCRanges: [0x4ab3a0..0x4ab574]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 9 BaseType int
+          Type: 119 StructureType main.lenFields
           Locations:
-            - Range: 0x4ab220..0x4ab29b
+            - Range: 0x4ab3a0..0x4ab574
+              Pieces: [{Size: 72, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0x4ab3a0..0x4ab472
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x4ab472..0x4ab475
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 72}
+                - Size: 8
+                  Op: {CfaOffset: 80}
+            - Range: 0x4ab475..0x4ab574
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 72}
+                - Size: 8
+                  Op: {CfaOffset: 80}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 44
+      Name: main.lenPtrStructFields
+      OutOfLinePCRanges: [0x4ab580..0x4ab70d]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 121 PointerType *main.lenFields
+          Locations:
+            - Range: 0x4ab580..0x4ab5fd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4ab29b..0x4ab34a
+            - Range: 0x4ab5fd..0x4ab70d
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4ab220..0x4ab2a0
+            - Range: 0x4ab580..0x4ab602
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4ab2a0..0x4ab2a3
+            - Range: 0x4ab602..0x4ab605
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4ab2a3..0x4ab34a
+            - Range: 0x4ab605..0x4ab70d
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -6801,34 +7123,72 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 44
+    - ID: 45
+      Name: main.lenErrInt
+      OutOfLinePCRanges: [0x4ab720..0x4ab84a]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x4ab720..0x4ab79b
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4ab79b..0x4ab84a
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0x4ab720..0x4ab7a0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4ab7a0..0x4ab7a3
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x4ab7a3..0x4ab84a
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 46
       Name: main.lenErrStruct
-      OutOfLinePCRanges: [0x4ab360..0x4ab49d]
+      OutOfLinePCRanges: [0x4ab860..0x4ab99d]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 116 StructureType main.condFields
           Locations:
-            - Range: 0x4ab360..0x4ab49d
+            - Range: 0x4ab860..0x4ab99d
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4ab360..0x4ab3f6
+            - Range: 0x4ab860..0x4ab8f6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4ab3f6..0x4ab3f9
+            - Range: 0x4ab8f6..0x4ab8f9
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
                 - Size: 8
                   Op: {CfaOffset: 88}
-            - Range: 0x4ab3f9..0x4ab49d
+            - Range: 0x4ab8f9..0x4ab99d
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
@@ -6837,28 +7197,28 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 45
+    - ID: 47
       Name: main.indexNilPtrSlice
-      OutOfLinePCRanges: [0x4ab4a0..0x4ab55c]
+      OutOfLinePCRanges: [0x4ab9a0..0x4aba5c]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 121 PointerType *main.lenFields
           Locations:
-            - Range: 0x4ab4a0..0x4ab4f5
+            - Range: 0x4ab9a0..0x4ab9f5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4ab4a0..0x4ab4f8
+            - Range: 0x4ab9a0..0x4ab9f8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4ab4f8..0x4ab4fd
+            - Range: 0x4ab9f8..0x4ab9fd
               Pieces:
                 - Size: 8
                   Op: null
@@ -6867,65 +7227,65 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 46
+    - ID: 48
       Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
-      OutOfLinePCRanges: [0x4ab560..0x4ab745]
+      OutOfLinePCRanges: [0x4aba60..0x4abc45]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 122 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
           Locations:
-            - Range: 0x4ab560..0x4ab72e
+            - Range: 0x4aba60..0x4abc2e
               Pieces: []
-            - Range: 0x4ab72e..0x4ab72f
+            - Range: 0x4abc2e..0x4abc2f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4ab72f..0x4ab745
+            - Range: 0x4abc2f..0x4abc45
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: m
           Type: 127 GoMapType map[string]map[int]main.aStructNotUsedAsAnArgument
-          Locations: [{Range: 0x4ab560..0x4ab745, Pieces: []}]
+          Locations: [{Range: 0x4aba60..0x4abc45, Pieces: []}]
           Role: Local
           DictIndex: -1
       DictRegister: null
-    - ID: 47
+    - ID: 49
       Name: main.bigArrayArg
-      OutOfLinePCRanges: [0x4ab760..0x4ab7ea]
+      OutOfLinePCRanges: [0x4abc60..0x4abcea]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 132 ArrayType [131072]int64
           Locations:
-            - Range: 0x4ab760..0x4ab7ea
+            - Range: 0x4abc60..0x4abcea
               Pieces: [{Size: 1048576, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 48
+    - ID: 50
       Name: main.bigArrayStructArg
-      OutOfLinePCRanges: [0x4ab800..0x4ab895]
+      OutOfLinePCRanges: [0x4abd00..0x4abd95]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 133 PointerType *main.bigArrayStruct
           Locations:
-            - Range: 0x4ab800..0x4ab826
+            - Range: 0x4abd00..0x4abd26
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4ab826..0x4ab895
+            - Range: 0x4abd26..0x4abd95
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 49
+    - ID: 51
       Name: main.structSliceArg
-      OutOfLinePCRanges: [0x4ab8a0..0x4ab97c]
+      OutOfLinePCRanges: [0x4abda0..0x4abe7c]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 135 GoSliceHeaderType []main.indexMemberStruct
           Locations:
-            - Range: 0x4ab8a0..0x4ab8d9
+            - Range: 0x4abda0..0x4abdd9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6933,7 +7293,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4ab8d9..0x4ab8de
+            - Range: 0x4abdd9..0x4abdde
               Pieces:
                 - Size: 8
                   Op: null
@@ -6941,7 +7301,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4ab937..0x4ab93a
+            - Range: 0x4abe37..0x4abe3a
               Pieces:
                 - Size: 8
                   Op: null
@@ -6949,7 +7309,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4ab93a..0x4ab97c
+            - Range: 0x4abe3a..0x4abe7c
               Pieces:
                 - Size: 8
                   Op: null
@@ -6962,129 +7322,19 @@ Subprograms:
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4ab8a0..0x4ab8de
+            - Range: 0x4abda0..0x4abdde
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
-            - Range: 0x4ab8de..0x4ab935
+            - Range: 0x4abdde..0x4abe35
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: {CfaOffset: 32}
-            - Range: 0x4ab935..0x4ab97c
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 50
-      Name: main.structArrayArg
-      OutOfLinePCRanges: [0x4ab980..0x4aba34]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 138 ArrayType [2]main.indexMemberStruct
-          Locations:
-            - Range: 0x4ab980..0x4aba34
-              Pieces: [{Size: 64, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 10 GoStringHeaderType string
-          Locations:
-            - Range: 0x4ab980..0x4ab9b4
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4ab9b4..0x4ab9b9
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 64}
-                - Size: 8
-                  Op: {CfaOffset: 72}
-            - Range: 0x4ab9b9..0x4aba34
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 64}
-                - Size: 8
-                  Op: {CfaOffset: 72}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 51
-      Name: main.ptrStructSliceArg
-      OutOfLinePCRanges: [0x4aba40..0x4abb25]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 139 GoSliceHeaderType []*main.indexMemberStruct
-          Locations:
-            - Range: 0x4aba40..0x4aba7a
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4aba7a..0x4aba7c
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: null
-            - Range: 0x4aba7c..0x4aba85
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: null
-            - Range: 0x4abade..0x4abae1
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4abae1..0x4abb25
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: null
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 10 GoStringHeaderType string
-          Locations:
-            - Range: 0x4aba40..0x4aba85
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-            - Range: 0x4aba85..0x4abadc
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 24}
-                - Size: 8
-                  Op: {CfaOffset: 32}
-            - Range: 0x4abadc..0x4abb25
+            - Range: 0x4abe35..0x4abe7c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -7094,33 +7344,143 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 52
+      Name: main.structArrayArg
+      OutOfLinePCRanges: [0x4abe80..0x4abf34]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 138 ArrayType [2]main.indexMemberStruct
+          Locations:
+            - Range: 0x4abe80..0x4abf34
+              Pieces: [{Size: 64, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0x4abe80..0x4abeb4
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x4abeb4..0x4abeb9
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 64}
+                - Size: 8
+                  Op: {CfaOffset: 72}
+            - Range: 0x4abeb9..0x4abf34
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 64}
+                - Size: 8
+                  Op: {CfaOffset: 72}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 53
+      Name: main.ptrStructSliceArg
+      OutOfLinePCRanges: [0x4abf40..0x4ac025]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 139 GoSliceHeaderType []*main.indexMemberStruct
+          Locations:
+            - Range: 0x4abf40..0x4abf7a
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4abf7a..0x4abf7c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: null
+            - Range: 0x4abf7c..0x4abf85
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: null
+            - Range: 0x4abfde..0x4abfe1
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4abfe1..0x4ac025
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: null
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0x4abf40..0x4abf85
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+            - Range: 0x4abf85..0x4abfdc
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 24}
+                - Size: 8
+                  Op: {CfaOffset: 32}
+            - Range: 0x4abfdc..0x4ac025
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 54
       Name: main.ptrStructArrayArg
-      OutOfLinePCRanges: [0x4abb40..0x4abbeb]
+      OutOfLinePCRanges: [0x4ac040..0x4ac0eb]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 141 ArrayType [2]*main.indexMemberStruct
           Locations:
-            - Range: 0x4abb40..0x4abbeb
+            - Range: 0x4ac040..0x4ac0eb
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4abb40..0x4abb71
+            - Range: 0x4ac040..0x4ac071
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4abb71..0x4abb76
+            - Range: 0x4ac071..0x4ac076
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0x4abb76..0x4abbeb
+            - Range: 0x4ac076..0x4ac0eb
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -7129,30 +7489,30 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 53
+    - ID: 55
       Name: main.indexMemberWrapperArg
-      OutOfLinePCRanges: [0x4abc00..0x4abce5]
+      OutOfLinePCRanges: [0x4ac100..0x4ac1e5]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 142 PointerType *main.indexMemberWrapper
           Locations:
-            - Range: 0x4abc00..0x4abc3a
+            - Range: 0x4ac100..0x4ac13a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4abc3a..0x4abce5
+            - Range: 0x4ac13a..0x4ac1e5
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4abc00..0x4abc3f
+            - Range: 0x4ac100..0x4ac13f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4abc3f..0x4abce5
+            - Range: 0x4ac13f..0x4ac1e5
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -7161,261 +7521,261 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 54
+    - ID: 56
       Name: main.mapIndexIntKey
-      OutOfLinePCRanges: [0x4abd00..0x4abd56]
+      OutOfLinePCRanges: [0x4ac200..0x4ac256]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 144 GoMapType map[int]string
           Locations:
-            - Range: 0x4abd00..0x4abd2d
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 55
-      Name: main.mapIndexStringKey
-      OutOfLinePCRanges: [0x4abd60..0x4abdb6]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 104 GoMapType map[string]int
-          Locations:
-            - Range: 0x4abd60..0x4abd8d
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 56
-      Name: main.mapIndexLargeMap
-      OutOfLinePCRanges: [0x4abdc0..0x4abe30]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 104 GoMapType map[string]int
-          Locations:
-            - Range: 0x4abdc0..0x4abde3
+            - Range: 0x4ac200..0x4ac22d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 57
-      Name: main.mapIndexMissing
-      OutOfLinePCRanges: [0x4abe40..0x4abe96]
+      Name: main.mapIndexStringKey
+      OutOfLinePCRanges: [0x4ac260..0x4ac2b6]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 104 GoMapType map[string]int
           Locations:
-            - Range: 0x4abe40..0x4abe6d
+            - Range: 0x4ac260..0x4ac28d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 58
-      Name: main.mapIndexKeyLen8
-      OutOfLinePCRanges: [0x4abfc0..0x4ac030]
+      Name: main.mapIndexLargeMap
+      OutOfLinePCRanges: [0x4ac2c0..0x4ac330]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 104 GoMapType map[string]int
           Locations:
-            - Range: 0x4abfc0..0x4abfe3
+            - Range: 0x4ac2c0..0x4ac2e3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 59
-      Name: main.mapIndexKeyLen24
-      OutOfLinePCRanges: [0x4ac040..0x4ac0b0]
+      Name: main.mapIndexMissing
+      OutOfLinePCRanges: [0x4ac340..0x4ac396]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 104 GoMapType map[string]int
           Locations:
-            - Range: 0x4ac040..0x4ac063
+            - Range: 0x4ac340..0x4ac36d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 60
-      Name: main.mapIndexKeyLen48
-      OutOfLinePCRanges: [0x4ac0c0..0x4ac130]
+      Name: main.mapIndexKeyLen8
+      OutOfLinePCRanges: [0x4ac4c0..0x4ac530]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 104 GoMapType map[string]int
           Locations:
-            - Range: 0x4ac0c0..0x4ac0e3
+            - Range: 0x4ac4c0..0x4ac4e3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 61
-      Name: main.mapIndexKeyLen96
-      OutOfLinePCRanges: [0x4ac140..0x4ac1b0]
+      Name: main.mapIndexKeyLen24
+      OutOfLinePCRanges: [0x4ac540..0x4ac5b0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 104 GoMapType map[string]int
           Locations:
-            - Range: 0x4ac140..0x4ac163
+            - Range: 0x4ac540..0x4ac563
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 62
-      Name: main.mapIndexKeyLen200
-      OutOfLinePCRanges: [0x4ac1c0..0x4ac230]
+      Name: main.mapIndexKeyLen48
+      OutOfLinePCRanges: [0x4ac5c0..0x4ac630]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 104 GoMapType map[string]int
           Locations:
-            - Range: 0x4ac1c0..0x4ac1e3
+            - Range: 0x4ac5c0..0x4ac5e3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 63
-      Name: main.mapIndexStructVal
-      OutOfLinePCRanges: [0x4ac240..0x4ac2be]
+      Name: main.mapIndexKeyLen96
+      OutOfLinePCRanges: [0x4ac640..0x4ac6b0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 149 GoMapType map[string]main.indexMemberStruct
+          Type: 104 GoMapType map[string]int
           Locations:
-            - Range: 0x4ac240..0x4ac26a
+            - Range: 0x4ac640..0x4ac663
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 64
-      Name: main.mapIndexPtrStructVal
-      OutOfLinePCRanges: [0x4ac2c0..0x4ac345]
+      Name: main.mapIndexKeyLen200
+      OutOfLinePCRanges: [0x4ac6c0..0x4ac730]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 154 GoMapType map[string]*main.indexMemberStruct
+          Type: 104 GoMapType map[string]int
           Locations:
-            - Range: 0x4ac2c0..0x4ac2ea
+            - Range: 0x4ac6c0..0x4ac6e3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 65
-      Name: main.mapIndexEmptyKey
-      OutOfLinePCRanges: [0x4ac360..0x4ac3dc]
+      Name: main.mapIndexStructVal
+      OutOfLinePCRanges: [0x4ac740..0x4ac7be]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 104 GoMapType map[string]int
+          Type: 149 GoMapType map[string]main.indexMemberStruct
           Locations:
-            - Range: 0x4ac360..0x4ac382
+            - Range: 0x4ac740..0x4ac76a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 66
-      Name: main.mapIndexKeyLen16
-      OutOfLinePCRanges: [0x4ac3e0..0x4ac450]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 104 GoMapType map[string]int
-          Locations:
-            - Range: 0x4ac3e0..0x4ac403
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 67
-      Name: main.mapIndexKeyLen17
-      OutOfLinePCRanges: [0x4ac460..0x4ac4d0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 104 GoMapType map[string]int
-          Locations:
-            - Range: 0x4ac460..0x4ac483
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 68
-      Name: main.mapIndexBoolKey
-      OutOfLinePCRanges: [0x4ac4e0..0x4ac536]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 159 GoMapType map[bool]int
-          Locations:
-            - Range: 0x4ac4e0..0x4ac50d
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 69
-      Name: main.mapIndexZeroValue
-      OutOfLinePCRanges: [0x4ac540..0x4ac596]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 104 GoMapType map[string]int
-          Locations:
-            - Range: 0x4ac540..0x4ac56d
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 70
-      Name: main.mapIndexNilPtrVal
-      OutOfLinePCRanges: [0x4ac5a0..0x4ac5f6]
+      Name: main.mapIndexPtrStructVal
+      OutOfLinePCRanges: [0x4ac7c0..0x4ac845]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 154 GoMapType map[string]*main.indexMemberStruct
           Locations:
-            - Range: 0x4ac5a0..0x4ac5cd
+            - Range: 0x4ac7c0..0x4ac7ea
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 67
+      Name: main.mapIndexEmptyKey
+      OutOfLinePCRanges: [0x4ac860..0x4ac8dc]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 104 GoMapType map[string]int
+          Locations:
+            - Range: 0x4ac860..0x4ac882
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 68
+      Name: main.mapIndexKeyLen16
+      OutOfLinePCRanges: [0x4ac8e0..0x4ac950]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 104 GoMapType map[string]int
+          Locations:
+            - Range: 0x4ac8e0..0x4ac903
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 69
+      Name: main.mapIndexKeyLen17
+      OutOfLinePCRanges: [0x4ac960..0x4ac9d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 104 GoMapType map[string]int
+          Locations:
+            - Range: 0x4ac960..0x4ac983
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 70
+      Name: main.mapIndexBoolKey
+      OutOfLinePCRanges: [0x4ac9e0..0x4aca36]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 159 GoMapType map[bool]int
+          Locations:
+            - Range: 0x4ac9e0..0x4aca0d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 71
-      Name: main.mapIndexLargeValue
-      OutOfLinePCRanges: [0x4ac600..0x4ac67e]
+      Name: main.mapIndexZeroValue
+      OutOfLinePCRanges: [0x4aca40..0x4aca96]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 164 GoMapType map[string]main.largeValueStruct
+          Type: 104 GoMapType map[string]int
           Locations:
-            - Range: 0x4ac600..0x4ac625
+            - Range: 0x4aca40..0x4aca6d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 72
+      Name: main.mapIndexNilPtrVal
+      OutOfLinePCRanges: [0x4acaa0..0x4acaf6]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 154 GoMapType map[string]*main.indexMemberStruct
+          Locations:
+            - Range: 0x4acaa0..0x4acacd
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 73
+      Name: main.mapIndexLargeValue
+      OutOfLinePCRanges: [0x4acb00..0x4acb7e]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 164 GoMapType map[string]main.largeValueStruct
+          Locations:
+            - Range: 0x4acb00..0x4acb25
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 74
       Name: main.condMultiReturn
-      OutOfLinePCRanges: [0x4ac700..0x4ac7d4]
+      OutOfLinePCRanges: [0x4acc00..0x4accd4]
       InlinePCRanges: []
       Variables:
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4ac700..0x4ac749
+            - Range: 0x4acc00..0x4acc49
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4ac749..0x4ac74e
+            - Range: 0x4acc49..0x4acc4e
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0x4ac74e..0x4ac7d4
+            - Range: 0x4acc4e..0x4accd4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -7426,51 +7786,51 @@ Subprograms:
         - Name: r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x4ac700..0x4ac7ac
+            - Range: 0x4acc00..0x4accac
               Pieces: []
-            - Range: 0x4ac7ac..0x4ac7ad
+            - Range: 0x4accac..0x4accad
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4ac7ad..0x4ac7d4
+            - Range: 0x4accad..0x4accd4
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: r1
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4ac700..0x4ac7ac
+            - Range: 0x4acc00..0x4accac
               Pieces: []
-            - Range: 0x4ac7ac..0x4ac7ad
+            - Range: 0x4accac..0x4accad
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4ac7ad..0x4ac7d4
+            - Range: 0x4accad..0x4accd4
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 73
+    - ID: 75
       Name: main.genericIdentity[go.shape.string]
-      OutOfLinePCRanges: [0x4ac7e0..0x4ac87d]
+      OutOfLinePCRanges: [0x4acce0..0x4acd7d]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 169 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x4ac7e0..0x4ac809
+            - Range: 0x4acce0..0x4acd09
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4ac809..0x4ac80e
+            - Range: 0x4acd09..0x4acd0e
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4ac80e..0x4ac87d
+            - Range: 0x4acd0e..0x4acd7d
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -7481,68 +7841,68 @@ Subprograms:
         - Name: ~r0
           Type: 169 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x4ac7e0..0x4ac84f
+            - Range: 0x4acce0..0x4acd4f
               Pieces: []
-            - Range: 0x4ac84f..0x4ac850
+            - Range: 0x4acd4f..0x4acd50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4ac850..0x4ac87d
+            - Range: 0x4acd50..0x4acd7d
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 74
+    - ID: 76
       Name: main.genericIdentity[go.shape.int]
-      OutOfLinePCRanges: [0x4ac880..0x4ac8fe]
+      OutOfLinePCRanges: [0x4acd80..0x4acdfe]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 170 BaseType go.shape.int
           Locations:
-            - Range: 0x4ac880..0x4ac8a6
+            - Range: 0x4acd80..0x4acda6
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x4ac8a6..0x4ac8fe
+            - Range: 0x4acda6..0x4acdfe
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 170 BaseType go.shape.int
           Locations:
-            - Range: 0x4ac880..0x4ac8dd
+            - Range: 0x4acd80..0x4acddd
               Pieces: []
-            - Range: 0x4ac8dd..0x4ac8de
+            - Range: 0x4acddd..0x4acdde
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4ac8de..0x4ac8fe
+            - Range: 0x4acdde..0x4acdfe
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 75
+    - ID: 77
       Name: main.inlined
-      OutOfLinePCRanges: [0x4a8fe0..0x4a9042]
+      OutOfLinePCRanges: [0x4a9220..0x4a9282]
       InlinePCRanges:
         - Ranges: [0x4a69fb..0x4a6a48]
-          RootRanges: [0x4a6860..0x4a8caa]
+          RootRanges: [0x4a6860..0x4a8eea]
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
             - Range: 0x4a69fb..0x4a6a48
               Pieces: []
-            - Range: 0x4a8fe0..0x4a8ff9
+            - Range: 0x4a9220..0x4a9239
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 76
+    - ID: 78
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x4a6c4c..0x4a6c86]
-          RootRanges: [0x4a6860..0x4a8caa]
+          RootRanges: [0x4a6860..0x4a8eea]
       Variables:
         - Name: ptr
           Type: 171 PointerType *****int
@@ -7552,12 +7912,12 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 77
+    - ID: 79
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x4a6c91..0x4a6ccb]
-          RootRanges: [0x4a6860..0x4a8caa]
+          RootRanges: [0x4a6860..0x4a8eea]
       Variables:
         - Name: ptr
           Type: 173 PointerType **int
@@ -7567,17 +7927,17 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 78
+    - ID: 80
       Name: main.(*methodValueReceiver).inlinedMethod
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x4ac90d..0x4ac910]
-          RootRanges: [0x4ac900..0x4ac922]
+        - Ranges: [0x4ace0d..0x4ace10]
+          RootRanges: [0x4ace00..0x4ace22]
       Variables:
         - Name: m
           Type: 174 PointerType *main.methodValueReceiver
           Locations:
-            - Range: 0x4ac90d..0x4ac922
+            - Range: 0x4ace0d..0x4ace22
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7587,28 +7947,28 @@ Types:
       ID: 171
       Name: '*****int'
       ByteSize: 8
-      GoRuntimeType: 34144
+      GoRuntimeType: 34176
       GoKind: 22
       Pointee: 172 PointerType ****int
     - __kind: PointerType
       ID: 172
       Name: '****int'
       ByteSize: 8
-      GoRuntimeType: 34080
+      GoRuntimeType: 34112
       GoKind: 22
       Pointee: 268 PointerType ***int
     - __kind: PointerType
       ID: 268
       Name: '***int'
       ByteSize: 8
-      GoRuntimeType: 34016
+      GoRuntimeType: 34048
       GoKind: 22
       Pointee: 173 PointerType **int
     - __kind: PointerType
       ID: 173
       Name: '**int'
       ByteSize: 8
-      GoRuntimeType: 33952
+      GoRuntimeType: 33984
       GoKind: 22
       Pointee: 93 PointerType *int
     - __kind: PointerType
@@ -7637,7 +7997,7 @@ Types:
       ID: 120
       Name: '*[]int'
       ByteSize: 8
-      GoRuntimeType: 33888
+      GoRuntimeType: 33920
       GoKind: 22
       Pointee: 100 GoSliceHeaderType []int
     - __kind: PointerType
@@ -7654,7 +8014,7 @@ Types:
       ID: 39
       Name: '*[]runtime.ancestorInfo'
       ByteSize: 8
-      GoRuntimeType: 37856
+      GoRuntimeType: 37888
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
@@ -7676,7 +8036,7 @@ Types:
       ID: 5
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 28576
+      GoRuntimeType: 28608
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
@@ -7733,28 +8093,28 @@ Types:
       ID: 95
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 27488
+      GoRuntimeType: 27520
       GoKind: 22
       Pointee: 18 GoInterfaceType error
     - __kind: PointerType
       ID: 228
       Name: '*errors.errorString'
       ByteSize: 8
-      GoRuntimeType: 54688
+      GoRuntimeType: 54816
       GoKind: 22
       Pointee: 229 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
       ID: 97
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 28448
+      GoRuntimeType: 28480
       GoKind: 22
       Pointee: 16 BaseType float32
     - __kind: PointerType
       ID: 91
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 28512
+      GoRuntimeType: 28544
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
@@ -7816,77 +8176,77 @@ Types:
       ID: 93
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 28128
+      GoRuntimeType: 28160
       GoKind: 22
       Pointee: 9 BaseType int
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 27872
+      GoRuntimeType: 27904
       GoKind: 22
       Pointee: 12 BaseType int32
     - __kind: PointerType
       ID: 92
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 28000
+      GoRuntimeType: 28032
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
       ID: 233
       Name: '*internal/bisect.parseError'
       ByteSize: 8
-      GoRuntimeType: 57568
+      GoRuntimeType: 57696
       GoKind: 22
       Pointee: 234 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
       ID: 259
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 71200
+      GoRuntimeType: 71328
       GoKind: 22
       Pointee: 260 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 257
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
-      GoRuntimeType: 71072
+      GoRuntimeType: 71200
       GoKind: 22
       Pointee: 258 StructureType internal/poll.errNetClosing
     - __kind: PointerType
       ID: 255
       Name: '*io/fs.PathError'
       ByteSize: 8
-      GoRuntimeType: 70944
+      GoRuntimeType: 71072
       GoKind: 22
       Pointee: 256 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
       ID: 133
       Name: '*main.bigArrayStruct'
       ByteSize: 8
-      GoRuntimeType: 25824
+      GoRuntimeType: 25856
       GoKind: 22
       Pointee: 134 StructureType main.bigArrayStruct
     - __kind: PointerType
       ID: 191
       Name: '*main.bigStruct'
       ByteSize: 8
-      GoRuntimeType: 25696
+      GoRuntimeType: 25728
       GoKind: 22
       Pointee: 192 StructureType main.bigStruct
     - __kind: PointerType
       ID: 118
       Name: '*main.condFields'
       ByteSize: 8
-      GoRuntimeType: 25440
+      GoRuntimeType: 25472
       GoKind: 22
       Pointee: 116 StructureType main.condFields
     - __kind: PointerType
       ID: 136
       Name: '*main.indexMemberStruct'
       ByteSize: 8
-      GoRuntimeType: 25632
+      GoRuntimeType: 25664
       GoKind: 22
       Pointee: 137 StructureType main.indexMemberStruct
     - __kind: PointerType
@@ -7899,14 +8259,14 @@ Types:
       ID: 217
       Name: '*main.largeValueStruct'
       ByteSize: 8
-      GoRuntimeType: 25760
+      GoRuntimeType: 25792
       GoKind: 22
       Pointee: 218 StructureType main.largeValueStruct
     - __kind: PointerType
       ID: 121
       Name: '*main.lenFields'
       ByteSize: 8
-      GoRuntimeType: 25504
+      GoRuntimeType: 25536
       GoKind: 22
       Pointee: 119 StructureType main.lenFields
     - __kind: PointerType
@@ -7919,77 +8279,77 @@ Types:
       ID: 251
       Name: '*os.SyscallError'
       ByteSize: 8
-      GoRuntimeType: 67744
+      GoRuntimeType: 67872
       GoKind: 22
       Pointee: 252 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 230
       Name: '*reflect.ValueError'
       ByteSize: 8
-      GoRuntimeType: 55552
+      GoRuntimeType: 55680
       GoKind: 22
       Pointee: 231 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
       ID: 244
       Name: '*runtime.PanicNilError'
       ByteSize: 8
-      GoRuntimeType: 63168
+      GoRuntimeType: 63296
       GoKind: 22
       Pointee: 245 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
       ID: 249
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
-      GoRuntimeType: 65088
+      GoRuntimeType: 65216
       GoKind: 22
       Pointee: 250 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
       ByteSize: 8
-      GoRuntimeType: 28768
+      GoRuntimeType: 28800
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._defer
     - __kind: PointerType
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 73856
+      GoRuntimeType: 73984
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 246
       Name: '*runtime.boundsError'
       ByteSize: 8
-      GoRuntimeType: 63296
+      GoRuntimeType: 63424
       GoKind: 22
       Pointee: 247 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 60
       Name: '*runtime.cgoCallers'
       ByteSize: 8
-      GoRuntimeType: 29408
+      GoRuntimeType: 29440
       GoKind: 22
       Pointee: 61 UnresolvedPointeeType runtime.cgoCallers
     - __kind: PointerType
       ID: 47
       Name: '*runtime.coro'
       ByteSize: 8
-      GoRuntimeType: 29472
+      GoRuntimeType: 29504
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
       ID: 253
       Name: '*runtime.errorAddressString'
       ByteSize: 8
-      GoRuntimeType: 70176
+      GoRuntimeType: 70304
       GoKind: 22
       Pointee: 254 StructureType runtime.errorAddressString
     - __kind: PointerType
       ID: 243
       Name: '*runtime.errorString'
       ByteSize: 8
-      GoRuntimeType: 62912
+      GoRuntimeType: 63040
       GoKind: 22
       Pointee: 235 GoStringHeaderType runtime.errorString
     - __kind: PointerType
@@ -8001,28 +8361,28 @@ Types:
       ID: 53
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 56320
+      GoRuntimeType: 56448
       GoKind: 22
       Pointee: 22 StructureType runtime.g
     - __kind: PointerType
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 64448
+      GoRuntimeType: 64576
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
       ID: 109
       Name: '*runtime.mapextra'
       ByteSize: 8
-      GoRuntimeType: 31392
+      GoRuntimeType: 31424
       GoKind: 22
       Pointee: 110 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 248
       Name: '*runtime.plainError'
       ByteSize: 8
-      GoRuntimeType: 64832
+      GoRuntimeType: 64960
       GoKind: 22
       Pointee: 238 GoStringHeaderType runtime.plainError
     - __kind: PointerType
@@ -8034,35 +8394,35 @@ Types:
       ID: 41
       Name: '*runtime.sudog'
       ByteSize: 8
-      GoRuntimeType: 30176
+      GoRuntimeType: 30208
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType runtime.sudog
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 118528
+      GoRuntimeType: 118656
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 72
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 90688
+      GoRuntimeType: 90816
       GoKind: 22
       Pointee: 73 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 241
       Name: '*strconv.NumError'
       ByteSize: 8
-      GoRuntimeType: 62016
+      GoRuntimeType: 62144
       GoKind: 22
       Pointee: 242 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 88
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 27552
+      GoRuntimeType: 27584
       GoKind: 22
       Pointee: 10 GoStringHeaderType string
     - __kind: PointerType
@@ -8074,14 +8434,14 @@ Types:
       ID: 262
       Name: '*syscall.Errno'
       ByteSize: 8
-      GoRuntimeType: 74976
+      GoRuntimeType: 75104
       GoKind: 22
       Pointee: 261 BaseType syscall.Errno
     - __kind: PointerType
       ID: 232
       Name: '*time.fileSizeError'
       ByteSize: 8
-      GoRuntimeType: 57088
+      GoRuntimeType: 57216
       GoKind: 22
       Pointee: 225 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
@@ -8093,46 +8453,46 @@ Types:
       ID: 98
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 28192
+      GoRuntimeType: 28224
       GoKind: 22
       Pointee: 15 BaseType uint
     - __kind: PointerType
       ID: 99
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 27808
+      GoRuntimeType: 27840
       GoKind: 22
       Pointee: 7 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 27936
+      GoRuntimeType: 27968
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 94
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 28064
+      GoRuntimeType: 28096
       GoKind: 22
       Pointee: 11 BaseType uint64
     - __kind: PointerType
       ID: 6
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 27680
+      GoRuntimeType: 27712
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 8
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 28256
+      GoRuntimeType: 28288
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 613
+      ID: 621
       Name: Probe[main.(*methodValueReceiver).inlinedMethod]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8144,12 +8504,12 @@ Types:
             Type: 174 PointerType *main.methodValueReceiver
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: m}
+                  Variable: {subprogram: 80, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 611
+      ID: 619
       Name: Probe[main.PointerChainArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -8161,7 +8521,7 @@ Types:
             Type: 171 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: ptr}
+                  Variable: {subprogram: 78, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -8172,12 +8532,12 @@ Types:
             Type: 171 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: ptr}
+                  Variable: {subprogram: 78, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 612
+      ID: 620
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8189,12 +8549,12 @@ Types:
             Type: 173 PointerType **int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: ptr}
+                  Variable: {subprogram: 79, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 525
+      ID: 533
       Name: Probe[main.bigArrayArg]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8206,12 +8566,12 @@ Types:
             Type: 13 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: s}
+                  Variable: {subprogram: 49, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 527
+      ID: 535
       Name: Probe[main.bigArrayArg]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8223,18 +8583,18 @@ Types:
             Type: 13 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: s}
+                  Variable: {subprogram: 49, index: 0, name: s}
                   Offset: 1048568
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 526
+      ID: 534
       Name: Probe[main.bigArrayArg]Return
     - __kind: EventRootType
-      ID: 528
+      ID: 536
       Name: Probe[main.bigArrayArg]Return
     - __kind: EventRootType
-      ID: 529
+      ID: 537
       Name: Probe[main.bigArrayStructArg]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8246,7 +8606,7 @@ Types:
             Type: 13 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: s}
+                  Variable: {subprogram: 50, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -8254,7 +8614,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 530
+      ID: 538
       Name: Probe[main.bigArrayStructArg]Return
     - __kind: EventRootType
       ID: 312
@@ -8685,6 +9045,85 @@ Types:
       ID: 319
       Name: Probe[main.condInt8]Return
     - __kind: EventRootType
+      ID: 422
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 423
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 424
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 425
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 426
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 427
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 428
+      Name: Probe[main.condLineMixed]Line
+      ByteSize: 131
+      ExprStatusArraySize: 2
+      Expressions:
+        - Name: s
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: b
+          Offset: 18
+          Kind: local
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 1
+          DictIndex: -1
+        - Name: x
+          Offset: 19
+          Kind: local
+          Expression:
+            Type: 116 StructureType main.condFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 80
+          DictIndex: -1
+        - Name: p
+          Offset: 99
+          Kind: local
+          Expression:
+            Type: 118 PointerType *main.condFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 3, name: p}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: ss
+          Offset: 107
+          Kind: local
+          Expression:
+            Type: 100 GoSliceHeaderType []int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 4, name: ss}
+                  Offset: 0
+                  ByteSize: 24
+          DictIndex: -1
+    - __kind: EventRootType
       ID: 418
       Name: Probe[main.condLine]Line
       ByteSize: 25
@@ -8758,10 +9197,38 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 603
+      ID: 421
+      Name: Probe[main.condLine]Line
+      ByteSize: 25
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: "n"
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 0, name: "n"}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: tag
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 611
       Name: Probe[main.condMultiReturn]
     - __kind: EventRootType
-      ID: 604
+      ID: 612
       Name: Probe[main.condMultiReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -8773,7 +9240,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 1, name: r0}
+                  Variable: {subprogram: 74, index: 1, name: r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -8784,7 +9251,7 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 2, name: r1}
+                  Variable: {subprogram: 74, index: 2, name: r1}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -8880,7 +9347,7 @@ Types:
       ID: 407
       Name: Probe[main.condNilPtrStruct]Return
     - __kind: EventRootType
-      ID: 427
+      ID: 435
       Name: Probe[main.condNullIface]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -8892,76 +9359,16 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 35, index: 1, name: tag}
+                  Variable: {subprogram: 37, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 428
+      ID: 436
       Name: Probe[main.condNullIface]Return
     - __kind: EventRootType
-      ID: 425
+      ID: 433
       Name: Probe[main.condNullMap]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 10 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 34, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 426
-      Name: Probe[main.condNullMap]Return
-    - __kind: EventRootType
-      ID: 421
-      Name: Probe[main.condNullPtr]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 10 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 32, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 422
-      Name: Probe[main.condNullPtr]Return
-    - __kind: EventRootType
-      ID: 423
-      Name: Probe[main.condNullSlice]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 10 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 33, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 424
-      Name: Probe[main.condNullSlice]Return
-    - __kind: EventRootType
-      ID: 429
-      Name: Probe[main.condNullUnsafePtr]
       ByteSize: 17
       ExprStatusArraySize: 1
       Expressions:
@@ -8977,7 +9384,67 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
+      ID: 434
+      Name: Probe[main.condNullMap]Return
+    - __kind: EventRootType
+      ID: 429
+      Name: Probe[main.condNullPtr]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
       ID: 430
+      Name: Probe[main.condNullPtr]Return
+    - __kind: EventRootType
+      ID: 431
+      Name: Probe[main.condNullSlice]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 432
+      Name: Probe[main.condNullSlice]Return
+    - __kind: EventRootType
+      ID: 437
+      Name: Probe[main.condNullUnsafePtr]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 438
       Name: Probe[main.condNullUnsafePtr]Return
     - __kind: EventRootType
       ID: 414
@@ -9789,7 +10256,7 @@ Types:
       ID: 341
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 607
+      ID: 615
       Name: Probe[main.genericIdentity[go.shape.int]]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -9802,12 +10269,12 @@ Types:
             Type: 170 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: x}
+                  Variable: {subprogram: 76, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 608
+      ID: 616
       Name: Probe[main.genericIdentity[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -9820,12 +10287,12 @@ Types:
             Type: 170 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 1, name: ~r0}
+                  Variable: {subprogram: 76, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 605
+      ID: 613
       Name: Probe[main.genericIdentity[go.shape.string]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -9838,12 +10305,12 @@ Types:
             Type: 169 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: x}
+                  Variable: {subprogram: 75, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 606
+      ID: 614
       Name: Probe[main.genericIdentity[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -9856,12 +10323,12 @@ Types:
             Type: 169 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 1, name: ~r0}
+                  Variable: {subprogram: 75, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 551
+      ID: 559
       Name: Probe[main.indexMemberWrapperArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -9873,7 +10340,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
+                  Variable: {subprogram: 55, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -9884,7 +10351,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 553
+      ID: 561
       Name: Probe[main.indexMemberWrapperArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -9896,7 +10363,7 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
+                  Variable: {subprogram: 55, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -9907,7 +10374,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 555
+      ID: 563
       Name: Probe[main.indexMemberWrapperArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -9919,7 +10386,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
+                  Variable: {subprogram: 55, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -9933,7 +10400,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 557
+      ID: 565
       Name: Probe[main.indexMemberWrapperArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -9945,7 +10412,7 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
+                  Variable: {subprogram: 55, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -9959,19 +10426,19 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 552
+      ID: 560
       Name: Probe[main.indexMemberWrapperArg]Return
     - __kind: EventRootType
-      ID: 554
+      ID: 562
       Name: Probe[main.indexMemberWrapperArg]Return
     - __kind: EventRootType
-      ID: 556
+      ID: 564
       Name: Probe[main.indexMemberWrapperArg]Return
     - __kind: EventRootType
-      ID: 558
+      ID: 566
       Name: Probe[main.indexMemberWrapperArg]Return
     - __kind: EventRootType
-      ID: 517
+      ID: 525
       Name: Probe[main.indexNilPtrSlice]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -9983,7 +10450,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: x}
+                  Variable: {subprogram: 47, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -9996,7 +10463,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 519
+      ID: 527
       Name: Probe[main.indexNilPtrSlice]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10008,12 +10475,12 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 1, name: tag}
+                  Variable: {subprogram: 47, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 521
+      ID: 529
       Name: Probe[main.indexNilPtrSlice]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10025,7 +10492,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: x}
+                  Variable: {subprogram: 47, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10038,16 +10505,16 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 518
+      ID: 526
       Name: Probe[main.indexNilPtrSlice]Return
     - __kind: EventRootType
-      ID: 520
+      ID: 528
       Name: Probe[main.indexNilPtrSlice]Return
     - __kind: EventRootType
-      ID: 522
+      ID: 530
       Name: Probe[main.indexNilPtrSlice]Return
     - __kind: EventRootType
-      ID: 609
+      ID: 617
       Name: Probe[main.inlined]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10059,12 +10526,12 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: x}
+                  Variable: {subprogram: 77, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 610
+      ID: 618
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
       ID: 269
@@ -10277,7 +10744,7 @@ Types:
       ID: 290
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 509
+      ID: 517
       Name: Probe[main.lenErrInt]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -10289,7 +10756,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: x}
+                  Variable: {subprogram: 45, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -10300,21 +10767,21 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 1, name: tag}
+                  Variable: {subprogram: 45, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 511
+      ID: 519
       Name: Probe[main.lenErrInt]
     - __kind: EventRootType
-      ID: 510
+      ID: 518
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 512
+      ID: 520
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 513
+      ID: 521
       Name: Probe[main.lenErrStruct]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -10326,7 +10793,7 @@ Types:
             Type: 116 StructureType main.condFields
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: x}
+                  Variable: {subprogram: 46, index: 0, name: x}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -10337,21 +10804,21 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 1, name: tag}
+                  Variable: {subprogram: 46, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 515
+      ID: 523
       Name: Probe[main.lenErrStruct]
     - __kind: EventRootType
-      ID: 514
+      ID: 522
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 516
+      ID: 524
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 463
+      ID: 471
       Name: Probe[main.lenMap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10363,12 +10830,12 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Variable: {subprogram: 41, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 465
+      ID: 473
       Name: Probe[main.lenMap]
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -10380,7 +10847,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: m}
+                  Variable: {subprogram: 41, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10394,7 +10861,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 467
+      ID: 475
       Name: Probe[main.lenMap]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10406,7 +10873,7 @@ Types:
             Type: 11 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: m}
+                  Variable: {subprogram: 41, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10414,7 +10881,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 469
+      ID: 477
       Name: Probe[main.lenMap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10426,12 +10893,12 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Variable: {subprogram: 41, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 471
+      ID: 479
       Name: Probe[main.lenMap]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10443,7 +10910,7 @@ Types:
             Type: 11 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: m}
+                  Variable: {subprogram: 41, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10451,7 +10918,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 473
+      ID: 481
       Name: Probe[main.lenMap]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -10463,7 +10930,7 @@ Types:
             Type: 104 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: m}
+                  Variable: {subprogram: 41, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -10474,22 +10941,10 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Variable: {subprogram: 41, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
-    - __kind: EventRootType
-      ID: 464
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 466
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 468
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 470
-      Name: Probe[main.lenMap]Return
     - __kind: EventRootType
       ID: 472
       Name: Probe[main.lenMap]Return
@@ -10497,7 +10952,19 @@ Types:
       ID: 474
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 475
+      ID: 476
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 478
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 480
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 482
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 483
       Name: Probe[main.lenPtrString]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10509,7 +10976,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: s}
+                  Variable: {subprogram: 42, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10517,7 +10984,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 477
+      ID: 485
       Name: Probe[main.lenPtrString]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -10529,66 +10996,7 @@ Types:
             Type: 88 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 8
-          DictIndex: -1
-        - Name: tag
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 10 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 476
-      Name: Probe[main.lenPtrString]Return
-    - __kind: EventRootType
-      ID: 478
-      Name: Probe[main.lenPtrString]Return
-    - __kind: EventRootType
-      ID: 499
-      Name: Probe[main.lenPtrStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: items_0
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 16
-                  ByteSize: 16
-                - __kind: SliceBoundsCheckOp
-                  Index: 0
-                - __kind: DereferenceOp
-                  Bias: 0
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 501
-      Name: Probe[main.lenPtrStructFields]
-      ByteSize: 25
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 121 PointerType *main.lenFields
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
+                  Variable: {subprogram: 42, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -10604,7 +11012,66 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 503
+      ID: 484
+      Name: Probe[main.lenPtrString]Return
+    - __kind: EventRootType
+      ID: 486
+      Name: Probe[main.lenPtrString]Return
+    - __kind: EventRootType
+      ID: 507
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: items_0
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 16
+                  ByteSize: 16
+                - __kind: SliceBoundsCheckOp
+                  Index: 0
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 509
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 25
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 121 PointerType *main.lenFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 511
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10616,7 +11083,7 @@ Types:
             Type: 11 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
+                  Variable: {subprogram: 44, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10627,7 +11094,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 505
+      ID: 513
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10639,7 +11106,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
+                  Variable: {subprogram: 44, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10647,7 +11114,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 507
+      ID: 515
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10659,7 +11126,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
+                  Variable: {subprogram: 44, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10667,22 +11134,22 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 500
-      Name: Probe[main.lenPtrStructFields]Return
-    - __kind: EventRootType
-      ID: 502
-      Name: Probe[main.lenPtrStructFields]Return
-    - __kind: EventRootType
-      ID: 504
-      Name: Probe[main.lenPtrStructFields]Return
-    - __kind: EventRootType
-      ID: 506
-      Name: Probe[main.lenPtrStructFields]Return
-    - __kind: EventRootType
       ID: 508
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 451
+      ID: 510
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 512
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 514
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 516
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 459
       Name: Probe[main.lenSlice]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10694,12 +11161,12 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 1, name: tag}
+                  Variable: {subprogram: 40, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 453
+      ID: 461
       Name: Probe[main.lenSlice]
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -10711,7 +11178,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: s}
+                  Variable: {subprogram: 40, index: 0, name: s}
                   Offset: 8
                   ByteSize: 8
                 - __kind: ExprPushOffsetOp
@@ -10722,7 +11189,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 455
+      ID: 463
       Name: Probe[main.lenSlice]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10734,12 +11201,12 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: s}
+                  Variable: {subprogram: 40, index: 0, name: s}
                   Offset: 8
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 457
+      ID: 465
       Name: Probe[main.lenSlice]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10751,12 +11218,12 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 1, name: tag}
+                  Variable: {subprogram: 40, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 459
+      ID: 467
       Name: Probe[main.lenSlice]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10768,12 +11235,12 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: s}
+                  Variable: {subprogram: 40, index: 0, name: s}
                   Offset: 8
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 461
+      ID: 469
       Name: Probe[main.lenSlice]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -10785,7 +11252,7 @@ Types:
             Type: 100 GoSliceHeaderType []int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: s}
+                  Variable: {subprogram: 40, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -10796,22 +11263,10 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 1, name: tag}
+                  Variable: {subprogram: 40, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
-    - __kind: EventRootType
-      ID: 452
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 454
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 456
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 458
-      Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
       ID: 460
       Name: Probe[main.lenSlice]Return
@@ -10819,7 +11274,19 @@ Types:
       ID: 462
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 431
+      ID: 464
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 466
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 468
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 470
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 439
       Name: Probe[main.lenString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -10831,7 +11298,7 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
+                  Variable: {subprogram: 39, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -10842,12 +11309,12 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 1, name: tag}
+                  Variable: {subprogram: 39, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 433
+      ID: 441
       Name: Probe[main.lenString]
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -10859,7 +11326,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
+                  Variable: {subprogram: 39, index: 0, name: s}
                   Offset: 8
                   ByteSize: 8
                 - __kind: ExprPushOffsetOp
@@ -10870,7 +11337,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 435
+      ID: 443
       Name: Probe[main.lenString]
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -10882,7 +11349,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
+                  Variable: {subprogram: 39, index: 0, name: s}
                   Offset: 8
                   ByteSize: 8
                 - __kind: ExprPushOffsetOp
@@ -10893,7 +11360,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 437
+      ID: 445
       Name: Probe[main.lenString]
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -10905,7 +11372,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
+                  Variable: {subprogram: 39, index: 0, name: s}
                   Offset: 8
                   ByteSize: 8
                 - __kind: ExprPushOffsetOp
@@ -10916,7 +11383,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 439
+      ID: 447
       Name: Probe[main.lenString]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10928,12 +11395,12 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 1, name: tag}
+                  Variable: {subprogram: 39, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 441
+      ID: 449
       Name: Probe[main.lenString]
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -10945,7 +11412,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
+                  Variable: {subprogram: 39, index: 0, name: s}
                   Offset: 8
                   ByteSize: 8
                 - __kind: ExprPushOffsetOp
@@ -10956,7 +11423,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 443
+      ID: 451
       Name: Probe[main.lenString]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10968,12 +11435,12 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
+                  Variable: {subprogram: 39, index: 0, name: s}
                   Offset: 8
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 445
+      ID: 453
       Name: Probe[main.lenString]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10985,12 +11452,12 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 1, name: tag}
+                  Variable: {subprogram: 39, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 447
+      ID: 455
       Name: Probe[main.lenString]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11002,12 +11469,12 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
+                  Variable: {subprogram: 39, index: 0, name: s}
                   Offset: 8
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 449
+      ID: 457
       Name: Probe[main.lenString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -11019,7 +11486,7 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
+                  Variable: {subprogram: 39, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -11030,22 +11497,10 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 1, name: tag}
+                  Variable: {subprogram: 39, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
-    - __kind: EventRootType
-      ID: 432
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 434
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 436
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 438
-      Name: Probe[main.lenString]Return
     - __kind: EventRootType
       ID: 440
       Name: Probe[main.lenString]Return
@@ -11065,7 +11520,19 @@ Types:
       ID: 450
       Name: Probe[main.lenString]Return
     - __kind: EventRootType
-      ID: 479
+      ID: 452
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 454
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 456
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 458
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 487
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11077,7 +11544,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
+                  Variable: {subprogram: 43, index: 0, name: x}
                   Offset: 16
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -11087,7 +11554,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 481
+      ID: 489
       Name: Probe[main.lenStructFields]
       ByteSize: 89
       ExprStatusArraySize: 1
@@ -11099,7 +11566,7 @@ Types:
             Type: 119 StructureType main.lenFields
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
+                  Variable: {subprogram: 43, index: 0, name: x}
                   Offset: 0
                   ByteSize: 72
           DictIndex: -1
@@ -11110,12 +11577,12 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 1, name: tag}
+                  Variable: {subprogram: 43, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 483
+      ID: 491
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11127,7 +11594,7 @@ Types:
             Type: 11 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
+                  Variable: {subprogram: 43, index: 0, name: x}
                   Offset: 40
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11135,7 +11602,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 485
+      ID: 493
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11147,7 +11614,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
+                  Variable: {subprogram: 43, index: 0, name: x}
                   Offset: 56
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11155,7 +11622,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 487
+      ID: 495
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11167,7 +11634,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
+                  Variable: {subprogram: 43, index: 0, name: x}
                   Offset: 48
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11175,7 +11642,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 489
+      ID: 497
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11187,12 +11654,12 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
+                  Variable: {subprogram: 43, index: 0, name: x}
                   Offset: 24
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 491
+      ID: 499
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11204,12 +11671,12 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
+                  Variable: {subprogram: 43, index: 0, name: x}
                   Offset: 8
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 493
+      ID: 501
       Name: Probe[main.lenStructFields]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -11221,12 +11688,12 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 1, name: tag}
+                  Variable: {subprogram: 43, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 495
+      ID: 503
       Name: Probe[main.lenStructFields]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -11238,12 +11705,12 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 1, name: tag}
+                  Variable: {subprogram: 43, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 497
+      ID: 505
       Name: Probe[main.lenStructFields]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -11255,22 +11722,10 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 1, name: tag}
+                  Variable: {subprogram: 43, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
-    - __kind: EventRootType
-      ID: 480
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 482
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 484
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 486
-      Name: Probe[main.lenStructFields]Return
     - __kind: EventRootType
       ID: 488
       Name: Probe[main.lenStructFields]Return
@@ -11288,6 +11743,18 @@ Types:
       Name: Probe[main.lenStructFields]Return
     - __kind: EventRootType
       ID: 498
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 500
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 502
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 504
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 506
       Name: Probe[main.lenStructFields]Return
     - __kind: EventRootType
       ID: 310
@@ -11321,136 +11788,136 @@ Types:
       ID: 311
       Name: Probe[main.mapArg]Return
     - __kind: EventRootType
-      ID: 593
-      Name: Probe[main.mapIndexBoolKey]
-    - __kind: EventRootType
-      ID: 595
-      Name: Probe[main.mapIndexBoolKey]
-    - __kind: EventRootType
-      ID: 594
-      Name: Probe[main.mapIndexBoolKey]Return
-    - __kind: EventRootType
-      ID: 596
-      Name: Probe[main.mapIndexBoolKey]Return
-    - __kind: EventRootType
-      ID: 587
-      Name: Probe[main.mapIndexEmptyKey]
-    - __kind: EventRootType
-      ID: 588
-      Name: Probe[main.mapIndexEmptyKey]Return
-    - __kind: EventRootType
-      ID: 559
-      Name: Probe[main.mapIndexIntKey]
-    - __kind: EventRootType
-      ID: 560
-      Name: Probe[main.mapIndexIntKey]Return
-    - __kind: EventRootType
-      ID: 589
-      Name: Probe[main.mapIndexKeyLen16]
-    - __kind: EventRootType
-      ID: 590
-      Name: Probe[main.mapIndexKeyLen16]Return
-    - __kind: EventRootType
-      ID: 591
-      Name: Probe[main.mapIndexKeyLen17]
-    - __kind: EventRootType
-      ID: 592
-      Name: Probe[main.mapIndexKeyLen17]Return
-    - __kind: EventRootType
-      ID: 577
-      Name: Probe[main.mapIndexKeyLen200]
-    - __kind: EventRootType
-      ID: 578
-      Name: Probe[main.mapIndexKeyLen200]Return
-    - __kind: EventRootType
-      ID: 571
-      Name: Probe[main.mapIndexKeyLen24]
-    - __kind: EventRootType
-      ID: 572
-      Name: Probe[main.mapIndexKeyLen24]Return
-    - __kind: EventRootType
-      ID: 573
-      Name: Probe[main.mapIndexKeyLen48]
-    - __kind: EventRootType
-      ID: 574
-      Name: Probe[main.mapIndexKeyLen48]Return
-    - __kind: EventRootType
-      ID: 569
-      Name: Probe[main.mapIndexKeyLen8]
-    - __kind: EventRootType
-      ID: 570
-      Name: Probe[main.mapIndexKeyLen8]Return
-    - __kind: EventRootType
-      ID: 575
-      Name: Probe[main.mapIndexKeyLen96]
-    - __kind: EventRootType
-      ID: 576
-      Name: Probe[main.mapIndexKeyLen96]Return
-    - __kind: EventRootType
-      ID: 565
-      Name: Probe[main.mapIndexLargeMap]
-    - __kind: EventRootType
-      ID: 566
-      Name: Probe[main.mapIndexLargeMap]Return
-    - __kind: EventRootType
       ID: 601
-      Name: Probe[main.mapIndexLargeValue]
+      Name: Probe[main.mapIndexBoolKey]
+    - __kind: EventRootType
+      ID: 603
+      Name: Probe[main.mapIndexBoolKey]
     - __kind: EventRootType
       ID: 602
-      Name: Probe[main.mapIndexLargeValue]Return
+      Name: Probe[main.mapIndexBoolKey]Return
+    - __kind: EventRootType
+      ID: 604
+      Name: Probe[main.mapIndexBoolKey]Return
+    - __kind: EventRootType
+      ID: 595
+      Name: Probe[main.mapIndexEmptyKey]
+    - __kind: EventRootType
+      ID: 596
+      Name: Probe[main.mapIndexEmptyKey]Return
     - __kind: EventRootType
       ID: 567
-      Name: Probe[main.mapIndexMissing]
+      Name: Probe[main.mapIndexIntKey]
     - __kind: EventRootType
       ID: 568
-      Name: Probe[main.mapIndexMissing]Return
-    - __kind: EventRootType
-      ID: 599
-      Name: Probe[main.mapIndexNilPtrVal]
-    - __kind: EventRootType
-      ID: 600
-      Name: Probe[main.mapIndexNilPtrVal]Return
-    - __kind: EventRootType
-      ID: 583
-      Name: Probe[main.mapIndexPtrStructVal]
-    - __kind: EventRootType
-      ID: 585
-      Name: Probe[main.mapIndexPtrStructVal]
-    - __kind: EventRootType
-      ID: 584
-      Name: Probe[main.mapIndexPtrStructVal]Return
-    - __kind: EventRootType
-      ID: 586
-      Name: Probe[main.mapIndexPtrStructVal]Return
-    - __kind: EventRootType
-      ID: 561
-      Name: Probe[main.mapIndexStringKey]
-    - __kind: EventRootType
-      ID: 563
-      Name: Probe[main.mapIndexStringKey]
-    - __kind: EventRootType
-      ID: 562
-      Name: Probe[main.mapIndexStringKey]Return
-    - __kind: EventRootType
-      ID: 564
-      Name: Probe[main.mapIndexStringKey]Return
-    - __kind: EventRootType
-      ID: 579
-      Name: Probe[main.mapIndexStructVal]
-    - __kind: EventRootType
-      ID: 581
-      Name: Probe[main.mapIndexStructVal]
-    - __kind: EventRootType
-      ID: 580
-      Name: Probe[main.mapIndexStructVal]Return
-    - __kind: EventRootType
-      ID: 582
-      Name: Probe[main.mapIndexStructVal]Return
+      Name: Probe[main.mapIndexIntKey]Return
     - __kind: EventRootType
       ID: 597
-      Name: Probe[main.mapIndexZeroValue]
+      Name: Probe[main.mapIndexKeyLen16]
     - __kind: EventRootType
       ID: 598
+      Name: Probe[main.mapIndexKeyLen16]Return
+    - __kind: EventRootType
+      ID: 599
+      Name: Probe[main.mapIndexKeyLen17]
+    - __kind: EventRootType
+      ID: 600
+      Name: Probe[main.mapIndexKeyLen17]Return
+    - __kind: EventRootType
+      ID: 585
+      Name: Probe[main.mapIndexKeyLen200]
+    - __kind: EventRootType
+      ID: 586
+      Name: Probe[main.mapIndexKeyLen200]Return
+    - __kind: EventRootType
+      ID: 579
+      Name: Probe[main.mapIndexKeyLen24]
+    - __kind: EventRootType
+      ID: 580
+      Name: Probe[main.mapIndexKeyLen24]Return
+    - __kind: EventRootType
+      ID: 581
+      Name: Probe[main.mapIndexKeyLen48]
+    - __kind: EventRootType
+      ID: 582
+      Name: Probe[main.mapIndexKeyLen48]Return
+    - __kind: EventRootType
+      ID: 577
+      Name: Probe[main.mapIndexKeyLen8]
+    - __kind: EventRootType
+      ID: 578
+      Name: Probe[main.mapIndexKeyLen8]Return
+    - __kind: EventRootType
+      ID: 583
+      Name: Probe[main.mapIndexKeyLen96]
+    - __kind: EventRootType
+      ID: 584
+      Name: Probe[main.mapIndexKeyLen96]Return
+    - __kind: EventRootType
+      ID: 573
+      Name: Probe[main.mapIndexLargeMap]
+    - __kind: EventRootType
+      ID: 574
+      Name: Probe[main.mapIndexLargeMap]Return
+    - __kind: EventRootType
+      ID: 609
+      Name: Probe[main.mapIndexLargeValue]
+    - __kind: EventRootType
+      ID: 610
+      Name: Probe[main.mapIndexLargeValue]Return
+    - __kind: EventRootType
+      ID: 575
+      Name: Probe[main.mapIndexMissing]
+    - __kind: EventRootType
+      ID: 576
+      Name: Probe[main.mapIndexMissing]Return
+    - __kind: EventRootType
+      ID: 607
+      Name: Probe[main.mapIndexNilPtrVal]
+    - __kind: EventRootType
+      ID: 608
+      Name: Probe[main.mapIndexNilPtrVal]Return
+    - __kind: EventRootType
+      ID: 591
+      Name: Probe[main.mapIndexPtrStructVal]
+    - __kind: EventRootType
+      ID: 593
+      Name: Probe[main.mapIndexPtrStructVal]
+    - __kind: EventRootType
+      ID: 592
+      Name: Probe[main.mapIndexPtrStructVal]Return
+    - __kind: EventRootType
+      ID: 594
+      Name: Probe[main.mapIndexPtrStructVal]Return
+    - __kind: EventRootType
+      ID: 569
+      Name: Probe[main.mapIndexStringKey]
+    - __kind: EventRootType
+      ID: 571
+      Name: Probe[main.mapIndexStringKey]
+    - __kind: EventRootType
+      ID: 570
+      Name: Probe[main.mapIndexStringKey]Return
+    - __kind: EventRootType
+      ID: 572
+      Name: Probe[main.mapIndexStringKey]Return
+    - __kind: EventRootType
+      ID: 587
+      Name: Probe[main.mapIndexStructVal]
+    - __kind: EventRootType
+      ID: 589
+      Name: Probe[main.mapIndexStructVal]
+    - __kind: EventRootType
+      ID: 588
+      Name: Probe[main.mapIndexStructVal]Return
+    - __kind: EventRootType
+      ID: 590
+      Name: Probe[main.mapIndexStructVal]Return
+    - __kind: EventRootType
+      ID: 605
+      Name: Probe[main.mapIndexZeroValue]
+    - __kind: EventRootType
+      ID: 606
       Name: Probe[main.mapIndexZeroValue]Return
     - __kind: EventRootType
       ID: 314
@@ -11459,7 +11926,7 @@ Types:
       ID: 315
       Name: Probe[main.noArgs]Return
     - __kind: EventRootType
-      ID: 547
+      ID: 555
       Name: Probe[main.ptrStructArrayArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -11471,7 +11938,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: s}
+                  Variable: {subprogram: 54, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11479,7 +11946,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 549
+      ID: 557
       Name: Probe[main.ptrStructArrayArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -11491,7 +11958,7 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: s}
+                  Variable: {subprogram: 54, index: 0, name: s}
                   Offset: 8
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11499,13 +11966,13 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 548
+      ID: 556
       Name: Probe[main.ptrStructArrayArg]Return
     - __kind: EventRootType
-      ID: 550
+      ID: 558
       Name: Probe[main.ptrStructArrayArg]Return
     - __kind: EventRootType
-      ID: 543
+      ID: 551
       Name: Probe[main.ptrStructSliceArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -11517,7 +11984,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: s}
+                  Variable: {subprogram: 53, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -11530,7 +11997,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 545
+      ID: 553
       Name: Probe[main.ptrStructSliceArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -11542,7 +12009,7 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: s}
+                  Variable: {subprogram: 53, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -11555,10 +12022,10 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 544
+      ID: 552
       Name: Probe[main.ptrStructSliceArg]Return
     - __kind: EventRootType
-      ID: 546
+      ID: 554
       Name: Probe[main.ptrStructSliceArg]Return
     - __kind: EventRootType
       ID: 271
@@ -11720,7 +12187,7 @@ Types:
       ID: 304
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 539
+      ID: 547
       Name: Probe[main.structArrayArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -11732,12 +12199,12 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: s}
+                  Variable: {subprogram: 52, index: 0, name: s}
                   Offset: 0
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 541
+      ID: 549
       Name: Probe[main.structArrayArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -11749,18 +12216,18 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: s}
+                  Variable: {subprogram: 52, index: 0, name: s}
                   Offset: 40
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 540
+      ID: 548
       Name: Probe[main.structArrayArg]Return
     - __kind: EventRootType
-      ID: 542
+      ID: 550
       Name: Probe[main.structArrayArg]Return
     - __kind: EventRootType
-      ID: 531
+      ID: 539
       Name: Probe[main.structSliceArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -11772,7 +12239,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: s}
+                  Variable: {subprogram: 51, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -11782,7 +12249,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 533
+      ID: 541
       Name: Probe[main.structSliceArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -11794,7 +12261,7 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: s}
+                  Variable: {subprogram: 51, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -11804,7 +12271,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 535
+      ID: 543
       Name: Probe[main.structSliceArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -11816,12 +12283,12 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 1, name: tag}
+                  Variable: {subprogram: 51, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 537
+      ID: 545
       Name: Probe[main.structSliceArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -11833,7 +12300,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: s}
+                  Variable: {subprogram: 51, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -11843,22 +12310,22 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 532
+      ID: 540
       Name: Probe[main.structSliceArg]Return
     - __kind: EventRootType
-      ID: 534
+      ID: 542
       Name: Probe[main.structSliceArg]Return
     - __kind: EventRootType
-      ID: 536
+      ID: 544
       Name: Probe[main.structSliceArg]Return
     - __kind: EventRootType
-      ID: 538
+      ID: 546
       Name: Probe[main.structSliceArg]Return
     - __kind: EventRootType
-      ID: 523
+      ID: 531
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 524
+      ID: 532
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11870,7 +12337,7 @@ Types:
             Type: 122 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: ~r0}
+                  Variable: {subprogram: 48, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -11878,7 +12345,7 @@ Types:
       ID: 85
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 50560
+      GoRuntimeType: 50688
       GoKind: 17
       Count: 10
       HasCount: true
@@ -11887,7 +12354,7 @@ Types:
       ID: 266
       Name: '[128]uint8'
       ByteSize: 128
-      GoRuntimeType: 44416
+      GoRuntimeType: 44448
       GoKind: 17
       Count: 128
       HasCount: true
@@ -11896,7 +12363,7 @@ Types:
       ID: 132
       Name: '[131072]int64'
       ByteSize: 1048576
-      GoRuntimeType: 45088
+      GoRuntimeType: 45120
       GoKind: 17
       Count: 131072
       HasCount: true
@@ -11905,7 +12372,7 @@ Types:
       ID: 267
       Name: '[256]uint8'
       ByteSize: 256
-      GoRuntimeType: 44704
+      GoRuntimeType: 44736
       GoKind: 17
       Count: 256
       HasCount: true
@@ -11922,7 +12389,7 @@ Types:
       ID: 71
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 50272
+      GoRuntimeType: 50400
       GoKind: 17
       Count: 2
       HasCount: true
@@ -11931,7 +12398,7 @@ Types:
       ID: 77
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 50464
+      GoRuntimeType: 50592
       GoKind: 17
       Count: 2
       HasCount: true
@@ -11948,7 +12415,7 @@ Types:
       ID: 52
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 46720
+      GoRuntimeType: 46848
       GoKind: 17
       Count: 2
       HasCount: true
@@ -11957,7 +12424,7 @@ Types:
       ID: 83
       Name: '[32]uint64'
       ByteSize: 256
-      GoRuntimeType: 52384
+      GoRuntimeType: 52512
       GoKind: 17
       Count: 32
       HasCount: true
@@ -11966,7 +12433,7 @@ Types:
       ID: 63
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 50080
+      GoRuntimeType: 50208
       GoKind: 17
       Count: 32
       HasCount: true
@@ -11975,7 +12442,7 @@ Types:
       ID: 101
       Name: '[3]int'
       ByteSize: 24
-      GoRuntimeType: 43936
+      GoRuntimeType: 43968
       GoKind: 17
       Count: 3
       HasCount: true
@@ -11984,7 +12451,7 @@ Types:
       ID: 117
       Name: '[3]int16'
       ByteSize: 6
-      GoRuntimeType: 43456
+      GoRuntimeType: 43488
       GoKind: 17
       Count: 3
       HasCount: true
@@ -11993,7 +12460,7 @@ Types:
       ID: 51
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 49792
+      GoRuntimeType: 49920
       GoKind: 17
       Count: 3
       HasCount: true
@@ -12002,7 +12469,7 @@ Types:
       ID: 103
       Name: '[3]string'
       ByteSize: 48
-      GoRuntimeType: 44032
+      GoRuntimeType: 44064
       GoKind: 17
       Count: 3
       HasCount: true
@@ -12011,7 +12478,7 @@ Types:
       ID: 84
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 51520
+      GoRuntimeType: 51648
       GoKind: 17
       Count: 4
       HasCount: true
@@ -12020,7 +12487,7 @@ Types:
       ID: 56
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 49024
+      GoRuntimeType: 49152
       GoKind: 17
       Count: 6
       HasCount: true
@@ -12029,7 +12496,7 @@ Types:
       ID: 78
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 50368
+      GoRuntimeType: 50496
       GoKind: 17
       Count: 8
       HasCount: true
@@ -12038,7 +12505,7 @@ Types:
       ID: 186
       Name: '[8]uint8'
       ByteSize: 8
-      GoRuntimeType: 43552
+      GoRuntimeType: 43584
       GoKind: 17
       Count: 8
       HasCount: true
@@ -12047,7 +12514,7 @@ Types:
       ID: 139
       Name: '[]*main.indexMemberStruct'
       ByteSize: 24
-      GoRuntimeType: 34336
+      GoRuntimeType: 34368
       GoKind: 23
       RawFields:
         - Name: array
@@ -12130,7 +12597,7 @@ Types:
       ID: 100
       Name: '[]int'
       ByteSize: 24
-      GoRuntimeType: 36000
+      GoRuntimeType: 36032
       GoKind: 23
       RawFields:
         - Name: array
@@ -12181,7 +12648,7 @@ Types:
       ID: 135
       Name: '[]main.indexMemberStruct'
       ByteSize: 24
-      GoRuntimeType: 34464
+      GoRuntimeType: 34496
       GoKind: 23
       RawFields:
         - Name: array
@@ -12208,7 +12675,7 @@ Types:
       ID: 102
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 36320
+      GoRuntimeType: 36352
       GoKind: 23
       RawFields:
         - Name: array
@@ -12231,7 +12698,7 @@ Types:
       ID: 38
       Name: '[]uint8'
       ByteSize: 24
-      GoRuntimeType: 35616
+      GoRuntimeType: 35648
       GoKind: 23
       RawFields:
         - Name: array
@@ -12254,7 +12721,7 @@ Types:
       ID: 43
       Name: '[]uintptr'
       ByteSize: 24
-      GoRuntimeType: 36128
+      GoRuntimeType: 36160
       GoKind: 23
       RawFields:
         - Name: array
@@ -12333,7 +12800,7 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 40608
+      GoRuntimeType: 40640
       GoKind: 1
     - __kind: GoHMapBucketType
       ID: 163
@@ -12529,19 +12996,19 @@ Types:
       ID: 90
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 40416
+      GoRuntimeType: 40448
       GoKind: 16
     - __kind: BaseType
       ID: 89
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 40352
+      GoRuntimeType: 40384
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 18
       Name: error
       ByteSize: 16
-      GoRuntimeType: 62784
+      GoRuntimeType: 62912
       GoKind: 20
       RawFields:
         - Name: tab
@@ -12558,25 +13025,25 @@ Types:
       ID: 16
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 40480
+      GoRuntimeType: 40512
       GoKind: 13
     - __kind: BaseType
       ID: 17
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 40544
+      GoRuntimeType: 40576
       GoKind: 14
     - __kind: GoSubroutineType
       ID: 57
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 34656
+      GoRuntimeType: 34688
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 67
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 54496
+      GoRuntimeType: 54624
       GoKind: 19
     - __kind: BaseType
       ID: 170
@@ -12945,31 +13412,31 @@ Types:
       ID: 9
       Name: int
       ByteSize: 8
-      GoRuntimeType: 40160
+      GoRuntimeType: 40192
       GoKind: 2
     - __kind: BaseType
       ID: 96
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 39776
+      GoRuntimeType: 39808
       GoKind: 4
     - __kind: BaseType
       ID: 12
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 39904
+      GoRuntimeType: 39936
       GoKind: 5
     - __kind: BaseType
       ID: 13
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 40032
+      GoRuntimeType: 40064
       GoKind: 6
     - __kind: BaseType
       ID: 14
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 39648
+      GoRuntimeType: 39680
       GoKind: 3
     - __kind: UnresolvedPointeeType
       ID: 234
@@ -12979,7 +13446,7 @@ Types:
       ID: 82
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 109472
+      GoRuntimeType: 109600
       GoKind: 25
       RawFields:
         - Name: buf
@@ -13004,14 +13471,14 @@ Types:
     - __kind: StructureType
       ID: 258
       Name: internal/poll.errNetClosing
-      GoRuntimeType: 83744
+      GoRuntimeType: 83872
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 71584
+      GoRuntimeType: 71712
       GoKind: 25
       RawFields:
         - Name: u
@@ -13021,7 +13488,7 @@ Types:
       ID: 65
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 94336
+      GoRuntimeType: 94464
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -13037,7 +13504,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 84224
+      GoRuntimeType: 84352
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -13050,7 +13517,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 84064
+      GoRuntimeType: 84192
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -13063,7 +13530,7 @@ Types:
       ID: 70
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 84384
+      GoRuntimeType: 84512
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -13075,13 +13542,13 @@ Types:
     - __kind: StructureType
       ID: 66
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 61216
+      GoRuntimeType: 61344
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 33
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 61120
+      GoRuntimeType: 61248
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -13092,14 +13559,14 @@ Types:
       ID: 223
       Name: main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 67104
+      GoRuntimeType: 67232
       GoKind: 25
       RawFields: [{Name: a, Offset: 0, Type: 9 BaseType int}]
     - __kind: StructureType
       ID: 134
       Name: main.bigArrayStruct
       ByteSize: 1048584
-      GoRuntimeType: 76704
+      GoRuntimeType: 76832
       GoKind: 25
       RawFields:
         - Name: tag
@@ -13112,7 +13579,7 @@ Types:
       ID: 192
       Name: main.bigStruct
       ByteSize: 184
-      GoRuntimeType: 116736
+      GoRuntimeType: 116864
       GoKind: 25
       RawFields:
         - Name: Field1
@@ -13143,7 +13610,7 @@ Types:
       ID: 116
       Name: main.condFields
       ByteSize: 80
-      GoRuntimeType: 122880
+      GoRuntimeType: 123008
       GoKind: 25
       RawFields:
         - Name: I8
@@ -13189,7 +13656,7 @@ Types:
       ID: 137
       Name: main.indexMemberStruct
       ByteSize: 32
-      GoRuntimeType: 87424
+      GoRuntimeType: 87552
       GoKind: 25
       RawFields:
         - Name: Val
@@ -13220,7 +13687,7 @@ Types:
       ID: 218
       Name: main.largeValueStruct
       ByteSize: 264
-      GoRuntimeType: 76544
+      GoRuntimeType: 76672
       GoKind: 25
       RawFields:
         - Name: Pad
@@ -13233,7 +13700,7 @@ Types:
       ID: 119
       Name: main.lenFields
       ByteSize: 72
-      GoRuntimeType: 111360
+      GoRuntimeType: 111488
       GoKind: 25
       RawFields:
         - Name: S
@@ -13264,70 +13731,70 @@ Types:
       ID: 159
       Name: map[bool]int
       ByteSize: 8
-      GoRuntimeType: 57760
+      GoRuntimeType: 57888
       GoKind: 21
       HeaderType: 161 GoHMapHeaderType hash<bool,int>
     - __kind: GoMapType
       ID: 196
       Name: map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 57856
+      GoRuntimeType: 57984
       GoKind: 21
       HeaderType: 198 GoHMapHeaderType hash<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 144
       Name: map[int]string
       ByteSize: 8
-      GoRuntimeType: 57952
+      GoRuntimeType: 58080
       GoKind: 21
       HeaderType: 146 GoHMapHeaderType hash<int,string>
     - __kind: GoMapType
       ID: 154
       Name: map[string]*main.indexMemberStruct
       ByteSize: 8
-      GoRuntimeType: 58048
+      GoRuntimeType: 58176
       GoKind: 21
       HeaderType: 156 GoHMapHeaderType hash<string,*main.indexMemberStruct>
     - __kind: GoMapType
       ID: 104
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 57664
+      GoRuntimeType: 57792
       GoKind: 21
       HeaderType: 106 GoHMapHeaderType hash<string,int>
     - __kind: GoMapType
       ID: 111
       Name: map[string]main.bigStruct
       ByteSize: 8
-      GoRuntimeType: 58144
+      GoRuntimeType: 58272
       GoKind: 21
       HeaderType: 113 GoHMapHeaderType hash<string,main.bigStruct>
     - __kind: GoMapType
       ID: 149
       Name: map[string]main.indexMemberStruct
       ByteSize: 8
-      GoRuntimeType: 58240
+      GoRuntimeType: 58368
       GoKind: 21
       HeaderType: 151 GoHMapHeaderType hash<string,main.indexMemberStruct>
     - __kind: GoMapType
       ID: 164
       Name: map[string]main.largeValueStruct
       ByteSize: 8
-      GoRuntimeType: 58336
+      GoRuntimeType: 58464
       GoKind: 21
       HeaderType: 166 GoHMapHeaderType hash<string,main.largeValueStruct>
     - __kind: GoMapType
       ID: 127
       Name: map[string]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 58432
+      GoRuntimeType: 58560
       GoKind: 21
       HeaderType: 129 GoHMapHeaderType hash<string,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 122
       Name: map[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 58528
+      GoRuntimeType: 58656
       GoKind: 21
       HeaderType: 124 GoHMapHeaderType hash<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: UnresolvedPointeeType
@@ -13358,7 +13825,7 @@ Types:
       ID: 247
       Name: runtime.boundsError
       ByteSize: 24
-      GoRuntimeType: 109920
+      GoRuntimeType: 110048
       GoKind: 25
       RawFields:
         - Name: x
@@ -13377,7 +13844,7 @@ Types:
       ID: 263
       Name: runtime.boundsErrorCode
       ByteSize: 1
-      GoRuntimeType: 40736
+      GoRuntimeType: 40768
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 61
@@ -13390,14 +13857,14 @@ Types:
     - __kind: StructureType
       ID: 80
       Name: runtime.dlogPerM
-      GoRuntimeType: 60544
+      GoRuntimeType: 60672
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 254
       Name: runtime.errorAddressString
       ByteSize: 24
-      GoRuntimeType: 103744
+      GoRuntimeType: 103872
       GoKind: 25
       RawFields:
         - Name: msg
@@ -13410,7 +13877,7 @@ Types:
       ID: 235
       Name: runtime.errorString
       ByteSize: 16
-      GoRuntimeType: 60160
+      GoRuntimeType: 60288
       GoKind: 24
       RawFields:
         - Name: str
@@ -13429,7 +13896,7 @@ Types:
       ID: 22
       Name: runtime.g
       ByteSize: 432
-      GoRuntimeType: 137152
+      GoRuntimeType: 137280
       GoKind: 25
       RawFields:
         - Name: stack
@@ -13604,7 +14071,7 @@ Types:
       ID: 49
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 69920
+      GoRuntimeType: 70048
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -13614,7 +14081,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 56
-      GoRuntimeType: 114720
+      GoRuntimeType: 114848
       GoKind: 25
       RawFields:
         - Name: sp
@@ -13642,7 +14109,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 81984
+      GoRuntimeType: 82112
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -13655,7 +14122,7 @@ Types:
       ID: 54
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 102784
+      GoRuntimeType: 102912
       GoKind: 25
       RawFields:
         - Name: stack
@@ -13674,13 +14141,13 @@ Types:
       ID: 31
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 53152
+      GoRuntimeType: 53280
       GoKind: 12
     - __kind: StructureType
       ID: 86
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 81824
+      GoRuntimeType: 81952
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -13693,7 +14160,7 @@ Types:
       ID: 74
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 113408
+      GoRuntimeType: 113536
       GoKind: 25
       RawFields:
         - Name: fn
@@ -13718,13 +14185,13 @@ Types:
       ID: 87
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 53056
+      GoRuntimeType: 53184
       GoKind: 2
     - __kind: StructureType
       ID: 29
       Name: runtime.m
       ByteSize: 1760
-      GoRuntimeType: 140320
+      GoRuntimeType: 140448
       GoKind: 25
       RawFields:
         - Name: g0
@@ -13944,7 +14411,7 @@ Types:
       ID: 64
       Name: runtime.mLockProfile
       ByteSize: 64
-      GoRuntimeType: 113152
+      GoRuntimeType: 113280
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -13969,7 +14436,7 @@ Types:
       ID: 81
       Name: runtime.mOS
       ByteSize: 8
-      GoRuntimeType: 91072
+      GoRuntimeType: 91200
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -13985,7 +14452,7 @@ Types:
       ID: 69
       Name: runtime.mTraceState
       ByteSize: 32
-      GoRuntimeType: 90880
+      GoRuntimeType: 91008
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -14005,20 +14472,20 @@ Types:
       ID: 37
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 52768
+      GoRuntimeType: 52896
       GoKind: 12
     - __kind: StructureType
       ID: 62
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 69536
+      GoRuntimeType: 69664
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: StructureType
       ID: 76
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 81664
+      GoRuntimeType: 81792
       GoKind: 25
       RawFields:
         - Name: entries
@@ -14031,7 +14498,7 @@ Types:
       ID: 79
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 103552
+      GoRuntimeType: 103680
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -14050,7 +14517,7 @@ Types:
       ID: 238
       Name: runtime.plainError
       ByteSize: 16
-      GoRuntimeType: 60736
+      GoRuntimeType: 60864
       GoKind: 24
       RawFields:
         - Name: str
@@ -14069,13 +14536,13 @@ Types:
       ID: 58
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 52960
+      GoRuntimeType: 53088
       GoKind: 12
     - __kind: ArrayType
       ID: 55
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 55936
+      GoRuntimeType: 56064
       GoKind: 17
       Count: 2
       HasCount: true
@@ -14084,7 +14551,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 80064
+      GoRuntimeType: 80192
       GoKind: 25
       RawFields:
         - Name: lo
@@ -14101,7 +14568,7 @@ Types:
       ID: 59
       Name: runtime.throwType
       ByteSize: 4
-      GoRuntimeType: 40864
+      GoRuntimeType: 40896
       GoKind: 10
     - __kind: UnresolvedPointeeType
       ID: 45
@@ -14111,7 +14578,7 @@ Types:
       ID: 68
       Name: runtime.traceBlockReason
       ByteSize: 1
-      GoRuntimeType: 40928
+      GoRuntimeType: 40960
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 73
@@ -14121,7 +14588,7 @@ Types:
       ID: 50
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 81024
+      GoRuntimeType: 81152
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -14134,12 +14601,12 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 66752
+      GoRuntimeType: 66880
       GoKind: 8
     - __kind: StructureType
       ID: 75
       Name: runtime.winlibcall
-      GoRuntimeType: 60448
+      GoRuntimeType: 60576
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -14150,7 +14617,7 @@ Types:
       ID: 10
       Name: string
       ByteSize: 16
-      GoRuntimeType: 39584
+      GoRuntimeType: 39616
       GoKind: 24
       RawFields:
         - Name: str
@@ -14169,13 +14636,13 @@ Types:
       ID: 261
       Name: syscall.Errno
       ByteSize: 8
-      GoRuntimeType: 72224
+      GoRuntimeType: 72352
       GoKind: 12
     - __kind: GoStringHeaderType
       ID: 225
       Name: time.fileSizeError
       ByteSize: 16
-      GoRuntimeType: 53248
+      GoRuntimeType: 53376
       GoKind: 24
       RawFields:
         - Name: str
@@ -14194,45 +14661,45 @@ Types:
       ID: 15
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 40224
+      GoRuntimeType: 40256
       GoKind: 7
     - __kind: BaseType
       ID: 7
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 39840
+      GoRuntimeType: 39872
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 39968
+      GoRuntimeType: 40000
       GoKind: 10
     - __kind: BaseType
       ID: 11
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 40096
+      GoRuntimeType: 40128
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 39712
+      GoRuntimeType: 39744
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 40288
+      GoRuntimeType: 40320
       GoKind: 12
     - __kind: VoidPointerType
       ID: 19
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 40672
+      GoRuntimeType: 40704
       GoKind: 26
-MaxTypeID: 613
+MaxTypeID: 621
 Issues:
     - probe_definition:
         id: condCompound_eq_of_eq
@@ -14541,6 +15008,48 @@ Issues:
         Kind: 7
         Message: condition variable "x" not available at any event
     - probe_definition:
+        id: condLineReturn_cond_return
+        version: 0
+        type: LOG_PROBE
+        where:
+            methodName: main.condLineReturn
+            sourceFile: main.go
+            lines: ["571"]
+        tags: ['issue:ConditionVariableUnavailable']
+        when:
+            dsl: '@return == 14'
+            json: {eq: [{ref: '@return'}, 14]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: matched
+        segments: [matched]
+        captureSnapshot: false
+      issue:
+        Kind: 7
+        Message: condition variable "@return" not found
+    - probe_definition:
+        id: condLine_local_cond
+        version: 0
+        type: LOG_PROBE
+        where:
+            methodName: main.condLine
+            sourceFile: main.go
+            lines: ["548"]
+        tags:
+            - skip_integration:arch=arm64,toolchain=go1.23.11
+            - skip_integration:arch=amd64,toolchain=go1.23.11
+            - issue:ConditionVariableUnavailable@arch=arm64,toolchain=go1.23.11
+            - issue:ConditionVariableUnavailable@arch=amd64,toolchain=go1.23.11
+        when: {dsl: result == 14, json: {eq: [{ref: result}, 14]}}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: tag={tag}
+        segments: [tag=, {json: {ref: tag}, dsl: tag}]
+        captureSnapshot: false
+      issue:
+        Kind: 7
+        Message: condition variable "result" not found
+    - probe_definition:
         id: condNull_int_vs_null
         version: 0
         type: LOG_PROBE
@@ -14647,8 +15156,8 @@ Issues:
       issue:
         Kind: 3
         Message: probe kind ProbeKindSpan is not supported
-GoModuledataInfo: {FirstModuledataAddr: "0x57f240", TypesOffset: 296}
-GoMapHashInfo: {UseAeshashAddr: "0x5a8a2a", AeskeyschedAddr: "0x5a9100"}
+GoModuledataInfo: {FirstModuledataAddr: "0x580240", TypesOffset: 296}
+GoMapHashInfo: {UseAeshashAddr: "0x5a9a2a", AeskeyschedAddr: "0x5aa100"}
 CommonTypes:
     G: 22 StructureType runtime.g
     M: 29 StructureType runtime.m

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -9,10 +9,10 @@ Probes:
       segments: ['ptr: ', {json: {ref: ptr}, dsl: ptr}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 76}
+        - subprogram: {subprogram: 78}
           events:
             - Kind: Entry
-              Type: 660 EventRootType Probe[main.PointerChainArg]
+              Type: 669 EventRootType Probe[main.PointerChainArg]
               InjectionPoints: [{PC: "0x4a8ccc", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -32,10 +32,10 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 77}
+        - subprogram: {subprogram: 79}
           events:
             - Kind: Entry
-              Type: 661 EventRootType Probe[main.PointerSmallChainArg]
+              Type: 670 EventRootType Probe[main.PointerSmallChainArg]
               InjectionPoints: [{PC: "0x4a8d11", Frameless: false}]
               Condition: null
     - id: bigMapArg
@@ -50,11 +50,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 359 EventRootType Probe[main.bigMapArg]
-              InjectionPoints: [{PC: "0x4ab1f3", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab433", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 360 EventRootType Probe[main.bigMapArg]Return
-              InjectionPoints: [{PC: "0x4ab27e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab4be", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 'm: {m}'
@@ -78,7 +78,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 405 EventRootType Probe[main.condBool]
-              InjectionPoints: [{PC: "0x4aba8a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abcca", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -95,7 +95,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 406 EventRootType Probe[main.condBool]Return
-              InjectionPoints: [{PC: "0x4abafa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abd3a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -119,7 +119,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 407 EventRootType Probe[main.condBool]
-              InjectionPoints: [{PC: "0x4aba8a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abcca", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -136,7 +136,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 408 EventRootType Probe[main.condBool]Return
-              InjectionPoints: [{PC: "0x4abafa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abd3a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -159,11 +159,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 409 EventRootType Probe[main.condBool]
-              InjectionPoints: [{PC: "0x4aba8a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abcca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 410 EventRootType Probe[main.condBool]Return
-              InjectionPoints: [{PC: "0x4abafa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abd3a", Frameless: false}]
               Condition: null
     - id: condCompound_and
       version: 0
@@ -188,7 +188,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 455 EventRootType Probe[main.condReturnAndLocal]
-              InjectionPoints: [{PC: "0x4abf6a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ac1aa", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -220,7 +220,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 456 EventRootType Probe[main.condReturnAndLocal]Return
-              InjectionPoints: [{PC: "0x4abfd5", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ac215", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: a == 1 && b == 1 [a={a}, b={b}]
@@ -262,7 +262,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 425 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0x4abc0e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abe4e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -292,7 +292,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 426 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0x4abd0f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abf4f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x.S == "world" && tag == "match" [x.S={x.S}, tag={tag}]
@@ -314,7 +314,7 @@ Probes:
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["519"]
+        lines: ["547"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -338,7 +338,7 @@ Probes:
           events:
             - Kind: Line
               Type: 465 EventRootType Probe[main.condLine]Line
-              InjectionPoints: [{PC: "0x4ac0e1", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ac321", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -412,7 +412,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 427 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0x4abc0e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abe4e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -460,7 +460,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 428 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0x4abd0f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abf4f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: (x.I32 == 300 || x.I32 == 999) && !isEmpty(x.S) [x.I32={x.I32}, x.S={x.S}, tag={tag}]
@@ -502,7 +502,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 411 EventRootType Probe[main.condBool]
-              InjectionPoints: [{PC: "0x4aba8a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abcca", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -520,7 +520,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 412 EventRootType Probe[main.condBool]Return
-              InjectionPoints: [{PC: "0x4abafa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abd3a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '!x [x={x}, tag={tag}]'
@@ -559,7 +559,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 371 EventRootType Probe[main.condInt32]
-              InjectionPoints: [{PC: "0x4ab48a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab6ca", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -591,7 +591,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 372 EventRootType Probe[main.condInt32]Return
-              InjectionPoints: [{PC: "0x4ab4fa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab73a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x == 42 || x == 100 [x={x}, tag={tag}]
@@ -629,16 +629,16 @@ Probes:
         - ']'
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 478 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4aca73", Frameless: false}]
+              Type: 487 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4acf73", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 37, index: 1, name: tag}
+                      Variable: {subprogram: 39, index: 1, name: tag}
                       Offset: 0
                       ByteSize: 16
                     - __kind: ExprReadStringOp
@@ -650,7 +650,7 @@ Probes:
                       Cond: true
                       Target: 1
                     - __kind: LocationOp
-                      Variable: {subprogram: 37, index: 0, name: s}
+                      Variable: {subprogram: 39, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -664,8 +664,8 @@ Probes:
                       ID: 1
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 479 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4acb65", Frameless: false}]
+              Type: 488 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4ad065", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag == "match" || !isEmpty(s) [s={s}, tag={tag}]
@@ -703,20 +703,20 @@ Probes:
         - ']'
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 72}
+        - subprogram: {subprogram: 74}
           events:
             - Kind: Entry
-              Type: 652 EventRootType Probe[main.condMultiReturn]
-              InjectionPoints: [{PC: "0x4ae7ee", Frameless: false}]
+              Type: 661 EventRootType Probe[main.condMultiReturn]
+              InjectionPoints: [{PC: "0x4aecee", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 653 EventRootType Probe[main.condMultiReturn]Return
-              InjectionPoints: [{PC: "0x4ae88c", Frameless: false}]
+              Type: 662 EventRootType Probe[main.condMultiReturn]Return
+              InjectionPoints: [{PC: "0x4aed8c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 72, index: 1, name: r0}
+                      Variable: {subprogram: 74, index: 1, name: r0}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -729,7 +729,7 @@ Probes:
                       Cond: false
                       Target: 1
                     - __kind: LocationOp
-                      Variable: {subprogram: 72, index: 2, name: r1}
+                      Variable: {subprogram: 74, index: 2, name: r1}
                       Offset: 0
                       ByteSize: 16
                     - __kind: ExprReadStringOp
@@ -777,7 +777,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 447 EventRootType Probe[main.condNilPtrStruct]
-              InjectionPoints: [{PC: "0x4abeae", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ac0ee", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -811,7 +811,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 448 EventRootType Probe[main.condNilPtrStruct]Return
-              InjectionPoints: [{PC: "0x4abf2e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ac16e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag == "nilptr" && x.I32 == 300 [tag={tag}]
@@ -845,7 +845,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 449 EventRootType Probe[main.condNilPtrStruct]
-              InjectionPoints: [{PC: "0x4abeae", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ac0ee", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -879,7 +879,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 450 EventRootType Probe[main.condNilPtrStruct]Return
-              InjectionPoints: [{PC: "0x4abf2e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ac16e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag == "nilptr" || x.I32 == 300 [tag={tag}]
@@ -903,11 +903,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 401 EventRootType Probe[main.condFloat32]
-              InjectionPoints: [{PC: "0x4ab90a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abb4a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 402 EventRootType Probe[main.condFloat32]Return
-              InjectionPoints: [{PC: "0x4ab97e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abbbe", Frameless: false}]
               Condition: null
     - id: condFloat64_nocond
       version: 0
@@ -922,11 +922,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 403 EventRootType Probe[main.condFloat64]
-              InjectionPoints: [{PC: "0x4ab9ca", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abc0a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 404 EventRootType Probe[main.condFloat64]Return
-              InjectionPoints: [{PC: "0x4aba3f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abc7f", Frameless: false}]
               Condition: null
     - id: condInt16_cond
       version: 0
@@ -942,7 +942,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 367 EventRootType Probe[main.condInt16]
-              InjectionPoints: [{PC: "0x4ab3ca", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab60a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -959,7 +959,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 368 EventRootType Probe[main.condInt16]Return
-              InjectionPoints: [{PC: "0x4ab43a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab67a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -982,11 +982,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 369 EventRootType Probe[main.condInt16]
-              InjectionPoints: [{PC: "0x4ab3ca", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab60a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 370 EventRootType Probe[main.condInt16]Return
-              InjectionPoints: [{PC: "0x4ab43a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab67a", Frameless: false}]
               Condition: null
     - id: condInt32_cond
       version: 0
@@ -1002,7 +1002,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 373 EventRootType Probe[main.condInt32]
-              InjectionPoints: [{PC: "0x4ab48a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab6ca", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1019,7 +1019,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 374 EventRootType Probe[main.condInt32]Return
-              InjectionPoints: [{PC: "0x4ab4fa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab73a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1046,7 +1046,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 375 EventRootType Probe[main.condInt32]
-              InjectionPoints: [{PC: "0x4ab48a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab6ca", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1063,7 +1063,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 376 EventRootType Probe[main.condInt32]Return
-              InjectionPoints: [{PC: "0x4ab4fa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab73a", Frameless: false}]
               Condition: null
     - id: condInt32_nocond
       version: 0
@@ -1078,11 +1078,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 377 EventRootType Probe[main.condInt32]
-              InjectionPoints: [{PC: "0x4ab48a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab6ca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 378 EventRootType Probe[main.condInt32]Return
-              InjectionPoints: [{PC: "0x4ab4fa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab73a", Frameless: false}]
               Condition: null
     - id: condInt64_cond
       version: 0
@@ -1098,7 +1098,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 379 EventRootType Probe[main.condInt64]
-              InjectionPoints: [{PC: "0x4ab54a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab78a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1115,7 +1115,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 380 EventRootType Probe[main.condInt64]Return
-              InjectionPoints: [{PC: "0x4ab5ba", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab7fa", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1138,11 +1138,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 381 EventRootType Probe[main.condInt64]
-              InjectionPoints: [{PC: "0x4ab54a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab78a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 382 EventRootType Probe[main.condInt64]Return
-              InjectionPoints: [{PC: "0x4ab5ba", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab7fa", Frameless: false}]
               Condition: null
     - id: condInt8_cond
       version: 0
@@ -1158,7 +1158,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 363 EventRootType Probe[main.condInt8]
-              InjectionPoints: [{PC: "0x4ab30a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab54a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1175,7 +1175,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 364 EventRootType Probe[main.condInt8]Return
-              InjectionPoints: [{PC: "0x4ab37a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab5ba", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1198,11 +1198,257 @@ Probes:
           events:
             - Kind: Entry
               Type: 365 EventRootType Probe[main.condInt8]
-              InjectionPoints: [{PC: "0x4ab30a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab54a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 366 EventRootType Probe[main.condInt8]Return
-              InjectionPoints: [{PC: "0x4ab37a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab5ba", Frameless: false}]
+              Condition: null
+    - id: condLineMixed_cond_bool
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when: {dsl: b == true, json: {eq: [{ref: b}, true]}}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 470 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0x4ac451", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 1, name: b}
+                      Offset: 0
+                      ByteSize: 1
+                    - __kind: ExprPushOffsetOp
+                      ByteSize: 1
+                    - __kind: ExprLoadLiteralOp
+                      Data: AQ==
+                    - __kind: ExprCmpEqBaseOp
+                      ByteSize: 1
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_isEmpty_slice
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when: {dsl: isEmpty(ss), json: {isEmpty: {ref: ss}}}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 471 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0x4ac451", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 4, name: ss}
+                      Offset: 8
+                      ByteSize: 8
+                    - __kind: ExprPushOffsetOp
+                      ByteSize: 8
+                    - __kind: ExprLoadLiteralOp
+                      Data: AAAAAAAAAAA=
+                    - __kind: ExprCmpEqBaseOp
+                      ByteSize: 8
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_len_string
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when:
+        dsl: len(s) == 5
+        json: {eq: [{len: {ref: s}}, 5]}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 472 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0x4ac451", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 0, name: s}
+                      Offset: 8
+                      ByteSize: 8
+                    - __kind: ExprPushOffsetOp
+                      ByteSize: 8
+                    - __kind: ExprLoadLiteralOp
+                      Data: BQAAAAAAAAA=
+                    - __kind: ExprCmpEqBaseOp
+                      ByteSize: 8
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_ptrstruct_field
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when:
+        dsl: p.S == "world"
+        json: {eq: [{getmember: [{ref: p}, S]}, world]}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 473 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0x4ac451", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 3, name: p}
+                      Offset: 0
+                      ByteSize: 8
+                    - __kind: DereferenceOp
+                      Bias: 56
+                      ByteSize: 16
+                    - __kind: ExprReadStringOp
+                      MaxLen: 255
+                    - __kind: ExprLoadLiteralOp
+                      Data: BQAAAHdvcmxk
+                    - __kind: ExprCmpEqStringOp
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_string
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when:
+        dsl: s == "hello"
+        json: {eq: [{ref: s}, hello]}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 474 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0x4ac451", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 0, name: s}
+                      Offset: 0
+                      ByteSize: 16
+                    - __kind: ExprReadStringOp
+                      MaxLen: 255
+                    - __kind: ExprLoadLiteralOp
+                      Data: BQAAAGhlbGxv
+                    - __kind: ExprCmpEqStringOp
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_struct_field
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when:
+        dsl: x.I32 == 300
+        json: {eq: [{getmember: [{ref: x}, I32]}, 300]}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 475 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0x4ac451", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 2, name: x}
+                      Offset: 4
+                      ByteSize: 4
+                    - __kind: ExprPushOffsetOp
+                      ByteSize: 4
+                    - __kind: ExprLoadLiteralOp
+                      Data: LAEAAA==
+                    - __kind: ExprCmpEqBaseOp
+                      ByteSize: 4
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_nocond
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 476 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0x4ac451", Frameless: false}]
               Condition: null
     - id: condLine_cond
       version: 0
@@ -1210,7 +1456,7 @@ Probes:
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["519"]
+        lines: ["547"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -1227,7 +1473,7 @@ Probes:
           events:
             - Kind: Line
               Type: 466 EventRootType Probe[main.condLine]Line
-              InjectionPoints: [{PC: "0x4ac0e1", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ac321", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1242,13 +1488,58 @@ Probes:
                     - __kind: ExprCmpEqBaseOp
                       ByteSize: 8
                     - __kind: ConditionCheckOp
-    - id: condLine_nocond
+    - id: condLine_local_cond
       version: 0
       type: LOG_PROBE
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["519"]
+        lines: ["548"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+        - issue:ConditionVariableUnavailable@arch=arm64,toolchain=go1.23.11
+        - issue:ConditionVariableUnavailable@arch=amd64,toolchain=go1.23.11
+      when: {dsl: result == 14, json: {eq: [{ref: result}, 14]}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 28}
+          events:
+            - Kind: Line
+              Type: 467 EventRootType Probe[main.condLine]Line
+              InjectionPoints: [{PC: "0x4ac327", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 28, index: 2, name: result}
+                      Offset: 0
+                      ByteSize: 8
+                    - __kind: ExprPushOffsetOp
+                      ByteSize: 8
+                    - __kind: ExprLoadLiteralOp
+                      Data: DgAAAAAAAAA=
+                    - __kind: ExprCmpEqBaseOp
+                      ByteSize: 8
+                    - __kind: ConditionCheckOp
+          probeTemplate:
+            TemplateString: tag={tag}
+            Segments:
+                - tag=
+                - JSON: {Ref: tag}
+                  DSL: tag
+                  EventKind: Line
+                  EventExpressionIndex: 0
+    - id: condLine_local_nocond
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLine
+        sourceFile: main.go
+        lines: ["548"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -1260,8 +1551,29 @@ Probes:
         - subprogram: {subprogram: 28}
           events:
             - Kind: Line
-              Type: 467 EventRootType Probe[main.condLine]Line
-              InjectionPoints: [{PC: "0x4ac0e1", Frameless: false}]
+              Type: 468 EventRootType Probe[main.condLine]Line
+              InjectionPoints: [{PC: "0x4ac327", Frameless: false}]
+              Condition: null
+    - id: condLine_nocond
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLine
+        sourceFile: main.go
+        lines: ["547"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 28}
+          events:
+            - Kind: Line
+              Type: 469 EventRootType Probe[main.condLine]Line
+              InjectionPoints: [{PC: "0x4ac321", Frameless: false}]
               Condition: null
     - id: condNilPtr_cond
       version: 0
@@ -1279,7 +1591,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 451 EventRootType Probe[main.condNilPtrStruct]
-              InjectionPoints: [{PC: "0x4abeae", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ac0ee", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1299,7 +1611,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 452 EventRootType Probe[main.condNilPtrStruct]Return
-              InjectionPoints: [{PC: "0x4abf2e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ac16e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: condNilPtr {tag}
@@ -1322,11 +1634,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 453 EventRootType Probe[main.condNilPtrStruct]
-              InjectionPoints: [{PC: "0x4abeae", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ac0ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 454 EventRootType Probe[main.condNilPtrStruct]Return
-              InjectionPoints: [{PC: "0x4abf2e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ac16e", Frameless: false}]
               Condition: null
     - id: condNull_iface
       version: 0
@@ -1338,16 +1650,16 @@ Probes:
       segments: ['i == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 35}
+        - subprogram: {subprogram: 37}
           events:
             - Kind: Entry
-              Type: 474 EventRootType Probe[main.condNullIface]
-              InjectionPoints: [{PC: "0x4ac7ce", Frameless: false}]
+              Type: 483 EventRootType Probe[main.condNullIface]
+              InjectionPoints: [{PC: "0x4accce", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 35, index: 0, name: i}
+                      Variable: {subprogram: 37, index: 0, name: i}
                       Offset: 0
                       ByteSize: 16
                     - __kind: ExprPushOffsetOp
@@ -1358,8 +1670,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 475 EventRootType Probe[main.condNullIface]Return
-              InjectionPoints: [{PC: "0x4ac8d6", Frameless: false}]
+              Type: 484 EventRootType Probe[main.condNullIface]Return
+              InjectionPoints: [{PC: "0x4acdd6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: i == nil [tag={tag}]
@@ -1380,16 +1692,16 @@ Probes:
       segments: ['m == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 34}
+        - subprogram: {subprogram: 36}
           events:
             - Kind: Entry
-              Type: 472 EventRootType Probe[main.condNullMap]
-              InjectionPoints: [{PC: "0x4ac6ae", Frameless: false}]
+              Type: 481 EventRootType Probe[main.condNullMap]
+              InjectionPoints: [{PC: "0x4acbae", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 34, index: 0, name: m}
+                      Variable: {subprogram: 36, index: 0, name: m}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -1400,8 +1712,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 473 EventRootType Probe[main.condNullMap]Return
-              InjectionPoints: [{PC: "0x4ac785", Frameless: false}]
+              Type: 482 EventRootType Probe[main.condNullMap]Return
+              InjectionPoints: [{PC: "0x4acc85", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: m == nil [tag={tag}]
@@ -1422,16 +1734,16 @@ Probes:
       segments: ['p == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 32}
+        - subprogram: {subprogram: 34}
           events:
             - Kind: Entry
-              Type: 468 EventRootType Probe[main.condNullPtr]
-              InjectionPoints: [{PC: "0x4ac40e", Frameless: false}]
+              Type: 477 EventRootType Probe[main.condNullPtr]
+              InjectionPoints: [{PC: "0x4ac90e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 32, index: 0, name: p}
+                      Variable: {subprogram: 34, index: 0, name: p}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -1442,8 +1754,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 469 EventRootType Probe[main.condNullPtr]Return
-              InjectionPoints: [{PC: "0x4ac4e5", Frameless: false}]
+              Type: 478 EventRootType Probe[main.condNullPtr]Return
+              InjectionPoints: [{PC: "0x4ac9e5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p == nil [tag={tag}]
@@ -1464,16 +1776,16 @@ Probes:
       segments: ['s == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 33}
+        - subprogram: {subprogram: 35}
           events:
             - Kind: Entry
-              Type: 470 EventRootType Probe[main.condNullSlice]
-              InjectionPoints: [{PC: "0x4ac533", Frameless: false}]
+              Type: 479 EventRootType Probe[main.condNullSlice]
+              InjectionPoints: [{PC: "0x4aca33", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 33, index: 0, name: s}
+                      Variable: {subprogram: 35, index: 0, name: s}
                       Offset: 0
                       ByteSize: 24
                     - __kind: ExprPushOffsetOp
@@ -1484,8 +1796,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 471 EventRootType Probe[main.condNullSlice]Return
-              InjectionPoints: [{PC: "0x4ac64b", Frameless: false}]
+              Type: 480 EventRootType Probe[main.condNullSlice]Return
+              InjectionPoints: [{PC: "0x4acb4b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: s == nil [tag={tag}]
@@ -1506,16 +1818,16 @@ Probes:
       segments: ['p == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 36}
+        - subprogram: {subprogram: 38}
           events:
             - Kind: Entry
-              Type: 476 EventRootType Probe[main.condNullUnsafePtr]
-              InjectionPoints: [{PC: "0x4ac92e", Frameless: false}]
+              Type: 485 EventRootType Probe[main.condNullUnsafePtr]
+              InjectionPoints: [{PC: "0x4ace2e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 36, index: 0, name: p}
+                      Variable: {subprogram: 38, index: 0, name: p}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -1526,8 +1838,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 477 EventRootType Probe[main.condNullUnsafePtr]Return
-              InjectionPoints: [{PC: "0x4aca05", Frameless: false}]
+              Type: 486 EventRootType Probe[main.condNullUnsafePtr]Return
+              InjectionPoints: [{PC: "0x4acf05", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p == nil [tag={tag}]
@@ -1552,7 +1864,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 461 EventRootType Probe[main.condOnly]
-              InjectionPoints: [{PC: "0x4ac00a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ac24a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1569,7 +1881,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 462 EventRootType Probe[main.condOnly]Return
-              InjectionPoints: [{PC: "0x4ac07a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ac2ba", Frameless: false}]
               Condition: null
     - id: condOnly_nocond
       version: 0
@@ -1584,11 +1896,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 463 EventRootType Probe[main.condOnly]
-              InjectionPoints: [{PC: "0x4ac00a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ac24a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 464 EventRootType Probe[main.condOnly]Return
-              InjectionPoints: [{PC: "0x4ac07a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ac2ba", Frameless: false}]
               Condition: null
     - id: condPtrStruct_field_i32
       version: 0
@@ -1606,7 +1918,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 441 EventRootType Probe[main.condPtrStructArg]
-              InjectionPoints: [{PC: "0x4abd4e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abf8e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1626,7 +1938,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 442 EventRootType Probe[main.condPtrStructArg]Return
-              InjectionPoints: [{PC: "0x4abe65", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ac0a5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1652,7 +1964,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 443 EventRootType Probe[main.condPtrStructArg]
-              InjectionPoints: [{PC: "0x4abd4e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abf8e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1671,7 +1983,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 444 EventRootType Probe[main.condPtrStructArg]Return
-              InjectionPoints: [{PC: "0x4abe65", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ac0a5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1694,11 +2006,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 445 EventRootType Probe[main.condPtrStructArg]
-              InjectionPoints: [{PC: "0x4abd4e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abf8e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 446 EventRootType Probe[main.condPtrStructArg]Return
-              InjectionPoints: [{PC: "0x4abe65", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ac0a5", Frameless: false}]
               Condition: null
     - id: condReturnAndLocal_cond_param
       version: 0
@@ -1714,7 +2026,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 457 EventRootType Probe[main.condReturnAndLocal]
-              InjectionPoints: [{PC: "0x4abf6a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ac1aa", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1731,7 +2043,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 458 EventRootType Probe[main.condReturnAndLocal]Return
-              InjectionPoints: [{PC: "0x4abfd5", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ac215", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: b={b}
@@ -1754,11 +2066,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 459 EventRootType Probe[main.condReturnAndLocal]
-              InjectionPoints: [{PC: "0x4abf6a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ac1aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 460 EventRootType Probe[main.condReturnAndLocal]Return
-              InjectionPoints: [{PC: "0x4abfd5", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ac215", Frameless: false}]
               Condition: null
     - id: condString_cond
       version: 0
@@ -1776,7 +2088,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 413 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0x4abb4a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abd8a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1792,7 +2104,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 414 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0x4abbbf", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abdff", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1816,7 +2128,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 415 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0x4abb4a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abd8a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1832,7 +2144,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 416 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0x4abbbf", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abdff", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1860,11 +2172,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 417 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0x4abb4a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abd8a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 418 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0x4abbbf", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abdff", Frameless: false}]
               Condition: null
     - id: condString_eq_template
       version: 0
@@ -1882,11 +2194,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 419 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0x4abb4a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abd8a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 420 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0x4abbbf", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abdff", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: eq={x == "hello"}
@@ -1909,11 +2221,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 421 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0x4abb4a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abd8a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 422 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0x4abbbf", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abdff", Frameless: false}]
               Condition: null
     - id: condString_snapshot_with_cond
       version: 0
@@ -1931,7 +2243,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 423 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0x4abb4a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abd8a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1947,7 +2259,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 424 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0x4abbbf", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abdff", Frameless: false}]
               Condition: null
     - id: condStruct_cond_i32_capture_tag
       version: 0
@@ -1968,7 +2280,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 429 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0x4abc0e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abe4e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1985,7 +2297,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 430 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0x4abd0f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abf4f", Frameless: false}]
               Condition: null
     - id: condStruct_field_bool
       version: 0
@@ -2003,7 +2315,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 431 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0x4abc0e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abe4e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2020,7 +2332,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 432 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0x4abd0f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abf4f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2046,7 +2358,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 433 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0x4abc0e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abe4e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2063,7 +2375,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 434 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0x4abd0f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abf4f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2089,7 +2401,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 435 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0x4abc0e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abe4e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2106,7 +2418,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 436 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0x4abd0f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abf4f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2132,7 +2444,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 437 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0x4abc0e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abe4e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2148,7 +2460,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 438 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0x4abd0f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abf4f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2171,11 +2483,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 439 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0x4abc0e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abe4e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 440 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0x4abd0f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abf4f", Frameless: false}]
               Condition: null
     - id: condUint16_cond
       version: 0
@@ -2191,7 +2503,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 389 EventRootType Probe[main.condUint16]
-              InjectionPoints: [{PC: "0x4ab6ca", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab90a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2208,7 +2520,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 390 EventRootType Probe[main.condUint16]Return
-              InjectionPoints: [{PC: "0x4ab73a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab97a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2231,11 +2543,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 391 EventRootType Probe[main.condUint16]
-              InjectionPoints: [{PC: "0x4ab6ca", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab90a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 392 EventRootType Probe[main.condUint16]Return
-              InjectionPoints: [{PC: "0x4ab73a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab97a", Frameless: false}]
               Condition: null
     - id: condUint32_cond
       version: 0
@@ -2251,7 +2563,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 393 EventRootType Probe[main.condUint32]
-              InjectionPoints: [{PC: "0x4ab78a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab9ca", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2268,7 +2580,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 394 EventRootType Probe[main.condUint32]Return
-              InjectionPoints: [{PC: "0x4ab7fa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4aba3a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2291,11 +2603,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 395 EventRootType Probe[main.condUint32]
-              InjectionPoints: [{PC: "0x4ab78a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab9ca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 396 EventRootType Probe[main.condUint32]Return
-              InjectionPoints: [{PC: "0x4ab7fa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4aba3a", Frameless: false}]
               Condition: null
     - id: condUint64_cond
       version: 0
@@ -2311,7 +2623,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 397 EventRootType Probe[main.condUint64]
-              InjectionPoints: [{PC: "0x4ab84a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4aba8a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2328,7 +2640,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 398 EventRootType Probe[main.condUint64]Return
-              InjectionPoints: [{PC: "0x4ab8ba", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abafa", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2351,11 +2663,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 399 EventRootType Probe[main.condUint64]
-              InjectionPoints: [{PC: "0x4ab84a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4aba8a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 400 EventRootType Probe[main.condUint64]Return
-              InjectionPoints: [{PC: "0x4ab8ba", Frameless: false}]
+              InjectionPoints: [{PC: "0x4abafa", Frameless: false}]
               Condition: null
     - id: condUint8_cond
       version: 0
@@ -2371,7 +2683,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 383 EventRootType Probe[main.condUint8]
-              InjectionPoints: [{PC: "0x4ab60a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab84a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2388,7 +2700,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 384 EventRootType Probe[main.condUint8]Return
-              InjectionPoints: [{PC: "0x4ab67a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab8ba", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2412,7 +2724,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 385 EventRootType Probe[main.condUint8]
-              InjectionPoints: [{PC: "0x4ab60a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab84a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2429,7 +2741,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 386 EventRootType Probe[main.condUint8]Return
-              InjectionPoints: [{PC: "0x4ab67a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab8ba", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2452,11 +2764,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 387 EventRootType Probe[main.condUint8]
-              InjectionPoints: [{PC: "0x4ab60a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab84a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 388 EventRootType Probe[main.condUint8]Return
-              InjectionPoints: [{PC: "0x4ab67a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab8ba", Frameless: false}]
               Condition: null
     - id: genericIdentity
       version: 0
@@ -2466,25 +2778,25 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 73}
+        - subprogram: {subprogram: 75}
           events:
             - Kind: Entry
-              Type: 654 EventRootType Probe[main.genericIdentity[go.shape.string]]
-              InjectionPoints: [{PC: "0x4ae8ca", Frameless: false}]
+              Type: 663 EventRootType Probe[main.genericIdentity[go.shape.string]]
+              InjectionPoints: [{PC: "0x4aedca", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 655 EventRootType Probe[main.genericIdentity[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x4ae92f", Frameless: false}]
+              Type: 664 EventRootType Probe[main.genericIdentity[go.shape.string]]Return
+              InjectionPoints: [{PC: "0x4aee2f", Frameless: false}]
               Condition: null
-        - subprogram: {subprogram: 74}
+        - subprogram: {subprogram: 76}
           events:
             - Kind: Entry
-              Type: 656 EventRootType Probe[main.genericIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0x4ae96a", Frameless: false}]
+              Type: 665 EventRootType Probe[main.genericIdentity[go.shape.int]]
+              InjectionPoints: [{PC: "0x4aee6a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 657 EventRootType Probe[main.genericIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x4ae9bd", Frameless: false}]
+              Type: 666 EventRootType Probe[main.genericIdentity[go.shape.int]]Return
+              InjectionPoints: [{PC: "0x4aeebd", Frameless: false}]
               Condition: null
     - id: indexBigArrayStruct_last
       version: 0
@@ -2500,15 +2812,15 @@ Probes:
             dsl: s.data[131071]
             json: {index: [{getmember: [{ref: s}, data]}, 131071]}
       instances:
-        - subprogram: {subprogram: 48}
+        - subprogram: {subprogram: 50}
           events:
             - Kind: Entry
-              Type: 576 EventRootType Probe[main.bigArrayStructArg]
-              InjectionPoints: [{PC: "0x4ad8ea", Frameless: false}]
+              Type: 585 EventRootType Probe[main.bigArrayStructArg]
+              InjectionPoints: [{PC: "0x4addea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 577 EventRootType Probe[main.bigArrayStructArg]Return
-              InjectionPoints: [{PC: "0x4ad957", Frameless: false}]
+              Type: 586 EventRootType Probe[main.bigArrayStructArg]Return
+              InjectionPoints: [{PC: "0x4ade57", Frameless: false}]
               Condition: null
     - id: indexBigArray_first
       version: 0
@@ -2522,15 +2834,15 @@ Probes:
         - name: s_0
           expr: {dsl: 's[0]', json: {index: [{ref: s}, 0]}}
       instances:
-        - subprogram: {subprogram: 47}
+        - subprogram: {subprogram: 49}
           events:
             - Kind: Entry
-              Type: 572 EventRootType Probe[main.bigArrayArg]
-              InjectionPoints: [{PC: "0x4ad84a", Frameless: false}]
+              Type: 581 EventRootType Probe[main.bigArrayArg]
+              InjectionPoints: [{PC: "0x4add4a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 573 EventRootType Probe[main.bigArrayArg]Return
-              InjectionPoints: [{PC: "0x4ad8b6", Frameless: false}]
+              Type: 582 EventRootType Probe[main.bigArrayArg]Return
+              InjectionPoints: [{PC: "0x4addb6", Frameless: false}]
               Condition: null
     - id: indexBigArray_last
       version: 0
@@ -2544,15 +2856,15 @@ Probes:
         - name: s_131071
           expr: {dsl: 's[131071]', json: {index: [{ref: s}, 131071]}}
       instances:
-        - subprogram: {subprogram: 47}
+        - subprogram: {subprogram: 49}
           events:
             - Kind: Entry
-              Type: 574 EventRootType Probe[main.bigArrayArg]
-              InjectionPoints: [{PC: "0x4ad84a", Frameless: false}]
+              Type: 583 EventRootType Probe[main.bigArrayArg]
+              InjectionPoints: [{PC: "0x4add4a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 575 EventRootType Probe[main.bigArrayArg]Return
-              InjectionPoints: [{PC: "0x4ad8b6", Frameless: false}]
+              Type: 584 EventRootType Probe[main.bigArrayArg]Return
+              InjectionPoints: [{PC: "0x4addb6", Frameless: false}]
               Condition: null
     - id: indexErr_array_oob_capture
       version: 0
@@ -2570,11 +2882,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 338 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0x4aaf2a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab16a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 339 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0x4aaf76", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab1b6", Frameless: false}]
               Condition: null
     - id: indexErr_array_oob_template
       version: 0
@@ -2589,11 +2901,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 340 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0x4aaf2a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab16a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 341 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0x4aaf76", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab1b6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's[3]: {s[3]}'
@@ -2617,11 +2929,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 324 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0x4aaeaa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab0ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 325 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0x4aaeef", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab12f", Frameless: false}]
               Condition: null
     - id: indexErr_slice_oob_cond
       version: 0
@@ -2639,7 +2951,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 326 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0x4aaeaa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab0ea", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2661,7 +2973,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 327 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0x4aaeef", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab12f", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: matched, Segments: [matched]}
     - id: indexErr_slice_oob_template
@@ -2677,11 +2989,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 328 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0x4aaeaa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab0ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 329 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0x4aaeef", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab12f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's[5]: {s[5]}'
@@ -2707,11 +3019,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 342 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0x4aaf2a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab16a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 343 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0x4aaf76", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab1b6", Frameless: false}]
               Condition: null
     - id: indexIntArray_cond
       version: 0
@@ -2729,7 +3041,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 344 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0x4aaf2a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab16a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2746,7 +3058,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 345 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0x4aaf76", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab1b6", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: matched, Segments: [matched]}
     - id: indexIntSlice_capture
@@ -2765,11 +3077,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 330 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0x4aaeaa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab0ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 331 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0x4aaeef", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab12f", Frameless: false}]
               Condition: null
     - id: indexIntSlice_cond
       version: 0
@@ -2787,7 +3099,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 332 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0x4aaeaa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab0ea", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2809,7 +3121,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 333 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0x4aaeef", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab12f", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: matched, Segments: [matched]}
     - id: indexIntSlice_template
@@ -2825,11 +3137,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 334 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0x4aaeaa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab0ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 335 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0x4aaeef", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab12f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's[1]: {s[1]}'
@@ -2853,15 +3165,15 @@ Probes:
             dsl: s[0].Val
             json: {getmember: [{index: [{ref: s}, 0]}, Val]}
       instances:
-        - subprogram: {subprogram: 50}
+        - subprogram: {subprogram: 52}
           events:
             - Kind: Entry
-              Type: 586 EventRootType Probe[main.structArrayArg]
-              InjectionPoints: [{PC: "0x4ada6e", Frameless: false}]
+              Type: 595 EventRootType Probe[main.structArrayArg]
+              InjectionPoints: [{PC: "0x4adf6e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 587 EventRootType Probe[main.structArrayArg]Return
-              InjectionPoints: [{PC: "0x4adaee", Frameless: false}]
+              Type: 596 EventRootType Probe[main.structArrayArg]Return
+              InjectionPoints: [{PC: "0x4adfee", Frameless: false}]
               Condition: null
     - id: indexMember_arrayStruct_capture_string
       version: 0
@@ -2877,15 +3189,15 @@ Probes:
             dsl: s[1].Txt
             json: {getmember: [{index: [{ref: s}, 1]}, Txt]}
       instances:
-        - subprogram: {subprogram: 50}
+        - subprogram: {subprogram: 52}
           events:
             - Kind: Entry
-              Type: 588 EventRootType Probe[main.structArrayArg]
-              InjectionPoints: [{PC: "0x4ada6e", Frameless: false}]
+              Type: 597 EventRootType Probe[main.structArrayArg]
+              InjectionPoints: [{PC: "0x4adf6e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 589 EventRootType Probe[main.structArrayArg]Return
-              InjectionPoints: [{PC: "0x4adaee", Frameless: false}]
+              Type: 598 EventRootType Probe[main.structArrayArg]Return
+              InjectionPoints: [{PC: "0x4adfee", Frameless: false}]
               Condition: null
     - id: indexMember_ptrArrayStruct_capture_int
       version: 0
@@ -2901,15 +3213,15 @@ Probes:
             dsl: s[0].Val
             json: {getmember: [{index: [{ref: s}, 0]}, Val]}
       instances:
-        - subprogram: {subprogram: 52}
+        - subprogram: {subprogram: 54}
           events:
             - Kind: Entry
-              Type: 594 EventRootType Probe[main.ptrStructArrayArg]
-              InjectionPoints: [{PC: "0x4adc2e", Frameless: false}]
+              Type: 603 EventRootType Probe[main.ptrStructArrayArg]
+              InjectionPoints: [{PC: "0x4ae12e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 595 EventRootType Probe[main.ptrStructArrayArg]Return
-              InjectionPoints: [{PC: "0x4adca5", Frameless: false}]
+              Type: 604 EventRootType Probe[main.ptrStructArrayArg]Return
+              InjectionPoints: [{PC: "0x4ae1a5", Frameless: false}]
               Condition: null
     - id: indexMember_ptrArrayStruct_capture_string
       version: 0
@@ -2925,15 +3237,15 @@ Probes:
             dsl: s[1].Txt
             json: {getmember: [{index: [{ref: s}, 1]}, Txt]}
       instances:
-        - subprogram: {subprogram: 52}
+        - subprogram: {subprogram: 54}
           events:
             - Kind: Entry
-              Type: 596 EventRootType Probe[main.ptrStructArrayArg]
-              InjectionPoints: [{PC: "0x4adc2e", Frameless: false}]
+              Type: 605 EventRootType Probe[main.ptrStructArrayArg]
+              InjectionPoints: [{PC: "0x4ae12e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 597 EventRootType Probe[main.ptrStructArrayArg]Return
-              InjectionPoints: [{PC: "0x4adca5", Frameless: false}]
+              Type: 606 EventRootType Probe[main.ptrStructArrayArg]Return
+              InjectionPoints: [{PC: "0x4ae1a5", Frameless: false}]
               Condition: null
     - id: indexMember_ptrSliceStruct_capture_int
       version: 0
@@ -2949,15 +3261,15 @@ Probes:
             dsl: s[0].Val
             json: {getmember: [{index: [{ref: s}, 0]}, Val]}
       instances:
-        - subprogram: {subprogram: 51}
+        - subprogram: {subprogram: 53}
           events:
             - Kind: Entry
-              Type: 590 EventRootType Probe[main.ptrStructSliceArg]
-              InjectionPoints: [{PC: "0x4adb2e", Frameless: false}]
+              Type: 599 EventRootType Probe[main.ptrStructSliceArg]
+              InjectionPoints: [{PC: "0x4ae02e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 591 EventRootType Probe[main.ptrStructSliceArg]Return
-              InjectionPoints: [{PC: "0x4adbb6", Frameless: false}]
+              Type: 600 EventRootType Probe[main.ptrStructSliceArg]Return
+              InjectionPoints: [{PC: "0x4ae0b6", Frameless: false}]
               Condition: null
     - id: indexMember_ptrSliceStruct_capture_string
       version: 0
@@ -2973,15 +3285,15 @@ Probes:
             dsl: s[1].Txt
             json: {getmember: [{index: [{ref: s}, 1]}, Txt]}
       instances:
-        - subprogram: {subprogram: 51}
+        - subprogram: {subprogram: 53}
           events:
             - Kind: Entry
-              Type: 592 EventRootType Probe[main.ptrStructSliceArg]
-              InjectionPoints: [{PC: "0x4adb2e", Frameless: false}]
+              Type: 601 EventRootType Probe[main.ptrStructSliceArg]
+              InjectionPoints: [{PC: "0x4ae02e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 593 EventRootType Probe[main.ptrStructSliceArg]Return
-              InjectionPoints: [{PC: "0x4adbb6", Frameless: false}]
+              Type: 602 EventRootType Probe[main.ptrStructSliceArg]Return
+              InjectionPoints: [{PC: "0x4ae0b6", Frameless: false}]
               Condition: null
     - id: indexMember_sliceStruct_capture_int
       version: 0
@@ -2997,15 +3309,15 @@ Probes:
             dsl: s[0].Val
             json: {getmember: [{index: [{ref: s}, 0]}, Val]}
       instances:
-        - subprogram: {subprogram: 49}
+        - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 578 EventRootType Probe[main.structSliceArg]
-              InjectionPoints: [{PC: "0x4ad98e", Frameless: false}]
+              Type: 587 EventRootType Probe[main.structSliceArg]
+              InjectionPoints: [{PC: "0x4ade8e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 579 EventRootType Probe[main.structSliceArg]Return
-              InjectionPoints: [{PC: "0x4ada0f", Frameless: false}]
+              Type: 588 EventRootType Probe[main.structSliceArg]Return
+              InjectionPoints: [{PC: "0x4adf0f", Frameless: false}]
               Condition: null
     - id: indexMember_sliceStruct_capture_string
       version: 0
@@ -3021,15 +3333,15 @@ Probes:
             dsl: s[1].Txt
             json: {getmember: [{index: [{ref: s}, 1]}, Txt]}
       instances:
-        - subprogram: {subprogram: 49}
+        - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 580 EventRootType Probe[main.structSliceArg]
-              InjectionPoints: [{PC: "0x4ad98e", Frameless: false}]
+              Type: 589 EventRootType Probe[main.structSliceArg]
+              InjectionPoints: [{PC: "0x4ade8e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 581 EventRootType Probe[main.structSliceArg]Return
-              InjectionPoints: [{PC: "0x4ada0f", Frameless: false}]
+              Type: 590 EventRootType Probe[main.structSliceArg]Return
+              InjectionPoints: [{PC: "0x4adf0f", Frameless: false}]
               Condition: null
     - id: indexMember_sliceStruct_cond
       version: 0
@@ -3044,16 +3356,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 49}
+        - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 582 EventRootType Probe[main.structSliceArg]
-              InjectionPoints: [{PC: "0x4ad98e", Frameless: false}]
+              Type: 591 EventRootType Probe[main.structSliceArg]
+              InjectionPoints: [{PC: "0x4ade8e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 49, index: 0, name: s}
+                      Variable: {subprogram: 51, index: 0, name: s}
                       Offset: 0
                       ByteSize: 16
                     - __kind: SliceBoundsCheckOp
@@ -3069,8 +3381,8 @@ Probes:
                       ByteSize: 4
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 583 EventRootType Probe[main.structSliceArg]Return
-              InjectionPoints: [{PC: "0x4ada0f", Frameless: false}]
+              Type: 592 EventRootType Probe[main.structSliceArg]Return
+              InjectionPoints: [{PC: "0x4adf0f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -3092,15 +3404,15 @@ Probes:
           dsl: s[0].Val
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 49}
+        - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 584 EventRootType Probe[main.structSliceArg]
-              InjectionPoints: [{PC: "0x4ad98e", Frameless: false}]
+              Type: 593 EventRootType Probe[main.structSliceArg]
+              InjectionPoints: [{PC: "0x4ade8e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 585 EventRootType Probe[main.structSliceArg]Return
-              InjectionPoints: [{PC: "0x4ada0f", Frameless: false}]
+              Type: 594 EventRootType Probe[main.structSliceArg]Return
+              InjectionPoints: [{PC: "0x4adf0f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: s[0].Val={s[0].Val}
@@ -3127,15 +3439,15 @@ Probes:
             json:
                 getmember: [{index: [{getmember: [{ref: s}, Arr]}, 0]}, Val]
       instances:
-        - subprogram: {subprogram: 53}
+        - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 598 EventRootType Probe[main.indexMemberWrapperArg]
-              InjectionPoints: [{PC: "0x4adcee", Frameless: false}]
+              Type: 607 EventRootType Probe[main.indexMemberWrapperArg]
+              InjectionPoints: [{PC: "0x4ae1ee", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 599 EventRootType Probe[main.indexMemberWrapperArg]Return
-              InjectionPoints: [{PC: "0x4add96", Frameless: false}]
+              Type: 608 EventRootType Probe[main.indexMemberWrapperArg]Return
+              InjectionPoints: [{PC: "0x4ae296", Frameless: false}]
               Condition: null
     - id: indexMember_wrapper_arr_capture_1
       version: 0
@@ -3152,15 +3464,15 @@ Probes:
             json:
                 getmember: [{index: [{getmember: [{ref: s}, Arr]}, 1]}, Txt]
       instances:
-        - subprogram: {subprogram: 53}
+        - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 600 EventRootType Probe[main.indexMemberWrapperArg]
-              InjectionPoints: [{PC: "0x4adcee", Frameless: false}]
+              Type: 609 EventRootType Probe[main.indexMemberWrapperArg]
+              InjectionPoints: [{PC: "0x4ae1ee", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 601 EventRootType Probe[main.indexMemberWrapperArg]Return
-              InjectionPoints: [{PC: "0x4add96", Frameless: false}]
+              Type: 610 EventRootType Probe[main.indexMemberWrapperArg]Return
+              InjectionPoints: [{PC: "0x4ae296", Frameless: false}]
               Condition: null
     - id: indexMember_wrapper_ptrArr_capture
       version: 0
@@ -3177,15 +3489,15 @@ Probes:
             json:
                 getmember: [{index: [{getmember: [{ref: s}, PtrArr]}, 0]}, Val]
       instances:
-        - subprogram: {subprogram: 53}
+        - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 602 EventRootType Probe[main.indexMemberWrapperArg]
-              InjectionPoints: [{PC: "0x4adcee", Frameless: false}]
+              Type: 611 EventRootType Probe[main.indexMemberWrapperArg]
+              InjectionPoints: [{PC: "0x4ae1ee", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 603 EventRootType Probe[main.indexMemberWrapperArg]Return
-              InjectionPoints: [{PC: "0x4add96", Frameless: false}]
+              Type: 612 EventRootType Probe[main.indexMemberWrapperArg]Return
+              InjectionPoints: [{PC: "0x4ae296", Frameless: false}]
               Condition: null
     - id: indexMember_wrapper_ptrArr_capture_1
       version: 0
@@ -3202,15 +3514,15 @@ Probes:
             json:
                 getmember: [{index: [{getmember: [{ref: s}, PtrArr]}, 1]}, Txt]
       instances:
-        - subprogram: {subprogram: 53}
+        - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 604 EventRootType Probe[main.indexMemberWrapperArg]
-              InjectionPoints: [{PC: "0x4adcee", Frameless: false}]
+              Type: 613 EventRootType Probe[main.indexMemberWrapperArg]
+              InjectionPoints: [{PC: "0x4ae1ee", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 605 EventRootType Probe[main.indexMemberWrapperArg]Return
-              InjectionPoints: [{PC: "0x4add96", Frameless: false}]
+              Type: 614 EventRootType Probe[main.indexMemberWrapperArg]Return
+              InjectionPoints: [{PC: "0x4ae296", Frameless: false}]
               Condition: null
     - id: indexNilPtr_capture
       version: 0
@@ -3226,15 +3538,15 @@ Probes:
             dsl: x.Items[0]
             json: {index: [{getmember: [{ref: x}, Items]}, 0]}
       instances:
-        - subprogram: {subprogram: 45}
+        - subprogram: {subprogram: 47}
           events:
             - Kind: Entry
-              Type: 564 EventRootType Probe[main.indexNilPtrSlice]
-              InjectionPoints: [{PC: "0x4ad58e", Frameless: false}]
+              Type: 573 EventRootType Probe[main.indexNilPtrSlice]
+              InjectionPoints: [{PC: "0x4ada8e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 565 EventRootType Probe[main.indexNilPtrSlice]Return
-              InjectionPoints: [{PC: "0x4ad60e", Frameless: false}]
+              Type: 574 EventRootType Probe[main.indexNilPtrSlice]Return
+              InjectionPoints: [{PC: "0x4adb0e", Frameless: false}]
               Condition: null
     - id: indexNilPtr_cond
       version: 0
@@ -3249,16 +3561,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 45}
+        - subprogram: {subprogram: 47}
           events:
             - Kind: Entry
-              Type: 566 EventRootType Probe[main.indexNilPtrSlice]
-              InjectionPoints: [{PC: "0x4ad58e", Frameless: false}]
+              Type: 575 EventRootType Probe[main.indexNilPtrSlice]
+              InjectionPoints: [{PC: "0x4ada8e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 45, index: 0, name: x}
+                      Variable: {subprogram: 47, index: 0, name: x}
                       Offset: 0
                       ByteSize: 8
                     - __kind: DereferenceOp
@@ -3277,8 +3589,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 567 EventRootType Probe[main.indexNilPtrSlice]Return
-              InjectionPoints: [{PC: "0x4ad60e", Frameless: false}]
+              Type: 576 EventRootType Probe[main.indexNilPtrSlice]Return
+              InjectionPoints: [{PC: "0x4adb0e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -3300,15 +3612,15 @@ Probes:
           dsl: x.Items[0]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 45}
+        - subprogram: {subprogram: 47}
           events:
             - Kind: Entry
-              Type: 568 EventRootType Probe[main.indexNilPtrSlice]
-              InjectionPoints: [{PC: "0x4ad58e", Frameless: false}]
+              Type: 577 EventRootType Probe[main.indexNilPtrSlice]
+              InjectionPoints: [{PC: "0x4ada8e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 569 EventRootType Probe[main.indexNilPtrSlice]Return
-              InjectionPoints: [{PC: "0x4ad60e", Frameless: false}]
+              Type: 578 EventRootType Probe[main.indexNilPtrSlice]Return
+              InjectionPoints: [{PC: "0x4adb0e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 'items[0]: {x.Items[0]}'
@@ -3334,15 +3646,15 @@ Probes:
             dsl: x.Items[0]
             json: {index: [{getmember: [{ref: x}, Items]}, 0]}
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 546 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0x4ad173", Frameless: false}]
+              Type: 555 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0x4ad673", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 547 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0x4ad2bc", Frameless: false}]
+              Type: 556 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0x4ad7bc", Frameless: false}]
               Condition: null
     - id: indexStringArray_capture
       version: 0
@@ -3360,11 +3672,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 352 EventRootType Probe[main.stringArrayArg]
-              InjectionPoints: [{PC: "0x4ab02a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab26a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 353 EventRootType Probe[main.stringArrayArg]Return
-              InjectionPoints: [{PC: "0x4ab076", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab2b6", Frameless: false}]
               Condition: null
     - id: indexStringSlice_capture
       version: 0
@@ -3382,11 +3694,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 348 EventRootType Probe[main.stringSliceArg]
-              InjectionPoints: [{PC: "0x4aafaa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab1ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 349 EventRootType Probe[main.stringSliceArg]Return
-              InjectionPoints: [{PC: "0x4aafef", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab22f", Frameless: false}]
               Condition: null
     - id: indexStructSliceField_capture
       version: 0
@@ -3402,15 +3714,15 @@ Probes:
             dsl: x.Items[2]
             json: {index: [{getmember: [{ref: x}, Items]}, 2]}
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 526 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4acf93", Frameless: false}]
+              Type: 535 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4ad493", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 527 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4ad128", Frameless: false}]
+              Type: 536 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4ad628", Frameless: false}]
               Condition: null
     - id: inlined
       version: 0
@@ -3421,19 +3733,19 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 75}
+        - subprogram: {subprogram: 77}
           events:
             - Kind: Entry
-              Type: 658 EventRootType Probe[main.inlined]
+              Type: 667 EventRootType Probe[main.inlined]
               InjectionPoints:
                 - PC: "0x4a8a7b"
                   Frameless: false
-                - PC: "0x4ab0ca"
+                - PC: "0x4ab30a"
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 659 EventRootType Probe[main.inlined]Return
-              InjectionPoints: [{PC: "0x4ab10a", Frameless: false}]
+              Type: 668 EventRootType Probe[main.inlined]Return
+              InjectionPoints: [{PC: "0x4ab34a", Frameless: false}]
               Condition: null
     - id: inlinedMethod
       version: 0
@@ -3443,11 +3755,11 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 78}
+        - subprogram: {subprogram: 80}
           events:
             - Kind: Entry
-              Type: 662 EventRootType Probe[main.(*methodValueReceiver).inlinedMethod]
-              InjectionPoints: [{PC: "0x4ae9ed", Frameless: true}]
+              Type: 671 EventRootType Probe[main.(*methodValueReceiver).inlinedMethod]
+              InjectionPoints: [{PC: "0x4aeeed", Frameless: true}]
               Condition: null
     - id: intArg
       version: 0
@@ -3461,11 +3773,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 316 EventRootType Probe[main.intArg]
-              InjectionPoints: [{PC: "0x4aadaa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4aafea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 317 EventRootType Probe[main.intArg]Return
-              InjectionPoints: [{PC: "0x4aadea", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab02a", Frameless: false}]
               Condition: null
     - id: intArrayArg
       version: 0
@@ -3479,11 +3791,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 346 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0x4aaf2a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab16a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 347 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0x4aaf76", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab1b6", Frameless: false}]
               Condition: null
     - id: intArrayArgFrameless
       version: 0
@@ -3497,7 +3809,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 356 EventRootType Probe[main.stringArrayArgFrameless]
-              InjectionPoints: [{PC: "0x4ab0a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x4ab2e0", Frameless: true}]
               Condition: null
     - id: intSliceArg
       version: 0
@@ -3511,11 +3823,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 336 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0x4aaeaa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab0ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 337 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0x4aaeef", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab12f", Frameless: false}]
               Condition: null
     - id: lenErrInt_nocond
       version: 0
@@ -3526,15 +3838,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 43}
+        - subprogram: {subprogram: 45}
           events:
             - Kind: Entry
-              Type: 556 EventRootType Probe[main.lenErrInt]
-              InjectionPoints: [{PC: "0x4ad313", Frameless: false}]
+              Type: 565 EventRootType Probe[main.lenErrInt]
+              InjectionPoints: [{PC: "0x4ad813", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 557 EventRootType Probe[main.lenErrInt]Return
-              InjectionPoints: [{PC: "0x4ad3fc", Frameless: false}]
+              Type: 566 EventRootType Probe[main.lenErrInt]Return
+              InjectionPoints: [{PC: "0x4ad8fc", Frameless: false}]
               Condition: null
     - id: lenErrStruct_nocond
       version: 0
@@ -3545,15 +3857,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 44}
+        - subprogram: {subprogram: 46}
           events:
             - Kind: Entry
-              Type: 560 EventRootType Probe[main.lenErrStruct]
-              InjectionPoints: [{PC: "0x4ad453", Frameless: false}]
+              Type: 569 EventRootType Probe[main.lenErrStruct]
+              InjectionPoints: [{PC: "0x4ad953", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 561 EventRootType Probe[main.lenErrStruct]Return
-              InjectionPoints: [{PC: "0x4ad556", Frameless: false}]
+              Type: 570 EventRootType Probe[main.lenErrStruct]Return
+              InjectionPoints: [{PC: "0x4ada56", Frameless: false}]
               Condition: null
     - id: lenErr_int
       version: 0
@@ -3564,15 +3876,15 @@ Probes:
       segments: [len=, {json: {len: {ref: x}}, dsl: len(x)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 43}
+        - subprogram: {subprogram: 45}
           events:
             - Kind: Entry
-              Type: 558 EventRootType Probe[main.lenErrInt]
-              InjectionPoints: [{PC: "0x4ad313", Frameless: false}]
+              Type: 567 EventRootType Probe[main.lenErrInt]
+              InjectionPoints: [{PC: "0x4ad813", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 559 EventRootType Probe[main.lenErrInt]Return
-              InjectionPoints: [{PC: "0x4ad3fc", Frameless: false}]
+              Type: 568 EventRootType Probe[main.lenErrInt]Return
+              InjectionPoints: [{PC: "0x4ad8fc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x)}
@@ -3589,15 +3901,15 @@ Probes:
       segments: [len=, {json: {len: {ref: x}}, dsl: len(x)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 44}
+        - subprogram: {subprogram: 46}
           events:
             - Kind: Entry
-              Type: 562 EventRootType Probe[main.lenErrStruct]
-              InjectionPoints: [{PC: "0x4ad453", Frameless: false}]
+              Type: 571 EventRootType Probe[main.lenErrStruct]
+              InjectionPoints: [{PC: "0x4ad953", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 563 EventRootType Probe[main.lenErrStruct]Return
-              InjectionPoints: [{PC: "0x4ad556", Frameless: false}]
+              Type: 572 EventRootType Probe[main.lenErrStruct]Return
+              InjectionPoints: [{PC: "0x4ada56", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x)}
@@ -3615,16 +3927,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 510 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0x4acd2e", Frameless: false}]
+              Type: 519 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0x4ad22e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 39, index: 0, name: m}
+                      Variable: {subprogram: 41, index: 0, name: m}
                       Offset: 0
                       ByteSize: 8
                     - __kind: DereferenceOp
@@ -3638,8 +3950,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 511 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0x4ace1c", Frameless: false}]
+              Type: 520 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0x4ad31c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -3661,15 +3973,15 @@ Probes:
           dsl: isEmpty(m)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 512 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0x4acd2e", Frameless: false}]
+              Type: 521 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0x4ad22e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 513 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0x4ace1c", Frameless: false}]
+              Type: 522 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0x4ad31c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: empty={isEmpty(m)}
@@ -3691,15 +4003,15 @@ Probes:
         - name: m_len
           expr: {dsl: len(m), json: {len: {ref: m}}}
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 514 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0x4acd2e", Frameless: false}]
+              Type: 523 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0x4ad22e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 515 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0x4ace1c", Frameless: false}]
+              Type: 524 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0x4ad31c", Frameless: false}]
               Condition: null
     - id: lenMap_len_eq_cond
       version: 0
@@ -3713,16 +4025,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 516 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0x4acd2e", Frameless: false}]
+              Type: 525 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0x4ad22e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 39, index: 0, name: m}
+                      Variable: {subprogram: 41, index: 0, name: m}
                       Offset: 0
                       ByteSize: 8
                     - __kind: DereferenceOp
@@ -3736,8 +4048,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 517 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0x4ace1c", Frameless: false}]
+              Type: 526 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0x4ad31c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -3756,15 +4068,15 @@ Probes:
       segments: [len=, {json: {len: {ref: m}}, dsl: len(m)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 518 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0x4acd2e", Frameless: false}]
+              Type: 527 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0x4ad22e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 519 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0x4ace1c", Frameless: false}]
+              Type: 528 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0x4ad31c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(m)}
@@ -3783,15 +4095,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 520 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0x4acd2e", Frameless: false}]
+              Type: 529 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0x4ad22e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 521 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0x4ace1c", Frameless: false}]
+              Type: 530 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0x4ad31c", Frameless: false}]
               Condition: null
     - id: lenPtrString_len_template
       version: 0
@@ -3802,15 +4114,15 @@ Probes:
       segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 40}
+        - subprogram: {subprogram: 42}
           events:
             - Kind: Entry
-              Type: 522 EventRootType Probe[main.lenPtrString]
-              InjectionPoints: [{PC: "0x4ace6e", Frameless: false}]
+              Type: 531 EventRootType Probe[main.lenPtrString]
+              InjectionPoints: [{PC: "0x4ad36e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 523 EventRootType Probe[main.lenPtrString]Return
-              InjectionPoints: [{PC: "0x4acf45", Frameless: false}]
+              Type: 532 EventRootType Probe[main.lenPtrString]Return
+              InjectionPoints: [{PC: "0x4ad445", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(s)}
@@ -3829,15 +4141,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 40}
+        - subprogram: {subprogram: 42}
           events:
             - Kind: Entry
-              Type: 524 EventRootType Probe[main.lenPtrString]
-              InjectionPoints: [{PC: "0x4ace6e", Frameless: false}]
+              Type: 533 EventRootType Probe[main.lenPtrString]
+              InjectionPoints: [{PC: "0x4ad36e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 525 EventRootType Probe[main.lenPtrString]Return
-              InjectionPoints: [{PC: "0x4acf45", Frameless: false}]
+              Type: 534 EventRootType Probe[main.lenPtrString]Return
+              InjectionPoints: [{PC: "0x4ad445", Frameless: false}]
               Condition: null
     - id: lenPtrStructFields_nocond
       version: 0
@@ -3848,15 +4160,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 548 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0x4ad173", Frameless: false}]
+              Type: 557 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0x4ad673", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 549 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0x4ad2bc", Frameless: false}]
+              Type: 558 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0x4ad7bc", Frameless: false}]
               Condition: null
     - id: lenPtrStruct_field_map
       version: 0
@@ -3870,15 +4182,15 @@ Probes:
           dsl: len(x.Dict)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 550 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0x4ad173", Frameless: false}]
+              Type: 559 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0x4ad673", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 551 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0x4ad2bc", Frameless: false}]
+              Type: 560 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0x4ad7bc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.Dict)}
@@ -3900,15 +4212,15 @@ Probes:
           dsl: len(x.Items)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 552 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0x4ad173", Frameless: false}]
+              Type: 561 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0x4ad673", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 553 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0x4ad2bc", Frameless: false}]
+              Type: 562 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0x4ad7bc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.Items)}
@@ -3930,15 +4242,15 @@ Probes:
           dsl: len(x.S)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 554 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0x4ad173", Frameless: false}]
+              Type: 563 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0x4ad673", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 555 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0x4ad2bc", Frameless: false}]
+              Type: 564 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0x4ad7bc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.S)}
@@ -3958,16 +4270,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 498 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0x4acbd3", Frameless: false}]
+              Type: 507 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0x4ad0d3", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 38, index: 0, name: s}
+                      Variable: {subprogram: 40, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -3978,8 +4290,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 499 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0x4accd6", Frameless: false}]
+              Type: 508 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0x4ad1d6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4001,15 +4313,15 @@ Probes:
           dsl: isEmpty(s)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 500 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0x4acbd3", Frameless: false}]
+              Type: 509 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0x4ad0d3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 501 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0x4accd6", Frameless: false}]
+              Type: 510 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0x4ad1d6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: empty={isEmpty(s)}
@@ -4031,15 +4343,15 @@ Probes:
         - name: s_len
           expr: {dsl: len(s), json: {len: {ref: s}}}
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 502 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0x4acbd3", Frameless: false}]
+              Type: 511 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0x4ad0d3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 503 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0x4accd6", Frameless: false}]
+              Type: 512 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0x4ad1d6", Frameless: false}]
               Condition: null
     - id: lenSlice_len_eq_cond
       version: 0
@@ -4053,16 +4365,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 504 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0x4acbd3", Frameless: false}]
+              Type: 513 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0x4ad0d3", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 38, index: 0, name: s}
+                      Variable: {subprogram: 40, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4073,8 +4385,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 505 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0x4accd6", Frameless: false}]
+              Type: 514 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0x4ad1d6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4093,15 +4405,15 @@ Probes:
       segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 506 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0x4acbd3", Frameless: false}]
+              Type: 515 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0x4ad0d3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 507 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0x4accd6", Frameless: false}]
+              Type: 516 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0x4ad1d6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(s)}
@@ -4120,15 +4432,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 508 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0x4acbd3", Frameless: false}]
+              Type: 517 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0x4ad0d3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 509 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0x4accd6", Frameless: false}]
+              Type: 518 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0x4ad1d6", Frameless: false}]
               Condition: null
     - id: lenString_eq_capture
       version: 0
@@ -4144,15 +4456,15 @@ Probes:
             dsl: len(s) == 5
             json: {eq: [{len: {ref: s}}, 5]}
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 480 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4aca73", Frameless: false}]
+              Type: 489 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4acf73", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 481 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4acb65", Frameless: false}]
+              Type: 490 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4ad065", Frameless: false}]
               Condition: null
     - id: lenString_eq_template
       version: 0
@@ -4166,15 +4478,15 @@ Probes:
           dsl: len(s) == 5
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 482 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4aca73", Frameless: false}]
+              Type: 491 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4acf73", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 483 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4acb65", Frameless: false}]
+              Type: 492 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4ad065", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: eq={len(s) == 5}
@@ -4196,15 +4508,15 @@ Probes:
         - name: s_isEmpty
           expr: {dsl: isEmpty(s), json: {isEmpty: {ref: s}}}
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 484 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4aca73", Frameless: false}]
+              Type: 493 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4acf73", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 485 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4acb65", Frameless: false}]
+              Type: 494 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4ad065", Frameless: false}]
               Condition: null
     - id: lenString_isEmpty_cond
       version: 0
@@ -4216,16 +4528,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 486 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4aca73", Frameless: false}]
+              Type: 495 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4acf73", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 37, index: 0, name: s}
+                      Variable: {subprogram: 39, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4236,8 +4548,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 487 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4acb65", Frameless: false}]
+              Type: 496 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4ad065", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4259,15 +4571,15 @@ Probes:
           dsl: isEmpty(s)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 488 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4aca73", Frameless: false}]
+              Type: 497 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4acf73", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 489 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4acb65", Frameless: false}]
+              Type: 498 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4ad065", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: empty={isEmpty(s)}
@@ -4289,15 +4601,15 @@ Probes:
         - name: s_len
           expr: {dsl: len(s), json: {len: {ref: s}}}
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 490 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4aca73", Frameless: false}]
+              Type: 499 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4acf73", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 491 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4acb65", Frameless: false}]
+              Type: 500 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4ad065", Frameless: false}]
               Condition: null
     - id: lenString_len_eq_cond
       version: 0
@@ -4311,16 +4623,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 492 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4aca73", Frameless: false}]
+              Type: 501 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4acf73", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 37, index: 0, name: s}
+                      Variable: {subprogram: 39, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4331,8 +4643,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 493 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4acb65", Frameless: false}]
+              Type: 502 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4ad065", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4351,15 +4663,15 @@ Probes:
       segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 494 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4aca73", Frameless: false}]
+              Type: 503 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4acf73", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 495 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4acb65", Frameless: false}]
+              Type: 504 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4ad065", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(s)}
@@ -4378,15 +4690,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 496 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4aca73", Frameless: false}]
+              Type: 505 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4acf73", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 497 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4acb65", Frameless: false}]
+              Type: 506 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4ad065", Frameless: false}]
               Condition: null
     - id: lenStructFields_nocond
       version: 0
@@ -4397,15 +4709,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 528 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4acf93", Frameless: false}]
+              Type: 537 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4ad493", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 529 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4ad128", Frameless: false}]
+              Type: 538 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4ad628", Frameless: false}]
               Condition: null
     - id: lenStruct_field_map
       version: 0
@@ -4419,15 +4731,15 @@ Probes:
           dsl: len(x.Dict)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 530 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4acf93", Frameless: false}]
+              Type: 539 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4ad493", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 531 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4ad128", Frameless: false}]
+              Type: 540 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4ad628", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.Dict)}
@@ -4449,15 +4761,15 @@ Probes:
           dsl: len(x.PtrSlice)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 532 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4acf93", Frameless: false}]
+              Type: 541 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4ad493", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 533 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4ad128", Frameless: false}]
+              Type: 542 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4ad628", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.PtrSlice)}
@@ -4479,15 +4791,15 @@ Probes:
           dsl: len(x.PtrStr)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 534 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4acf93", Frameless: false}]
+              Type: 543 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4ad493", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 535 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4ad128", Frameless: false}]
+              Type: 544 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4ad628", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.PtrStr)}
@@ -4509,15 +4821,15 @@ Probes:
           dsl: len(x.Items)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 536 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4acf93", Frameless: false}]
+              Type: 545 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4ad493", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 537 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4ad128", Frameless: false}]
+              Type: 546 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4ad628", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.Items)}
@@ -4539,15 +4851,15 @@ Probes:
           dsl: len(x.S)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 538 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4acf93", Frameless: false}]
+              Type: 547 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4ad493", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 539 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4ad128", Frameless: false}]
+              Type: 548 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4ad628", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.S)}
@@ -4569,16 +4881,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 540 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4acf93", Frameless: false}]
+              Type: 549 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4ad493", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 41, index: 0, name: x}
+                      Variable: {subprogram: 43, index: 0, name: x}
                       Offset: 40
                       ByteSize: 8
                     - __kind: DereferenceOp
@@ -4592,8 +4904,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 541 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4ad128", Frameless: false}]
+              Type: 550 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4ad628", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4615,16 +4927,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 542 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4acf93", Frameless: false}]
+              Type: 551 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4ad493", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 41, index: 0, name: x}
+                      Variable: {subprogram: 43, index: 0, name: x}
                       Offset: 24
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4635,8 +4947,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 543 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4ad128", Frameless: false}]
+              Type: 552 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4ad628", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4658,16 +4970,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 544 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4acf93", Frameless: false}]
+              Type: 553 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4ad493", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 41, index: 0, name: x}
+                      Variable: {subprogram: 43, index: 0, name: x}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4678,8 +4990,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 545 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4ad128", Frameless: false}]
+              Type: 554 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4ad628", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4701,11 +5013,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 318 EventRootType Probe[main.stringArg]
-              InjectionPoints: [{PC: "0x4aae2a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab06a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 319 EventRootType Probe[main.stringArg]Return
-              InjectionPoints: [{PC: "0x4aae6f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab0af", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's: {s}'
@@ -4727,11 +5039,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 320 EventRootType Probe[main.stringArg]
-              InjectionPoints: [{PC: "0x4aae2a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab06a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 321 EventRootType Probe[main.stringArg]Return
-              InjectionPoints: [{PC: "0x4aae6f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab0af", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 'x: {x}'
@@ -4751,11 +5063,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 357 EventRootType Probe[main.mapArg]
-              InjectionPoints: [{PC: "0x4ab18a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab3ca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 358 EventRootType Probe[main.mapArg]Return
-              InjectionPoints: [{PC: "0x4ab1bf", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab3ff", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 'm: {m}'
@@ -4780,15 +5092,15 @@ Probes:
         - name: false_val
           expr: {dsl: 'm[false]', json: {index: [{ref: m}, false]}}
       instances:
-        - subprogram: {subprogram: 68}
+        - subprogram: {subprogram: 70}
           events:
             - Kind: Entry
-              Type: 642 EventRootType Probe[main.mapIndexBoolKey]
-              InjectionPoints: [{PC: "0x4ae5ca", Frameless: false}]
+              Type: 651 EventRootType Probe[main.mapIndexBoolKey]
+              InjectionPoints: [{PC: "0x4aeaca", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 643 EventRootType Probe[main.mapIndexBoolKey]Return
-              InjectionPoints: [{PC: "0x4ae5ff", Frameless: false}]
+              Type: 652 EventRootType Probe[main.mapIndexBoolKey]Return
+              InjectionPoints: [{PC: "0x4aeaff", Frameless: false}]
               Condition: null
     - id: mapIndex_boolKey_true
       version: 0
@@ -4805,15 +5117,15 @@ Probes:
         - name: true_val
           expr: {dsl: 'm[true]', json: {index: [{ref: m}, true]}}
       instances:
-        - subprogram: {subprogram: 68}
+        - subprogram: {subprogram: 70}
           events:
             - Kind: Entry
-              Type: 644 EventRootType Probe[main.mapIndexBoolKey]
-              InjectionPoints: [{PC: "0x4ae5ca", Frameless: false}]
+              Type: 653 EventRootType Probe[main.mapIndexBoolKey]
+              InjectionPoints: [{PC: "0x4aeaca", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 645 EventRootType Probe[main.mapIndexBoolKey]Return
-              InjectionPoints: [{PC: "0x4ae5ff", Frameless: false}]
+              Type: 654 EventRootType Probe[main.mapIndexBoolKey]Return
+              InjectionPoints: [{PC: "0x4aeaff", Frameless: false}]
               Condition: null
     - id: mapIndex_emptyKey_capture
       version: 0
@@ -4830,15 +5142,15 @@ Probes:
         - name: empty_val
           expr: {dsl: 'm[""]', json: {index: [{ref: m}, ""]}}
       instances:
-        - subprogram: {subprogram: 65}
+        - subprogram: {subprogram: 67}
           events:
             - Kind: Entry
-              Type: 636 EventRootType Probe[main.mapIndexEmptyKey]
-              InjectionPoints: [{PC: "0x4ae44a", Frameless: false}]
+              Type: 645 EventRootType Probe[main.mapIndexEmptyKey]
+              InjectionPoints: [{PC: "0x4ae94a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 637 EventRootType Probe[main.mapIndexEmptyKey]Return
-              InjectionPoints: [{PC: "0x4ae4a5", Frameless: false}]
+              Type: 646 EventRootType Probe[main.mapIndexEmptyKey]Return
+              InjectionPoints: [{PC: "0x4ae9a5", Frameless: false}]
               Condition: null
     - id: mapIndex_intKey_capture
       version: 0
@@ -4855,15 +5167,15 @@ Probes:
         - name: m_2
           expr: {dsl: 'm[2]', json: {index: [{ref: m}, 2]}}
       instances:
-        - subprogram: {subprogram: 54}
+        - subprogram: {subprogram: 56}
           events:
             - Kind: Entry
-              Type: 606 EventRootType Probe[main.mapIndexIntKey]
-              InjectionPoints: [{PC: "0x4addea", Frameless: false}]
+              Type: 615 EventRootType Probe[main.mapIndexIntKey]
+              InjectionPoints: [{PC: "0x4ae2ea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 607 EventRootType Probe[main.mapIndexIntKey]Return
-              InjectionPoints: [{PC: "0x4ade1f", Frameless: false}]
+              Type: 616 EventRootType Probe[main.mapIndexIntKey]Return
+              InjectionPoints: [{PC: "0x4ae31f", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen16
       version: 0
@@ -4882,15 +5194,15 @@ Probes:
             dsl: m["000000000000002a"]
             json: {index: [{ref: m}, 000000000000002a]}
       instances:
-        - subprogram: {subprogram: 66}
+        - subprogram: {subprogram: 68}
           events:
             - Kind: Entry
-              Type: 638 EventRootType Probe[main.mapIndexKeyLen16]
-              InjectionPoints: [{PC: "0x4ae4ca", Frameless: false}]
+              Type: 647 EventRootType Probe[main.mapIndexKeyLen16]
+              InjectionPoints: [{PC: "0x4ae9ca", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 639 EventRootType Probe[main.mapIndexKeyLen16]Return
-              InjectionPoints: [{PC: "0x4ae519", Frameless: false}]
+              Type: 648 EventRootType Probe[main.mapIndexKeyLen16]Return
+              InjectionPoints: [{PC: "0x4aea19", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen17
       version: 0
@@ -4909,15 +5221,15 @@ Probes:
             dsl: m["0000000000000002a"]
             json: {index: [{ref: m}, 0000000000000002a]}
       instances:
-        - subprogram: {subprogram: 67}
+        - subprogram: {subprogram: 69}
           events:
             - Kind: Entry
-              Type: 640 EventRootType Probe[main.mapIndexKeyLen17]
-              InjectionPoints: [{PC: "0x4ae54a", Frameless: false}]
+              Type: 649 EventRootType Probe[main.mapIndexKeyLen17]
+              InjectionPoints: [{PC: "0x4aea4a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 641 EventRootType Probe[main.mapIndexKeyLen17]Return
-              InjectionPoints: [{PC: "0x4ae599", Frameless: false}]
+              Type: 650 EventRootType Probe[main.mapIndexKeyLen17]Return
+              InjectionPoints: [{PC: "0x4aea99", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen200
       version: 0
@@ -4939,15 +5251,15 @@ Probes:
                     - ref: m
                     - 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002a
       instances:
-        - subprogram: {subprogram: 62}
+        - subprogram: {subprogram: 64}
           events:
             - Kind: Entry
-              Type: 626 EventRootType Probe[main.mapIndexKeyLen200]
-              InjectionPoints: [{PC: "0x4ae2aa", Frameless: false}]
+              Type: 635 EventRootType Probe[main.mapIndexKeyLen200]
+              InjectionPoints: [{PC: "0x4ae7aa", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 627 EventRootType Probe[main.mapIndexKeyLen200]Return
-              InjectionPoints: [{PC: "0x4ae2f9", Frameless: false}]
+              Type: 636 EventRootType Probe[main.mapIndexKeyLen200]Return
+              InjectionPoints: [{PC: "0x4ae7f9", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen24
       version: 0
@@ -4966,15 +5278,15 @@ Probes:
             dsl: m["00000000000000000000002a"]
             json: {index: [{ref: m}, 00000000000000000000002a]}
       instances:
-        - subprogram: {subprogram: 59}
+        - subprogram: {subprogram: 61}
           events:
             - Kind: Entry
-              Type: 620 EventRootType Probe[main.mapIndexKeyLen24]
-              InjectionPoints: [{PC: "0x4ae12a", Frameless: false}]
+              Type: 629 EventRootType Probe[main.mapIndexKeyLen24]
+              InjectionPoints: [{PC: "0x4ae62a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 621 EventRootType Probe[main.mapIndexKeyLen24]Return
-              InjectionPoints: [{PC: "0x4ae179", Frameless: false}]
+              Type: 630 EventRootType Probe[main.mapIndexKeyLen24]Return
+              InjectionPoints: [{PC: "0x4ae679", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen48
       version: 0
@@ -4996,15 +5308,15 @@ Probes:
                     - ref: m
                     - 00000000000000000000000000000000000000000000002a
       instances:
-        - subprogram: {subprogram: 60}
+        - subprogram: {subprogram: 62}
           events:
             - Kind: Entry
-              Type: 622 EventRootType Probe[main.mapIndexKeyLen48]
-              InjectionPoints: [{PC: "0x4ae1aa", Frameless: false}]
+              Type: 631 EventRootType Probe[main.mapIndexKeyLen48]
+              InjectionPoints: [{PC: "0x4ae6aa", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 623 EventRootType Probe[main.mapIndexKeyLen48]Return
-              InjectionPoints: [{PC: "0x4ae1f9", Frameless: false}]
+              Type: 632 EventRootType Probe[main.mapIndexKeyLen48]Return
+              InjectionPoints: [{PC: "0x4ae6f9", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen8
       version: 0
@@ -5023,15 +5335,15 @@ Probes:
             dsl: m["0000002a"]
             json: {index: [{ref: m}, 0000002a]}
       instances:
-        - subprogram: {subprogram: 58}
+        - subprogram: {subprogram: 60}
           events:
             - Kind: Entry
-              Type: 618 EventRootType Probe[main.mapIndexKeyLen8]
-              InjectionPoints: [{PC: "0x4ae0aa", Frameless: false}]
+              Type: 627 EventRootType Probe[main.mapIndexKeyLen8]
+              InjectionPoints: [{PC: "0x4ae5aa", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 619 EventRootType Probe[main.mapIndexKeyLen8]Return
-              InjectionPoints: [{PC: "0x4ae0f9", Frameless: false}]
+              Type: 628 EventRootType Probe[main.mapIndexKeyLen8]Return
+              InjectionPoints: [{PC: "0x4ae5f9", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen96
       version: 0
@@ -5053,15 +5365,15 @@ Probes:
                     - ref: m
                     - 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002a
       instances:
-        - subprogram: {subprogram: 61}
+        - subprogram: {subprogram: 63}
           events:
             - Kind: Entry
-              Type: 624 EventRootType Probe[main.mapIndexKeyLen96]
-              InjectionPoints: [{PC: "0x4ae22a", Frameless: false}]
+              Type: 633 EventRootType Probe[main.mapIndexKeyLen96]
+              InjectionPoints: [{PC: "0x4ae72a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 625 EventRootType Probe[main.mapIndexKeyLen96]Return
-              InjectionPoints: [{PC: "0x4ae279", Frameless: false}]
+              Type: 634 EventRootType Probe[main.mapIndexKeyLen96]Return
+              InjectionPoints: [{PC: "0x4ae779", Frameless: false}]
               Condition: null
     - id: mapIndex_largeMap_capture
       version: 0
@@ -5080,15 +5392,15 @@ Probes:
             dsl: m["key42"]
             json: {index: [{ref: m}, key42]}
       instances:
-        - subprogram: {subprogram: 56}
+        - subprogram: {subprogram: 58}
           events:
             - Kind: Entry
-              Type: 614 EventRootType Probe[main.mapIndexLargeMap]
-              InjectionPoints: [{PC: "0x4adeaa", Frameless: false}]
+              Type: 623 EventRootType Probe[main.mapIndexLargeMap]
+              InjectionPoints: [{PC: "0x4ae3aa", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 615 EventRootType Probe[main.mapIndexLargeMap]Return
-              InjectionPoints: [{PC: "0x4adef9", Frameless: false}]
+              Type: 624 EventRootType Probe[main.mapIndexLargeMap]Return
+              InjectionPoints: [{PC: "0x4ae3f9", Frameless: false}]
               Condition: null
     - id: mapIndex_largeValue_capture
       version: 0
@@ -5107,15 +5419,15 @@ Probes:
             dsl: m["k"].Val
             json: {getmember: [{index: [{ref: m}, k]}, Val]}
       instances:
-        - subprogram: {subprogram: 71}
+        - subprogram: {subprogram: 73}
           events:
             - Kind: Entry
-              Type: 650 EventRootType Probe[main.mapIndexLargeValue]
-              InjectionPoints: [{PC: "0x4ae6ea", Frameless: false}]
+              Type: 659 EventRootType Probe[main.mapIndexLargeValue]
+              InjectionPoints: [{PC: "0x4aebea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 651 EventRootType Probe[main.mapIndexLargeValue]Return
-              InjectionPoints: [{PC: "0x4ae747", Frameless: false}]
+              Type: 660 EventRootType Probe[main.mapIndexLargeValue]Return
+              InjectionPoints: [{PC: "0x4aec47", Frameless: false}]
               Condition: null
     - id: mapIndex_missing_capture
       version: 0
@@ -5134,15 +5446,15 @@ Probes:
             dsl: m["missing"]
             json: {index: [{ref: m}, missing]}
       instances:
-        - subprogram: {subprogram: 57}
+        - subprogram: {subprogram: 59}
           events:
             - Kind: Entry
-              Type: 616 EventRootType Probe[main.mapIndexMissing]
-              InjectionPoints: [{PC: "0x4adf2a", Frameless: false}]
+              Type: 625 EventRootType Probe[main.mapIndexMissing]
+              InjectionPoints: [{PC: "0x4ae42a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 617 EventRootType Probe[main.mapIndexMissing]Return
-              InjectionPoints: [{PC: "0x4adf5f", Frameless: false}]
+              Type: 626 EventRootType Probe[main.mapIndexMissing]Return
+              InjectionPoints: [{PC: "0x4ae45f", Frameless: false}]
               Condition: null
     - id: mapIndex_nilPtrVal_capture
       version: 0
@@ -5161,15 +5473,15 @@ Probes:
             dsl: m["nil_key"].Val
             json: {getmember: [{index: [{ref: m}, nil_key]}, Val]}
       instances:
-        - subprogram: {subprogram: 70}
+        - subprogram: {subprogram: 72}
           events:
             - Kind: Entry
-              Type: 648 EventRootType Probe[main.mapIndexNilPtrVal]
-              InjectionPoints: [{PC: "0x4ae68a", Frameless: false}]
+              Type: 657 EventRootType Probe[main.mapIndexNilPtrVal]
+              InjectionPoints: [{PC: "0x4aeb8a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 649 EventRootType Probe[main.mapIndexNilPtrVal]Return
-              InjectionPoints: [{PC: "0x4ae6bf", Frameless: false}]
+              Type: 658 EventRootType Probe[main.mapIndexNilPtrVal]Return
+              InjectionPoints: [{PC: "0x4aebbf", Frameless: false}]
               Condition: null
     - id: mapIndex_ptrStructVal_capture_int
       version: 0
@@ -5188,15 +5500,15 @@ Probes:
             dsl: m["x"].Val
             json: {getmember: [{index: [{ref: m}, x]}, Val]}
       instances:
-        - subprogram: {subprogram: 64}
+        - subprogram: {subprogram: 66}
           events:
             - Kind: Entry
-              Type: 632 EventRootType Probe[main.mapIndexPtrStructVal]
-              InjectionPoints: [{PC: "0x4ae3aa", Frameless: false}]
+              Type: 641 EventRootType Probe[main.mapIndexPtrStructVal]
+              InjectionPoints: [{PC: "0x4ae8aa", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 633 EventRootType Probe[main.mapIndexPtrStructVal]Return
-              InjectionPoints: [{PC: "0x4ae40a", Frameless: false}]
+              Type: 642 EventRootType Probe[main.mapIndexPtrStructVal]Return
+              InjectionPoints: [{PC: "0x4ae90a", Frameless: false}]
               Condition: null
     - id: mapIndex_ptrStructVal_capture_string
       version: 0
@@ -5215,15 +5527,15 @@ Probes:
             dsl: m["y"].Txt
             json: {getmember: [{index: [{ref: m}, "y"]}, Txt]}
       instances:
-        - subprogram: {subprogram: 64}
+        - subprogram: {subprogram: 66}
           events:
             - Kind: Entry
-              Type: 634 EventRootType Probe[main.mapIndexPtrStructVal]
-              InjectionPoints: [{PC: "0x4ae3aa", Frameless: false}]
+              Type: 643 EventRootType Probe[main.mapIndexPtrStructVal]
+              InjectionPoints: [{PC: "0x4ae8aa", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 635 EventRootType Probe[main.mapIndexPtrStructVal]Return
-              InjectionPoints: [{PC: "0x4ae40a", Frameless: false}]
+              Type: 644 EventRootType Probe[main.mapIndexPtrStructVal]Return
+              InjectionPoints: [{PC: "0x4ae90a", Frameless: false}]
               Condition: null
     - id: mapIndex_stringKey_capture
       version: 0
@@ -5242,15 +5554,15 @@ Probes:
             dsl: m["beta"]
             json: {index: [{ref: m}, beta]}
       instances:
-        - subprogram: {subprogram: 55}
+        - subprogram: {subprogram: 57}
           events:
             - Kind: Entry
-              Type: 608 EventRootType Probe[main.mapIndexStringKey]
-              InjectionPoints: [{PC: "0x4ade4a", Frameless: false}]
+              Type: 617 EventRootType Probe[main.mapIndexStringKey]
+              InjectionPoints: [{PC: "0x4ae34a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 609 EventRootType Probe[main.mapIndexStringKey]Return
-              InjectionPoints: [{PC: "0x4ade7f", Frameless: false}]
+              Type: 618 EventRootType Probe[main.mapIndexStringKey]Return
+              InjectionPoints: [{PC: "0x4ae37f", Frameless: false}]
               Condition: null
     - id: mapIndex_stringKey_cond
       version: 0
@@ -5267,16 +5579,16 @@ Probes:
       segments: [matched]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 55}
+        - subprogram: {subprogram: 57}
           events:
             - Kind: Entry
-              Type: 610 EventRootType Probe[main.mapIndexStringKey]
-              InjectionPoints: [{PC: "0x4ade4a", Frameless: false}]
+              Type: 619 EventRootType Probe[main.mapIndexStringKey]
+              InjectionPoints: [{PC: "0x4ae34a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 55, index: 0, name: m}
+                      Variable: {subprogram: 57, index: 0, name: m}
                       Offset: 0
                       ByteSize: 8
                     - __kind: DereferenceOp
@@ -5309,8 +5621,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 611 EventRootType Probe[main.mapIndexStringKey]Return
-              InjectionPoints: [{PC: "0x4ade7f", Frameless: false}]
+              Type: 620 EventRootType Probe[main.mapIndexStringKey]Return
+              InjectionPoints: [{PC: "0x4ae37f", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: matched, Segments: [matched]}
     - id: mapIndex_stringKey_template
@@ -5328,15 +5640,15 @@ Probes:
           dsl: m["beta"]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 55}
+        - subprogram: {subprogram: 57}
           events:
             - Kind: Entry
-              Type: 612 EventRootType Probe[main.mapIndexStringKey]
-              InjectionPoints: [{PC: "0x4ade4a", Frameless: false}]
+              Type: 621 EventRootType Probe[main.mapIndexStringKey]
+              InjectionPoints: [{PC: "0x4ae34a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 613 EventRootType Probe[main.mapIndexStringKey]Return
-              InjectionPoints: [{PC: "0x4ade7f", Frameless: false}]
+              Type: 622 EventRootType Probe[main.mapIndexStringKey]Return
+              InjectionPoints: [{PC: "0x4ae37f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: beta={m["beta"]}
@@ -5363,15 +5675,15 @@ Probes:
             dsl: m["a"].Val
             json: {getmember: [{index: [{ref: m}, a]}, Val]}
       instances:
-        - subprogram: {subprogram: 63}
+        - subprogram: {subprogram: 65}
           events:
             - Kind: Entry
-              Type: 628 EventRootType Probe[main.mapIndexStructVal]
-              InjectionPoints: [{PC: "0x4ae32a", Frameless: false}]
+              Type: 637 EventRootType Probe[main.mapIndexStructVal]
+              InjectionPoints: [{PC: "0x4ae82a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 629 EventRootType Probe[main.mapIndexStructVal]Return
-              InjectionPoints: [{PC: "0x4ae387", Frameless: false}]
+              Type: 638 EventRootType Probe[main.mapIndexStructVal]Return
+              InjectionPoints: [{PC: "0x4ae887", Frameless: false}]
               Condition: null
     - id: mapIndex_structVal_capture_string
       version: 0
@@ -5390,15 +5702,15 @@ Probes:
             dsl: m["b"].Txt
             json: {getmember: [{index: [{ref: m}, b]}, Txt]}
       instances:
-        - subprogram: {subprogram: 63}
+        - subprogram: {subprogram: 65}
           events:
             - Kind: Entry
-              Type: 630 EventRootType Probe[main.mapIndexStructVal]
-              InjectionPoints: [{PC: "0x4ae32a", Frameless: false}]
+              Type: 639 EventRootType Probe[main.mapIndexStructVal]
+              InjectionPoints: [{PC: "0x4ae82a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 631 EventRootType Probe[main.mapIndexStructVal]Return
-              InjectionPoints: [{PC: "0x4ae387", Frameless: false}]
+              Type: 640 EventRootType Probe[main.mapIndexStructVal]Return
+              InjectionPoints: [{PC: "0x4ae887", Frameless: false}]
               Condition: null
     - id: mapIndex_zeroValue_capture
       version: 0
@@ -5417,15 +5729,15 @@ Probes:
             dsl: m["zero"]
             json: {index: [{ref: m}, zero]}
       instances:
-        - subprogram: {subprogram: 69}
+        - subprogram: {subprogram: 71}
           events:
             - Kind: Entry
-              Type: 646 EventRootType Probe[main.mapIndexZeroValue]
-              InjectionPoints: [{PC: "0x4ae62a", Frameless: false}]
+              Type: 655 EventRootType Probe[main.mapIndexZeroValue]
+              InjectionPoints: [{PC: "0x4aeb2a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 647 EventRootType Probe[main.mapIndexZeroValue]Return
-              InjectionPoints: [{PC: "0x4ae65f", Frameless: false}]
+              Type: 656 EventRootType Probe[main.mapIndexZeroValue]Return
+              InjectionPoints: [{PC: "0x4aeb5f", Frameless: false}]
               Condition: null
     - id: noArgs
       version: 0
@@ -5439,11 +5751,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 361 EventRootType Probe[main.noArgs]
-              InjectionPoints: [{PC: "0x4ab2aa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab4ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 362 EventRootType Probe[main.noArgs]Return
-              InjectionPoints: [{PC: "0x4ab2e6", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab526", Frameless: false}]
               Condition: null
     - id: stringArg
       version: 0
@@ -5457,11 +5769,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 322 EventRootType Probe[main.stringArg]
-              InjectionPoints: [{PC: "0x4aae2a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab06a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 323 EventRootType Probe[main.stringArg]Return
-              InjectionPoints: [{PC: "0x4aae6f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab0af", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's: {s}'
@@ -5483,11 +5795,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 354 EventRootType Probe[main.stringArrayArg]
-              InjectionPoints: [{PC: "0x4ab02a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab26a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 355 EventRootType Probe[main.stringArrayArg]Return
-              InjectionPoints: [{PC: "0x4ab076", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab2b6", Frameless: false}]
               Condition: null
     - id: stringSliceArg
       version: 0
@@ -5501,11 +5813,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 350 EventRootType Probe[main.stringSliceArg]
-              InjectionPoints: [{PC: "0x4aafaa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab1ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 351 EventRootType Probe[main.stringSliceArg]Return
-              InjectionPoints: [{PC: "0x4aafef", Frameless: false}]
+              InjectionPoints: [{PC: "0x4ab22f", Frameless: false}]
               Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
       version: 0
@@ -5516,39 +5828,39 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 46}
+        - subprogram: {subprogram: 48}
           events:
             - Kind: Entry
-              Type: 570 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
-              InjectionPoints: [{PC: "0x4ad656", Frameless: false}]
+              Type: 579 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+              InjectionPoints: [{PC: "0x4adb56", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 571 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
-              InjectionPoints: [{PC: "0x4ad81c", Frameless: false}]
+              Type: 580 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+              InjectionPoints: [{PC: "0x4add1c", Frameless: false}]
               Condition: null
 Subprograms:
     - ID: 1
       Name: main.intArg
-      OutOfLinePCRanges: [0x4aada0..0x4aae02]
+      OutOfLinePCRanges: [0x4aafe0..0x4ab042]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4aada0..0x4aadb9
+            - Range: 0x4aafe0..0x4aaff9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 2
       Name: main.stringArg
-      OutOfLinePCRanges: [0x4aae20..0x4aae91]
+      OutOfLinePCRanges: [0x4ab060..0x4ab0d1]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4aae20..0x4aae3e
+            - Range: 0x4ab060..0x4ab07e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -5559,13 +5871,13 @@ Subprograms:
       DictRegister: null
     - ID: 3
       Name: main.intSliceArg
-      OutOfLinePCRanges: [0x4aaea0..0x4aaf1a]
+      OutOfLinePCRanges: [0x4ab0e0..0x4ab15a]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 105 GoSliceHeaderType []int
           Locations:
-            - Range: 0x4aaea0..0x4aaebe
+            - Range: 0x4ab0e0..0x4ab0fe
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -5578,26 +5890,26 @@ Subprograms:
       DictRegister: null
     - ID: 4
       Name: main.intArrayArg
-      OutOfLinePCRanges: [0x4aaf20..0x4aaf87]
+      OutOfLinePCRanges: [0x4ab160..0x4ab1c7]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 106 ArrayType [3]int
           Locations:
-            - Range: 0x4aaf20..0x4aaf87
+            - Range: 0x4ab160..0x4ab1c7
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 5
       Name: main.stringSliceArg
-      OutOfLinePCRanges: [0x4aafa0..0x4ab01a]
+      OutOfLinePCRanges: [0x4ab1e0..0x4ab25a]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 107 GoSliceHeaderType []string
           Locations:
-            - Range: 0x4aafa0..0x4aafbe
+            - Range: 0x4ab1e0..0x4ab1fe
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -5610,86 +5922,86 @@ Subprograms:
       DictRegister: null
     - ID: 6
       Name: main.stringArrayArg
-      OutOfLinePCRanges: [0x4ab020..0x4ab087]
+      OutOfLinePCRanges: [0x4ab260..0x4ab2c7]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 108 ArrayType [3]string
           Locations:
-            - Range: 0x4ab020..0x4ab087
+            - Range: 0x4ab260..0x4ab2c7
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 7
       Name: main.stringArrayArgFrameless
-      OutOfLinePCRanges: [0x4ab0a0..0x4ab0a1]
+      OutOfLinePCRanges: [0x4ab2e0..0x4ab2e1]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 108 ArrayType [3]string
           Locations:
-            - Range: 0x4ab0a0..0x4ab0a1
+            - Range: 0x4ab2e0..0x4ab2e1
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 8
       Name: main.mapArg
-      OutOfLinePCRanges: [0x4ab180..0x4ab1d6]
+      OutOfLinePCRanges: [0x4ab3c0..0x4ab416]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 109 GoMapType map[string]int
           Locations:
-            - Range: 0x4ab180..0x4ab1ad
+            - Range: 0x4ab3c0..0x4ab3ed
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 9
       Name: main.bigMapArg
-      OutOfLinePCRanges: [0x4ab1e0..0x4ab29b]
+      OutOfLinePCRanges: [0x4ab420..0x4ab4db]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 114 GoMapType map[string]main.bigStruct
           Locations:
-            - Range: 0x4ab1e0..0x4ab213
+            - Range: 0x4ab420..0x4ab453
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4ab213..0x4ab29b
+            - Range: 0x4ab453..0x4ab4db
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 10
       Name: main.noArgs
-      OutOfLinePCRanges: [0x4ab2a0..0x4ab2f3]
+      OutOfLinePCRanges: [0x4ab4e0..0x4ab533]
       InlinePCRanges: []
       Variables: []
       DictRegister: null
     - ID: 11
       Name: main.condInt8
-      OutOfLinePCRanges: [0x4ab300..0x4ab3a8]
+      OutOfLinePCRanges: [0x4ab540..0x4ab5e8]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 BaseType int8
           Locations:
-            - Range: 0x4ab300..0x4ab341
+            - Range: 0x4ab540..0x4ab581
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4ab300..0x4ab344
+            - Range: 0x4ab540..0x4ab584
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4ab344..0x4ab349
+            - Range: 0x4ab584..0x4ab589
               Pieces:
                 - Size: 8
                   Op: null
@@ -5700,26 +6012,26 @@ Subprograms:
       DictRegister: null
     - ID: 12
       Name: main.condInt16
-      OutOfLinePCRanges: [0x4ab3c0..0x4ab469]
+      OutOfLinePCRanges: [0x4ab600..0x4ab6a9]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 101 BaseType int16
           Locations:
-            - Range: 0x4ab3c0..0x4ab3e9
+            - Range: 0x4ab600..0x4ab629
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4ab3c0..0x4ab3e9
+            - Range: 0x4ab600..0x4ab629
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4ab3e9..0x4ab469
+            - Range: 0x4ab629..0x4ab6a9
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -5730,26 +6042,26 @@ Subprograms:
       DictRegister: null
     - ID: 13
       Name: main.condInt32
-      OutOfLinePCRanges: [0x4ab480..0x4ab527]
+      OutOfLinePCRanges: [0x4ab6c0..0x4ab767]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType int32
           Locations:
-            - Range: 0x4ab480..0x4ab4a9
+            - Range: 0x4ab6c0..0x4ab6e9
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4ab480..0x4ab4a9
+            - Range: 0x4ab6c0..0x4ab6e9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4ab4a9..0x4ab527
+            - Range: 0x4ab6e9..0x4ab767
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -5760,26 +6072,26 @@ Subprograms:
       DictRegister: null
     - ID: 14
       Name: main.condInt64
-      OutOfLinePCRanges: [0x4ab540..0x4ab5e9]
+      OutOfLinePCRanges: [0x4ab780..0x4ab829]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType int64
           Locations:
-            - Range: 0x4ab540..0x4ab569
+            - Range: 0x4ab780..0x4ab7a9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4ab540..0x4ab569
+            - Range: 0x4ab780..0x4ab7a9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4ab569..0x4ab5e9
+            - Range: 0x4ab7a9..0x4ab829
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -5790,26 +6102,26 @@ Subprograms:
       DictRegister: null
     - ID: 15
       Name: main.condUint8
-      OutOfLinePCRanges: [0x4ab600..0x4ab6a8]
+      OutOfLinePCRanges: [0x4ab840..0x4ab8e8]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x4ab600..0x4ab641
+            - Range: 0x4ab840..0x4ab881
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4ab600..0x4ab644
+            - Range: 0x4ab840..0x4ab884
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4ab644..0x4ab649
+            - Range: 0x4ab884..0x4ab889
               Pieces:
                 - Size: 8
                   Op: null
@@ -5820,26 +6132,26 @@ Subprograms:
       DictRegister: null
     - ID: 16
       Name: main.condUint16
-      OutOfLinePCRanges: [0x4ab6c0..0x4ab769]
+      OutOfLinePCRanges: [0x4ab900..0x4ab9a9]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0x4ab6c0..0x4ab6e9
+            - Range: 0x4ab900..0x4ab929
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4ab6c0..0x4ab6e9
+            - Range: 0x4ab900..0x4ab929
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4ab6e9..0x4ab769
+            - Range: 0x4ab929..0x4ab9a9
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -5850,26 +6162,26 @@ Subprograms:
       DictRegister: null
     - ID: 17
       Name: main.condUint32
-      OutOfLinePCRanges: [0x4ab780..0x4ab827]
+      OutOfLinePCRanges: [0x4ab9c0..0x4aba67]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x4ab780..0x4ab7a9
+            - Range: 0x4ab9c0..0x4ab9e9
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4ab780..0x4ab7a9
+            - Range: 0x4ab9c0..0x4ab9e9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4ab7a9..0x4ab827
+            - Range: 0x4ab9e9..0x4aba67
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -5880,26 +6192,26 @@ Subprograms:
       DictRegister: null
     - ID: 18
       Name: main.condUint64
-      OutOfLinePCRanges: [0x4ab840..0x4ab8e9]
+      OutOfLinePCRanges: [0x4aba80..0x4abb29]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x4ab840..0x4ab869
+            - Range: 0x4aba80..0x4abaa9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4ab840..0x4ab869
+            - Range: 0x4aba80..0x4abaa9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4ab869..0x4ab8e9
+            - Range: 0x4abaa9..0x4abb29
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -5910,32 +6222,32 @@ Subprograms:
       DictRegister: null
     - ID: 19
       Name: main.condFloat32
-      OutOfLinePCRanges: [0x4ab900..0x4ab9ae]
+      OutOfLinePCRanges: [0x4abb40..0x4abbee]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType float32
           Locations:
-            - Range: 0x4ab900..0x4ab92d
+            - Range: 0x4abb40..0x4abb6d
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4ab900..0x4ab928
+            - Range: 0x4abb40..0x4abb68
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4ab928..0x4ab92d
+            - Range: 0x4abb68..0x4abb6d
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4ab92d..0x4ab9ae
+            - Range: 0x4abb6d..0x4abbee
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -5946,32 +6258,32 @@ Subprograms:
       DictRegister: null
     - ID: 20
       Name: main.condFloat64
-      OutOfLinePCRanges: [0x4ab9c0..0x4aba6f]
+      OutOfLinePCRanges: [0x4abc00..0x4abcaf]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 18 BaseType float64
           Locations:
-            - Range: 0x4ab9c0..0x4ab9ee
+            - Range: 0x4abc00..0x4abc2e
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4ab9c0..0x4ab9e9
+            - Range: 0x4abc00..0x4abc29
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4ab9e9..0x4ab9ee
+            - Range: 0x4abc29..0x4abc2e
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4ab9ee..0x4aba6f
+            - Range: 0x4abc2e..0x4abcaf
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -5982,26 +6294,26 @@ Subprograms:
       DictRegister: null
     - ID: 21
       Name: main.condBool
-      OutOfLinePCRanges: [0x4aba80..0x4abb28]
+      OutOfLinePCRanges: [0x4abcc0..0x4abd68]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x4aba80..0x4abac1
+            - Range: 0x4abcc0..0x4abd01
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4aba80..0x4abac4
+            - Range: 0x4abcc0..0x4abd04
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4abac4..0x4abac9
+            - Range: 0x4abd04..0x4abd09
               Pieces:
                 - Size: 8
                   Op: null
@@ -6012,13 +6324,13 @@ Subprograms:
       DictRegister: null
     - ID: 22
       Name: main.condString
-      OutOfLinePCRanges: [0x4abb40..0x4abbf7]
+      OutOfLinePCRanges: [0x4abd80..0x4abe37]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4abb40..0x4abb6e
+            - Range: 0x4abd80..0x4abdae
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6029,13 +6341,13 @@ Subprograms:
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4abb40..0x4abb6e
+            - Range: 0x4abd80..0x4abdae
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x4abb6e..0x4abbf7
+            - Range: 0x4abdae..0x4abe37
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -6046,32 +6358,32 @@ Subprograms:
       DictRegister: null
     - ID: 23
       Name: main.condStructArg
-      OutOfLinePCRanges: [0x4abc00..0x4abd34]
+      OutOfLinePCRanges: [0x4abe40..0x4abf74]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 119 StructureType main.condFields
           Locations:
-            - Range: 0x4abc00..0x4abd34
+            - Range: 0x4abe40..0x4abf74
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4abc00..0x4abc45
+            - Range: 0x4abe40..0x4abe85
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4abc45..0x4abc4a
+            - Range: 0x4abe85..0x4abe8a
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
                 - Size: 8
                   Op: {CfaOffset: 88}
-            - Range: 0x4abc4a..0x4abd34
+            - Range: 0x4abe8a..0x4abf74
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
@@ -6082,28 +6394,28 @@ Subprograms:
       DictRegister: null
     - ID: 24
       Name: main.condPtrStructArg
-      OutOfLinePCRanges: [0x4abd40..0x4abe93]
+      OutOfLinePCRanges: [0x4abf80..0x4ac0d3]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 121 PointerType *main.condFields
           Locations:
-            - Range: 0x4abd40..0x4abd96
+            - Range: 0x4abf80..0x4abfd6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4abd96..0x4abe93
+            - Range: 0x4abfd6..0x4ac0d3
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4abd40..0x4abd9b
+            - Range: 0x4abf80..0x4abfdb
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4abd9b..0x4abe93
+            - Range: 0x4abfdb..0x4ac0d3
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -6114,26 +6426,26 @@ Subprograms:
       DictRegister: null
     - ID: 25
       Name: main.condNilPtrStruct
-      OutOfLinePCRanges: [0x4abea0..0x4abf5c]
+      OutOfLinePCRanges: [0x4ac0e0..0x4ac19c]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 121 PointerType *main.condFields
           Locations:
-            - Range: 0x4abea0..0x4abef5
+            - Range: 0x4ac0e0..0x4ac135
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4abea0..0x4abef8
+            - Range: 0x4ac0e0..0x4ac138
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4abef8..0x4abefd
+            - Range: 0x4ac138..0x4ac13d
               Pieces:
                 - Size: 8
                   Op: null
@@ -6144,66 +6456,66 @@ Subprograms:
       DictRegister: null
     - ID: 26
       Name: main.condReturnAndLocal
-      OutOfLinePCRanges: [0x4abf60..0x4abff9]
+      OutOfLinePCRanges: [0x4ac1a0..0x4ac239]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4abf60..0x4abf71
+            - Range: 0x4ac1a0..0x4ac1b1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4abf60..0x4abf9f
+            - Range: 0x4ac1a0..0x4ac1df
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4abf60..0x4abfd5
+            - Range: 0x4ac1a0..0x4ac215
               Pieces: []
-            - Range: 0x4abfd5..0x4abfd6
+            - Range: 0x4ac215..0x4ac216
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4abfd6..0x4abff9
+            - Range: 0x4ac216..0x4ac239
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: sum
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4abf71..0x4abf9f
+            - Range: 0x4ac1b1..0x4ac1df
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4abf9f..0x4abff9
+            - Range: 0x4ac1df..0x4ac239
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 27
       Name: main.condOnly
-      OutOfLinePCRanges: [0x4ac000..0x4ac0a9]
+      OutOfLinePCRanges: [0x4ac240..0x4ac2e9]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4ac000..0x4ac029
+            - Range: 0x4ac240..0x4ac269
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4ac000..0x4ac029
+            - Range: 0x4ac240..0x4ac269
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4ac029..0x4ac0a9
+            - Range: 0x4ac269..0x4ac2e9
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -6214,34 +6526,34 @@ Subprograms:
       DictRegister: null
     - ID: 28
       Name: main.condLine
-      OutOfLinePCRanges: [0x4ac0c0..0x4ac1a5]
+      OutOfLinePCRanges: [0x4ac300..0x4ac3e5]
       InlinePCRanges: []
       Variables:
         - Name: "n"
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4ac0c0..0x4ac0fc
+            - Range: 0x4ac300..0x4ac33c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4ac0fc..0x4ac1a5
+            - Range: 0x4ac33c..0x4ac3e5
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4ac0c0..0x4ac0e4
+            - Range: 0x4ac300..0x4ac324
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4ac0e4..0x4ac105
+            - Range: 0x4ac324..0x4ac345
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4ac105..0x4ac1a5
+            - Range: 0x4ac345..0x4ac3e5
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -6252,20 +6564,122 @@ Subprograms:
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4ac0e7..0x4ac105
+            - Range: 0x4ac327..0x4ac345
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 29
+      Name: main.condLineMixed
+      OutOfLinePCRanges: [0x4ac400..0x4ac629]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4ac400..0x4ac476
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x4ac476..0x4ac47b
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 80}
+                - Size: 8
+                  Op: {CfaOffset: 88}
+            - Range: 0x4ac47b..0x4ac629
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 80}
+                - Size: 8
+                  Op: {CfaOffset: 88}
+          Role: Parameter
+          DictIndex: -1
+        - Name: b
+          Type: 4 BaseType bool
+          Locations:
+            - Range: 0x4ac400..0x4ac47b
+              Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0x4ac47b..0x4ac629
+              Pieces: [{Size: 1, Op: {CfaOffset: 96}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: x
+          Type: 119 StructureType main.condFields
+          Locations:
+            - Range: 0x4ac400..0x4ac629
+              Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: p
+          Type: 121 PointerType *main.condFields
+          Locations:
+            - Range: 0x4ac400..0x4ac456
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+            - Range: 0x4ac456..0x4ac629
+              Pieces: [{Size: 8, Op: {CfaOffset: 104}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: ss
+          Type: 105 GoSliceHeaderType []int
+          Locations:
+            - Range: 0x4ac400..0x4ac47b
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+            - Range: 0x4ac47b..0x4ac629
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 112}
+                - Size: 8
+                  Op: {CfaOffset: 120}
+                - Size: 8
+                  Op: {CfaOffset: 128}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 30
+      Name: main.condLineReturn
+      OutOfLinePCRanges: [0x4ac640..0x4ac6b2]
+      InlinePCRanges: []
+      Variables:
+        - Name: "n"
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x4ac640..0x4ac651
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations: [{Range: 0x4ac640..0x4ac6b2, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: doubled
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x4ac651..0x4ac665
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4ac665..0x4ac6b2
+              Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
+          Role: Local
+          DictIndex: -1
+      DictRegister: null
+    - ID: 31
       Name: main.condSliceArg
-      OutOfLinePCRanges: [0x4ac1c0..0x4ac285]
+      OutOfLinePCRanges: [0x4ac6c0..0x4ac785]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 105 GoSliceHeaderType []int
           Locations:
-            - Range: 0x4ac1c0..0x4ac1ee
+            - Range: 0x4ac6c0..0x4ac6ee
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6278,13 +6692,13 @@ Subprograms:
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4ac1c0..0x4ac1ee
+            - Range: 0x4ac6c0..0x4ac6ee
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
-            - Range: 0x4ac1ee..0x4ac285
+            - Range: 0x4ac6ee..0x4ac785
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
@@ -6293,28 +6707,28 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 30
+    - ID: 32
       Name: main.condMapArg
-      OutOfLinePCRanges: [0x4ac2a0..0x4ac33a]
+      OutOfLinePCRanges: [0x4ac7a0..0x4ac83a]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 109 GoMapType map[string]int
           Locations:
-            - Range: 0x4ac2a0..0x4ac2d3
+            - Range: 0x4ac7a0..0x4ac7d3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4ac2a0..0x4ac2d6
+            - Range: 0x4ac7a0..0x4ac7d6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4ac2d6..0x4ac2db
+            - Range: 0x4ac7d6..0x4ac7db
               Pieces:
                 - Size: 8
                   Op: null
@@ -6323,34 +6737,34 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 31
+    - ID: 33
       Name: main.condStructDirect
-      OutOfLinePCRanges: [0x4ac340..0x4ac3fa]
+      OutOfLinePCRanges: [0x4ac840..0x4ac8fa]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 119 StructureType main.condFields
           Locations:
-            - Range: 0x4ac340..0x4ac3fa
+            - Range: 0x4ac840..0x4ac8fa
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4ac340..0x4ac375
+            - Range: 0x4ac840..0x4ac875
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4ac375..0x4ac37a
+            - Range: 0x4ac875..0x4ac87a
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
                 - Size: 8
                   Op: {CfaOffset: 88}
-            - Range: 0x4ac37a..0x4ac3fa
+            - Range: 0x4ac87a..0x4ac8fa
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
@@ -6359,134 +6773,36 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 32
+    - ID: 34
       Name: main.condNullPtr
-      OutOfLinePCRanges: [0x4ac400..0x4ac513]
+      OutOfLinePCRanges: [0x4ac900..0x4aca13]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 98 PointerType *int
           Locations:
-            - Range: 0x4ac400..0x4ac46c
+            - Range: 0x4ac900..0x4ac96c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4ac46c..0x4ac513
+            - Range: 0x4ac96c..0x4aca13
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4ac400..0x4ac471
+            - Range: 0x4ac900..0x4ac971
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4ac471..0x4ac474
+            - Range: 0x4ac971..0x4ac974
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4ac474..0x4ac513
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 33
-      Name: main.condNullSlice
-      OutOfLinePCRanges: [0x4ac520..0x4ac690]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 105 GoSliceHeaderType []int
-          Locations:
-            - Range: 0x4ac520..0x4ac5be
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4ac5be..0x4ac5c3
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 0}
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-            - Range: 0x4ac5c3..0x4ac5c6
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 0}
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-            - Range: 0x4ac5c6..0x4ac690
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 0}
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x4ac520..0x4ac5cb
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-            - Range: 0x4ac5cb..0x4ac690
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 24}
-                - Size: 8
-                  Op: {CfaOffset: 32}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 34
-      Name: main.condNullMap
-      OutOfLinePCRanges: [0x4ac6a0..0x4ac7b3]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 109 GoMapType map[string]int
-          Locations:
-            - Range: 0x4ac6a0..0x4ac70c
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4ac70c..0x4ac7b3
-              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x4ac6a0..0x4ac711
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4ac711..0x4ac714
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-            - Range: 0x4ac714..0x4ac7b3
+            - Range: 0x4ac974..0x4aca13
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -6496,87 +6812,95 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 35
-      Name: main.condNullIface
-      OutOfLinePCRanges: [0x4ac7c0..0x4ac90e]
+      Name: main.condNullSlice
+      OutOfLinePCRanges: [0x4aca20..0x4acb90]
       InlinePCRanges: []
       Variables:
-        - Name: i
-          Type: 13 GoInterfaceType error
+        - Name: s
+          Type: 105 GoSliceHeaderType []int
           Locations:
-            - Range: 0x4ac7c0..0x4ac84c
+            - Range: 0x4aca20..0x4acabe
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4ac84c..0x4ac851
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4acabe..0x4acac3
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0x4ac851..0x4ac90e
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x4acac3..0x4acac6
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x4acac6..0x4acb90
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 0}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4ac7c0..0x4ac854
+            - Range: 0x4aca20..0x4acacb
               Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x4ac854..0x4ac859
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+            - Range: 0x4acacb..0x4acb90
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 16}
-                - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0x4ac859..0x4ac90e
-              Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 16}
-                - Size: 8
-                  Op: {CfaOffset: 24}
+                  Op: {CfaOffset: 32}
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 36
-      Name: main.condNullUnsafePtr
-      OutOfLinePCRanges: [0x4ac920..0x4aca33]
+      Name: main.condNullMap
+      OutOfLinePCRanges: [0x4acba0..0x4accb3]
       InlinePCRanges: []
       Variables:
-        - Name: p
-          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: m
+          Type: 109 GoMapType map[string]int
           Locations:
-            - Range: 0x4ac920..0x4ac98c
+            - Range: 0x4acba0..0x4acc0c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4ac98c..0x4aca33
+            - Range: 0x4acc0c..0x4accb3
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4ac920..0x4ac991
+            - Range: 0x4acba0..0x4acc11
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4ac991..0x4ac994
+            - Range: 0x4acc11..0x4acc14
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4ac994..0x4aca33
+            - Range: 0x4acc14..0x4accb3
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -6586,41 +6910,49 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 37
-      Name: main.lenString
-      OutOfLinePCRanges: [0x4aca60..0x4acba5]
+      Name: main.condNullIface
+      OutOfLinePCRanges: [0x4accc0..0x4ace0e]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 9 GoStringHeaderType string
+        - Name: i
+          Type: 13 GoInterfaceType error
           Locations:
-            - Range: 0x4aca60..0x4acae7
+            - Range: 0x4accc0..0x4acd4c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4acae7..0x4acaec
-              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x4acaec..0x4acba5
-              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
+            - Range: 0x4acd4c..0x4acd51
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 0}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+            - Range: 0x4acd51..0x4ace0e
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 0}
+                - Size: 8
+                  Op: {CfaOffset: 8}
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4aca60..0x4acaef
+            - Range: 0x4accc0..0x4acd54
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x4acaef..0x4acaf4
+            - Range: 0x4acd54..0x4acd59
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0x4acaf4..0x4acba5
+            - Range: 0x4acd59..0x4ace0e
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -6630,14 +6962,96 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 38
+      Name: main.condNullUnsafePtr
+      OutOfLinePCRanges: [0x4ace20..0x4acf33]
+      InlinePCRanges: []
+      Variables:
+        - Name: p
+          Type: 14 VoidPointerType unsafe.Pointer
+          Locations:
+            - Range: 0x4ace20..0x4ace8c
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4ace8c..0x4acf33
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4ace20..0x4ace91
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4ace91..0x4ace94
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x4ace94..0x4acf33
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 39
+      Name: main.lenString
+      OutOfLinePCRanges: [0x4acf60..0x4ad0a5]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4acf60..0x4acfe7
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x4acfe7..0x4acfec
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
+            - Range: 0x4acfec..0x4ad0a5
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4acf60..0x4acfef
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+            - Range: 0x4acfef..0x4acff4
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0x4acff4..0x4ad0a5
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 40
       Name: main.lenSlice
-      OutOfLinePCRanges: [0x4acbc0..0x4acd1b]
+      OutOfLinePCRanges: [0x4ad0c0..0x4ad21b]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 105 GoSliceHeaderType []int
           Locations:
-            - Range: 0x4acbc0..0x4acc56
+            - Range: 0x4ad0c0..0x4ad156
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6645,7 +7059,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4acc56..0x4acc5b
+            - Range: 0x4ad156..0x4ad15b
               Pieces:
                 - Size: 8
                   Op: null
@@ -6653,7 +7067,7 @@ Subprograms:
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4acc5b..0x4acc5e
+            - Range: 0x4ad15b..0x4ad15e
               Pieces:
                 - Size: 8
                   Op: null
@@ -6661,7 +7075,7 @@ Subprograms:
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4acc5e..0x4acd1b
+            - Range: 0x4ad15e..0x4ad21b
               Pieces:
                 - Size: 8
                   Op: null
@@ -6674,13 +7088,13 @@ Subprograms:
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4acbc0..0x4acc65
+            - Range: 0x4ad0c0..0x4ad165
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
-            - Range: 0x4acc65..0x4acd1b
+            - Range: 0x4ad165..0x4ad21b
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
@@ -6689,36 +7103,36 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 39
+    - ID: 41
       Name: main.lenMap
-      OutOfLinePCRanges: [0x4acd20..0x4ace4a]
+      OutOfLinePCRanges: [0x4ad220..0x4ad34a]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 109 GoMapType map[string]int
           Locations:
-            - Range: 0x4acd20..0x4acd8c
+            - Range: 0x4ad220..0x4ad28c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4acd8c..0x4ace4a
+            - Range: 0x4ad28c..0x4ad34a
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4acd20..0x4acd91
+            - Range: 0x4ad220..0x4ad291
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4acd91..0x4acd94
+            - Range: 0x4ad291..0x4ad294
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4acd94..0x4ace4a
+            - Range: 0x4ad294..0x4ad34a
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -6727,110 +7141,36 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 40
+    - ID: 42
       Name: main.lenPtrString
-      OutOfLinePCRanges: [0x4ace60..0x4acf73]
+      OutOfLinePCRanges: [0x4ad360..0x4ad473]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 93 PointerType *string
           Locations:
-            - Range: 0x4ace60..0x4acecc
+            - Range: 0x4ad360..0x4ad3cc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4acecc..0x4acf73
+            - Range: 0x4ad3cc..0x4ad473
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4ace60..0x4aced1
+            - Range: 0x4ad360..0x4ad3d1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4aced1..0x4aced4
+            - Range: 0x4ad3d1..0x4ad3d4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4aced4..0x4acf73
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 41
-      Name: main.lenStructFields
-      OutOfLinePCRanges: [0x4acf80..0x4ad154]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 122 StructureType main.lenFields
-          Locations:
-            - Range: 0x4acf80..0x4ad154
-              Pieces: [{Size: 72, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x4acf80..0x4ad04d
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4ad04d..0x4ad052
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 72}
-                - Size: 8
-                  Op: {CfaOffset: 80}
-            - Range: 0x4ad052..0x4ad154
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 72}
-                - Size: 8
-                  Op: {CfaOffset: 80}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 42
-      Name: main.lenPtrStructFields
-      OutOfLinePCRanges: [0x4ad160..0x4ad2ed]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 124 PointerType *main.lenFields
-          Locations:
-            - Range: 0x4ad160..0x4ad1dd
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4ad1dd..0x4ad2ed
-              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x4ad160..0x4ad1e2
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4ad1e2..0x4ad1e5
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-            - Range: 0x4ad1e5..0x4ad2ed
+            - Range: 0x4ad3d4..0x4ad473
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -6840,35 +7180,71 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 43
-      Name: main.lenErrInt
-      OutOfLinePCRanges: [0x4ad300..0x4ad42a]
+      Name: main.lenStructFields
+      OutOfLinePCRanges: [0x4ad480..0x4ad654]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 7 BaseType int
+          Type: 122 StructureType main.lenFields
           Locations:
-            - Range: 0x4ad300..0x4ad37b
+            - Range: 0x4ad480..0x4ad654
+              Pieces: [{Size: 72, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4ad480..0x4ad54d
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x4ad54d..0x4ad552
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 72}
+                - Size: 8
+                  Op: {CfaOffset: 80}
+            - Range: 0x4ad552..0x4ad654
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 72}
+                - Size: 8
+                  Op: {CfaOffset: 80}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 44
+      Name: main.lenPtrStructFields
+      OutOfLinePCRanges: [0x4ad660..0x4ad7ed]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 124 PointerType *main.lenFields
+          Locations:
+            - Range: 0x4ad660..0x4ad6dd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4ad37b..0x4ad42a
+            - Range: 0x4ad6dd..0x4ad7ed
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4ad300..0x4ad380
+            - Range: 0x4ad660..0x4ad6e2
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4ad380..0x4ad383
+            - Range: 0x4ad6e2..0x4ad6e5
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4ad383..0x4ad42a
+            - Range: 0x4ad6e5..0x4ad7ed
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -6877,34 +7253,72 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 44
+    - ID: 45
+      Name: main.lenErrInt
+      OutOfLinePCRanges: [0x4ad800..0x4ad92a]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x4ad800..0x4ad87b
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4ad87b..0x4ad92a
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4ad800..0x4ad880
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4ad880..0x4ad883
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x4ad883..0x4ad92a
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 46
       Name: main.lenErrStruct
-      OutOfLinePCRanges: [0x4ad440..0x4ad57d]
+      OutOfLinePCRanges: [0x4ad940..0x4ada7d]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 119 StructureType main.condFields
           Locations:
-            - Range: 0x4ad440..0x4ad57d
+            - Range: 0x4ad940..0x4ada7d
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4ad440..0x4ad4d1
+            - Range: 0x4ad940..0x4ad9d1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4ad4d1..0x4ad4d6
+            - Range: 0x4ad9d1..0x4ad9d6
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
                 - Size: 8
                   Op: {CfaOffset: 88}
-            - Range: 0x4ad4d6..0x4ad57d
+            - Range: 0x4ad9d6..0x4ada7d
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
@@ -6913,28 +7327,28 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 45
+    - ID: 47
       Name: main.indexNilPtrSlice
-      OutOfLinePCRanges: [0x4ad580..0x4ad63c]
+      OutOfLinePCRanges: [0x4ada80..0x4adb3c]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 124 PointerType *main.lenFields
           Locations:
-            - Range: 0x4ad580..0x4ad5d5
+            - Range: 0x4ada80..0x4adad5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4ad580..0x4ad5d8
+            - Range: 0x4ada80..0x4adad8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4ad5d8..0x4ad5dd
+            - Range: 0x4adad8..0x4adadd
               Pieces:
                 - Size: 8
                   Op: null
@@ -6943,60 +7357,60 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 46
+    - ID: 48
       Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
-      OutOfLinePCRanges: [0x4ad640..0x4ad82f]
+      OutOfLinePCRanges: [0x4adb40..0x4add2f]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 125 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
           Locations:
-            - Range: 0x4ad640..0x4ad81c
+            - Range: 0x4adb40..0x4add1c
               Pieces: []
-            - Range: 0x4ad81c..0x4ad81d
+            - Range: 0x4add1c..0x4add1d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4ad81d..0x4ad82f
+            - Range: 0x4add1d..0x4add2f
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 47
+    - ID: 49
       Name: main.bigArrayArg
-      OutOfLinePCRanges: [0x4ad840..0x4ad8ca]
+      OutOfLinePCRanges: [0x4add40..0x4addca]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 130 ArrayType [131072]int64
           Locations:
-            - Range: 0x4ad840..0x4ad8ca
+            - Range: 0x4add40..0x4addca
               Pieces: [{Size: 1048576, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 48
+    - ID: 50
       Name: main.bigArrayStructArg
-      OutOfLinePCRanges: [0x4ad8e0..0x4ad971]
+      OutOfLinePCRanges: [0x4adde0..0x4ade71]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 131 PointerType *main.bigArrayStruct
           Locations:
-            - Range: 0x4ad8e0..0x4ad903
+            - Range: 0x4adde0..0x4ade03
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4ad903..0x4ad971
+            - Range: 0x4ade03..0x4ade71
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 49
+    - ID: 51
       Name: main.structSliceArg
-      OutOfLinePCRanges: [0x4ad980..0x4ada5c]
+      OutOfLinePCRanges: [0x4ade80..0x4adf5c]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 133 GoSliceHeaderType []main.indexMemberStruct
           Locations:
-            - Range: 0x4ad980..0x4ad9b9
+            - Range: 0x4ade80..0x4adeb9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7004,7 +7418,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4ad9b9..0x4ad9be
+            - Range: 0x4adeb9..0x4adebe
               Pieces:
                 - Size: 8
                   Op: null
@@ -7012,7 +7426,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4ada17..0x4ada1a
+            - Range: 0x4adf17..0x4adf1a
               Pieces:
                 - Size: 8
                   Op: null
@@ -7020,7 +7434,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4ada1a..0x4ada5c
+            - Range: 0x4adf1a..0x4adf5c
               Pieces:
                 - Size: 8
                   Op: null
@@ -7033,129 +7447,19 @@ Subprograms:
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4ad980..0x4ad9be
+            - Range: 0x4ade80..0x4adebe
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
-            - Range: 0x4ad9be..0x4ada15
+            - Range: 0x4adebe..0x4adf15
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: {CfaOffset: 32}
-            - Range: 0x4ada15..0x4ada5c
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 50
-      Name: main.structArrayArg
-      OutOfLinePCRanges: [0x4ada60..0x4adb14]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 136 ArrayType [2]main.indexMemberStruct
-          Locations:
-            - Range: 0x4ada60..0x4adb14
-              Pieces: [{Size: 64, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x4ada60..0x4ada92
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4ada92..0x4ada97
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 64}
-                - Size: 8
-                  Op: {CfaOffset: 72}
-            - Range: 0x4ada97..0x4adb14
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 64}
-                - Size: 8
-                  Op: {CfaOffset: 72}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 51
-      Name: main.ptrStructSliceArg
-      OutOfLinePCRanges: [0x4adb20..0x4adc05]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 137 GoSliceHeaderType []*main.indexMemberStruct
-          Locations:
-            - Range: 0x4adb20..0x4adb5a
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4adb5a..0x4adb5c
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: null
-            - Range: 0x4adb5c..0x4adb65
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: null
-            - Range: 0x4adbbe..0x4adbc1
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4adbc1..0x4adc05
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: null
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x4adb20..0x4adb65
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-            - Range: 0x4adb65..0x4adbbc
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 24}
-                - Size: 8
-                  Op: {CfaOffset: 32}
-            - Range: 0x4adbbc..0x4adc05
+            - Range: 0x4adf15..0x4adf5c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -7165,33 +7469,143 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 52
+      Name: main.structArrayArg
+      OutOfLinePCRanges: [0x4adf60..0x4ae014]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 136 ArrayType [2]main.indexMemberStruct
+          Locations:
+            - Range: 0x4adf60..0x4ae014
+              Pieces: [{Size: 64, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4adf60..0x4adf92
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x4adf92..0x4adf97
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 64}
+                - Size: 8
+                  Op: {CfaOffset: 72}
+            - Range: 0x4adf97..0x4ae014
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 64}
+                - Size: 8
+                  Op: {CfaOffset: 72}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 53
+      Name: main.ptrStructSliceArg
+      OutOfLinePCRanges: [0x4ae020..0x4ae105]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 137 GoSliceHeaderType []*main.indexMemberStruct
+          Locations:
+            - Range: 0x4ae020..0x4ae05a
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4ae05a..0x4ae05c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: null
+            - Range: 0x4ae05c..0x4ae065
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: null
+            - Range: 0x4ae0be..0x4ae0c1
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4ae0c1..0x4ae105
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: null
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4ae020..0x4ae065
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+            - Range: 0x4ae065..0x4ae0bc
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 24}
+                - Size: 8
+                  Op: {CfaOffset: 32}
+            - Range: 0x4ae0bc..0x4ae105
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 54
       Name: main.ptrStructArrayArg
-      OutOfLinePCRanges: [0x4adc20..0x4adcc9]
+      OutOfLinePCRanges: [0x4ae120..0x4ae1c9]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 139 ArrayType [2]*main.indexMemberStruct
           Locations:
-            - Range: 0x4adc20..0x4adcc9
+            - Range: 0x4ae120..0x4ae1c9
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4adc20..0x4adc4f
+            - Range: 0x4ae120..0x4ae14f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4adc4f..0x4adc54
+            - Range: 0x4ae14f..0x4ae154
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0x4adc54..0x4adcc9
+            - Range: 0x4ae154..0x4ae1c9
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -7200,36 +7614,36 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 53
+    - ID: 55
       Name: main.indexMemberWrapperArg
-      OutOfLinePCRanges: [0x4adce0..0x4addc5]
+      OutOfLinePCRanges: [0x4ae1e0..0x4ae2c5]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 140 PointerType *main.indexMemberWrapper
           Locations:
-            - Range: 0x4adce0..0x4add18
+            - Range: 0x4ae1e0..0x4ae218
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4add18..0x4addc5
+            - Range: 0x4ae218..0x4ae2c5
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4adce0..0x4add16
+            - Range: 0x4ae1e0..0x4ae216
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4add16..0x4add1d
+            - Range: 0x4ae216..0x4ae21d
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4add1d..0x4addc5
+            - Range: 0x4ae21d..0x4ae2c5
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -7238,261 +7652,261 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 54
+    - ID: 56
       Name: main.mapIndexIntKey
-      OutOfLinePCRanges: [0x4adde0..0x4ade36]
+      OutOfLinePCRanges: [0x4ae2e0..0x4ae336]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 142 GoMapType map[int]string
           Locations:
-            - Range: 0x4adde0..0x4ade0d
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 55
-      Name: main.mapIndexStringKey
-      OutOfLinePCRanges: [0x4ade40..0x4ade96]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 109 GoMapType map[string]int
-          Locations:
-            - Range: 0x4ade40..0x4ade6d
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 56
-      Name: main.mapIndexLargeMap
-      OutOfLinePCRanges: [0x4adea0..0x4adf10]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 109 GoMapType map[string]int
-          Locations:
-            - Range: 0x4adea0..0x4adec3
+            - Range: 0x4ae2e0..0x4ae30d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 57
-      Name: main.mapIndexMissing
-      OutOfLinePCRanges: [0x4adf20..0x4adf76]
+      Name: main.mapIndexStringKey
+      OutOfLinePCRanges: [0x4ae340..0x4ae396]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 109 GoMapType map[string]int
           Locations:
-            - Range: 0x4adf20..0x4adf4d
+            - Range: 0x4ae340..0x4ae36d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 58
-      Name: main.mapIndexKeyLen8
-      OutOfLinePCRanges: [0x4ae0a0..0x4ae110]
+      Name: main.mapIndexLargeMap
+      OutOfLinePCRanges: [0x4ae3a0..0x4ae410]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 109 GoMapType map[string]int
           Locations:
-            - Range: 0x4ae0a0..0x4ae0c3
+            - Range: 0x4ae3a0..0x4ae3c3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 59
-      Name: main.mapIndexKeyLen24
-      OutOfLinePCRanges: [0x4ae120..0x4ae190]
+      Name: main.mapIndexMissing
+      OutOfLinePCRanges: [0x4ae420..0x4ae476]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 109 GoMapType map[string]int
           Locations:
-            - Range: 0x4ae120..0x4ae143
+            - Range: 0x4ae420..0x4ae44d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 60
-      Name: main.mapIndexKeyLen48
-      OutOfLinePCRanges: [0x4ae1a0..0x4ae210]
+      Name: main.mapIndexKeyLen8
+      OutOfLinePCRanges: [0x4ae5a0..0x4ae610]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 109 GoMapType map[string]int
           Locations:
-            - Range: 0x4ae1a0..0x4ae1c3
+            - Range: 0x4ae5a0..0x4ae5c3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 61
-      Name: main.mapIndexKeyLen96
-      OutOfLinePCRanges: [0x4ae220..0x4ae290]
+      Name: main.mapIndexKeyLen24
+      OutOfLinePCRanges: [0x4ae620..0x4ae690]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 109 GoMapType map[string]int
           Locations:
-            - Range: 0x4ae220..0x4ae243
+            - Range: 0x4ae620..0x4ae643
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 62
-      Name: main.mapIndexKeyLen200
-      OutOfLinePCRanges: [0x4ae2a0..0x4ae310]
+      Name: main.mapIndexKeyLen48
+      OutOfLinePCRanges: [0x4ae6a0..0x4ae710]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 109 GoMapType map[string]int
           Locations:
-            - Range: 0x4ae2a0..0x4ae2c3
+            - Range: 0x4ae6a0..0x4ae6c3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 63
-      Name: main.mapIndexStructVal
-      OutOfLinePCRanges: [0x4ae320..0x4ae39e]
+      Name: main.mapIndexKeyLen96
+      OutOfLinePCRanges: [0x4ae720..0x4ae790]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 147 GoMapType map[string]main.indexMemberStruct
+          Type: 109 GoMapType map[string]int
           Locations:
-            - Range: 0x4ae320..0x4ae34a
+            - Range: 0x4ae720..0x4ae743
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 64
-      Name: main.mapIndexPtrStructVal
-      OutOfLinePCRanges: [0x4ae3a0..0x4ae425]
+      Name: main.mapIndexKeyLen200
+      OutOfLinePCRanges: [0x4ae7a0..0x4ae810]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 152 GoMapType map[string]*main.indexMemberStruct
+          Type: 109 GoMapType map[string]int
           Locations:
-            - Range: 0x4ae3a0..0x4ae3ca
+            - Range: 0x4ae7a0..0x4ae7c3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 65
-      Name: main.mapIndexEmptyKey
-      OutOfLinePCRanges: [0x4ae440..0x4ae4bc]
+      Name: main.mapIndexStructVal
+      OutOfLinePCRanges: [0x4ae820..0x4ae89e]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 109 GoMapType map[string]int
+          Type: 147 GoMapType map[string]main.indexMemberStruct
           Locations:
-            - Range: 0x4ae440..0x4ae462
+            - Range: 0x4ae820..0x4ae84a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 66
-      Name: main.mapIndexKeyLen16
-      OutOfLinePCRanges: [0x4ae4c0..0x4ae530]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 109 GoMapType map[string]int
-          Locations:
-            - Range: 0x4ae4c0..0x4ae4e3
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 67
-      Name: main.mapIndexKeyLen17
-      OutOfLinePCRanges: [0x4ae540..0x4ae5b0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 109 GoMapType map[string]int
-          Locations:
-            - Range: 0x4ae540..0x4ae563
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 68
-      Name: main.mapIndexBoolKey
-      OutOfLinePCRanges: [0x4ae5c0..0x4ae616]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 157 GoMapType map[bool]int
-          Locations:
-            - Range: 0x4ae5c0..0x4ae5ed
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 69
-      Name: main.mapIndexZeroValue
-      OutOfLinePCRanges: [0x4ae620..0x4ae676]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 109 GoMapType map[string]int
-          Locations:
-            - Range: 0x4ae620..0x4ae64d
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 70
-      Name: main.mapIndexNilPtrVal
-      OutOfLinePCRanges: [0x4ae680..0x4ae6d6]
+      Name: main.mapIndexPtrStructVal
+      OutOfLinePCRanges: [0x4ae8a0..0x4ae925]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 152 GoMapType map[string]*main.indexMemberStruct
           Locations:
-            - Range: 0x4ae680..0x4ae6ad
+            - Range: 0x4ae8a0..0x4ae8ca
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 67
+      Name: main.mapIndexEmptyKey
+      OutOfLinePCRanges: [0x4ae940..0x4ae9bc]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 109 GoMapType map[string]int
+          Locations:
+            - Range: 0x4ae940..0x4ae962
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 68
+      Name: main.mapIndexKeyLen16
+      OutOfLinePCRanges: [0x4ae9c0..0x4aea30]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 109 GoMapType map[string]int
+          Locations:
+            - Range: 0x4ae9c0..0x4ae9e3
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 69
+      Name: main.mapIndexKeyLen17
+      OutOfLinePCRanges: [0x4aea40..0x4aeab0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 109 GoMapType map[string]int
+          Locations:
+            - Range: 0x4aea40..0x4aea63
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 70
+      Name: main.mapIndexBoolKey
+      OutOfLinePCRanges: [0x4aeac0..0x4aeb16]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 157 GoMapType map[bool]int
+          Locations:
+            - Range: 0x4aeac0..0x4aeaed
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 71
-      Name: main.mapIndexLargeValue
-      OutOfLinePCRanges: [0x4ae6e0..0x4ae75e]
+      Name: main.mapIndexZeroValue
+      OutOfLinePCRanges: [0x4aeb20..0x4aeb76]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 162 GoMapType map[string]main.largeValueStruct
+          Type: 109 GoMapType map[string]int
           Locations:
-            - Range: 0x4ae6e0..0x4ae705
+            - Range: 0x4aeb20..0x4aeb4d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 72
+      Name: main.mapIndexNilPtrVal
+      OutOfLinePCRanges: [0x4aeb80..0x4aebd6]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 152 GoMapType map[string]*main.indexMemberStruct
+          Locations:
+            - Range: 0x4aeb80..0x4aebad
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 73
+      Name: main.mapIndexLargeValue
+      OutOfLinePCRanges: [0x4aebe0..0x4aec5e]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 162 GoMapType map[string]main.largeValueStruct
+          Locations:
+            - Range: 0x4aebe0..0x4aec05
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 74
       Name: main.condMultiReturn
-      OutOfLinePCRanges: [0x4ae7e0..0x4ae8b4]
+      OutOfLinePCRanges: [0x4aece0..0x4aedb4]
       InlinePCRanges: []
       Variables:
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4ae7e0..0x4ae829
+            - Range: 0x4aece0..0x4aed29
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4ae829..0x4ae82e
+            - Range: 0x4aed29..0x4aed2e
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0x4ae82e..0x4ae8b4
+            - Range: 0x4aed2e..0x4aedb4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -7503,51 +7917,51 @@ Subprograms:
         - Name: r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4ae7e0..0x4ae88c
+            - Range: 0x4aece0..0x4aed8c
               Pieces: []
-            - Range: 0x4ae88c..0x4ae88d
+            - Range: 0x4aed8c..0x4aed8d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4ae88d..0x4ae8b4
+            - Range: 0x4aed8d..0x4aedb4
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: r1
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4ae7e0..0x4ae88c
+            - Range: 0x4aece0..0x4aed8c
               Pieces: []
-            - Range: 0x4ae88c..0x4ae88d
+            - Range: 0x4aed8c..0x4aed8d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4ae88d..0x4ae8b4
+            - Range: 0x4aed8d..0x4aedb4
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 73
+    - ID: 75
       Name: main.genericIdentity[go.shape.string]
-      OutOfLinePCRanges: [0x4ae8c0..0x4ae95d]
+      OutOfLinePCRanges: [0x4aedc0..0x4aee5d]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 167 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x4ae8c0..0x4ae8e9
+            - Range: 0x4aedc0..0x4aede9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4ae8e9..0x4ae8ee
+            - Range: 0x4aede9..0x4aedee
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4ae8ee..0x4ae95d
+            - Range: 0x4aedee..0x4aee5d
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -7558,68 +7972,68 @@ Subprograms:
         - Name: ~r0
           Type: 167 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x4ae8c0..0x4ae92f
+            - Range: 0x4aedc0..0x4aee2f
               Pieces: []
-            - Range: 0x4ae92f..0x4ae930
+            - Range: 0x4aee2f..0x4aee30
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4ae930..0x4ae95d
+            - Range: 0x4aee30..0x4aee5d
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 74
+    - ID: 76
       Name: main.genericIdentity[go.shape.int]
-      OutOfLinePCRanges: [0x4ae960..0x4ae9de]
+      OutOfLinePCRanges: [0x4aee60..0x4aeede]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 168 BaseType go.shape.int
           Locations:
-            - Range: 0x4ae960..0x4ae986
+            - Range: 0x4aee60..0x4aee86
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x4ae986..0x4ae9de
+            - Range: 0x4aee86..0x4aeede
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 168 BaseType go.shape.int
           Locations:
-            - Range: 0x4ae960..0x4ae9bd
+            - Range: 0x4aee60..0x4aeebd
               Pieces: []
-            - Range: 0x4ae9bd..0x4ae9be
+            - Range: 0x4aeebd..0x4aeebe
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4ae9be..0x4ae9de
+            - Range: 0x4aeebe..0x4aeede
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 75
+    - ID: 77
       Name: main.inlined
-      OutOfLinePCRanges: [0x4ab0c0..0x4ab122]
+      OutOfLinePCRanges: [0x4ab300..0x4ab362]
       InlinePCRanges:
         - Ranges: [0x4a8a7b..0x4a8ac8]
-          RootRanges: [0x4a88e0..0x4aad8a]
+          RootRanges: [0x4a88e0..0x4aafca]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
             - Range: 0x4a8a7b..0x4a8ac8
               Pieces: []
-            - Range: 0x4ab0c0..0x4ab0d9
+            - Range: 0x4ab300..0x4ab319
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 76
+    - ID: 78
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x4a8ccc..0x4a8d06]
-          RootRanges: [0x4a88e0..0x4aad8a]
+          RootRanges: [0x4a88e0..0x4aafca]
       Variables:
         - Name: ptr
           Type: 169 PointerType *****int
@@ -7629,12 +8043,12 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 77
+    - ID: 79
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x4a8d11..0x4a8d4b]
-          RootRanges: [0x4a88e0..0x4aad8a]
+          RootRanges: [0x4a88e0..0x4aafca]
       Variables:
         - Name: ptr
           Type: 171 PointerType **int
@@ -7644,17 +8058,17 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 78
+    - ID: 80
       Name: main.(*methodValueReceiver).inlinedMethod
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x4ae9ed..0x4ae9f0]
-          RootRanges: [0x4ae9e0..0x4aea02]
+        - Ranges: [0x4aeeed..0x4aeef0]
+          RootRanges: [0x4aeee0..0x4aef02]
       Variables:
         - Name: m
           Type: 172 PointerType *main.methodValueReceiver
           Locations:
-            - Range: 0x4ae9ed..0x4aea02
+            - Range: 0x4aeeed..0x4aef02
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7812,7 +8226,7 @@ Types:
       ID: 275
       Name: '*errors.errorString'
       ByteSize: 8
-      GoRuntimeType: 60992
+      GoRuntimeType: 61088
       GoKind: 22
       Pointee: 276 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
@@ -7859,28 +8273,28 @@ Types:
       ID: 280
       Name: '*internal/bisect.parseError'
       ByteSize: 8
-      GoRuntimeType: 63968
+      GoRuntimeType: 64064
       GoKind: 22
       Pointee: 281 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
       ID: 306
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 78272
+      GoRuntimeType: 78368
       GoKind: 22
       Pointee: 307 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 304
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
-      GoRuntimeType: 78144
+      GoRuntimeType: 78240
       GoKind: 22
       Pointee: 305 StructureType internal/poll.errNetClosing
     - __kind: PointerType
       ID: 302
       Name: '*io/fs.PathError'
       ByteSize: 8
-      GoRuntimeType: 78016
+      GoRuntimeType: 78112
       GoKind: 22
       Pointee: 303 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
@@ -8031,28 +8445,28 @@ Types:
       ID: 298
       Name: '*os.SyscallError'
       ByteSize: 8
-      GoRuntimeType: 75072
+      GoRuntimeType: 75168
       GoKind: 22
       Pointee: 299 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 277
       Name: '*reflect.ValueError'
       ByteSize: 8
-      GoRuntimeType: 61856
+      GoRuntimeType: 61952
       GoKind: 22
       Pointee: 278 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
       ID: 292
       Name: '*runtime.PanicNilError'
       ByteSize: 8
-      GoRuntimeType: 68064
+      GoRuntimeType: 68160
       GoKind: 22
       Pointee: 293 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
       ID: 296
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
-      GoRuntimeType: 69856
+      GoRuntimeType: 69952
       GoKind: 22
       Pointee: 297 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
@@ -8066,14 +8480,14 @@ Types:
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 86688
+      GoRuntimeType: 86784
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 294
       Name: '*runtime.boundsError'
       ByteSize: 8
-      GoRuntimeType: 68192
+      GoRuntimeType: 68288
       GoKind: 22
       Pointee: 295 StructureType runtime.boundsError
     - __kind: PointerType
@@ -8094,14 +8508,14 @@ Types:
       ID: 300
       Name: '*runtime.errorAddressString'
       ByteSize: 8
-      GoRuntimeType: 77504
+      GoRuntimeType: 77600
       GoKind: 22
       Pointee: 301 StructureType runtime.errorAddressString
     - __kind: PointerType
       ID: 290
       Name: '*runtime.errorString'
       ByteSize: 8
-      GoRuntimeType: 67680
+      GoRuntimeType: 67776
       GoKind: 22
       Pointee: 282 GoStringHeaderType runtime.errorString
     - __kind: PointerType
@@ -8113,21 +8527,21 @@ Types:
       ID: 55
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 62624
+      GoRuntimeType: 62720
       GoKind: 22
       Pointee: 22 StructureType runtime.g
     - __kind: PointerType
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 69344
+      GoRuntimeType: 69440
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
       ID: 291
       Name: '*runtime.plainError'
       ByteSize: 8
-      GoRuntimeType: 67808
+      GoRuntimeType: 67904
       GoKind: 22
       Pointee: 285 GoStringHeaderType runtime.plainError
     - __kind: PointerType
@@ -8146,28 +8560,28 @@ Types:
       ID: 49
       Name: '*runtime.synctestGroup'
       ByteSize: 8
-      GoRuntimeType: 98976
+      GoRuntimeType: 99072
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.synctestGroup
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 130464
+      GoRuntimeType: 130560
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 76
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 104352
+      GoRuntimeType: 104448
       GoKind: 22
       Pointee: 77 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 288
       Name: '*strconv.NumError'
       ByteSize: 8
-      GoRuntimeType: 66784
+      GoRuntimeType: 66880
       GoKind: 22
       Pointee: 289 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
@@ -8186,7 +8600,7 @@ Types:
       ID: 309
       Name: '*syscall.Errno'
       ByteSize: 8
-      GoRuntimeType: 87968
+      GoRuntimeType: 88064
       GoKind: 22
       Pointee: 308 BaseType syscall.Errno
     - __kind: PointerType
@@ -8238,7 +8652,7 @@ Types:
       ID: 279
       Name: '*time.fileSizeError'
       ByteSize: 8
-      GoRuntimeType: 63392
+      GoRuntimeType: 63488
       GoKind: 22
       Pointee: 272 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
@@ -8289,7 +8703,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 662
+      ID: 671
       Name: Probe[main.(*methodValueReceiver).inlinedMethod]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8301,12 +8715,12 @@ Types:
             Type: 172 PointerType *main.methodValueReceiver
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: m}
+                  Variable: {subprogram: 80, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 660
+      ID: 669
       Name: Probe[main.PointerChainArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -8318,7 +8732,7 @@ Types:
             Type: 169 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: ptr}
+                  Variable: {subprogram: 78, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -8329,12 +8743,12 @@ Types:
             Type: 169 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: ptr}
+                  Variable: {subprogram: 78, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 661
+      ID: 670
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8346,12 +8760,12 @@ Types:
             Type: 171 PointerType **int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: ptr}
+                  Variable: {subprogram: 79, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 572
+      ID: 581
       Name: Probe[main.bigArrayArg]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8363,12 +8777,12 @@ Types:
             Type: 12 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: s}
+                  Variable: {subprogram: 49, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 574
+      ID: 583
       Name: Probe[main.bigArrayArg]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8380,18 +8794,18 @@ Types:
             Type: 12 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: s}
+                  Variable: {subprogram: 49, index: 0, name: s}
                   Offset: 1048568
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 573
+      ID: 582
       Name: Probe[main.bigArrayArg]Return
     - __kind: EventRootType
-      ID: 575
+      ID: 584
       Name: Probe[main.bigArrayArg]Return
     - __kind: EventRootType
-      ID: 576
+      ID: 585
       Name: Probe[main.bigArrayStructArg]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8403,7 +8817,7 @@ Types:
             Type: 12 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: s}
+                  Variable: {subprogram: 50, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -8411,7 +8825,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 577
+      ID: 586
       Name: Probe[main.bigArrayStructArg]Return
     - __kind: EventRootType
       ID: 359
@@ -8842,6 +9256,85 @@ Types:
       ID: 366
       Name: Probe[main.condInt8]Return
     - __kind: EventRootType
+      ID: 470
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 471
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 472
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 473
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 474
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 475
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 476
+      Name: Probe[main.condLineMixed]Line
+      ByteSize: 131
+      ExprStatusArraySize: 2
+      Expressions:
+        - Name: s
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: b
+          Offset: 18
+          Kind: local
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 1
+          DictIndex: -1
+        - Name: x
+          Offset: 19
+          Kind: local
+          Expression:
+            Type: 119 StructureType main.condFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 80
+          DictIndex: -1
+        - Name: p
+          Offset: 99
+          Kind: local
+          Expression:
+            Type: 121 PointerType *main.condFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 3, name: p}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: ss
+          Offset: 107
+          Kind: local
+          Expression:
+            Type: 105 GoSliceHeaderType []int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 4, name: ss}
+                  Offset: 0
+                  ByteSize: 24
+          DictIndex: -1
+    - __kind: EventRootType
       ID: 465
       Name: Probe[main.condLine]Line
       ByteSize: 25
@@ -8889,6 +9382,62 @@ Types:
     - __kind: EventRootType
       ID: 467
       Name: Probe[main.condLine]Line
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 468
+      Name: Probe[main.condLine]Line
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: "n"
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 0, name: "n"}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: tag
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: result
+          Offset: 25
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 2, name: result}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 469
+      Name: Probe[main.condLine]Line
       ByteSize: 25
       ExprStatusArraySize: 1
       Expressions:
@@ -8915,10 +9464,10 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 652
+      ID: 661
       Name: Probe[main.condMultiReturn]
     - __kind: EventRootType
-      ID: 653
+      ID: 662
       Name: Probe[main.condMultiReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -8930,7 +9479,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 1, name: r0}
+                  Variable: {subprogram: 74, index: 1, name: r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -8941,7 +9490,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 2, name: r1}
+                  Variable: {subprogram: 74, index: 2, name: r1}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -9037,7 +9586,7 @@ Types:
       ID: 454
       Name: Probe[main.condNilPtrStruct]Return
     - __kind: EventRootType
-      ID: 474
+      ID: 483
       Name: Probe[main.condNullIface]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -9049,76 +9598,16 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 35, index: 1, name: tag}
+                  Variable: {subprogram: 37, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 475
+      ID: 484
       Name: Probe[main.condNullIface]Return
     - __kind: EventRootType
-      ID: 472
+      ID: 481
       Name: Probe[main.condNullMap]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 34, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 473
-      Name: Probe[main.condNullMap]Return
-    - __kind: EventRootType
-      ID: 468
-      Name: Probe[main.condNullPtr]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 32, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 469
-      Name: Probe[main.condNullPtr]Return
-    - __kind: EventRootType
-      ID: 470
-      Name: Probe[main.condNullSlice]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 33, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 471
-      Name: Probe[main.condNullSlice]Return
-    - __kind: EventRootType
-      ID: 476
-      Name: Probe[main.condNullUnsafePtr]
       ByteSize: 17
       ExprStatusArraySize: 1
       Expressions:
@@ -9134,7 +9623,67 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
+      ID: 482
+      Name: Probe[main.condNullMap]Return
+    - __kind: EventRootType
       ID: 477
+      Name: Probe[main.condNullPtr]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 478
+      Name: Probe[main.condNullPtr]Return
+    - __kind: EventRootType
+      ID: 479
+      Name: Probe[main.condNullSlice]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 480
+      Name: Probe[main.condNullSlice]Return
+    - __kind: EventRootType
+      ID: 485
+      Name: Probe[main.condNullUnsafePtr]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 486
       Name: Probe[main.condNullUnsafePtr]Return
     - __kind: EventRootType
       ID: 461
@@ -9946,7 +10495,7 @@ Types:
       ID: 388
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 656
+      ID: 665
       Name: Probe[main.genericIdentity[go.shape.int]]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -9959,12 +10508,12 @@ Types:
             Type: 168 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: x}
+                  Variable: {subprogram: 76, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 657
+      ID: 666
       Name: Probe[main.genericIdentity[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -9977,12 +10526,12 @@ Types:
             Type: 168 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 1, name: ~r0}
+                  Variable: {subprogram: 76, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 654
+      ID: 663
       Name: Probe[main.genericIdentity[go.shape.string]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -9995,12 +10544,12 @@ Types:
             Type: 167 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: x}
+                  Variable: {subprogram: 75, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 655
+      ID: 664
       Name: Probe[main.genericIdentity[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -10013,12 +10562,12 @@ Types:
             Type: 167 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 1, name: ~r0}
+                  Variable: {subprogram: 75, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 598
+      ID: 607
       Name: Probe[main.indexMemberWrapperArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -10030,7 +10579,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
+                  Variable: {subprogram: 55, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10041,7 +10590,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 600
+      ID: 609
       Name: Probe[main.indexMemberWrapperArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10053,7 +10602,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
+                  Variable: {subprogram: 55, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10064,7 +10613,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 602
+      ID: 611
       Name: Probe[main.indexMemberWrapperArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -10076,7 +10625,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
+                  Variable: {subprogram: 55, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10090,7 +10639,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 604
+      ID: 613
       Name: Probe[main.indexMemberWrapperArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10102,7 +10651,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
+                  Variable: {subprogram: 55, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10116,19 +10665,19 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 599
+      ID: 608
       Name: Probe[main.indexMemberWrapperArg]Return
     - __kind: EventRootType
-      ID: 601
+      ID: 610
       Name: Probe[main.indexMemberWrapperArg]Return
     - __kind: EventRootType
-      ID: 603
+      ID: 612
       Name: Probe[main.indexMemberWrapperArg]Return
     - __kind: EventRootType
-      ID: 605
+      ID: 614
       Name: Probe[main.indexMemberWrapperArg]Return
     - __kind: EventRootType
-      ID: 564
+      ID: 573
       Name: Probe[main.indexNilPtrSlice]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10140,7 +10689,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: x}
+                  Variable: {subprogram: 47, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10153,7 +10702,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 566
+      ID: 575
       Name: Probe[main.indexNilPtrSlice]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10165,12 +10714,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 1, name: tag}
+                  Variable: {subprogram: 47, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 568
+      ID: 577
       Name: Probe[main.indexNilPtrSlice]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10182,7 +10731,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: x}
+                  Variable: {subprogram: 47, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10195,16 +10744,16 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 565
+      ID: 574
       Name: Probe[main.indexNilPtrSlice]Return
     - __kind: EventRootType
-      ID: 567
+      ID: 576
       Name: Probe[main.indexNilPtrSlice]Return
     - __kind: EventRootType
-      ID: 569
+      ID: 578
       Name: Probe[main.indexNilPtrSlice]Return
     - __kind: EventRootType
-      ID: 658
+      ID: 667
       Name: Probe[main.inlined]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10216,12 +10765,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: x}
+                  Variable: {subprogram: 77, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 659
+      ID: 668
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
       ID: 316
@@ -10434,7 +10983,7 @@ Types:
       ID: 337
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 556
+      ID: 565
       Name: Probe[main.lenErrInt]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -10446,7 +10995,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: x}
+                  Variable: {subprogram: 45, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -10457,21 +11006,21 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 1, name: tag}
+                  Variable: {subprogram: 45, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 558
+      ID: 567
       Name: Probe[main.lenErrInt]
     - __kind: EventRootType
-      ID: 557
+      ID: 566
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 559
+      ID: 568
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 560
+      ID: 569
       Name: Probe[main.lenErrStruct]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -10483,7 +11032,7 @@ Types:
             Type: 119 StructureType main.condFields
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: x}
+                  Variable: {subprogram: 46, index: 0, name: x}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -10494,21 +11043,21 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 1, name: tag}
+                  Variable: {subprogram: 46, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 562
+      ID: 571
       Name: Probe[main.lenErrStruct]
     - __kind: EventRootType
-      ID: 561
+      ID: 570
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 563
+      ID: 572
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 510
+      ID: 519
       Name: Probe[main.lenMap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10520,12 +11069,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Variable: {subprogram: 41, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 512
+      ID: 521
       Name: Probe[main.lenMap]
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -10537,7 +11086,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: m}
+                  Variable: {subprogram: 41, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10551,7 +11100,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 514
+      ID: 523
       Name: Probe[main.lenMap]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10563,845 +11112,16 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: m}
+                  Variable: {subprogram: 41, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
                   Bias: 0
                   ByteSize: 8
           DictIndex: -1
-    - __kind: EventRootType
-      ID: 516
-      Name: Probe[main.lenMap]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 518
-      Name: Probe[main.lenMap]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(m)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 8 BaseType uint64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 0
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 520
-      Name: Probe[main.lenMap]
-      ByteSize: 25
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 109 GoMapType map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-          DictIndex: -1
-        - Name: tag
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 511
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 513
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 515
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 517
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 519
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 521
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 522
-      Name: Probe[main.lenPtrString]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(s)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 524
-      Name: Probe[main.lenPtrString]
-      ByteSize: 25
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 93 PointerType *string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 8
-          DictIndex: -1
-        - Name: tag
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 523
-      Name: Probe[main.lenPtrString]Return
     - __kind: EventRootType
       ID: 525
-      Name: Probe[main.lenPtrString]Return
-    - __kind: EventRootType
-      ID: 546
-      Name: Probe[main.lenPtrStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: items_0
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 16
-                  ByteSize: 16
-                - __kind: SliceBoundsCheckOp
-                  Index: 0
-                - __kind: DereferenceOp
-                  Bias: 0
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 548
-      Name: Probe[main.lenPtrStructFields]
-      ByteSize: 25
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 124 PointerType *main.lenFields
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-          DictIndex: -1
-        - Name: tag
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 550
-      Name: Probe[main.lenPtrStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.Dict)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 8 BaseType uint64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 40
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 0
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 552
-      Name: Probe[main.lenPtrStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.Items)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 24
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 554
-      Name: Probe[main.lenPtrStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.S)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 547
-      Name: Probe[main.lenPtrStructFields]Return
-    - __kind: EventRootType
-      ID: 549
-      Name: Probe[main.lenPtrStructFields]Return
-    - __kind: EventRootType
-      ID: 551
-      Name: Probe[main.lenPtrStructFields]Return
-    - __kind: EventRootType
-      ID: 553
-      Name: Probe[main.lenPtrStructFields]Return
-    - __kind: EventRootType
-      ID: 555
-      Name: Probe[main.lenPtrStructFields]Return
-    - __kind: EventRootType
-      ID: 498
-      Name: Probe[main.lenSlice]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 500
-      Name: Probe[main.lenSlice]
-      ByteSize: 2
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: isEmpty(s)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-                - __kind: ExprPushOffsetOp
-                  ByteSize: 8
-                - __kind: ExprLoadLiteralOp
-                  Data: AAAAAAAAAAA=
-                - __kind: ExprCmpEqBaseOp
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 502
-      Name: Probe[main.lenSlice]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s_len
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 504
-      Name: Probe[main.lenSlice]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 506
-      Name: Probe[main.lenSlice]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(s)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 508
-      Name: Probe[main.lenSlice]
-      ByteSize: 41
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 105 GoSliceHeaderType []int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 24
-          DictIndex: -1
-        - Name: tag
-          Offset: 25
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 499
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 501
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 503
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 505
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 507
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 509
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 478
-      Name: Probe[main.lenString]
-      ByteSize: 33
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-        - Name: tag
-          Offset: 17
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 480
-      Name: Probe[main.lenString]
-      ByteSize: 2
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s_len_eq_5
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-                - __kind: ExprPushOffsetOp
-                  ByteSize: 8
-                - __kind: ExprLoadLiteralOp
-                  Data: BQAAAAAAAAA=
-                - __kind: ExprCmpEqBaseOp
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 482
-      Name: Probe[main.lenString]
-      ByteSize: 2
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(s) == 5
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-                - __kind: ExprPushOffsetOp
-                  ByteSize: 8
-                - __kind: ExprLoadLiteralOp
-                  Data: BQAAAAAAAAA=
-                - __kind: ExprCmpEqBaseOp
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 484
-      Name: Probe[main.lenString]
-      ByteSize: 2
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s_isEmpty
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-                - __kind: ExprPushOffsetOp
-                  ByteSize: 8
-                - __kind: ExprLoadLiteralOp
-                  Data: AAAAAAAAAAA=
-                - __kind: ExprCmpEqBaseOp
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 486
-      Name: Probe[main.lenString]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 488
-      Name: Probe[main.lenString]
-      ByteSize: 2
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: isEmpty(s)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-                - __kind: ExprPushOffsetOp
-                  ByteSize: 8
-                - __kind: ExprLoadLiteralOp
-                  Data: AAAAAAAAAAA=
-                - __kind: ExprCmpEqBaseOp
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 490
-      Name: Probe[main.lenString]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s_len
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 492
-      Name: Probe[main.lenString]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 494
-      Name: Probe[main.lenString]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(s)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 496
-      Name: Probe[main.lenString]
-      ByteSize: 33
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-        - Name: tag
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 479
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 481
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 483
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 485
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 487
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 489
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 491
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 493
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 495
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 497
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 526
-      Name: Probe[main.lenStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: items_2
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 16
-                  ByteSize: 16
-                - __kind: SliceBoundsCheckOp
-                  Index: 2
-                - __kind: DereferenceOp
-                  Bias: 16
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 528
-      Name: Probe[main.lenStructFields]
-      ByteSize: 89
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 122 StructureType main.lenFields
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 72
-          DictIndex: -1
-        - Name: tag
-          Offset: 73
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 530
-      Name: Probe[main.lenStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.Dict)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 8 BaseType uint64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 40
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 0
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 532
-      Name: Probe[main.lenStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.PtrSlice)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 56
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 534
-      Name: Probe[main.lenStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.PtrStr)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 48
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 536
-      Name: Probe[main.lenStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.Items)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 24
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 538
-      Name: Probe[main.lenStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.S)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 540
-      Name: Probe[main.lenStructFields]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 542
-      Name: Probe[main.lenStructFields]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 544
-      Name: Probe[main.lenStructFields]
+      Name: Probe[main.lenMap]
       ByteSize: 17
       ExprStatusArraySize: 1
       Expressions:
@@ -11418,33 +11138,862 @@ Types:
           DictIndex: -1
     - __kind: EventRootType
       ID: 527
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenMap]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(m)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 41, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+          DictIndex: -1
     - __kind: EventRootType
       ID: 529
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenMap]
+      ByteSize: 25
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 109 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 41, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 41, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 520
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 522
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 524
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 526
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 528
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 530
+      Name: Probe[main.lenMap]Return
     - __kind: EventRootType
       ID: 531
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenPtrString]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 42, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+          DictIndex: -1
     - __kind: EventRootType
       ID: 533
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenPtrString]
+      ByteSize: 25
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 93 PointerType *string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 42, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 42, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 532
+      Name: Probe[main.lenPtrString]Return
+    - __kind: EventRootType
+      ID: 534
+      Name: Probe[main.lenPtrString]Return
+    - __kind: EventRootType
+      ID: 555
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: items_0
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 16
+                  ByteSize: 16
+                - __kind: SliceBoundsCheckOp
+                  Index: 0
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 557
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 25
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 124 PointerType *main.lenFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 559
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.Dict)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 40
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 561
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.Items)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 24
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 563
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.S)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 556
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 558
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 560
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 562
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 564
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 507
+      Name: Probe[main.lenSlice]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 509
+      Name: Probe[main.lenSlice]
+      ByteSize: 2
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: isEmpty(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 511
+      Name: Probe[main.lenSlice]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s_len
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 513
+      Name: Probe[main.lenSlice]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 515
+      Name: Probe[main.lenSlice]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 517
+      Name: Probe[main.lenSlice]
+      ByteSize: 41
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 105 GoSliceHeaderType []int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+          DictIndex: -1
+        - Name: tag
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 508
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 510
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 512
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 514
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 516
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 518
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 487
+      Name: Probe[main.lenString]
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: tag
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 489
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s_len_eq_5
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 491
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(s) == 5
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 493
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s_isEmpty
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 495
+      Name: Probe[main.lenString]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 497
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: isEmpty(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 499
+      Name: Probe[main.lenString]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s_len
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 501
+      Name: Probe[main.lenString]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 503
+      Name: Probe[main.lenString]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 505
+      Name: Probe[main.lenString]
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: tag
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 488
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 490
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 492
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 494
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 496
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 498
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 500
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 502
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 504
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 506
+      Name: Probe[main.lenString]Return
     - __kind: EventRootType
       ID: 535
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: items_2
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 16
+                  ByteSize: 16
+                - __kind: SliceBoundsCheckOp
+                  Index: 2
+                - __kind: DereferenceOp
+                  Bias: 16
+                  ByteSize: 8
+          DictIndex: -1
     - __kind: EventRootType
       ID: 537
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenStructFields]
+      ByteSize: 89
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 122 StructureType main.lenFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 72
+          DictIndex: -1
+        - Name: tag
+          Offset: 73
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
     - __kind: EventRootType
       ID: 539
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.Dict)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 40
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+          DictIndex: -1
     - __kind: EventRootType
       ID: 541
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.PtrSlice)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 56
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+          DictIndex: -1
     - __kind: EventRootType
       ID: 543
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.PtrStr)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 48
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+          DictIndex: -1
     - __kind: EventRootType
       ID: 545
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.Items)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 24
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 547
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.S)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 8
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 549
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 551
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 553
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 536
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 538
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 540
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 542
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 544
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 546
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 548
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 550
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 552
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 554
       Name: Probe[main.lenStructFields]Return
     - __kind: EventRootType
       ID: 357
@@ -11478,7 +12027,7 @@ Types:
       ID: 358
       Name: Probe[main.mapArg]Return
     - __kind: EventRootType
-      ID: 642
+      ID: 651
       Name: Probe[main.mapIndexBoolKey]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11490,7 +12039,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11517,7 +12066,7 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 644
+      ID: 653
       Name: Probe[main.mapIndexBoolKey]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11529,7 +12078,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11556,13 +12105,13 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 643
+      ID: 652
+      Name: Probe[main.mapIndexBoolKey]Return
+    - __kind: EventRootType
+      ID: 654
       Name: Probe[main.mapIndexBoolKey]Return
     - __kind: EventRootType
       ID: 645
-      Name: Probe[main.mapIndexBoolKey]Return
-    - __kind: EventRootType
-      ID: 636
       Name: Probe[main.mapIndexEmptyKey]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11574,7 +12123,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11601,10 +12150,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 637
+      ID: 646
       Name: Probe[main.mapIndexEmptyKey]Return
     - __kind: EventRootType
-      ID: 606
+      ID: 615
       Name: Probe[main.mapIndexIntKey]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -11616,7 +12165,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: m}
+                  Variable: {subprogram: 56, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11643,10 +12192,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 607
+      ID: 616
       Name: Probe[main.mapIndexIntKey]Return
     - __kind: EventRootType
-      ID: 638
+      ID: 647
       Name: Probe[main.mapIndexKeyLen16]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11658,7 +12207,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11685,10 +12234,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 639
+      ID: 648
       Name: Probe[main.mapIndexKeyLen16]Return
     - __kind: EventRootType
-      ID: 640
+      ID: 649
       Name: Probe[main.mapIndexKeyLen17]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11700,7 +12249,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11727,10 +12276,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 641
+      ID: 650
       Name: Probe[main.mapIndexKeyLen17]Return
     - __kind: EventRootType
-      ID: 626
+      ID: 635
       Name: Probe[main.mapIndexKeyLen200]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11742,7 +12291,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
+                  Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11769,10 +12318,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 627
+      ID: 636
       Name: Probe[main.mapIndexKeyLen200]Return
     - __kind: EventRootType
-      ID: 620
+      ID: 629
       Name: Probe[main.mapIndexKeyLen24]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11784,7 +12333,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
+                  Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11811,10 +12360,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 621
+      ID: 630
       Name: Probe[main.mapIndexKeyLen24]Return
     - __kind: EventRootType
-      ID: 622
+      ID: 631
       Name: Probe[main.mapIndexKeyLen48]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11826,7 +12375,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
+                  Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11853,10 +12402,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 623
+      ID: 632
       Name: Probe[main.mapIndexKeyLen48]Return
     - __kind: EventRootType
-      ID: 618
+      ID: 627
       Name: Probe[main.mapIndexKeyLen8]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11868,7 +12417,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
+                  Variable: {subprogram: 60, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11895,10 +12444,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 619
+      ID: 628
       Name: Probe[main.mapIndexKeyLen8]Return
     - __kind: EventRootType
-      ID: 624
+      ID: 633
       Name: Probe[main.mapIndexKeyLen96]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11910,7 +12459,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11937,10 +12486,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 625
+      ID: 634
       Name: Probe[main.mapIndexKeyLen96]Return
     - __kind: EventRootType
-      ID: 614
+      ID: 623
       Name: Probe[main.mapIndexLargeMap]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11952,7 +12501,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: m}
+                  Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11979,10 +12528,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 615
+      ID: 624
       Name: Probe[main.mapIndexLargeMap]Return
     - __kind: EventRootType
-      ID: 650
+      ID: 659
       Name: Probe[main.mapIndexLargeValue]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11994,7 +12543,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12024,10 +12573,10 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 651
+      ID: 660
       Name: Probe[main.mapIndexLargeValue]Return
     - __kind: EventRootType
-      ID: 616
+      ID: 625
       Name: Probe[main.mapIndexMissing]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12039,7 +12588,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
+                  Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12066,10 +12615,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 617
+      ID: 626
       Name: Probe[main.mapIndexMissing]Return
     - __kind: EventRootType
-      ID: 648
+      ID: 657
       Name: Probe[main.mapIndexNilPtrVal]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12081,7 +12630,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 72, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12111,10 +12660,10 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 649
+      ID: 658
       Name: Probe[main.mapIndexNilPtrVal]Return
     - __kind: EventRootType
-      ID: 632
+      ID: 641
       Name: Probe[main.mapIndexPtrStructVal]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12126,7 +12675,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12156,7 +12705,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 634
+      ID: 643
       Name: Probe[main.mapIndexPtrStructVal]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12168,7 +12717,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12198,13 +12747,13 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 633
+      ID: 642
       Name: Probe[main.mapIndexPtrStructVal]Return
     - __kind: EventRootType
-      ID: 635
+      ID: 644
       Name: Probe[main.mapIndexPtrStructVal]Return
     - __kind: EventRootType
-      ID: 608
+      ID: 617
       Name: Probe[main.mapIndexStringKey]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12216,7 +12765,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12243,10 +12792,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 610
+      ID: 619
       Name: Probe[main.mapIndexStringKey]
     - __kind: EventRootType
-      ID: 612
+      ID: 621
       Name: Probe[main.mapIndexStringKey]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12258,7 +12807,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12285,16 +12834,16 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 609
+      ID: 618
       Name: Probe[main.mapIndexStringKey]Return
     - __kind: EventRootType
-      ID: 611
+      ID: 620
       Name: Probe[main.mapIndexStringKey]Return
     - __kind: EventRootType
-      ID: 613
+      ID: 622
       Name: Probe[main.mapIndexStringKey]Return
     - __kind: EventRootType
-      ID: 628
+      ID: 637
       Name: Probe[main.mapIndexStructVal]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12306,7 +12855,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12333,7 +12882,7 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 630
+      ID: 639
       Name: Probe[main.mapIndexStructVal]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12345,7 +12894,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12372,13 +12921,13 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 629
+      ID: 638
       Name: Probe[main.mapIndexStructVal]Return
     - __kind: EventRootType
-      ID: 631
+      ID: 640
       Name: Probe[main.mapIndexStructVal]Return
     - __kind: EventRootType
-      ID: 646
+      ID: 655
       Name: Probe[main.mapIndexZeroValue]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12390,7 +12939,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12417,7 +12966,7 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 647
+      ID: 656
       Name: Probe[main.mapIndexZeroValue]Return
     - __kind: EventRootType
       ID: 361
@@ -12426,7 +12975,7 @@ Types:
       ID: 362
       Name: Probe[main.noArgs]Return
     - __kind: EventRootType
-      ID: 594
+      ID: 603
       Name: Probe[main.ptrStructArrayArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12438,7 +12987,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: s}
+                  Variable: {subprogram: 54, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12446,7 +12995,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 596
+      ID: 605
       Name: Probe[main.ptrStructArrayArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12458,7 +13007,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: s}
+                  Variable: {subprogram: 54, index: 0, name: s}
                   Offset: 8
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12466,13 +13015,13 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 595
+      ID: 604
       Name: Probe[main.ptrStructArrayArg]Return
     - __kind: EventRootType
-      ID: 597
+      ID: 606
       Name: Probe[main.ptrStructArrayArg]Return
     - __kind: EventRootType
-      ID: 590
+      ID: 599
       Name: Probe[main.ptrStructSliceArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12484,7 +13033,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: s}
+                  Variable: {subprogram: 53, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -12497,7 +13046,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 592
+      ID: 601
       Name: Probe[main.ptrStructSliceArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12509,7 +13058,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: s}
+                  Variable: {subprogram: 53, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -12522,10 +13071,10 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 591
+      ID: 600
       Name: Probe[main.ptrStructSliceArg]Return
     - __kind: EventRootType
-      ID: 593
+      ID: 602
       Name: Probe[main.ptrStructSliceArg]Return
     - __kind: EventRootType
       ID: 318
@@ -12687,7 +13236,7 @@ Types:
       ID: 351
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 586
+      ID: 595
       Name: Probe[main.structArrayArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12699,12 +13248,12 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: s}
+                  Variable: {subprogram: 52, index: 0, name: s}
                   Offset: 0
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 588
+      ID: 597
       Name: Probe[main.structArrayArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12716,18 +13265,18 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: s}
+                  Variable: {subprogram: 52, index: 0, name: s}
                   Offset: 40
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
+      ID: 596
+      Name: Probe[main.structArrayArg]Return
+    - __kind: EventRootType
+      ID: 598
+      Name: Probe[main.structArrayArg]Return
+    - __kind: EventRootType
       ID: 587
-      Name: Probe[main.structArrayArg]Return
-    - __kind: EventRootType
-      ID: 589
-      Name: Probe[main.structArrayArg]Return
-    - __kind: EventRootType
-      ID: 578
       Name: Probe[main.structSliceArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12739,7 +13288,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: s}
+                  Variable: {subprogram: 51, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -12749,7 +13298,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 580
+      ID: 589
       Name: Probe[main.structSliceArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12761,7 +13310,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: s}
+                  Variable: {subprogram: 51, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -12771,7 +13320,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 582
+      ID: 591
       Name: Probe[main.structSliceArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12783,12 +13332,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 1, name: tag}
+                  Variable: {subprogram: 51, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 584
+      ID: 593
       Name: Probe[main.structSliceArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12800,7 +13349,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: s}
+                  Variable: {subprogram: 51, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -12810,22 +13359,22 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
+      ID: 588
+      Name: Probe[main.structSliceArg]Return
+    - __kind: EventRootType
+      ID: 590
+      Name: Probe[main.structSliceArg]Return
+    - __kind: EventRootType
+      ID: 592
+      Name: Probe[main.structSliceArg]Return
+    - __kind: EventRootType
+      ID: 594
+      Name: Probe[main.structSliceArg]Return
+    - __kind: EventRootType
       ID: 579
-      Name: Probe[main.structSliceArg]Return
-    - __kind: EventRootType
-      ID: 581
-      Name: Probe[main.structSliceArg]Return
-    - __kind: EventRootType
-      ID: 583
-      Name: Probe[main.structSliceArg]Return
-    - __kind: EventRootType
-      ID: 585
-      Name: Probe[main.structSliceArg]Return
-    - __kind: EventRootType
-      ID: 570
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 571
+      ID: 580
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12837,14 +13386,14 @@ Types:
             Type: 125 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: ~r0}
+                  Variable: {subprogram: 48, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: ArrayType
       ID: 92
       Name: '[0]uint8'
-      GoRuntimeType: 56512
+      GoRuntimeType: 56608
       GoKind: 17
       HasCount: true
       Element: 3 BaseType uint8
@@ -12852,7 +13401,7 @@ Types:
       ID: 89
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 56416
+      GoRuntimeType: 56512
       GoKind: 17
       Count: 10
       HasCount: true
@@ -12896,7 +13445,7 @@ Types:
       ID: 75
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 56032
+      GoRuntimeType: 56128
       GoKind: 17
       Count: 2
       HasCount: true
@@ -12905,7 +13454,7 @@ Types:
       ID: 74
       Name: '[2][2]*runtime.traceBuf'
       ByteSize: 32
-      GoRuntimeType: 56128
+      GoRuntimeType: 56224
       GoKind: 17
       Count: 2
       HasCount: true
@@ -12914,7 +13463,7 @@ Types:
       ID: 81
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 56320
+      GoRuntimeType: 56416
       GoKind: 17
       Count: 2
       HasCount: true
@@ -12931,7 +13480,7 @@ Types:
       ID: 54
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 52288
+      GoRuntimeType: 52384
       GoKind: 17
       Count: 2
       HasCount: true
@@ -12940,7 +13489,7 @@ Types:
       ID: 87
       Name: '[32]uint64'
       ByteSize: 256
-      GoRuntimeType: 58432
+      GoRuntimeType: 58528
       GoKind: 17
       Count: 32
       HasCount: true
@@ -12949,7 +13498,7 @@ Types:
       ID: 65
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 55840
+      GoRuntimeType: 55936
       GoKind: 17
       Count: 32
       HasCount: true
@@ -12976,7 +13525,7 @@ Types:
       ID: 53
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 55552
+      GoRuntimeType: 55648
       GoKind: 17
       Count: 3
       HasCount: true
@@ -12994,7 +13543,7 @@ Types:
       ID: 88
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 57568
+      GoRuntimeType: 57664
       GoKind: 17
       Count: 4
       HasCount: true
@@ -13003,7 +13552,7 @@ Types:
       ID: 58
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 54784
+      GoRuntimeType: 54880
       GoKind: 17
       Count: 6
       HasCount: true
@@ -13012,7 +13561,7 @@ Types:
       ID: 82
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 56224
+      GoRuntimeType: 56320
       GoKind: 17
       Count: 8
       HasCount: true
@@ -13287,7 +13836,7 @@ Types:
       ID: 13
       Name: error
       ByteSize: 16
-      GoRuntimeType: 67552
+      GoRuntimeType: 67648
       GoKind: 20
       RawFields:
         - Name: tab
@@ -13322,7 +13871,7 @@ Types:
       ID: 70
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 60704
+      GoRuntimeType: 60800
       GoKind: 19
     - __kind: BaseType
       ID: 168
@@ -13511,7 +14060,7 @@ Types:
       ID: 86
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 120128
+      GoRuntimeType: 120224
       GoKind: 25
       RawFields:
         - Name: buf
@@ -13536,14 +14085,14 @@ Types:
     - __kind: StructureType
       ID: 305
       Name: internal/poll.errNetClosing
-      GoRuntimeType: 96736
+      GoRuntimeType: 96832
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 78784
+      GoRuntimeType: 78880
       GoKind: 25
       RawFields:
         - Name: u
@@ -13553,7 +14102,7 @@ Types:
       ID: 68
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 107424
+      GoRuntimeType: 107520
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -13569,7 +14118,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 97536
+      GoRuntimeType: 97632
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -13582,7 +14131,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 97376
+      GoRuntimeType: 97472
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -13595,7 +14144,7 @@ Types:
       ID: 73
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 97696
+      GoRuntimeType: 97792
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -13607,13 +14156,13 @@ Types:
     - __kind: StructureType
       ID: 69
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 65984
+      GoRuntimeType: 66080
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 33
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 65888
+      GoRuntimeType: 65984
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -13624,14 +14173,14 @@ Types:
       ID: 269
       Name: main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 74432
+      GoRuntimeType: 74528
       GoKind: 25
       RawFields: [{Name: a, Offset: 0, Type: 7 BaseType int}]
     - __kind: StructureType
       ID: 132
       Name: main.bigArrayStruct
       ByteSize: 1048584
-      GoRuntimeType: 90016
+      GoRuntimeType: 90112
       GoKind: 25
       RawFields:
         - Name: tag
@@ -13644,7 +14193,7 @@ Types:
       ID: 199
       Name: main.bigStruct
       ByteSize: 184
-      GoRuntimeType: 128096
+      GoRuntimeType: 128192
       GoKind: 25
       RawFields:
         - Name: Field1
@@ -13675,7 +14224,7 @@ Types:
       ID: 119
       Name: main.condFields
       ByteSize: 80
-      GoRuntimeType: 135168
+      GoRuntimeType: 135264
       GoKind: 25
       RawFields:
         - Name: I8
@@ -13721,7 +14270,7 @@ Types:
       ID: 135
       Name: main.indexMemberStruct
       ByteSize: 32
-      GoRuntimeType: 100896
+      GoRuntimeType: 100992
       GoKind: 25
       RawFields:
         - Name: Val
@@ -13752,7 +14301,7 @@ Types:
       ID: 258
       Name: main.largeValueStruct
       ByteSize: 264
-      GoRuntimeType: 89856
+      GoRuntimeType: 89952
       GoKind: 25
       RawFields:
         - Name: Pad
@@ -13765,7 +14314,7 @@ Types:
       ID: 122
       Name: main.lenFields
       ByteSize: 72
-      GoRuntimeType: 122464
+      GoRuntimeType: 122560
       GoKind: 25
       RawFields:
         - Name: S
@@ -14084,63 +14633,63 @@ Types:
       ID: 157
       Name: map[bool]int
       ByteSize: 8
-      GoRuntimeType: 71776
+      GoRuntimeType: 71872
       GoKind: 21
       HeaderType: 159 GoSwissMapHeaderType map<bool,int>
     - __kind: GoMapType
       ID: 208
       Name: map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 71904
+      GoRuntimeType: 72000
       GoKind: 21
       HeaderType: 210 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 142
       Name: map[int]string
       ByteSize: 8
-      GoRuntimeType: 72032
+      GoRuntimeType: 72128
       GoKind: 21
       HeaderType: 144 GoSwissMapHeaderType map<int,string>
     - __kind: GoMapType
       ID: 152
       Name: map[string]*main.indexMemberStruct
       ByteSize: 8
-      GoRuntimeType: 72160
+      GoRuntimeType: 72256
       GoKind: 21
       HeaderType: 154 GoSwissMapHeaderType map<string,*main.indexMemberStruct>
     - __kind: GoMapType
       ID: 109
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 71648
+      GoRuntimeType: 71744
       GoKind: 21
       HeaderType: 111 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 114
       Name: map[string]main.bigStruct
       ByteSize: 8
-      GoRuntimeType: 72288
+      GoRuntimeType: 72384
       GoKind: 21
       HeaderType: 116 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: GoMapType
       ID: 147
       Name: map[string]main.indexMemberStruct
       ByteSize: 8
-      GoRuntimeType: 72416
+      GoRuntimeType: 72512
       GoKind: 21
       HeaderType: 149 GoSwissMapHeaderType map<string,main.indexMemberStruct>
     - __kind: GoMapType
       ID: 162
       Name: map[string]main.largeValueStruct
       ByteSize: 8
-      GoRuntimeType: 72544
+      GoRuntimeType: 72640
       GoKind: 21
       HeaderType: 164 GoSwissMapHeaderType map<string,main.largeValueStruct>
     - __kind: GoMapType
       ID: 125
       Name: map[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 72800
+      GoRuntimeType: 72896
       GoKind: 21
       HeaderType: 127 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: ArrayType
@@ -14228,7 +14777,7 @@ Types:
       ID: 246
       Name: noalg.map.group[bool]int
       ByteSize: 136
-      GoRuntimeType: 80448
+      GoRuntimeType: 80544
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14241,7 +14790,7 @@ Types:
       ID: 266
       Name: noalg.map.group[int]main.aStructNotUsedAsAnArgument
       ByteSize: 136
-      GoRuntimeType: 80704
+      GoRuntimeType: 80800
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14254,7 +14803,7 @@ Types:
       ID: 222
       Name: noalg.map.group[int]string
       ByteSize: 200
-      GoRuntimeType: 80960
+      GoRuntimeType: 81056
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14267,7 +14816,7 @@ Types:
       ID: 238
       Name: noalg.map.group[string]*main.indexMemberStruct
       ByteSize: 200
-      GoRuntimeType: 81216
+      GoRuntimeType: 81312
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14280,7 +14829,7 @@ Types:
       ID: 187
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 80192
+      GoRuntimeType: 80288
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14293,7 +14842,7 @@ Types:
       ID: 195
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
-      GoRuntimeType: 81472
+      GoRuntimeType: 81568
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14306,7 +14855,7 @@ Types:
       ID: 230
       Name: noalg.map.group[string]main.indexMemberStruct
       ByteSize: 392
-      GoRuntimeType: 81728
+      GoRuntimeType: 81824
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14319,7 +14868,7 @@ Types:
       ID: 254
       Name: noalg.map.group[string]main.largeValueStruct
       ByteSize: 200
-      GoRuntimeType: 81984
+      GoRuntimeType: 82080
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14332,7 +14881,7 @@ Types:
       ID: 205
       Name: noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 136
-      GoRuntimeType: 82496
+      GoRuntimeType: 82592
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14345,7 +14894,7 @@ Types:
       ID: 248
       Name: noalg.struct { key bool; elem int }
       ByteSize: 16
-      GoRuntimeType: 80320
+      GoRuntimeType: 80416
       GoKind: 25
       RawFields:
         - Name: key
@@ -14358,7 +14907,7 @@ Types:
       ID: 268
       Name: noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
       ByteSize: 16
-      GoRuntimeType: 80576
+      GoRuntimeType: 80672
       GoKind: 25
       RawFields:
         - Name: key
@@ -14371,7 +14920,7 @@ Types:
       ID: 224
       Name: noalg.struct { key int; elem string }
       ByteSize: 24
-      GoRuntimeType: 80832
+      GoRuntimeType: 80928
       GoKind: 25
       RawFields:
         - Name: key
@@ -14384,7 +14933,7 @@ Types:
       ID: 197
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
-      GoRuntimeType: 81344
+      GoRuntimeType: 81440
       GoKind: 25
       RawFields:
         - Name: key
@@ -14397,7 +14946,7 @@ Types:
       ID: 240
       Name: noalg.struct { key string; elem *main.indexMemberStruct }
       ByteSize: 24
-      GoRuntimeType: 81088
+      GoRuntimeType: 81184
       GoKind: 25
       RawFields:
         - Name: key
@@ -14410,7 +14959,7 @@ Types:
       ID: 256
       Name: noalg.struct { key string; elem *main.largeValueStruct }
       ByteSize: 24
-      GoRuntimeType: 81856
+      GoRuntimeType: 81952
       GoKind: 25
       RawFields:
         - Name: key
@@ -14423,7 +14972,7 @@ Types:
       ID: 189
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 80064
+      GoRuntimeType: 80160
       GoKind: 25
       RawFields:
         - Name: key
@@ -14436,7 +14985,7 @@ Types:
       ID: 232
       Name: noalg.struct { key string; elem main.indexMemberStruct }
       ByteSize: 48
-      GoRuntimeType: 81600
+      GoRuntimeType: 81696
       GoKind: 25
       RawFields:
         - Name: key
@@ -14449,7 +14998,7 @@ Types:
       ID: 207
       Name: noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
       ByteSize: 16
-      GoRuntimeType: 82368
+      GoRuntimeType: 82464
       GoKind: 25
       RawFields:
         - Name: key
@@ -14486,7 +15035,7 @@ Types:
       ID: 295
       Name: runtime.boundsError
       ByteSize: 24
-      GoRuntimeType: 121024
+      GoRuntimeType: 121120
       GoKind: 25
       RawFields:
         - Name: x
@@ -14518,14 +15067,14 @@ Types:
     - __kind: StructureType
       ID: 84
       Name: runtime.dlogPerM
-      GoRuntimeType: 65120
+      GoRuntimeType: 65216
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 301
       Name: runtime.errorAddressString
       ByteSize: 24
-      GoRuntimeType: 113568
+      GoRuntimeType: 113664
       GoKind: 25
       RawFields:
         - Name: msg
@@ -14538,7 +15087,7 @@ Types:
       ID: 282
       Name: runtime.errorString
       ByteSize: 16
-      GoRuntimeType: 64640
+      GoRuntimeType: 64736
       GoKind: 24
       RawFields:
         - Name: str
@@ -14557,7 +15106,7 @@ Types:
       ID: 22
       Name: runtime.g
       ByteSize: 440
-      GoRuntimeType: 150368
+      GoRuntimeType: 150464
       GoKind: 25
       RawFields:
         - Name: stack
@@ -14738,7 +15287,7 @@ Types:
       ID: 51
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 77248
+      GoRuntimeType: 77344
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -14748,7 +15297,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 56
-      GoRuntimeType: 126080
+      GoRuntimeType: 126176
       GoKind: 25
       RawFields:
         - Name: sp
@@ -14776,7 +15325,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 94976
+      GoRuntimeType: 95072
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -14789,7 +15338,7 @@ Types:
       ID: 56
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 112608
+      GoRuntimeType: 112704
       GoKind: 25
       RawFields:
         - Name: stack
@@ -14808,13 +15357,13 @@ Types:
       ID: 31
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 59264
+      GoRuntimeType: 59360
       GoKind: 12
     - __kind: StructureType
       ID: 90
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 94816
+      GoRuntimeType: 94912
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -14827,7 +15376,7 @@ Types:
       ID: 78
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 124256
+      GoRuntimeType: 124352
       GoKind: 25
       RawFields:
         - Name: fn
@@ -14852,13 +15401,13 @@ Types:
       ID: 91
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 59168
+      GoRuntimeType: 59264
       GoKind: 2
     - __kind: StructureType
       ID: 29
       Name: runtime.m
       ByteSize: 1808
-      GoRuntimeType: 155424
+      GoRuntimeType: 155520
       GoKind: 25
       RawFields:
         - Name: g0
@@ -15081,7 +15630,7 @@ Types:
       ID: 67
       Name: runtime.mLockProfile
       ByteSize: 64
-      GoRuntimeType: 126368
+      GoRuntimeType: 126464
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -15109,7 +15658,7 @@ Types:
       ID: 85
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 118784
+      GoRuntimeType: 118880
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -15131,7 +15680,7 @@ Types:
       ID: 72
       Name: runtime.mTraceState
       ByteSize: 56
-      GoRuntimeType: 118560
+      GoRuntimeType: 118656
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -15153,7 +15702,7 @@ Types:
       ID: 66
       Name: runtime.mWaitList
       ByteSize: 8
-      GoRuntimeType: 76992
+      GoRuntimeType: 77088
       GoKind: 25
       RawFields:
         - Name: next
@@ -15163,20 +15712,20 @@ Types:
       ID: 37
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 58880
+      GoRuntimeType: 58976
       GoKind: 12
     - __kind: StructureType
       ID: 64
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 76864
+      GoRuntimeType: 76960
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: StructureType
       ID: 80
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 94656
+      GoRuntimeType: 94752
       GoKind: 25
       RawFields:
         - Name: entries
@@ -15189,7 +15738,7 @@ Types:
       ID: 83
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 113376
+      GoRuntimeType: 113472
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -15208,7 +15757,7 @@ Types:
       ID: 285
       Name: runtime.plainError
       ByteSize: 16
-      GoRuntimeType: 64736
+      GoRuntimeType: 64832
       GoKind: 24
       RawFields:
         - Name: str
@@ -15227,13 +15776,13 @@ Types:
       ID: 60
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 59072
+      GoRuntimeType: 59168
       GoKind: 12
     - __kind: ArrayType
       ID: 57
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 62240
+      GoRuntimeType: 62336
       GoKind: 17
       Count: 2
       HasCount: true
@@ -15242,7 +15791,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 93056
+      GoRuntimeType: 93152
       GoKind: 25
       RawFields:
         - Name: lo
@@ -15283,7 +15832,7 @@ Types:
       ID: 52
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 94016
+      GoRuntimeType: 94112
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -15296,12 +15845,12 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 79808
+      GoRuntimeType: 79904
       GoKind: 8
     - __kind: StructureType
       ID: 79
       Name: runtime.winlibcall
-      GoRuntimeType: 65024
+      GoRuntimeType: 65120
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -15331,7 +15880,7 @@ Types:
       ID: 308
       Name: syscall.Errno
       ByteSize: 8
-      GoRuntimeType: 79936
+      GoRuntimeType: 80032
       GoKind: 12
     - __kind: StructureType
       ID: 243
@@ -15553,7 +16102,7 @@ Types:
       ID: 272
       Name: time.fileSizeError
       ByteSize: 16
-      GoRuntimeType: 59360
+      GoRuntimeType: 59456
       GoKind: 24
       RawFields:
         - Name: str
@@ -15610,7 +16159,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 45376
       GoKind: 26
-MaxTypeID: 662
+MaxTypeID: 671
 Issues:
     - probe_definition:
         id: condCompound_eq_of_eq
@@ -15919,6 +16468,26 @@ Issues:
         Kind: 7
         Message: condition variable "x" not available at any event
     - probe_definition:
+        id: condLineReturn_cond_return
+        version: 0
+        type: LOG_PROBE
+        where:
+            methodName: main.condLineReturn
+            sourceFile: main.go
+            lines: ["571"]
+        tags: ['issue:ConditionVariableUnavailable']
+        when:
+            dsl: '@return == 14'
+            json: {eq: [{ref: '@return'}, 14]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: matched
+        segments: [matched]
+        captureSnapshot: false
+      issue:
+        Kind: 7
+        Message: condition variable "@return" not found
+    - probe_definition:
         id: condNull_int_vs_null
         version: 0
         type: LOG_PROBE
@@ -16006,8 +16575,8 @@ Issues:
       issue:
         Kind: 3
         Message: probe kind ProbeKindSpan is not supported
-GoModuledataInfo: {FirstModuledataAddr: "0x58b340", TypesOffset: 296}
-GoMapHashInfo: {UseAeshashAddr: "0x5b466a", AeskeyschedAddr: "0x5b4d60"}
+GoModuledataInfo: {FirstModuledataAddr: "0x58c340", TypesOffset: 296}
+GoMapHashInfo: {UseAeshashAddr: "0x5b566a", AeskeyschedAddr: "0x5b5d60"}
 CommonTypes:
     G: 22 StructureType runtime.g
     M: 29 StructureType runtime.m

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
@@ -9,10 +9,10 @@ Probes:
       segments: ['ptr: ', {json: {ref: ptr}, dsl: ptr}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 76}
+        - subprogram: {subprogram: 78}
           events:
             - Kind: Entry
-              Type: 675 EventRootType Probe[main.PointerChainArg]
+              Type: 684 EventRootType Probe[main.PointerChainArg]
               InjectionPoints: [{PC: "0x4af3c6", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -32,10 +32,10 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 77}
+        - subprogram: {subprogram: 79}
           events:
             - Kind: Entry
-              Type: 676 EventRootType Probe[main.PointerSmallChainArg]
+              Type: 685 EventRootType Probe[main.PointerSmallChainArg]
               InjectionPoints: [{PC: "0x4af410", Frameless: false}]
               Condition: null
     - id: bigMapArg
@@ -50,11 +50,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 374 EventRootType Probe[main.bigMapArg]
-              InjectionPoints: [{PC: "0x4b18b3", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1af3", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 375 EventRootType Probe[main.bigMapArg]Return
-              InjectionPoints: [{PC: "0x4b193e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1b7e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 'm: {m}'
@@ -78,7 +78,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 420 EventRootType Probe[main.condBool]
-              InjectionPoints: [{PC: "0x4b214a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b238a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -95,7 +95,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 421 EventRootType Probe[main.condBool]Return
-              InjectionPoints: [{PC: "0x4b21ba", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b23fa", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -119,7 +119,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 422 EventRootType Probe[main.condBool]
-              InjectionPoints: [{PC: "0x4b214a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b238a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -136,7 +136,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 423 EventRootType Probe[main.condBool]Return
-              InjectionPoints: [{PC: "0x4b21ba", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b23fa", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -159,11 +159,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 424 EventRootType Probe[main.condBool]
-              InjectionPoints: [{PC: "0x4b214a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b238a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 425 EventRootType Probe[main.condBool]Return
-              InjectionPoints: [{PC: "0x4b21ba", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b23fa", Frameless: false}]
               Condition: null
     - id: condCompound_and
       version: 0
@@ -188,7 +188,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 470 EventRootType Probe[main.condReturnAndLocal]
-              InjectionPoints: [{PC: "0x4b262a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b286a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -220,7 +220,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 471 EventRootType Probe[main.condReturnAndLocal]Return
-              InjectionPoints: [{PC: "0x4b2695", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b28d5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: a == 1 && b == 1 [a={a}, b={b}]
@@ -262,7 +262,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 440 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0x4b22ce", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b250e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -292,7 +292,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 441 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0x4b23cf", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b260f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x.S == "world" && tag == "match" [x.S={x.S}, tag={tag}]
@@ -314,7 +314,7 @@ Probes:
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["519"]
+        lines: ["547"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -338,7 +338,7 @@ Probes:
           events:
             - Kind: Line
               Type: 480 EventRootType Probe[main.condLine]Line
-              InjectionPoints: [{PC: "0x4b27a1", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b29e1", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -412,7 +412,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 442 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0x4b22ce", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b250e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -460,7 +460,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 443 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0x4b23cf", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b260f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: (x.I32 == 300 || x.I32 == 999) && !isEmpty(x.S) [x.I32={x.I32}, x.S={x.S}, tag={tag}]
@@ -502,7 +502,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 426 EventRootType Probe[main.condBool]
-              InjectionPoints: [{PC: "0x4b214a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b238a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -520,7 +520,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 427 EventRootType Probe[main.condBool]Return
-              InjectionPoints: [{PC: "0x4b21ba", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b23fa", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '!x [x={x}, tag={tag}]'
@@ -559,7 +559,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 386 EventRootType Probe[main.condInt32]
-              InjectionPoints: [{PC: "0x4b1b4a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1d8a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -591,7 +591,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 387 EventRootType Probe[main.condInt32]Return
-              InjectionPoints: [{PC: "0x4b1bba", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1dfa", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x == 42 || x == 100 [x={x}, tag={tag}]
@@ -629,16 +629,16 @@ Probes:
         - ']'
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 493 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4b3113", Frameless: false}]
+              Type: 502 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4b3613", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 37, index: 1, name: tag}
+                      Variable: {subprogram: 39, index: 1, name: tag}
                       Offset: 0
                       ByteSize: 16
                     - __kind: ExprReadStringOp
@@ -650,7 +650,7 @@ Probes:
                       Cond: true
                       Target: 1
                     - __kind: LocationOp
-                      Variable: {subprogram: 37, index: 0, name: s}
+                      Variable: {subprogram: 39, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -664,8 +664,8 @@ Probes:
                       ID: 1
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 494 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4b31fc", Frameless: false}]
+              Type: 503 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4b36fc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag == "match" || !isEmpty(s) [s={s}, tag={tag}]
@@ -703,20 +703,20 @@ Probes:
         - ']'
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 72}
+        - subprogram: {subprogram: 74}
           events:
             - Kind: Entry
-              Type: 667 EventRootType Probe[main.condMultiReturn]
-              InjectionPoints: [{PC: "0x4b4e0e", Frameless: false}]
+              Type: 676 EventRootType Probe[main.condMultiReturn]
+              InjectionPoints: [{PC: "0x4b530e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 668 EventRootType Probe[main.condMultiReturn]Return
-              InjectionPoints: [{PC: "0x4b4eac", Frameless: false}]
+              Type: 677 EventRootType Probe[main.condMultiReturn]Return
+              InjectionPoints: [{PC: "0x4b53ac", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 72, index: 1, name: r0}
+                      Variable: {subprogram: 74, index: 1, name: r0}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -729,7 +729,7 @@ Probes:
                       Cond: false
                       Target: 1
                     - __kind: LocationOp
-                      Variable: {subprogram: 72, index: 2, name: r1}
+                      Variable: {subprogram: 74, index: 2, name: r1}
                       Offset: 0
                       ByteSize: 16
                     - __kind: ExprReadStringOp
@@ -777,7 +777,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 462 EventRootType Probe[main.condNilPtrStruct]
-              InjectionPoints: [{PC: "0x4b256e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b27ae", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -811,7 +811,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 463 EventRootType Probe[main.condNilPtrStruct]Return
-              InjectionPoints: [{PC: "0x4b25ee", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b282e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag == "nilptr" && x.I32 == 300 [tag={tag}]
@@ -845,7 +845,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 464 EventRootType Probe[main.condNilPtrStruct]
-              InjectionPoints: [{PC: "0x4b256e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b27ae", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -879,7 +879,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 465 EventRootType Probe[main.condNilPtrStruct]Return
-              InjectionPoints: [{PC: "0x4b25ee", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b282e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag == "nilptr" || x.I32 == 300 [tag={tag}]
@@ -903,11 +903,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 416 EventRootType Probe[main.condFloat32]
-              InjectionPoints: [{PC: "0x4b1fca", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b220a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 417 EventRootType Probe[main.condFloat32]Return
-              InjectionPoints: [{PC: "0x4b203e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b227e", Frameless: false}]
               Condition: null
     - id: condFloat64_nocond
       version: 0
@@ -922,11 +922,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 418 EventRootType Probe[main.condFloat64]
-              InjectionPoints: [{PC: "0x4b208a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b22ca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 419 EventRootType Probe[main.condFloat64]Return
-              InjectionPoints: [{PC: "0x4b20ff", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b233f", Frameless: false}]
               Condition: null
     - id: condInt16_cond
       version: 0
@@ -942,7 +942,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 382 EventRootType Probe[main.condInt16]
-              InjectionPoints: [{PC: "0x4b1a8a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1cca", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -959,7 +959,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 383 EventRootType Probe[main.condInt16]Return
-              InjectionPoints: [{PC: "0x4b1afa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1d3a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -982,11 +982,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 384 EventRootType Probe[main.condInt16]
-              InjectionPoints: [{PC: "0x4b1a8a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1cca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 385 EventRootType Probe[main.condInt16]Return
-              InjectionPoints: [{PC: "0x4b1afa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1d3a", Frameless: false}]
               Condition: null
     - id: condInt32_cond
       version: 0
@@ -1002,7 +1002,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 388 EventRootType Probe[main.condInt32]
-              InjectionPoints: [{PC: "0x4b1b4a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1d8a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1019,7 +1019,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 389 EventRootType Probe[main.condInt32]Return
-              InjectionPoints: [{PC: "0x4b1bba", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1dfa", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1046,7 +1046,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 390 EventRootType Probe[main.condInt32]
-              InjectionPoints: [{PC: "0x4b1b4a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1d8a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1063,7 +1063,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 391 EventRootType Probe[main.condInt32]Return
-              InjectionPoints: [{PC: "0x4b1bba", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1dfa", Frameless: false}]
               Condition: null
     - id: condInt32_nocond
       version: 0
@@ -1078,11 +1078,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 392 EventRootType Probe[main.condInt32]
-              InjectionPoints: [{PC: "0x4b1b4a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1d8a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 393 EventRootType Probe[main.condInt32]Return
-              InjectionPoints: [{PC: "0x4b1bba", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1dfa", Frameless: false}]
               Condition: null
     - id: condInt64_cond
       version: 0
@@ -1098,7 +1098,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 394 EventRootType Probe[main.condInt64]
-              InjectionPoints: [{PC: "0x4b1c0a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1e4a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1115,7 +1115,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 395 EventRootType Probe[main.condInt64]Return
-              InjectionPoints: [{PC: "0x4b1c7a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1eba", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1138,11 +1138,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 396 EventRootType Probe[main.condInt64]
-              InjectionPoints: [{PC: "0x4b1c0a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1e4a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 397 EventRootType Probe[main.condInt64]Return
-              InjectionPoints: [{PC: "0x4b1c7a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1eba", Frameless: false}]
               Condition: null
     - id: condInt8_cond
       version: 0
@@ -1158,7 +1158,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 378 EventRootType Probe[main.condInt8]
-              InjectionPoints: [{PC: "0x4b19ca", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1c0a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1175,7 +1175,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 379 EventRootType Probe[main.condInt8]Return
-              InjectionPoints: [{PC: "0x4b1a3a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1c7a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1198,11 +1198,257 @@ Probes:
           events:
             - Kind: Entry
               Type: 380 EventRootType Probe[main.condInt8]
-              InjectionPoints: [{PC: "0x4b19ca", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1c0a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 381 EventRootType Probe[main.condInt8]Return
-              InjectionPoints: [{PC: "0x4b1a3a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1c7a", Frameless: false}]
+              Condition: null
+    - id: condLineMixed_cond_bool
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when: {dsl: b == true, json: {eq: [{ref: b}, true]}}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 485 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0x4b2af1", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 1, name: b}
+                      Offset: 0
+                      ByteSize: 1
+                    - __kind: ExprPushOffsetOp
+                      ByteSize: 1
+                    - __kind: ExprLoadLiteralOp
+                      Data: AQ==
+                    - __kind: ExprCmpEqBaseOp
+                      ByteSize: 1
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_isEmpty_slice
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when: {dsl: isEmpty(ss), json: {isEmpty: {ref: ss}}}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 486 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0x4b2af1", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 4, name: ss}
+                      Offset: 8
+                      ByteSize: 8
+                    - __kind: ExprPushOffsetOp
+                      ByteSize: 8
+                    - __kind: ExprLoadLiteralOp
+                      Data: AAAAAAAAAAA=
+                    - __kind: ExprCmpEqBaseOp
+                      ByteSize: 8
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_len_string
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when:
+        dsl: len(s) == 5
+        json: {eq: [{len: {ref: s}}, 5]}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 487 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0x4b2af1", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 0, name: s}
+                      Offset: 8
+                      ByteSize: 8
+                    - __kind: ExprPushOffsetOp
+                      ByteSize: 8
+                    - __kind: ExprLoadLiteralOp
+                      Data: BQAAAAAAAAA=
+                    - __kind: ExprCmpEqBaseOp
+                      ByteSize: 8
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_ptrstruct_field
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when:
+        dsl: p.S == "world"
+        json: {eq: [{getmember: [{ref: p}, S]}, world]}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 488 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0x4b2af1", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 3, name: p}
+                      Offset: 0
+                      ByteSize: 8
+                    - __kind: DereferenceOp
+                      Bias: 56
+                      ByteSize: 16
+                    - __kind: ExprReadStringOp
+                      MaxLen: 255
+                    - __kind: ExprLoadLiteralOp
+                      Data: BQAAAHdvcmxk
+                    - __kind: ExprCmpEqStringOp
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_string
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when:
+        dsl: s == "hello"
+        json: {eq: [{ref: s}, hello]}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 489 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0x4b2af1", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 0, name: s}
+                      Offset: 0
+                      ByteSize: 16
+                    - __kind: ExprReadStringOp
+                      MaxLen: 255
+                    - __kind: ExprLoadLiteralOp
+                      Data: BQAAAGhlbGxv
+                    - __kind: ExprCmpEqStringOp
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_struct_field
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when:
+        dsl: x.I32 == 300
+        json: {eq: [{getmember: [{ref: x}, I32]}, 300]}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 490 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0x4b2af1", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 2, name: x}
+                      Offset: 4
+                      ByteSize: 4
+                    - __kind: ExprPushOffsetOp
+                      ByteSize: 4
+                    - __kind: ExprLoadLiteralOp
+                      Data: LAEAAA==
+                    - __kind: ExprCmpEqBaseOp
+                      ByteSize: 4
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_nocond
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 491 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0x4b2af1", Frameless: false}]
               Condition: null
     - id: condLine_cond
       version: 0
@@ -1210,7 +1456,7 @@ Probes:
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["519"]
+        lines: ["547"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -1227,7 +1473,7 @@ Probes:
           events:
             - Kind: Line
               Type: 481 EventRootType Probe[main.condLine]Line
-              InjectionPoints: [{PC: "0x4b27a1", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b29e1", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1242,13 +1488,58 @@ Probes:
                     - __kind: ExprCmpEqBaseOp
                       ByteSize: 8
                     - __kind: ConditionCheckOp
-    - id: condLine_nocond
+    - id: condLine_local_cond
       version: 0
       type: LOG_PROBE
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["519"]
+        lines: ["548"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+        - issue:ConditionVariableUnavailable@arch=arm64,toolchain=go1.23.11
+        - issue:ConditionVariableUnavailable@arch=amd64,toolchain=go1.23.11
+      when: {dsl: result == 14, json: {eq: [{ref: result}, 14]}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 28}
+          events:
+            - Kind: Line
+              Type: 482 EventRootType Probe[main.condLine]Line
+              InjectionPoints: [{PC: "0x4b29e4", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 28, index: 2, name: result}
+                      Offset: 0
+                      ByteSize: 8
+                    - __kind: ExprPushOffsetOp
+                      ByteSize: 8
+                    - __kind: ExprLoadLiteralOp
+                      Data: DgAAAAAAAAA=
+                    - __kind: ExprCmpEqBaseOp
+                      ByteSize: 8
+                    - __kind: ConditionCheckOp
+          probeTemplate:
+            TemplateString: tag={tag}
+            Segments:
+                - tag=
+                - JSON: {Ref: tag}
+                  DSL: tag
+                  EventKind: Line
+                  EventExpressionIndex: 0
+    - id: condLine_local_nocond
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLine
+        sourceFile: main.go
+        lines: ["548"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -1260,8 +1551,29 @@ Probes:
         - subprogram: {subprogram: 28}
           events:
             - Kind: Line
-              Type: 482 EventRootType Probe[main.condLine]Line
-              InjectionPoints: [{PC: "0x4b27a1", Frameless: false}]
+              Type: 483 EventRootType Probe[main.condLine]Line
+              InjectionPoints: [{PC: "0x4b29e4", Frameless: false}]
+              Condition: null
+    - id: condLine_nocond
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLine
+        sourceFile: main.go
+        lines: ["547"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 28}
+          events:
+            - Kind: Line
+              Type: 484 EventRootType Probe[main.condLine]Line
+              InjectionPoints: [{PC: "0x4b29e1", Frameless: false}]
               Condition: null
     - id: condNilPtr_cond
       version: 0
@@ -1279,7 +1591,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 466 EventRootType Probe[main.condNilPtrStruct]
-              InjectionPoints: [{PC: "0x4b256e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b27ae", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1299,7 +1611,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 467 EventRootType Probe[main.condNilPtrStruct]Return
-              InjectionPoints: [{PC: "0x4b25ee", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b282e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: condNilPtr {tag}
@@ -1322,11 +1634,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 468 EventRootType Probe[main.condNilPtrStruct]
-              InjectionPoints: [{PC: "0x4b256e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b27ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 469 EventRootType Probe[main.condNilPtrStruct]Return
-              InjectionPoints: [{PC: "0x4b25ee", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b282e", Frameless: false}]
               Condition: null
     - id: condNull_iface
       version: 0
@@ -1338,16 +1650,16 @@ Probes:
       segments: ['i == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 35}
+        - subprogram: {subprogram: 37}
           events:
             - Kind: Entry
-              Type: 489 EventRootType Probe[main.condNullIface]
-              InjectionPoints: [{PC: "0x4b2e6e", Frameless: false}]
+              Type: 498 EventRootType Probe[main.condNullIface]
+              InjectionPoints: [{PC: "0x4b336e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 35, index: 0, name: i}
+                      Variable: {subprogram: 37, index: 0, name: i}
                       Offset: 0
                       ByteSize: 16
                     - __kind: ExprPushOffsetOp
@@ -1358,8 +1670,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 490 EventRootType Probe[main.condNullIface]Return
-              InjectionPoints: [{PC: "0x4b2f76", Frameless: false}]
+              Type: 499 EventRootType Probe[main.condNullIface]Return
+              InjectionPoints: [{PC: "0x4b3476", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: i == nil [tag={tag}]
@@ -1380,16 +1692,16 @@ Probes:
       segments: ['m == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 34}
+        - subprogram: {subprogram: 36}
           events:
             - Kind: Entry
-              Type: 487 EventRootType Probe[main.condNullMap]
-              InjectionPoints: [{PC: "0x4b2d4e", Frameless: false}]
+              Type: 496 EventRootType Probe[main.condNullMap]
+              InjectionPoints: [{PC: "0x4b324e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 34, index: 0, name: m}
+                      Variable: {subprogram: 36, index: 0, name: m}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -1400,8 +1712,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 488 EventRootType Probe[main.condNullMap]Return
-              InjectionPoints: [{PC: "0x4b2e18", Frameless: false}]
+              Type: 497 EventRootType Probe[main.condNullMap]Return
+              InjectionPoints: [{PC: "0x4b3318", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: m == nil [tag={tag}]
@@ -1422,16 +1734,16 @@ Probes:
       segments: ['p == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 32}
+        - subprogram: {subprogram: 34}
           events:
             - Kind: Entry
-              Type: 483 EventRootType Probe[main.condNullPtr]
-              InjectionPoints: [{PC: "0x4b2aae", Frameless: false}]
+              Type: 492 EventRootType Probe[main.condNullPtr]
+              InjectionPoints: [{PC: "0x4b2fae", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 32, index: 0, name: p}
+                      Variable: {subprogram: 34, index: 0, name: p}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -1442,8 +1754,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 484 EventRootType Probe[main.condNullPtr]Return
-              InjectionPoints: [{PC: "0x4b2b78", Frameless: false}]
+              Type: 493 EventRootType Probe[main.condNullPtr]Return
+              InjectionPoints: [{PC: "0x4b3078", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p == nil [tag={tag}]
@@ -1464,16 +1776,16 @@ Probes:
       segments: ['s == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 33}
+        - subprogram: {subprogram: 35}
           events:
             - Kind: Entry
-              Type: 485 EventRootType Probe[main.condNullSlice]
-              InjectionPoints: [{PC: "0x4b2bd3", Frameless: false}]
+              Type: 494 EventRootType Probe[main.condNullSlice]
+              InjectionPoints: [{PC: "0x4b30d3", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 33, index: 0, name: s}
+                      Variable: {subprogram: 35, index: 0, name: s}
                       Offset: 0
                       ByteSize: 24
                     - __kind: ExprPushOffsetOp
@@ -1484,8 +1796,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 486 EventRootType Probe[main.condNullSlice]Return
-              InjectionPoints: [{PC: "0x4b2cdf", Frameless: false}]
+              Type: 495 EventRootType Probe[main.condNullSlice]Return
+              InjectionPoints: [{PC: "0x4b31df", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: s == nil [tag={tag}]
@@ -1506,16 +1818,16 @@ Probes:
       segments: ['p == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 36}
+        - subprogram: {subprogram: 38}
           events:
             - Kind: Entry
-              Type: 491 EventRootType Probe[main.condNullUnsafePtr]
-              InjectionPoints: [{PC: "0x4b2fce", Frameless: false}]
+              Type: 500 EventRootType Probe[main.condNullUnsafePtr]
+              InjectionPoints: [{PC: "0x4b34ce", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 36, index: 0, name: p}
+                      Variable: {subprogram: 38, index: 0, name: p}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -1526,8 +1838,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 492 EventRootType Probe[main.condNullUnsafePtr]Return
-              InjectionPoints: [{PC: "0x4b3098", Frameless: false}]
+              Type: 501 EventRootType Probe[main.condNullUnsafePtr]Return
+              InjectionPoints: [{PC: "0x4b3598", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p == nil [tag={tag}]
@@ -1552,7 +1864,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 476 EventRootType Probe[main.condOnly]
-              InjectionPoints: [{PC: "0x4b26ca", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b290a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1569,7 +1881,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 477 EventRootType Probe[main.condOnly]Return
-              InjectionPoints: [{PC: "0x4b273a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b297a", Frameless: false}]
               Condition: null
     - id: condOnly_nocond
       version: 0
@@ -1584,11 +1896,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 478 EventRootType Probe[main.condOnly]
-              InjectionPoints: [{PC: "0x4b26ca", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b290a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 479 EventRootType Probe[main.condOnly]Return
-              InjectionPoints: [{PC: "0x4b273a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b297a", Frameless: false}]
               Condition: null
     - id: condPtrStruct_field_i32
       version: 0
@@ -1606,7 +1918,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 456 EventRootType Probe[main.condPtrStructArg]
-              InjectionPoints: [{PC: "0x4b240e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b264e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1626,7 +1938,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 457 EventRootType Probe[main.condPtrStructArg]Return
-              InjectionPoints: [{PC: "0x4b2525", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b2765", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1652,7 +1964,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 458 EventRootType Probe[main.condPtrStructArg]
-              InjectionPoints: [{PC: "0x4b240e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b264e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1671,7 +1983,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 459 EventRootType Probe[main.condPtrStructArg]Return
-              InjectionPoints: [{PC: "0x4b2525", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b2765", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1694,11 +2006,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 460 EventRootType Probe[main.condPtrStructArg]
-              InjectionPoints: [{PC: "0x4b240e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b264e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 461 EventRootType Probe[main.condPtrStructArg]Return
-              InjectionPoints: [{PC: "0x4b2525", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b2765", Frameless: false}]
               Condition: null
     - id: condReturnAndLocal_cond_param
       version: 0
@@ -1714,7 +2026,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 472 EventRootType Probe[main.condReturnAndLocal]
-              InjectionPoints: [{PC: "0x4b262a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b286a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1731,7 +2043,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 473 EventRootType Probe[main.condReturnAndLocal]Return
-              InjectionPoints: [{PC: "0x4b2695", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b28d5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: b={b}
@@ -1754,11 +2066,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 474 EventRootType Probe[main.condReturnAndLocal]
-              InjectionPoints: [{PC: "0x4b262a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b286a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 475 EventRootType Probe[main.condReturnAndLocal]Return
-              InjectionPoints: [{PC: "0x4b2695", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b28d5", Frameless: false}]
               Condition: null
     - id: condString_cond
       version: 0
@@ -1776,7 +2088,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 428 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0x4b220a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b244a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1792,7 +2104,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 429 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0x4b227f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b24bf", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1816,7 +2128,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 430 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0x4b220a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b244a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1832,7 +2144,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 431 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0x4b227f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b24bf", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1860,11 +2172,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 432 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0x4b220a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b244a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 433 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0x4b227f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b24bf", Frameless: false}]
               Condition: null
     - id: condString_eq_template
       version: 0
@@ -1882,11 +2194,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 434 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0x4b220a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b244a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 435 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0x4b227f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b24bf", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: eq={x == "hello"}
@@ -1909,11 +2221,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 436 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0x4b220a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b244a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 437 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0x4b227f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b24bf", Frameless: false}]
               Condition: null
     - id: condString_snapshot_with_cond
       version: 0
@@ -1931,7 +2243,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 438 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0x4b220a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b244a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1947,7 +2259,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 439 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0x4b227f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b24bf", Frameless: false}]
               Condition: null
     - id: condStruct_cond_i32_capture_tag
       version: 0
@@ -1968,7 +2280,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 444 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0x4b22ce", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b250e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1985,7 +2297,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 445 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0x4b23cf", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b260f", Frameless: false}]
               Condition: null
     - id: condStruct_field_bool
       version: 0
@@ -2003,7 +2315,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 446 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0x4b22ce", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b250e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2020,7 +2332,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 447 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0x4b23cf", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b260f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2046,7 +2358,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 448 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0x4b22ce", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b250e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2063,7 +2375,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 449 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0x4b23cf", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b260f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2089,7 +2401,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 450 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0x4b22ce", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b250e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2106,7 +2418,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 451 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0x4b23cf", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b260f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2132,7 +2444,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 452 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0x4b22ce", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b250e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2148,7 +2460,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 453 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0x4b23cf", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b260f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2171,11 +2483,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 454 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0x4b22ce", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b250e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 455 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0x4b23cf", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b260f", Frameless: false}]
               Condition: null
     - id: condUint16_cond
       version: 0
@@ -2191,7 +2503,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 404 EventRootType Probe[main.condUint16]
-              InjectionPoints: [{PC: "0x4b1d8a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1fca", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2208,7 +2520,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 405 EventRootType Probe[main.condUint16]Return
-              InjectionPoints: [{PC: "0x4b1dfa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b203a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2231,11 +2543,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 406 EventRootType Probe[main.condUint16]
-              InjectionPoints: [{PC: "0x4b1d8a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1fca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 407 EventRootType Probe[main.condUint16]Return
-              InjectionPoints: [{PC: "0x4b1dfa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b203a", Frameless: false}]
               Condition: null
     - id: condUint32_cond
       version: 0
@@ -2251,7 +2563,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 408 EventRootType Probe[main.condUint32]
-              InjectionPoints: [{PC: "0x4b1e4a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b208a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2268,7 +2580,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 409 EventRootType Probe[main.condUint32]Return
-              InjectionPoints: [{PC: "0x4b1eba", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b20fa", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2291,11 +2603,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 410 EventRootType Probe[main.condUint32]
-              InjectionPoints: [{PC: "0x4b1e4a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b208a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 411 EventRootType Probe[main.condUint32]Return
-              InjectionPoints: [{PC: "0x4b1eba", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b20fa", Frameless: false}]
               Condition: null
     - id: condUint64_cond
       version: 0
@@ -2311,7 +2623,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 412 EventRootType Probe[main.condUint64]
-              InjectionPoints: [{PC: "0x4b1f0a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b214a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2328,7 +2640,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 413 EventRootType Probe[main.condUint64]Return
-              InjectionPoints: [{PC: "0x4b1f7a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b21ba", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2351,11 +2663,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 414 EventRootType Probe[main.condUint64]
-              InjectionPoints: [{PC: "0x4b1f0a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b214a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 415 EventRootType Probe[main.condUint64]Return
-              InjectionPoints: [{PC: "0x4b1f7a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b21ba", Frameless: false}]
               Condition: null
     - id: condUint8_cond
       version: 0
@@ -2371,7 +2683,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 398 EventRootType Probe[main.condUint8]
-              InjectionPoints: [{PC: "0x4b1cca", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1f0a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2388,7 +2700,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 399 EventRootType Probe[main.condUint8]Return
-              InjectionPoints: [{PC: "0x4b1d3a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1f7a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2412,7 +2724,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 400 EventRootType Probe[main.condUint8]
-              InjectionPoints: [{PC: "0x4b1cca", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1f0a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2429,7 +2741,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 401 EventRootType Probe[main.condUint8]Return
-              InjectionPoints: [{PC: "0x4b1d3a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1f7a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2452,11 +2764,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 402 EventRootType Probe[main.condUint8]
-              InjectionPoints: [{PC: "0x4b1cca", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1f0a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 403 EventRootType Probe[main.condUint8]Return
-              InjectionPoints: [{PC: "0x4b1d3a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1f7a", Frameless: false}]
               Condition: null
     - id: genericIdentity
       version: 0
@@ -2466,25 +2778,25 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 73}
+        - subprogram: {subprogram: 75}
           events:
             - Kind: Entry
-              Type: 669 EventRootType Probe[main.genericIdentity[go.shape.string]]
-              InjectionPoints: [{PC: "0x4b4eea", Frameless: false}]
+              Type: 678 EventRootType Probe[main.genericIdentity[go.shape.string]]
+              InjectionPoints: [{PC: "0x4b53ea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 670 EventRootType Probe[main.genericIdentity[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x4b4f4f", Frameless: false}]
+              Type: 679 EventRootType Probe[main.genericIdentity[go.shape.string]]Return
+              InjectionPoints: [{PC: "0x4b544f", Frameless: false}]
               Condition: null
-        - subprogram: {subprogram: 74}
+        - subprogram: {subprogram: 76}
           events:
             - Kind: Entry
-              Type: 671 EventRootType Probe[main.genericIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0x4b4f8a", Frameless: false}]
+              Type: 680 EventRootType Probe[main.genericIdentity[go.shape.int]]
+              InjectionPoints: [{PC: "0x4b548a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 672 EventRootType Probe[main.genericIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x4b4fdd", Frameless: false}]
+              Type: 681 EventRootType Probe[main.genericIdentity[go.shape.int]]Return
+              InjectionPoints: [{PC: "0x4b54dd", Frameless: false}]
               Condition: null
     - id: indexBigArrayStruct_last
       version: 0
@@ -2500,15 +2812,15 @@ Probes:
             dsl: s.data[131071]
             json: {index: [{getmember: [{ref: s}, data]}, 131071]}
       instances:
-        - subprogram: {subprogram: 48}
+        - subprogram: {subprogram: 50}
           events:
             - Kind: Entry
-              Type: 591 EventRootType Probe[main.bigArrayStructArg]
-              InjectionPoints: [{PC: "0x4b3f0a", Frameless: false}]
+              Type: 600 EventRootType Probe[main.bigArrayStructArg]
+              InjectionPoints: [{PC: "0x4b440a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 592 EventRootType Probe[main.bigArrayStructArg]Return
-              InjectionPoints: [{PC: "0x4b3f77", Frameless: false}]
+              Type: 601 EventRootType Probe[main.bigArrayStructArg]Return
+              InjectionPoints: [{PC: "0x4b4477", Frameless: false}]
               Condition: null
     - id: indexBigArray_first
       version: 0
@@ -2522,15 +2834,15 @@ Probes:
         - name: s_0
           expr: {dsl: 's[0]', json: {index: [{ref: s}, 0]}}
       instances:
-        - subprogram: {subprogram: 47}
+        - subprogram: {subprogram: 49}
           events:
             - Kind: Entry
-              Type: 587 EventRootType Probe[main.bigArrayArg]
-              InjectionPoints: [{PC: "0x4b3e6a", Frameless: false}]
+              Type: 596 EventRootType Probe[main.bigArrayArg]
+              InjectionPoints: [{PC: "0x4b436a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 588 EventRootType Probe[main.bigArrayArg]Return
-              InjectionPoints: [{PC: "0x4b3ed6", Frameless: false}]
+              Type: 597 EventRootType Probe[main.bigArrayArg]Return
+              InjectionPoints: [{PC: "0x4b43d6", Frameless: false}]
               Condition: null
     - id: indexBigArray_last
       version: 0
@@ -2544,15 +2856,15 @@ Probes:
         - name: s_131071
           expr: {dsl: 's[131071]', json: {index: [{ref: s}, 131071]}}
       instances:
-        - subprogram: {subprogram: 47}
+        - subprogram: {subprogram: 49}
           events:
             - Kind: Entry
-              Type: 589 EventRootType Probe[main.bigArrayArg]
-              InjectionPoints: [{PC: "0x4b3e6a", Frameless: false}]
+              Type: 598 EventRootType Probe[main.bigArrayArg]
+              InjectionPoints: [{PC: "0x4b436a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 590 EventRootType Probe[main.bigArrayArg]Return
-              InjectionPoints: [{PC: "0x4b3ed6", Frameless: false}]
+              Type: 599 EventRootType Probe[main.bigArrayArg]Return
+              InjectionPoints: [{PC: "0x4b43d6", Frameless: false}]
               Condition: null
     - id: indexErr_array_oob_capture
       version: 0
@@ -2570,11 +2882,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 353 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0x4b15ea", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b182a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 354 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0x4b1636", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1876", Frameless: false}]
               Condition: null
     - id: indexErr_array_oob_template
       version: 0
@@ -2589,11 +2901,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 355 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0x4b15ea", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b182a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 356 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0x4b1636", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1876", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's[3]: {s[3]}'
@@ -2617,11 +2929,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 339 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0x4b156a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b17aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 340 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0x4b15af", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b17ef", Frameless: false}]
               Condition: null
     - id: indexErr_slice_oob_cond
       version: 0
@@ -2639,7 +2951,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 341 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0x4b156a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b17aa", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2661,7 +2973,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 342 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0x4b15af", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b17ef", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: matched, Segments: [matched]}
     - id: indexErr_slice_oob_template
@@ -2677,11 +2989,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 343 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0x4b156a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b17aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 344 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0x4b15af", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b17ef", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's[5]: {s[5]}'
@@ -2707,11 +3019,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 357 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0x4b15ea", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b182a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 358 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0x4b1636", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1876", Frameless: false}]
               Condition: null
     - id: indexIntArray_cond
       version: 0
@@ -2729,7 +3041,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 359 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0x4b15ea", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b182a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2746,7 +3058,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 360 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0x4b1636", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1876", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: matched, Segments: [matched]}
     - id: indexIntSlice_capture
@@ -2765,11 +3077,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 345 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0x4b156a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b17aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 346 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0x4b15af", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b17ef", Frameless: false}]
               Condition: null
     - id: indexIntSlice_cond
       version: 0
@@ -2787,7 +3099,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 347 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0x4b156a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b17aa", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2809,7 +3121,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 348 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0x4b15af", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b17ef", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: matched, Segments: [matched]}
     - id: indexIntSlice_template
@@ -2825,11 +3137,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 349 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0x4b156a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b17aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 350 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0x4b15af", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b17ef", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's[1]: {s[1]}'
@@ -2853,15 +3165,15 @@ Probes:
             dsl: s[0].Val
             json: {getmember: [{index: [{ref: s}, 0]}, Val]}
       instances:
-        - subprogram: {subprogram: 50}
+        - subprogram: {subprogram: 52}
           events:
             - Kind: Entry
-              Type: 601 EventRootType Probe[main.structArrayArg]
-              InjectionPoints: [{PC: "0x4b408e", Frameless: false}]
+              Type: 610 EventRootType Probe[main.structArrayArg]
+              InjectionPoints: [{PC: "0x4b458e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 602 EventRootType Probe[main.structArrayArg]Return
-              InjectionPoints: [{PC: "0x4b410e", Frameless: false}]
+              Type: 611 EventRootType Probe[main.structArrayArg]Return
+              InjectionPoints: [{PC: "0x4b460e", Frameless: false}]
               Condition: null
     - id: indexMember_arrayStruct_capture_string
       version: 0
@@ -2877,15 +3189,15 @@ Probes:
             dsl: s[1].Txt
             json: {getmember: [{index: [{ref: s}, 1]}, Txt]}
       instances:
-        - subprogram: {subprogram: 50}
+        - subprogram: {subprogram: 52}
           events:
             - Kind: Entry
-              Type: 603 EventRootType Probe[main.structArrayArg]
-              InjectionPoints: [{PC: "0x4b408e", Frameless: false}]
+              Type: 612 EventRootType Probe[main.structArrayArg]
+              InjectionPoints: [{PC: "0x4b458e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 604 EventRootType Probe[main.structArrayArg]Return
-              InjectionPoints: [{PC: "0x4b410e", Frameless: false}]
+              Type: 613 EventRootType Probe[main.structArrayArg]Return
+              InjectionPoints: [{PC: "0x4b460e", Frameless: false}]
               Condition: null
     - id: indexMember_ptrArrayStruct_capture_int
       version: 0
@@ -2901,15 +3213,15 @@ Probes:
             dsl: s[0].Val
             json: {getmember: [{index: [{ref: s}, 0]}, Val]}
       instances:
-        - subprogram: {subprogram: 52}
+        - subprogram: {subprogram: 54}
           events:
             - Kind: Entry
-              Type: 609 EventRootType Probe[main.ptrStructArrayArg]
-              InjectionPoints: [{PC: "0x4b424e", Frameless: false}]
+              Type: 618 EventRootType Probe[main.ptrStructArrayArg]
+              InjectionPoints: [{PC: "0x4b474e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 610 EventRootType Probe[main.ptrStructArrayArg]Return
-              InjectionPoints: [{PC: "0x4b42c5", Frameless: false}]
+              Type: 619 EventRootType Probe[main.ptrStructArrayArg]Return
+              InjectionPoints: [{PC: "0x4b47c5", Frameless: false}]
               Condition: null
     - id: indexMember_ptrArrayStruct_capture_string
       version: 0
@@ -2925,15 +3237,15 @@ Probes:
             dsl: s[1].Txt
             json: {getmember: [{index: [{ref: s}, 1]}, Txt]}
       instances:
-        - subprogram: {subprogram: 52}
+        - subprogram: {subprogram: 54}
           events:
             - Kind: Entry
-              Type: 611 EventRootType Probe[main.ptrStructArrayArg]
-              InjectionPoints: [{PC: "0x4b424e", Frameless: false}]
+              Type: 620 EventRootType Probe[main.ptrStructArrayArg]
+              InjectionPoints: [{PC: "0x4b474e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 612 EventRootType Probe[main.ptrStructArrayArg]Return
-              InjectionPoints: [{PC: "0x4b42c5", Frameless: false}]
+              Type: 621 EventRootType Probe[main.ptrStructArrayArg]Return
+              InjectionPoints: [{PC: "0x4b47c5", Frameless: false}]
               Condition: null
     - id: indexMember_ptrSliceStruct_capture_int
       version: 0
@@ -2949,15 +3261,15 @@ Probes:
             dsl: s[0].Val
             json: {getmember: [{index: [{ref: s}, 0]}, Val]}
       instances:
-        - subprogram: {subprogram: 51}
+        - subprogram: {subprogram: 53}
           events:
             - Kind: Entry
-              Type: 605 EventRootType Probe[main.ptrStructSliceArg]
-              InjectionPoints: [{PC: "0x4b414e", Frameless: false}]
+              Type: 614 EventRootType Probe[main.ptrStructSliceArg]
+              InjectionPoints: [{PC: "0x4b464e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 606 EventRootType Probe[main.ptrStructSliceArg]Return
-              InjectionPoints: [{PC: "0x4b41d6", Frameless: false}]
+              Type: 615 EventRootType Probe[main.ptrStructSliceArg]Return
+              InjectionPoints: [{PC: "0x4b46d6", Frameless: false}]
               Condition: null
     - id: indexMember_ptrSliceStruct_capture_string
       version: 0
@@ -2973,15 +3285,15 @@ Probes:
             dsl: s[1].Txt
             json: {getmember: [{index: [{ref: s}, 1]}, Txt]}
       instances:
-        - subprogram: {subprogram: 51}
+        - subprogram: {subprogram: 53}
           events:
             - Kind: Entry
-              Type: 607 EventRootType Probe[main.ptrStructSliceArg]
-              InjectionPoints: [{PC: "0x4b414e", Frameless: false}]
+              Type: 616 EventRootType Probe[main.ptrStructSliceArg]
+              InjectionPoints: [{PC: "0x4b464e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 608 EventRootType Probe[main.ptrStructSliceArg]Return
-              InjectionPoints: [{PC: "0x4b41d6", Frameless: false}]
+              Type: 617 EventRootType Probe[main.ptrStructSliceArg]Return
+              InjectionPoints: [{PC: "0x4b46d6", Frameless: false}]
               Condition: null
     - id: indexMember_sliceStruct_capture_int
       version: 0
@@ -2997,15 +3309,15 @@ Probes:
             dsl: s[0].Val
             json: {getmember: [{index: [{ref: s}, 0]}, Val]}
       instances:
-        - subprogram: {subprogram: 49}
+        - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 593 EventRootType Probe[main.structSliceArg]
-              InjectionPoints: [{PC: "0x4b3fae", Frameless: false}]
+              Type: 602 EventRootType Probe[main.structSliceArg]
+              InjectionPoints: [{PC: "0x4b44ae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 594 EventRootType Probe[main.structSliceArg]Return
-              InjectionPoints: [{PC: "0x4b402f", Frameless: false}]
+              Type: 603 EventRootType Probe[main.structSliceArg]Return
+              InjectionPoints: [{PC: "0x4b452f", Frameless: false}]
               Condition: null
     - id: indexMember_sliceStruct_capture_string
       version: 0
@@ -3021,15 +3333,15 @@ Probes:
             dsl: s[1].Txt
             json: {getmember: [{index: [{ref: s}, 1]}, Txt]}
       instances:
-        - subprogram: {subprogram: 49}
+        - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 595 EventRootType Probe[main.structSliceArg]
-              InjectionPoints: [{PC: "0x4b3fae", Frameless: false}]
+              Type: 604 EventRootType Probe[main.structSliceArg]
+              InjectionPoints: [{PC: "0x4b44ae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 596 EventRootType Probe[main.structSliceArg]Return
-              InjectionPoints: [{PC: "0x4b402f", Frameless: false}]
+              Type: 605 EventRootType Probe[main.structSliceArg]Return
+              InjectionPoints: [{PC: "0x4b452f", Frameless: false}]
               Condition: null
     - id: indexMember_sliceStruct_cond
       version: 0
@@ -3044,16 +3356,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 49}
+        - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 597 EventRootType Probe[main.structSliceArg]
-              InjectionPoints: [{PC: "0x4b3fae", Frameless: false}]
+              Type: 606 EventRootType Probe[main.structSliceArg]
+              InjectionPoints: [{PC: "0x4b44ae", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 49, index: 0, name: s}
+                      Variable: {subprogram: 51, index: 0, name: s}
                       Offset: 0
                       ByteSize: 16
                     - __kind: SliceBoundsCheckOp
@@ -3069,8 +3381,8 @@ Probes:
                       ByteSize: 4
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 598 EventRootType Probe[main.structSliceArg]Return
-              InjectionPoints: [{PC: "0x4b402f", Frameless: false}]
+              Type: 607 EventRootType Probe[main.structSliceArg]Return
+              InjectionPoints: [{PC: "0x4b452f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -3092,15 +3404,15 @@ Probes:
           dsl: s[0].Val
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 49}
+        - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 599 EventRootType Probe[main.structSliceArg]
-              InjectionPoints: [{PC: "0x4b3fae", Frameless: false}]
+              Type: 608 EventRootType Probe[main.structSliceArg]
+              InjectionPoints: [{PC: "0x4b44ae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 600 EventRootType Probe[main.structSliceArg]Return
-              InjectionPoints: [{PC: "0x4b402f", Frameless: false}]
+              Type: 609 EventRootType Probe[main.structSliceArg]Return
+              InjectionPoints: [{PC: "0x4b452f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: s[0].Val={s[0].Val}
@@ -3127,15 +3439,15 @@ Probes:
             json:
                 getmember: [{index: [{getmember: [{ref: s}, Arr]}, 0]}, Val]
       instances:
-        - subprogram: {subprogram: 53}
+        - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 613 EventRootType Probe[main.indexMemberWrapperArg]
-              InjectionPoints: [{PC: "0x4b430e", Frameless: false}]
+              Type: 622 EventRootType Probe[main.indexMemberWrapperArg]
+              InjectionPoints: [{PC: "0x4b480e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 614 EventRootType Probe[main.indexMemberWrapperArg]Return
-              InjectionPoints: [{PC: "0x4b43b6", Frameless: false}]
+              Type: 623 EventRootType Probe[main.indexMemberWrapperArg]Return
+              InjectionPoints: [{PC: "0x4b48b6", Frameless: false}]
               Condition: null
     - id: indexMember_wrapper_arr_capture_1
       version: 0
@@ -3152,15 +3464,15 @@ Probes:
             json:
                 getmember: [{index: [{getmember: [{ref: s}, Arr]}, 1]}, Txt]
       instances:
-        - subprogram: {subprogram: 53}
+        - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 615 EventRootType Probe[main.indexMemberWrapperArg]
-              InjectionPoints: [{PC: "0x4b430e", Frameless: false}]
+              Type: 624 EventRootType Probe[main.indexMemberWrapperArg]
+              InjectionPoints: [{PC: "0x4b480e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 616 EventRootType Probe[main.indexMemberWrapperArg]Return
-              InjectionPoints: [{PC: "0x4b43b6", Frameless: false}]
+              Type: 625 EventRootType Probe[main.indexMemberWrapperArg]Return
+              InjectionPoints: [{PC: "0x4b48b6", Frameless: false}]
               Condition: null
     - id: indexMember_wrapper_ptrArr_capture
       version: 0
@@ -3177,15 +3489,15 @@ Probes:
             json:
                 getmember: [{index: [{getmember: [{ref: s}, PtrArr]}, 0]}, Val]
       instances:
-        - subprogram: {subprogram: 53}
+        - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 617 EventRootType Probe[main.indexMemberWrapperArg]
-              InjectionPoints: [{PC: "0x4b430e", Frameless: false}]
+              Type: 626 EventRootType Probe[main.indexMemberWrapperArg]
+              InjectionPoints: [{PC: "0x4b480e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 618 EventRootType Probe[main.indexMemberWrapperArg]Return
-              InjectionPoints: [{PC: "0x4b43b6", Frameless: false}]
+              Type: 627 EventRootType Probe[main.indexMemberWrapperArg]Return
+              InjectionPoints: [{PC: "0x4b48b6", Frameless: false}]
               Condition: null
     - id: indexMember_wrapper_ptrArr_capture_1
       version: 0
@@ -3202,15 +3514,15 @@ Probes:
             json:
                 getmember: [{index: [{getmember: [{ref: s}, PtrArr]}, 1]}, Txt]
       instances:
-        - subprogram: {subprogram: 53}
+        - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 619 EventRootType Probe[main.indexMemberWrapperArg]
-              InjectionPoints: [{PC: "0x4b430e", Frameless: false}]
+              Type: 628 EventRootType Probe[main.indexMemberWrapperArg]
+              InjectionPoints: [{PC: "0x4b480e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 620 EventRootType Probe[main.indexMemberWrapperArg]Return
-              InjectionPoints: [{PC: "0x4b43b6", Frameless: false}]
+              Type: 629 EventRootType Probe[main.indexMemberWrapperArg]Return
+              InjectionPoints: [{PC: "0x4b48b6", Frameless: false}]
               Condition: null
     - id: indexNilPtr_capture
       version: 0
@@ -3226,15 +3538,15 @@ Probes:
             dsl: x.Items[0]
             json: {index: [{getmember: [{ref: x}, Items]}, 0]}
       instances:
-        - subprogram: {subprogram: 45}
+        - subprogram: {subprogram: 47}
           events:
             - Kind: Entry
-              Type: 579 EventRootType Probe[main.indexNilPtrSlice]
-              InjectionPoints: [{PC: "0x4b3bae", Frameless: false}]
+              Type: 588 EventRootType Probe[main.indexNilPtrSlice]
+              InjectionPoints: [{PC: "0x4b40ae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 580 EventRootType Probe[main.indexNilPtrSlice]Return
-              InjectionPoints: [{PC: "0x4b3c2e", Frameless: false}]
+              Type: 589 EventRootType Probe[main.indexNilPtrSlice]Return
+              InjectionPoints: [{PC: "0x4b412e", Frameless: false}]
               Condition: null
     - id: indexNilPtr_cond
       version: 0
@@ -3249,16 +3561,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 45}
+        - subprogram: {subprogram: 47}
           events:
             - Kind: Entry
-              Type: 581 EventRootType Probe[main.indexNilPtrSlice]
-              InjectionPoints: [{PC: "0x4b3bae", Frameless: false}]
+              Type: 590 EventRootType Probe[main.indexNilPtrSlice]
+              InjectionPoints: [{PC: "0x4b40ae", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 45, index: 0, name: x}
+                      Variable: {subprogram: 47, index: 0, name: x}
                       Offset: 0
                       ByteSize: 8
                     - __kind: DereferenceOp
@@ -3277,8 +3589,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 582 EventRootType Probe[main.indexNilPtrSlice]Return
-              InjectionPoints: [{PC: "0x4b3c2e", Frameless: false}]
+              Type: 591 EventRootType Probe[main.indexNilPtrSlice]Return
+              InjectionPoints: [{PC: "0x4b412e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -3300,15 +3612,15 @@ Probes:
           dsl: x.Items[0]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 45}
+        - subprogram: {subprogram: 47}
           events:
             - Kind: Entry
-              Type: 583 EventRootType Probe[main.indexNilPtrSlice]
-              InjectionPoints: [{PC: "0x4b3bae", Frameless: false}]
+              Type: 592 EventRootType Probe[main.indexNilPtrSlice]
+              InjectionPoints: [{PC: "0x4b40ae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 584 EventRootType Probe[main.indexNilPtrSlice]Return
-              InjectionPoints: [{PC: "0x4b3c2e", Frameless: false}]
+              Type: 593 EventRootType Probe[main.indexNilPtrSlice]Return
+              InjectionPoints: [{PC: "0x4b412e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 'items[0]: {x.Items[0]}'
@@ -3334,15 +3646,15 @@ Probes:
             dsl: x.Items[0]
             json: {index: [{getmember: [{ref: x}, Items]}, 0]}
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 561 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0x4b37d3", Frameless: false}]
+              Type: 570 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0x4b3cd3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 562 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0x4b390b", Frameless: false}]
+              Type: 571 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0x4b3e0b", Frameless: false}]
               Condition: null
     - id: indexStringArray_capture
       version: 0
@@ -3360,11 +3672,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 367 EventRootType Probe[main.stringArrayArg]
-              InjectionPoints: [{PC: "0x4b16ea", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b192a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 368 EventRootType Probe[main.stringArrayArg]Return
-              InjectionPoints: [{PC: "0x4b1736", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1976", Frameless: false}]
               Condition: null
     - id: indexStringSlice_capture
       version: 0
@@ -3382,11 +3694,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 363 EventRootType Probe[main.stringSliceArg]
-              InjectionPoints: [{PC: "0x4b166a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b18aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 364 EventRootType Probe[main.stringSliceArg]Return
-              InjectionPoints: [{PC: "0x4b16af", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b18ef", Frameless: false}]
               Condition: null
     - id: indexStructSliceField_capture
       version: 0
@@ -3402,15 +3714,15 @@ Probes:
             dsl: x.Items[2]
             json: {index: [{getmember: [{ref: x}, Items]}, 2]}
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 541 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4b35f3", Frameless: false}]
+              Type: 550 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4b3af3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 542 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4b3788", Frameless: false}]
+              Type: 551 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4b3c88", Frameless: false}]
               Condition: null
     - id: inlined
       version: 0
@@ -3421,19 +3733,19 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 75}
+        - subprogram: {subprogram: 77}
           events:
             - Kind: Entry
-              Type: 673 EventRootType Probe[main.inlined]
+              Type: 682 EventRootType Probe[main.inlined]
               InjectionPoints:
                 - PC: "0x4af17b"
                   Frameless: false
-                - PC: "0x4b178a"
+                - PC: "0x4b19ca"
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 674 EventRootType Probe[main.inlined]Return
-              InjectionPoints: [{PC: "0x4b17ca", Frameless: false}]
+              Type: 683 EventRootType Probe[main.inlined]Return
+              InjectionPoints: [{PC: "0x4b1a0a", Frameless: false}]
               Condition: null
     - id: inlinedMethod
       version: 0
@@ -3443,11 +3755,11 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 78}
+        - subprogram: {subprogram: 80}
           events:
             - Kind: Entry
-              Type: 677 EventRootType Probe[main.(*methodValueReceiver).inlinedMethod]
-              InjectionPoints: [{PC: "0x4b500d", Frameless: true}]
+              Type: 686 EventRootType Probe[main.(*methodValueReceiver).inlinedMethod]
+              InjectionPoints: [{PC: "0x4b550d", Frameless: true}]
               Condition: null
     - id: intArg
       version: 0
@@ -3461,11 +3773,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 331 EventRootType Probe[main.intArg]
-              InjectionPoints: [{PC: "0x4b146a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b16aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 332 EventRootType Probe[main.intArg]Return
-              InjectionPoints: [{PC: "0x4b14aa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b16ea", Frameless: false}]
               Condition: null
     - id: intArrayArg
       version: 0
@@ -3479,11 +3791,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 361 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0x4b15ea", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b182a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 362 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0x4b1636", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1876", Frameless: false}]
               Condition: null
     - id: intArrayArgFrameless
       version: 0
@@ -3497,7 +3809,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 371 EventRootType Probe[main.stringArrayArgFrameless]
-              InjectionPoints: [{PC: "0x4b1760", Frameless: true}]
+              InjectionPoints: [{PC: "0x4b19a0", Frameless: true}]
               Condition: null
     - id: intSliceArg
       version: 0
@@ -3511,11 +3823,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 351 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0x4b156a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b17aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 352 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0x4b15af", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b17ef", Frameless: false}]
               Condition: null
     - id: lenErrInt_nocond
       version: 0
@@ -3526,15 +3838,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 43}
+        - subprogram: {subprogram: 45}
           events:
             - Kind: Entry
-              Type: 571 EventRootType Probe[main.lenErrInt]
-              InjectionPoints: [{PC: "0x4b3953", Frameless: false}]
+              Type: 580 EventRootType Probe[main.lenErrInt]
+              InjectionPoints: [{PC: "0x4b3e53", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 572 EventRootType Probe[main.lenErrInt]Return
-              InjectionPoints: [{PC: "0x4b3a2c", Frameless: false}]
+              Type: 581 EventRootType Probe[main.lenErrInt]Return
+              InjectionPoints: [{PC: "0x4b3f2c", Frameless: false}]
               Condition: null
     - id: lenErrStruct_nocond
       version: 0
@@ -3545,15 +3857,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 44}
+        - subprogram: {subprogram: 46}
           events:
             - Kind: Entry
-              Type: 575 EventRootType Probe[main.lenErrStruct]
-              InjectionPoints: [{PC: "0x4b3a73", Frameless: false}]
+              Type: 584 EventRootType Probe[main.lenErrStruct]
+              InjectionPoints: [{PC: "0x4b3f73", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 576 EventRootType Probe[main.lenErrStruct]Return
-              InjectionPoints: [{PC: "0x4b3b76", Frameless: false}]
+              Type: 585 EventRootType Probe[main.lenErrStruct]Return
+              InjectionPoints: [{PC: "0x4b4076", Frameless: false}]
               Condition: null
     - id: lenErr_int
       version: 0
@@ -3564,15 +3876,15 @@ Probes:
       segments: [len=, {json: {len: {ref: x}}, dsl: len(x)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 43}
+        - subprogram: {subprogram: 45}
           events:
             - Kind: Entry
-              Type: 573 EventRootType Probe[main.lenErrInt]
-              InjectionPoints: [{PC: "0x4b3953", Frameless: false}]
+              Type: 582 EventRootType Probe[main.lenErrInt]
+              InjectionPoints: [{PC: "0x4b3e53", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 574 EventRootType Probe[main.lenErrInt]Return
-              InjectionPoints: [{PC: "0x4b3a2c", Frameless: false}]
+              Type: 583 EventRootType Probe[main.lenErrInt]Return
+              InjectionPoints: [{PC: "0x4b3f2c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x)}
@@ -3589,15 +3901,15 @@ Probes:
       segments: [len=, {json: {len: {ref: x}}, dsl: len(x)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 44}
+        - subprogram: {subprogram: 46}
           events:
             - Kind: Entry
-              Type: 577 EventRootType Probe[main.lenErrStruct]
-              InjectionPoints: [{PC: "0x4b3a73", Frameless: false}]
+              Type: 586 EventRootType Probe[main.lenErrStruct]
+              InjectionPoints: [{PC: "0x4b3f73", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 578 EventRootType Probe[main.lenErrStruct]Return
-              InjectionPoints: [{PC: "0x4b3b76", Frameless: false}]
+              Type: 587 EventRootType Probe[main.lenErrStruct]Return
+              InjectionPoints: [{PC: "0x4b4076", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x)}
@@ -3615,16 +3927,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 525 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0x4b33ae", Frameless: false}]
+              Type: 534 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0x4b38ae", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 39, index: 0, name: m}
+                      Variable: {subprogram: 41, index: 0, name: m}
                       Offset: 0
                       ByteSize: 8
                     - __kind: DereferenceOp
@@ -3638,8 +3950,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 526 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0x4b348c", Frameless: false}]
+              Type: 535 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0x4b398c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -3661,15 +3973,15 @@ Probes:
           dsl: isEmpty(m)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 527 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0x4b33ae", Frameless: false}]
+              Type: 536 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0x4b38ae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 528 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0x4b348c", Frameless: false}]
+              Type: 537 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0x4b398c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: empty={isEmpty(m)}
@@ -3691,15 +4003,15 @@ Probes:
         - name: m_len
           expr: {dsl: len(m), json: {len: {ref: m}}}
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 529 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0x4b33ae", Frameless: false}]
+              Type: 538 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0x4b38ae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 530 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0x4b348c", Frameless: false}]
+              Type: 539 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0x4b398c", Frameless: false}]
               Condition: null
     - id: lenMap_len_eq_cond
       version: 0
@@ -3713,16 +4025,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 531 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0x4b33ae", Frameless: false}]
+              Type: 540 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0x4b38ae", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 39, index: 0, name: m}
+                      Variable: {subprogram: 41, index: 0, name: m}
                       Offset: 0
                       ByteSize: 8
                     - __kind: DereferenceOp
@@ -3736,8 +4048,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 532 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0x4b348c", Frameless: false}]
+              Type: 541 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0x4b398c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -3756,15 +4068,15 @@ Probes:
       segments: [len=, {json: {len: {ref: m}}, dsl: len(m)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 533 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0x4b33ae", Frameless: false}]
+              Type: 542 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0x4b38ae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 534 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0x4b348c", Frameless: false}]
+              Type: 543 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0x4b398c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(m)}
@@ -3783,15 +4095,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 535 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0x4b33ae", Frameless: false}]
+              Type: 544 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0x4b38ae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 536 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0x4b348c", Frameless: false}]
+              Type: 545 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0x4b398c", Frameless: false}]
               Condition: null
     - id: lenPtrString_len_template
       version: 0
@@ -3802,15 +4114,15 @@ Probes:
       segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 40}
+        - subprogram: {subprogram: 42}
           events:
             - Kind: Entry
-              Type: 537 EventRootType Probe[main.lenPtrString]
-              InjectionPoints: [{PC: "0x4b34ce", Frameless: false}]
+              Type: 546 EventRootType Probe[main.lenPtrString]
+              InjectionPoints: [{PC: "0x4b39ce", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 538 EventRootType Probe[main.lenPtrString]Return
-              InjectionPoints: [{PC: "0x4b3598", Frameless: false}]
+              Type: 547 EventRootType Probe[main.lenPtrString]Return
+              InjectionPoints: [{PC: "0x4b3a98", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(s)}
@@ -3829,15 +4141,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 40}
+        - subprogram: {subprogram: 42}
           events:
             - Kind: Entry
-              Type: 539 EventRootType Probe[main.lenPtrString]
-              InjectionPoints: [{PC: "0x4b34ce", Frameless: false}]
+              Type: 548 EventRootType Probe[main.lenPtrString]
+              InjectionPoints: [{PC: "0x4b39ce", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 540 EventRootType Probe[main.lenPtrString]Return
-              InjectionPoints: [{PC: "0x4b3598", Frameless: false}]
+              Type: 549 EventRootType Probe[main.lenPtrString]Return
+              InjectionPoints: [{PC: "0x4b3a98", Frameless: false}]
               Condition: null
     - id: lenPtrStructFields_nocond
       version: 0
@@ -3848,15 +4160,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 563 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0x4b37d3", Frameless: false}]
+              Type: 572 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0x4b3cd3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 564 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0x4b390b", Frameless: false}]
+              Type: 573 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0x4b3e0b", Frameless: false}]
               Condition: null
     - id: lenPtrStruct_field_map
       version: 0
@@ -3870,15 +4182,15 @@ Probes:
           dsl: len(x.Dict)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 565 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0x4b37d3", Frameless: false}]
+              Type: 574 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0x4b3cd3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 566 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0x4b390b", Frameless: false}]
+              Type: 575 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0x4b3e0b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.Dict)}
@@ -3900,15 +4212,15 @@ Probes:
           dsl: len(x.Items)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 567 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0x4b37d3", Frameless: false}]
+              Type: 576 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0x4b3cd3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 568 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0x4b390b", Frameless: false}]
+              Type: 577 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0x4b3e0b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.Items)}
@@ -3930,15 +4242,15 @@ Probes:
           dsl: len(x.S)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 569 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0x4b37d3", Frameless: false}]
+              Type: 578 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0x4b3cd3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 570 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0x4b390b", Frameless: false}]
+              Type: 579 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0x4b3e0b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.S)}
@@ -3958,16 +4270,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 513 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0x4b3253", Frameless: false}]
+              Type: 522 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0x4b3753", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 38, index: 0, name: s}
+                      Variable: {subprogram: 40, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -3978,8 +4290,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 514 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0x4b3347", Frameless: false}]
+              Type: 523 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0x4b3847", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4001,15 +4313,15 @@ Probes:
           dsl: isEmpty(s)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 515 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0x4b3253", Frameless: false}]
+              Type: 524 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0x4b3753", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 516 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0x4b3347", Frameless: false}]
+              Type: 525 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0x4b3847", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: empty={isEmpty(s)}
@@ -4031,15 +4343,15 @@ Probes:
         - name: s_len
           expr: {dsl: len(s), json: {len: {ref: s}}}
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 517 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0x4b3253", Frameless: false}]
+              Type: 526 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0x4b3753", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 518 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0x4b3347", Frameless: false}]
+              Type: 527 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0x4b3847", Frameless: false}]
               Condition: null
     - id: lenSlice_len_eq_cond
       version: 0
@@ -4053,16 +4365,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 519 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0x4b3253", Frameless: false}]
+              Type: 528 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0x4b3753", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 38, index: 0, name: s}
+                      Variable: {subprogram: 40, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4073,8 +4385,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 520 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0x4b3347", Frameless: false}]
+              Type: 529 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0x4b3847", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4093,15 +4405,15 @@ Probes:
       segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 521 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0x4b3253", Frameless: false}]
+              Type: 530 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0x4b3753", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 522 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0x4b3347", Frameless: false}]
+              Type: 531 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0x4b3847", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(s)}
@@ -4120,15 +4432,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 523 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0x4b3253", Frameless: false}]
+              Type: 532 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0x4b3753", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 524 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0x4b3347", Frameless: false}]
+              Type: 533 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0x4b3847", Frameless: false}]
               Condition: null
     - id: lenString_eq_capture
       version: 0
@@ -4144,15 +4456,15 @@ Probes:
             dsl: len(s) == 5
             json: {eq: [{len: {ref: s}}, 5]}
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 495 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4b3113", Frameless: false}]
+              Type: 504 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4b3613", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 496 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4b31fc", Frameless: false}]
+              Type: 505 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4b36fc", Frameless: false}]
               Condition: null
     - id: lenString_eq_template
       version: 0
@@ -4166,15 +4478,15 @@ Probes:
           dsl: len(s) == 5
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 497 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4b3113", Frameless: false}]
+              Type: 506 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4b3613", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 498 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4b31fc", Frameless: false}]
+              Type: 507 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4b36fc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: eq={len(s) == 5}
@@ -4196,15 +4508,15 @@ Probes:
         - name: s_isEmpty
           expr: {dsl: isEmpty(s), json: {isEmpty: {ref: s}}}
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 499 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4b3113", Frameless: false}]
+              Type: 508 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4b3613", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 500 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4b31fc", Frameless: false}]
+              Type: 509 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4b36fc", Frameless: false}]
               Condition: null
     - id: lenString_isEmpty_cond
       version: 0
@@ -4216,16 +4528,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 501 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4b3113", Frameless: false}]
+              Type: 510 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4b3613", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 37, index: 0, name: s}
+                      Variable: {subprogram: 39, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4236,8 +4548,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 502 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4b31fc", Frameless: false}]
+              Type: 511 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4b36fc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4259,15 +4571,15 @@ Probes:
           dsl: isEmpty(s)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 503 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4b3113", Frameless: false}]
+              Type: 512 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4b3613", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 504 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4b31fc", Frameless: false}]
+              Type: 513 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4b36fc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: empty={isEmpty(s)}
@@ -4289,15 +4601,15 @@ Probes:
         - name: s_len
           expr: {dsl: len(s), json: {len: {ref: s}}}
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 505 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4b3113", Frameless: false}]
+              Type: 514 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4b3613", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 506 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4b31fc", Frameless: false}]
+              Type: 515 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4b36fc", Frameless: false}]
               Condition: null
     - id: lenString_len_eq_cond
       version: 0
@@ -4311,16 +4623,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 507 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4b3113", Frameless: false}]
+              Type: 516 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4b3613", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 37, index: 0, name: s}
+                      Variable: {subprogram: 39, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4331,8 +4643,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 508 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4b31fc", Frameless: false}]
+              Type: 517 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4b36fc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4351,15 +4663,15 @@ Probes:
       segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 509 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4b3113", Frameless: false}]
+              Type: 518 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4b3613", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 510 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4b31fc", Frameless: false}]
+              Type: 519 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4b36fc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(s)}
@@ -4378,15 +4690,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 511 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4b3113", Frameless: false}]
+              Type: 520 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4b3613", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 512 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4b31fc", Frameless: false}]
+              Type: 521 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4b36fc", Frameless: false}]
               Condition: null
     - id: lenStructFields_nocond
       version: 0
@@ -4397,15 +4709,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 543 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4b35f3", Frameless: false}]
+              Type: 552 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4b3af3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 544 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4b3788", Frameless: false}]
+              Type: 553 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4b3c88", Frameless: false}]
               Condition: null
     - id: lenStruct_field_map
       version: 0
@@ -4419,15 +4731,15 @@ Probes:
           dsl: len(x.Dict)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 545 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4b35f3", Frameless: false}]
+              Type: 554 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4b3af3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 546 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4b3788", Frameless: false}]
+              Type: 555 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4b3c88", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.Dict)}
@@ -4449,15 +4761,15 @@ Probes:
           dsl: len(x.PtrSlice)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 547 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4b35f3", Frameless: false}]
+              Type: 556 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4b3af3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 548 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4b3788", Frameless: false}]
+              Type: 557 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4b3c88", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.PtrSlice)}
@@ -4479,15 +4791,15 @@ Probes:
           dsl: len(x.PtrStr)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 549 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4b35f3", Frameless: false}]
+              Type: 558 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4b3af3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 550 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4b3788", Frameless: false}]
+              Type: 559 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4b3c88", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.PtrStr)}
@@ -4509,15 +4821,15 @@ Probes:
           dsl: len(x.Items)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 551 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4b35f3", Frameless: false}]
+              Type: 560 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4b3af3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 552 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4b3788", Frameless: false}]
+              Type: 561 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4b3c88", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.Items)}
@@ -4539,15 +4851,15 @@ Probes:
           dsl: len(x.S)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 553 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4b35f3", Frameless: false}]
+              Type: 562 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4b3af3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 554 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4b3788", Frameless: false}]
+              Type: 563 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4b3c88", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.S)}
@@ -4569,16 +4881,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 555 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4b35f3", Frameless: false}]
+              Type: 564 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4b3af3", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 41, index: 0, name: x}
+                      Variable: {subprogram: 43, index: 0, name: x}
                       Offset: 40
                       ByteSize: 8
                     - __kind: DereferenceOp
@@ -4592,8 +4904,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 556 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4b3788", Frameless: false}]
+              Type: 565 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4b3c88", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4615,16 +4927,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 557 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4b35f3", Frameless: false}]
+              Type: 566 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4b3af3", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 41, index: 0, name: x}
+                      Variable: {subprogram: 43, index: 0, name: x}
                       Offset: 24
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4635,8 +4947,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 558 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4b3788", Frameless: false}]
+              Type: 567 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4b3c88", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4658,16 +4970,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 559 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4b35f3", Frameless: false}]
+              Type: 568 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4b3af3", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 41, index: 0, name: x}
+                      Variable: {subprogram: 43, index: 0, name: x}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4678,8 +4990,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 560 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4b3788", Frameless: false}]
+              Type: 569 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4b3c88", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4701,11 +5013,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 333 EventRootType Probe[main.stringArg]
-              InjectionPoints: [{PC: "0x4b14ea", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b172a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 334 EventRootType Probe[main.stringArg]Return
-              InjectionPoints: [{PC: "0x4b152f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b176f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's: {s}'
@@ -4727,11 +5039,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 335 EventRootType Probe[main.stringArg]
-              InjectionPoints: [{PC: "0x4b14ea", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b172a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 336 EventRootType Probe[main.stringArg]Return
-              InjectionPoints: [{PC: "0x4b152f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b176f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 'x: {x}'
@@ -4751,11 +5063,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 372 EventRootType Probe[main.mapArg]
-              InjectionPoints: [{PC: "0x4b184a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1a8a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 373 EventRootType Probe[main.mapArg]Return
-              InjectionPoints: [{PC: "0x4b187f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1abf", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 'm: {m}'
@@ -4780,15 +5092,15 @@ Probes:
         - name: false_val
           expr: {dsl: 'm[false]', json: {index: [{ref: m}, false]}}
       instances:
-        - subprogram: {subprogram: 68}
+        - subprogram: {subprogram: 70}
           events:
             - Kind: Entry
-              Type: 657 EventRootType Probe[main.mapIndexBoolKey]
-              InjectionPoints: [{PC: "0x4b4bea", Frameless: false}]
+              Type: 666 EventRootType Probe[main.mapIndexBoolKey]
+              InjectionPoints: [{PC: "0x4b50ea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 658 EventRootType Probe[main.mapIndexBoolKey]Return
-              InjectionPoints: [{PC: "0x4b4c1f", Frameless: false}]
+              Type: 667 EventRootType Probe[main.mapIndexBoolKey]Return
+              InjectionPoints: [{PC: "0x4b511f", Frameless: false}]
               Condition: null
     - id: mapIndex_boolKey_true
       version: 0
@@ -4805,15 +5117,15 @@ Probes:
         - name: true_val
           expr: {dsl: 'm[true]', json: {index: [{ref: m}, true]}}
       instances:
-        - subprogram: {subprogram: 68}
+        - subprogram: {subprogram: 70}
           events:
             - Kind: Entry
-              Type: 659 EventRootType Probe[main.mapIndexBoolKey]
-              InjectionPoints: [{PC: "0x4b4bea", Frameless: false}]
+              Type: 668 EventRootType Probe[main.mapIndexBoolKey]
+              InjectionPoints: [{PC: "0x4b50ea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 660 EventRootType Probe[main.mapIndexBoolKey]Return
-              InjectionPoints: [{PC: "0x4b4c1f", Frameless: false}]
+              Type: 669 EventRootType Probe[main.mapIndexBoolKey]Return
+              InjectionPoints: [{PC: "0x4b511f", Frameless: false}]
               Condition: null
     - id: mapIndex_emptyKey_capture
       version: 0
@@ -4830,15 +5142,15 @@ Probes:
         - name: empty_val
           expr: {dsl: 'm[""]', json: {index: [{ref: m}, ""]}}
       instances:
-        - subprogram: {subprogram: 65}
+        - subprogram: {subprogram: 67}
           events:
             - Kind: Entry
-              Type: 651 EventRootType Probe[main.mapIndexEmptyKey]
-              InjectionPoints: [{PC: "0x4b4a6a", Frameless: false}]
+              Type: 660 EventRootType Probe[main.mapIndexEmptyKey]
+              InjectionPoints: [{PC: "0x4b4f6a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 652 EventRootType Probe[main.mapIndexEmptyKey]Return
-              InjectionPoints: [{PC: "0x4b4ac5", Frameless: false}]
+              Type: 661 EventRootType Probe[main.mapIndexEmptyKey]Return
+              InjectionPoints: [{PC: "0x4b4fc5", Frameless: false}]
               Condition: null
     - id: mapIndex_intKey_capture
       version: 0
@@ -4855,15 +5167,15 @@ Probes:
         - name: m_2
           expr: {dsl: 'm[2]', json: {index: [{ref: m}, 2]}}
       instances:
-        - subprogram: {subprogram: 54}
+        - subprogram: {subprogram: 56}
           events:
             - Kind: Entry
-              Type: 621 EventRootType Probe[main.mapIndexIntKey]
-              InjectionPoints: [{PC: "0x4b440a", Frameless: false}]
+              Type: 630 EventRootType Probe[main.mapIndexIntKey]
+              InjectionPoints: [{PC: "0x4b490a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 622 EventRootType Probe[main.mapIndexIntKey]Return
-              InjectionPoints: [{PC: "0x4b443f", Frameless: false}]
+              Type: 631 EventRootType Probe[main.mapIndexIntKey]Return
+              InjectionPoints: [{PC: "0x4b493f", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen16
       version: 0
@@ -4882,15 +5194,15 @@ Probes:
             dsl: m["000000000000002a"]
             json: {index: [{ref: m}, 000000000000002a]}
       instances:
-        - subprogram: {subprogram: 66}
+        - subprogram: {subprogram: 68}
           events:
             - Kind: Entry
-              Type: 653 EventRootType Probe[main.mapIndexKeyLen16]
-              InjectionPoints: [{PC: "0x4b4aea", Frameless: false}]
+              Type: 662 EventRootType Probe[main.mapIndexKeyLen16]
+              InjectionPoints: [{PC: "0x4b4fea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 654 EventRootType Probe[main.mapIndexKeyLen16]Return
-              InjectionPoints: [{PC: "0x4b4b39", Frameless: false}]
+              Type: 663 EventRootType Probe[main.mapIndexKeyLen16]Return
+              InjectionPoints: [{PC: "0x4b5039", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen17
       version: 0
@@ -4909,15 +5221,15 @@ Probes:
             dsl: m["0000000000000002a"]
             json: {index: [{ref: m}, 0000000000000002a]}
       instances:
-        - subprogram: {subprogram: 67}
+        - subprogram: {subprogram: 69}
           events:
             - Kind: Entry
-              Type: 655 EventRootType Probe[main.mapIndexKeyLen17]
-              InjectionPoints: [{PC: "0x4b4b6a", Frameless: false}]
+              Type: 664 EventRootType Probe[main.mapIndexKeyLen17]
+              InjectionPoints: [{PC: "0x4b506a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 656 EventRootType Probe[main.mapIndexKeyLen17]Return
-              InjectionPoints: [{PC: "0x4b4bb9", Frameless: false}]
+              Type: 665 EventRootType Probe[main.mapIndexKeyLen17]Return
+              InjectionPoints: [{PC: "0x4b50b9", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen200
       version: 0
@@ -4939,15 +5251,15 @@ Probes:
                     - ref: m
                     - 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002a
       instances:
-        - subprogram: {subprogram: 62}
+        - subprogram: {subprogram: 64}
           events:
             - Kind: Entry
-              Type: 641 EventRootType Probe[main.mapIndexKeyLen200]
-              InjectionPoints: [{PC: "0x4b48ca", Frameless: false}]
+              Type: 650 EventRootType Probe[main.mapIndexKeyLen200]
+              InjectionPoints: [{PC: "0x4b4dca", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 642 EventRootType Probe[main.mapIndexKeyLen200]Return
-              InjectionPoints: [{PC: "0x4b4919", Frameless: false}]
+              Type: 651 EventRootType Probe[main.mapIndexKeyLen200]Return
+              InjectionPoints: [{PC: "0x4b4e19", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen24
       version: 0
@@ -4966,15 +5278,15 @@ Probes:
             dsl: m["00000000000000000000002a"]
             json: {index: [{ref: m}, 00000000000000000000002a]}
       instances:
-        - subprogram: {subprogram: 59}
+        - subprogram: {subprogram: 61}
           events:
             - Kind: Entry
-              Type: 635 EventRootType Probe[main.mapIndexKeyLen24]
-              InjectionPoints: [{PC: "0x4b474a", Frameless: false}]
+              Type: 644 EventRootType Probe[main.mapIndexKeyLen24]
+              InjectionPoints: [{PC: "0x4b4c4a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 636 EventRootType Probe[main.mapIndexKeyLen24]Return
-              InjectionPoints: [{PC: "0x4b4799", Frameless: false}]
+              Type: 645 EventRootType Probe[main.mapIndexKeyLen24]Return
+              InjectionPoints: [{PC: "0x4b4c99", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen48
       version: 0
@@ -4996,15 +5308,15 @@ Probes:
                     - ref: m
                     - 00000000000000000000000000000000000000000000002a
       instances:
-        - subprogram: {subprogram: 60}
+        - subprogram: {subprogram: 62}
           events:
             - Kind: Entry
-              Type: 637 EventRootType Probe[main.mapIndexKeyLen48]
-              InjectionPoints: [{PC: "0x4b47ca", Frameless: false}]
+              Type: 646 EventRootType Probe[main.mapIndexKeyLen48]
+              InjectionPoints: [{PC: "0x4b4cca", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 638 EventRootType Probe[main.mapIndexKeyLen48]Return
-              InjectionPoints: [{PC: "0x4b4819", Frameless: false}]
+              Type: 647 EventRootType Probe[main.mapIndexKeyLen48]Return
+              InjectionPoints: [{PC: "0x4b4d19", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen8
       version: 0
@@ -5023,15 +5335,15 @@ Probes:
             dsl: m["0000002a"]
             json: {index: [{ref: m}, 0000002a]}
       instances:
-        - subprogram: {subprogram: 58}
+        - subprogram: {subprogram: 60}
           events:
             - Kind: Entry
-              Type: 633 EventRootType Probe[main.mapIndexKeyLen8]
-              InjectionPoints: [{PC: "0x4b46ca", Frameless: false}]
+              Type: 642 EventRootType Probe[main.mapIndexKeyLen8]
+              InjectionPoints: [{PC: "0x4b4bca", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 634 EventRootType Probe[main.mapIndexKeyLen8]Return
-              InjectionPoints: [{PC: "0x4b4719", Frameless: false}]
+              Type: 643 EventRootType Probe[main.mapIndexKeyLen8]Return
+              InjectionPoints: [{PC: "0x4b4c19", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen96
       version: 0
@@ -5053,15 +5365,15 @@ Probes:
                     - ref: m
                     - 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002a
       instances:
-        - subprogram: {subprogram: 61}
+        - subprogram: {subprogram: 63}
           events:
             - Kind: Entry
-              Type: 639 EventRootType Probe[main.mapIndexKeyLen96]
-              InjectionPoints: [{PC: "0x4b484a", Frameless: false}]
+              Type: 648 EventRootType Probe[main.mapIndexKeyLen96]
+              InjectionPoints: [{PC: "0x4b4d4a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 640 EventRootType Probe[main.mapIndexKeyLen96]Return
-              InjectionPoints: [{PC: "0x4b4899", Frameless: false}]
+              Type: 649 EventRootType Probe[main.mapIndexKeyLen96]Return
+              InjectionPoints: [{PC: "0x4b4d99", Frameless: false}]
               Condition: null
     - id: mapIndex_largeMap_capture
       version: 0
@@ -5080,15 +5392,15 @@ Probes:
             dsl: m["key42"]
             json: {index: [{ref: m}, key42]}
       instances:
-        - subprogram: {subprogram: 56}
+        - subprogram: {subprogram: 58}
           events:
             - Kind: Entry
-              Type: 629 EventRootType Probe[main.mapIndexLargeMap]
-              InjectionPoints: [{PC: "0x4b44ca", Frameless: false}]
+              Type: 638 EventRootType Probe[main.mapIndexLargeMap]
+              InjectionPoints: [{PC: "0x4b49ca", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 630 EventRootType Probe[main.mapIndexLargeMap]Return
-              InjectionPoints: [{PC: "0x4b4519", Frameless: false}]
+              Type: 639 EventRootType Probe[main.mapIndexLargeMap]Return
+              InjectionPoints: [{PC: "0x4b4a19", Frameless: false}]
               Condition: null
     - id: mapIndex_largeValue_capture
       version: 0
@@ -5107,15 +5419,15 @@ Probes:
             dsl: m["k"].Val
             json: {getmember: [{index: [{ref: m}, k]}, Val]}
       instances:
-        - subprogram: {subprogram: 71}
+        - subprogram: {subprogram: 73}
           events:
             - Kind: Entry
-              Type: 665 EventRootType Probe[main.mapIndexLargeValue]
-              InjectionPoints: [{PC: "0x4b4d0a", Frameless: false}]
+              Type: 674 EventRootType Probe[main.mapIndexLargeValue]
+              InjectionPoints: [{PC: "0x4b520a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 666 EventRootType Probe[main.mapIndexLargeValue]Return
-              InjectionPoints: [{PC: "0x4b4d67", Frameless: false}]
+              Type: 675 EventRootType Probe[main.mapIndexLargeValue]Return
+              InjectionPoints: [{PC: "0x4b5267", Frameless: false}]
               Condition: null
     - id: mapIndex_missing_capture
       version: 0
@@ -5134,15 +5446,15 @@ Probes:
             dsl: m["missing"]
             json: {index: [{ref: m}, missing]}
       instances:
-        - subprogram: {subprogram: 57}
+        - subprogram: {subprogram: 59}
           events:
             - Kind: Entry
-              Type: 631 EventRootType Probe[main.mapIndexMissing]
-              InjectionPoints: [{PC: "0x4b454a", Frameless: false}]
+              Type: 640 EventRootType Probe[main.mapIndexMissing]
+              InjectionPoints: [{PC: "0x4b4a4a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 632 EventRootType Probe[main.mapIndexMissing]Return
-              InjectionPoints: [{PC: "0x4b457f", Frameless: false}]
+              Type: 641 EventRootType Probe[main.mapIndexMissing]Return
+              InjectionPoints: [{PC: "0x4b4a7f", Frameless: false}]
               Condition: null
     - id: mapIndex_nilPtrVal_capture
       version: 0
@@ -5161,15 +5473,15 @@ Probes:
             dsl: m["nil_key"].Val
             json: {getmember: [{index: [{ref: m}, nil_key]}, Val]}
       instances:
-        - subprogram: {subprogram: 70}
+        - subprogram: {subprogram: 72}
           events:
             - Kind: Entry
-              Type: 663 EventRootType Probe[main.mapIndexNilPtrVal]
-              InjectionPoints: [{PC: "0x4b4caa", Frameless: false}]
+              Type: 672 EventRootType Probe[main.mapIndexNilPtrVal]
+              InjectionPoints: [{PC: "0x4b51aa", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 664 EventRootType Probe[main.mapIndexNilPtrVal]Return
-              InjectionPoints: [{PC: "0x4b4cdf", Frameless: false}]
+              Type: 673 EventRootType Probe[main.mapIndexNilPtrVal]Return
+              InjectionPoints: [{PC: "0x4b51df", Frameless: false}]
               Condition: null
     - id: mapIndex_ptrStructVal_capture_int
       version: 0
@@ -5188,15 +5500,15 @@ Probes:
             dsl: m["x"].Val
             json: {getmember: [{index: [{ref: m}, x]}, Val]}
       instances:
-        - subprogram: {subprogram: 64}
+        - subprogram: {subprogram: 66}
           events:
             - Kind: Entry
-              Type: 647 EventRootType Probe[main.mapIndexPtrStructVal]
-              InjectionPoints: [{PC: "0x4b49ca", Frameless: false}]
+              Type: 656 EventRootType Probe[main.mapIndexPtrStructVal]
+              InjectionPoints: [{PC: "0x4b4eca", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 648 EventRootType Probe[main.mapIndexPtrStructVal]Return
-              InjectionPoints: [{PC: "0x4b4a2a", Frameless: false}]
+              Type: 657 EventRootType Probe[main.mapIndexPtrStructVal]Return
+              InjectionPoints: [{PC: "0x4b4f2a", Frameless: false}]
               Condition: null
     - id: mapIndex_ptrStructVal_capture_string
       version: 0
@@ -5215,15 +5527,15 @@ Probes:
             dsl: m["y"].Txt
             json: {getmember: [{index: [{ref: m}, "y"]}, Txt]}
       instances:
-        - subprogram: {subprogram: 64}
+        - subprogram: {subprogram: 66}
           events:
             - Kind: Entry
-              Type: 649 EventRootType Probe[main.mapIndexPtrStructVal]
-              InjectionPoints: [{PC: "0x4b49ca", Frameless: false}]
+              Type: 658 EventRootType Probe[main.mapIndexPtrStructVal]
+              InjectionPoints: [{PC: "0x4b4eca", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 650 EventRootType Probe[main.mapIndexPtrStructVal]Return
-              InjectionPoints: [{PC: "0x4b4a2a", Frameless: false}]
+              Type: 659 EventRootType Probe[main.mapIndexPtrStructVal]Return
+              InjectionPoints: [{PC: "0x4b4f2a", Frameless: false}]
               Condition: null
     - id: mapIndex_stringKey_capture
       version: 0
@@ -5242,15 +5554,15 @@ Probes:
             dsl: m["beta"]
             json: {index: [{ref: m}, beta]}
       instances:
-        - subprogram: {subprogram: 55}
+        - subprogram: {subprogram: 57}
           events:
             - Kind: Entry
-              Type: 623 EventRootType Probe[main.mapIndexStringKey]
-              InjectionPoints: [{PC: "0x4b446a", Frameless: false}]
+              Type: 632 EventRootType Probe[main.mapIndexStringKey]
+              InjectionPoints: [{PC: "0x4b496a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 624 EventRootType Probe[main.mapIndexStringKey]Return
-              InjectionPoints: [{PC: "0x4b449f", Frameless: false}]
+              Type: 633 EventRootType Probe[main.mapIndexStringKey]Return
+              InjectionPoints: [{PC: "0x4b499f", Frameless: false}]
               Condition: null
     - id: mapIndex_stringKey_cond
       version: 0
@@ -5267,16 +5579,16 @@ Probes:
       segments: [matched]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 55}
+        - subprogram: {subprogram: 57}
           events:
             - Kind: Entry
-              Type: 625 EventRootType Probe[main.mapIndexStringKey]
-              InjectionPoints: [{PC: "0x4b446a", Frameless: false}]
+              Type: 634 EventRootType Probe[main.mapIndexStringKey]
+              InjectionPoints: [{PC: "0x4b496a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 55, index: 0, name: m}
+                      Variable: {subprogram: 57, index: 0, name: m}
                       Offset: 0
                       ByteSize: 8
                     - __kind: DereferenceOp
@@ -5309,8 +5621,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 626 EventRootType Probe[main.mapIndexStringKey]Return
-              InjectionPoints: [{PC: "0x4b449f", Frameless: false}]
+              Type: 635 EventRootType Probe[main.mapIndexStringKey]Return
+              InjectionPoints: [{PC: "0x4b499f", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: matched, Segments: [matched]}
     - id: mapIndex_stringKey_template
@@ -5328,15 +5640,15 @@ Probes:
           dsl: m["beta"]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 55}
+        - subprogram: {subprogram: 57}
           events:
             - Kind: Entry
-              Type: 627 EventRootType Probe[main.mapIndexStringKey]
-              InjectionPoints: [{PC: "0x4b446a", Frameless: false}]
+              Type: 636 EventRootType Probe[main.mapIndexStringKey]
+              InjectionPoints: [{PC: "0x4b496a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 628 EventRootType Probe[main.mapIndexStringKey]Return
-              InjectionPoints: [{PC: "0x4b449f", Frameless: false}]
+              Type: 637 EventRootType Probe[main.mapIndexStringKey]Return
+              InjectionPoints: [{PC: "0x4b499f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: beta={m["beta"]}
@@ -5363,15 +5675,15 @@ Probes:
             dsl: m["a"].Val
             json: {getmember: [{index: [{ref: m}, a]}, Val]}
       instances:
-        - subprogram: {subprogram: 63}
+        - subprogram: {subprogram: 65}
           events:
             - Kind: Entry
-              Type: 643 EventRootType Probe[main.mapIndexStructVal]
-              InjectionPoints: [{PC: "0x4b494a", Frameless: false}]
+              Type: 652 EventRootType Probe[main.mapIndexStructVal]
+              InjectionPoints: [{PC: "0x4b4e4a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 644 EventRootType Probe[main.mapIndexStructVal]Return
-              InjectionPoints: [{PC: "0x4b49a7", Frameless: false}]
+              Type: 653 EventRootType Probe[main.mapIndexStructVal]Return
+              InjectionPoints: [{PC: "0x4b4ea7", Frameless: false}]
               Condition: null
     - id: mapIndex_structVal_capture_string
       version: 0
@@ -5390,15 +5702,15 @@ Probes:
             dsl: m["b"].Txt
             json: {getmember: [{index: [{ref: m}, b]}, Txt]}
       instances:
-        - subprogram: {subprogram: 63}
+        - subprogram: {subprogram: 65}
           events:
             - Kind: Entry
-              Type: 645 EventRootType Probe[main.mapIndexStructVal]
-              InjectionPoints: [{PC: "0x4b494a", Frameless: false}]
+              Type: 654 EventRootType Probe[main.mapIndexStructVal]
+              InjectionPoints: [{PC: "0x4b4e4a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 646 EventRootType Probe[main.mapIndexStructVal]Return
-              InjectionPoints: [{PC: "0x4b49a7", Frameless: false}]
+              Type: 655 EventRootType Probe[main.mapIndexStructVal]Return
+              InjectionPoints: [{PC: "0x4b4ea7", Frameless: false}]
               Condition: null
     - id: mapIndex_zeroValue_capture
       version: 0
@@ -5417,15 +5729,15 @@ Probes:
             dsl: m["zero"]
             json: {index: [{ref: m}, zero]}
       instances:
-        - subprogram: {subprogram: 69}
+        - subprogram: {subprogram: 71}
           events:
             - Kind: Entry
-              Type: 661 EventRootType Probe[main.mapIndexZeroValue]
-              InjectionPoints: [{PC: "0x4b4c4a", Frameless: false}]
+              Type: 670 EventRootType Probe[main.mapIndexZeroValue]
+              InjectionPoints: [{PC: "0x4b514a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 662 EventRootType Probe[main.mapIndexZeroValue]Return
-              InjectionPoints: [{PC: "0x4b4c7f", Frameless: false}]
+              Type: 671 EventRootType Probe[main.mapIndexZeroValue]Return
+              InjectionPoints: [{PC: "0x4b517f", Frameless: false}]
               Condition: null
     - id: noArgs
       version: 0
@@ -5439,11 +5751,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 376 EventRootType Probe[main.noArgs]
-              InjectionPoints: [{PC: "0x4b196a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1baa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 377 EventRootType Probe[main.noArgs]Return
-              InjectionPoints: [{PC: "0x4b19a6", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1be6", Frameless: false}]
               Condition: null
     - id: stringArg
       version: 0
@@ -5457,11 +5769,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 337 EventRootType Probe[main.stringArg]
-              InjectionPoints: [{PC: "0x4b14ea", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b172a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 338 EventRootType Probe[main.stringArg]Return
-              InjectionPoints: [{PC: "0x4b152f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b176f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's: {s}'
@@ -5483,11 +5795,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 369 EventRootType Probe[main.stringArrayArg]
-              InjectionPoints: [{PC: "0x4b16ea", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b192a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 370 EventRootType Probe[main.stringArrayArg]Return
-              InjectionPoints: [{PC: "0x4b1736", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b1976", Frameless: false}]
               Condition: null
     - id: stringSliceArg
       version: 0
@@ -5501,11 +5813,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 365 EventRootType Probe[main.stringSliceArg]
-              InjectionPoints: [{PC: "0x4b166a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b18aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 366 EventRootType Probe[main.stringSliceArg]Return
-              InjectionPoints: [{PC: "0x4b16af", Frameless: false}]
+              InjectionPoints: [{PC: "0x4b18ef", Frameless: false}]
               Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
       version: 0
@@ -5516,39 +5828,39 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 46}
+        - subprogram: {subprogram: 48}
           events:
             - Kind: Entry
-              Type: 585 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
-              InjectionPoints: [{PC: "0x4b3c76", Frameless: false}]
+              Type: 594 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+              InjectionPoints: [{PC: "0x4b4176", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 586 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
-              InjectionPoints: [{PC: "0x4b3e44", Frameless: false}]
+              Type: 595 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+              InjectionPoints: [{PC: "0x4b4344", Frameless: false}]
               Condition: null
 Subprograms:
     - ID: 1
       Name: main.intArg
-      OutOfLinePCRanges: [0x4b1460..0x4b14c2]
+      OutOfLinePCRanges: [0x4b16a0..0x4b1702]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4b1460..0x4b1479
+            - Range: 0x4b16a0..0x4b16b9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 2
       Name: main.stringArg
-      OutOfLinePCRanges: [0x4b14e0..0x4b1551]
+      OutOfLinePCRanges: [0x4b1720..0x4b1791]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b14e0..0x4b14fe
+            - Range: 0x4b1720..0x4b173e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -5559,13 +5871,13 @@ Subprograms:
       DictRegister: null
     - ID: 3
       Name: main.intSliceArg
-      OutOfLinePCRanges: [0x4b1560..0x4b15da]
+      OutOfLinePCRanges: [0x4b17a0..0x4b181a]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 107 GoSliceHeaderType []int
           Locations:
-            - Range: 0x4b1560..0x4b157e
+            - Range: 0x4b17a0..0x4b17be
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -5578,26 +5890,26 @@ Subprograms:
       DictRegister: null
     - ID: 4
       Name: main.intArrayArg
-      OutOfLinePCRanges: [0x4b15e0..0x4b1647]
+      OutOfLinePCRanges: [0x4b1820..0x4b1887]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 108 ArrayType [3]int
           Locations:
-            - Range: 0x4b15e0..0x4b1647
+            - Range: 0x4b1820..0x4b1887
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 5
       Name: main.stringSliceArg
-      OutOfLinePCRanges: [0x4b1660..0x4b16da]
+      OutOfLinePCRanges: [0x4b18a0..0x4b191a]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 109 GoSliceHeaderType []string
           Locations:
-            - Range: 0x4b1660..0x4b167e
+            - Range: 0x4b18a0..0x4b18be
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -5610,86 +5922,86 @@ Subprograms:
       DictRegister: null
     - ID: 6
       Name: main.stringArrayArg
-      OutOfLinePCRanges: [0x4b16e0..0x4b1747]
+      OutOfLinePCRanges: [0x4b1920..0x4b1987]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 110 ArrayType [3]string
           Locations:
-            - Range: 0x4b16e0..0x4b1747
+            - Range: 0x4b1920..0x4b1987
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 7
       Name: main.stringArrayArgFrameless
-      OutOfLinePCRanges: [0x4b1760..0x4b1761]
+      OutOfLinePCRanges: [0x4b19a0..0x4b19a1]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 110 ArrayType [3]string
           Locations:
-            - Range: 0x4b1760..0x4b1761
+            - Range: 0x4b19a0..0x4b19a1
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 8
       Name: main.mapArg
-      OutOfLinePCRanges: [0x4b1840..0x4b1896]
+      OutOfLinePCRanges: [0x4b1a80..0x4b1ad6]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 111 GoMapType map[string]int
           Locations:
-            - Range: 0x4b1840..0x4b186d
+            - Range: 0x4b1a80..0x4b1aad
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 9
       Name: main.bigMapArg
-      OutOfLinePCRanges: [0x4b18a0..0x4b195b]
+      OutOfLinePCRanges: [0x4b1ae0..0x4b1b9b]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 116 GoMapType map[string]main.bigStruct
           Locations:
-            - Range: 0x4b18a0..0x4b18d3
+            - Range: 0x4b1ae0..0x4b1b13
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4b18d3..0x4b195b
+            - Range: 0x4b1b13..0x4b1b9b
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 10
       Name: main.noArgs
-      OutOfLinePCRanges: [0x4b1960..0x4b19b3]
+      OutOfLinePCRanges: [0x4b1ba0..0x4b1bf3]
       InlinePCRanges: []
       Variables: []
       DictRegister: null
     - ID: 11
       Name: main.condInt8
-      OutOfLinePCRanges: [0x4b19c0..0x4b1a68]
+      OutOfLinePCRanges: [0x4b1c00..0x4b1ca8]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 BaseType int8
           Locations:
-            - Range: 0x4b19c0..0x4b1a01
+            - Range: 0x4b1c00..0x4b1c41
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b19c0..0x4b1a04
+            - Range: 0x4b1c00..0x4b1c44
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4b1a04..0x4b1a09
+            - Range: 0x4b1c44..0x4b1c49
               Pieces:
                 - Size: 8
                   Op: null
@@ -5700,26 +6012,26 @@ Subprograms:
       DictRegister: null
     - ID: 12
       Name: main.condInt16
-      OutOfLinePCRanges: [0x4b1a80..0x4b1b29]
+      OutOfLinePCRanges: [0x4b1cc0..0x4b1d69]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 103 BaseType int16
           Locations:
-            - Range: 0x4b1a80..0x4b1aa9
+            - Range: 0x4b1cc0..0x4b1ce9
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b1a80..0x4b1aa9
+            - Range: 0x4b1cc0..0x4b1ce9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4b1aa9..0x4b1b29
+            - Range: 0x4b1ce9..0x4b1d69
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -5730,26 +6042,26 @@ Subprograms:
       DictRegister: null
     - ID: 13
       Name: main.condInt32
-      OutOfLinePCRanges: [0x4b1b40..0x4b1be7]
+      OutOfLinePCRanges: [0x4b1d80..0x4b1e27]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType int32
           Locations:
-            - Range: 0x4b1b40..0x4b1b69
+            - Range: 0x4b1d80..0x4b1da9
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b1b40..0x4b1b69
+            - Range: 0x4b1d80..0x4b1da9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4b1b69..0x4b1be7
+            - Range: 0x4b1da9..0x4b1e27
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -5760,26 +6072,26 @@ Subprograms:
       DictRegister: null
     - ID: 14
       Name: main.condInt64
-      OutOfLinePCRanges: [0x4b1c00..0x4b1ca9]
+      OutOfLinePCRanges: [0x4b1e40..0x4b1ee9]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType int64
           Locations:
-            - Range: 0x4b1c00..0x4b1c29
+            - Range: 0x4b1e40..0x4b1e69
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b1c00..0x4b1c29
+            - Range: 0x4b1e40..0x4b1e69
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4b1c29..0x4b1ca9
+            - Range: 0x4b1e69..0x4b1ee9
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -5790,26 +6102,26 @@ Subprograms:
       DictRegister: null
     - ID: 15
       Name: main.condUint8
-      OutOfLinePCRanges: [0x4b1cc0..0x4b1d68]
+      OutOfLinePCRanges: [0x4b1f00..0x4b1fa8]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x4b1cc0..0x4b1d01
+            - Range: 0x4b1f00..0x4b1f41
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b1cc0..0x4b1d04
+            - Range: 0x4b1f00..0x4b1f44
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4b1d04..0x4b1d09
+            - Range: 0x4b1f44..0x4b1f49
               Pieces:
                 - Size: 8
                   Op: null
@@ -5820,26 +6132,26 @@ Subprograms:
       DictRegister: null
     - ID: 16
       Name: main.condUint16
-      OutOfLinePCRanges: [0x4b1d80..0x4b1e29]
+      OutOfLinePCRanges: [0x4b1fc0..0x4b2069]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0x4b1d80..0x4b1da9
+            - Range: 0x4b1fc0..0x4b1fe9
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b1d80..0x4b1da9
+            - Range: 0x4b1fc0..0x4b1fe9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4b1da9..0x4b1e29
+            - Range: 0x4b1fe9..0x4b2069
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -5850,26 +6162,26 @@ Subprograms:
       DictRegister: null
     - ID: 17
       Name: main.condUint32
-      OutOfLinePCRanges: [0x4b1e40..0x4b1ee7]
+      OutOfLinePCRanges: [0x4b2080..0x4b2127]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x4b1e40..0x4b1e69
+            - Range: 0x4b2080..0x4b20a9
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b1e40..0x4b1e69
+            - Range: 0x4b2080..0x4b20a9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4b1e69..0x4b1ee7
+            - Range: 0x4b20a9..0x4b2127
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -5880,26 +6192,26 @@ Subprograms:
       DictRegister: null
     - ID: 18
       Name: main.condUint64
-      OutOfLinePCRanges: [0x4b1f00..0x4b1fa9]
+      OutOfLinePCRanges: [0x4b2140..0x4b21e9]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x4b1f00..0x4b1f29
+            - Range: 0x4b2140..0x4b2169
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b1f00..0x4b1f29
+            - Range: 0x4b2140..0x4b2169
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4b1f29..0x4b1fa9
+            - Range: 0x4b2169..0x4b21e9
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -5910,32 +6222,32 @@ Subprograms:
       DictRegister: null
     - ID: 19
       Name: main.condFloat32
-      OutOfLinePCRanges: [0x4b1fc0..0x4b206e]
+      OutOfLinePCRanges: [0x4b2200..0x4b22ae]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 18 BaseType float32
           Locations:
-            - Range: 0x4b1fc0..0x4b1fed
+            - Range: 0x4b2200..0x4b222d
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b1fc0..0x4b1fe8
+            - Range: 0x4b2200..0x4b2228
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4b1fe8..0x4b1fed
+            - Range: 0x4b2228..0x4b222d
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4b1fed..0x4b206e
+            - Range: 0x4b222d..0x4b22ae
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -5946,32 +6258,32 @@ Subprograms:
       DictRegister: null
     - ID: 20
       Name: main.condFloat64
-      OutOfLinePCRanges: [0x4b2080..0x4b212f]
+      OutOfLinePCRanges: [0x4b22c0..0x4b236f]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 BaseType float64
           Locations:
-            - Range: 0x4b2080..0x4b20ae
+            - Range: 0x4b22c0..0x4b22ee
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b2080..0x4b20a9
+            - Range: 0x4b22c0..0x4b22e9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4b20a9..0x4b20ae
+            - Range: 0x4b22e9..0x4b22ee
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4b20ae..0x4b212f
+            - Range: 0x4b22ee..0x4b236f
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -5982,26 +6294,26 @@ Subprograms:
       DictRegister: null
     - ID: 21
       Name: main.condBool
-      OutOfLinePCRanges: [0x4b2140..0x4b21e8]
+      OutOfLinePCRanges: [0x4b2380..0x4b2428]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x4b2140..0x4b2181
+            - Range: 0x4b2380..0x4b23c1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b2140..0x4b2184
+            - Range: 0x4b2380..0x4b23c4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4b2184..0x4b2189
+            - Range: 0x4b23c4..0x4b23c9
               Pieces:
                 - Size: 8
                   Op: null
@@ -6012,13 +6324,13 @@ Subprograms:
       DictRegister: null
     - ID: 22
       Name: main.condString
-      OutOfLinePCRanges: [0x4b2200..0x4b22b7]
+      OutOfLinePCRanges: [0x4b2440..0x4b24f7]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b2200..0x4b222e
+            - Range: 0x4b2440..0x4b246e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6029,13 +6341,13 @@ Subprograms:
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b2200..0x4b222e
+            - Range: 0x4b2440..0x4b246e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x4b222e..0x4b22b7
+            - Range: 0x4b246e..0x4b24f7
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -6046,32 +6358,32 @@ Subprograms:
       DictRegister: null
     - ID: 23
       Name: main.condStructArg
-      OutOfLinePCRanges: [0x4b22c0..0x4b23f4]
+      OutOfLinePCRanges: [0x4b2500..0x4b2634]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 121 StructureType main.condFields
           Locations:
-            - Range: 0x4b22c0..0x4b23f4
+            - Range: 0x4b2500..0x4b2634
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b22c0..0x4b2305
+            - Range: 0x4b2500..0x4b2545
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4b2305..0x4b230a
+            - Range: 0x4b2545..0x4b254a
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
                 - Size: 8
                   Op: {CfaOffset: 88}
-            - Range: 0x4b230a..0x4b23f4
+            - Range: 0x4b254a..0x4b2634
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
@@ -6082,28 +6394,28 @@ Subprograms:
       DictRegister: null
     - ID: 24
       Name: main.condPtrStructArg
-      OutOfLinePCRanges: [0x4b2400..0x4b2553]
+      OutOfLinePCRanges: [0x4b2640..0x4b2793]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 123 PointerType *main.condFields
           Locations:
-            - Range: 0x4b2400..0x4b2456
+            - Range: 0x4b2640..0x4b2696
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4b2456..0x4b2553
+            - Range: 0x4b2696..0x4b2793
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b2400..0x4b245b
+            - Range: 0x4b2640..0x4b269b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4b245b..0x4b2553
+            - Range: 0x4b269b..0x4b2793
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -6114,26 +6426,26 @@ Subprograms:
       DictRegister: null
     - ID: 25
       Name: main.condNilPtrStruct
-      OutOfLinePCRanges: [0x4b2560..0x4b261c]
+      OutOfLinePCRanges: [0x4b27a0..0x4b285c]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 123 PointerType *main.condFields
           Locations:
-            - Range: 0x4b2560..0x4b25b5
+            - Range: 0x4b27a0..0x4b27f5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b2560..0x4b25b8
+            - Range: 0x4b27a0..0x4b27f8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4b25b8..0x4b25bd
+            - Range: 0x4b27f8..0x4b27fd
               Pieces:
                 - Size: 8
                   Op: null
@@ -6144,66 +6456,66 @@ Subprograms:
       DictRegister: null
     - ID: 26
       Name: main.condReturnAndLocal
-      OutOfLinePCRanges: [0x4b2620..0x4b26b9]
+      OutOfLinePCRanges: [0x4b2860..0x4b28f9]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4b2620..0x4b2631
+            - Range: 0x4b2860..0x4b2871
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4b2620..0x4b265f
+            - Range: 0x4b2860..0x4b289f
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4b2620..0x4b2695
+            - Range: 0x4b2860..0x4b28d5
               Pieces: []
-            - Range: 0x4b2695..0x4b2696
+            - Range: 0x4b28d5..0x4b28d6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4b2696..0x4b26b9
+            - Range: 0x4b28d6..0x4b28f9
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: sum
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4b2631..0x4b265f
+            - Range: 0x4b2871..0x4b289f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4b265f..0x4b26b9
+            - Range: 0x4b289f..0x4b28f9
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 27
       Name: main.condOnly
-      OutOfLinePCRanges: [0x4b26c0..0x4b2769]
+      OutOfLinePCRanges: [0x4b2900..0x4b29a9]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4b26c0..0x4b26e9
+            - Range: 0x4b2900..0x4b2929
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b26c0..0x4b26e9
+            - Range: 0x4b2900..0x4b2929
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4b26e9..0x4b2769
+            - Range: 0x4b2929..0x4b29a9
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -6214,28 +6526,28 @@ Subprograms:
       DictRegister: null
     - ID: 28
       Name: main.condLine
-      OutOfLinePCRanges: [0x4b2780..0x4b2859]
+      OutOfLinePCRanges: [0x4b29c0..0x4b2a99]
       InlinePCRanges: []
       Variables:
         - Name: "n"
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4b2780..0x4b27a4
+            - Range: 0x4b29c0..0x4b29e4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4b27a4..0x4b2859
+            - Range: 0x4b29e4..0x4b2a99
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b2780..0x4b27bb
+            - Range: 0x4b29c0..0x4b29fb
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4b27bb..0x4b2859
+            - Range: 0x4b29fb..0x4b2a99
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -6246,20 +6558,122 @@ Subprograms:
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4b27a4..0x4b27bb
+            - Range: 0x4b29e4..0x4b29fb
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 29
+      Name: main.condLineMixed
+      OutOfLinePCRanges: [0x4b2aa0..0x4b2cc9]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4b2aa0..0x4b2b16
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x4b2b16..0x4b2b1b
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 80}
+                - Size: 8
+                  Op: {CfaOffset: 88}
+            - Range: 0x4b2b1b..0x4b2cc9
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 80}
+                - Size: 8
+                  Op: {CfaOffset: 88}
+          Role: Parameter
+          DictIndex: -1
+        - Name: b
+          Type: 4 BaseType bool
+          Locations:
+            - Range: 0x4b2aa0..0x4b2b1b
+              Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0x4b2b1b..0x4b2cc9
+              Pieces: [{Size: 1, Op: {CfaOffset: 96}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: x
+          Type: 121 StructureType main.condFields
+          Locations:
+            - Range: 0x4b2aa0..0x4b2cc9
+              Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: p
+          Type: 123 PointerType *main.condFields
+          Locations:
+            - Range: 0x4b2aa0..0x4b2af6
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+            - Range: 0x4b2af6..0x4b2cc9
+              Pieces: [{Size: 8, Op: {CfaOffset: 104}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: ss
+          Type: 107 GoSliceHeaderType []int
+          Locations:
+            - Range: 0x4b2aa0..0x4b2b1b
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+            - Range: 0x4b2b1b..0x4b2cc9
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 112}
+                - Size: 8
+                  Op: {CfaOffset: 120}
+                - Size: 8
+                  Op: {CfaOffset: 128}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 30
+      Name: main.condLineReturn
+      OutOfLinePCRanges: [0x4b2ce0..0x4b2d52]
+      InlinePCRanges: []
+      Variables:
+        - Name: "n"
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x4b2ce0..0x4b2cf1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations: [{Range: 0x4b2ce0..0x4b2d52, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: doubled
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x4b2cf1..0x4b2d05
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4b2d05..0x4b2d52
+              Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
+          Role: Local
+          DictIndex: -1
+      DictRegister: null
+    - ID: 31
       Name: main.condSliceArg
-      OutOfLinePCRanges: [0x4b2860..0x4b2925]
+      OutOfLinePCRanges: [0x4b2d60..0x4b2e25]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 107 GoSliceHeaderType []int
           Locations:
-            - Range: 0x4b2860..0x4b288e
+            - Range: 0x4b2d60..0x4b2d8e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6272,13 +6686,13 @@ Subprograms:
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b2860..0x4b288e
+            - Range: 0x4b2d60..0x4b2d8e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
-            - Range: 0x4b288e..0x4b2925
+            - Range: 0x4b2d8e..0x4b2e25
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
@@ -6287,28 +6701,28 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 30
+    - ID: 32
       Name: main.condMapArg
-      OutOfLinePCRanges: [0x4b2940..0x4b29da]
+      OutOfLinePCRanges: [0x4b2e40..0x4b2eda]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 111 GoMapType map[string]int
           Locations:
-            - Range: 0x4b2940..0x4b2973
+            - Range: 0x4b2e40..0x4b2e73
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b2940..0x4b2976
+            - Range: 0x4b2e40..0x4b2e76
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4b2976..0x4b297b
+            - Range: 0x4b2e76..0x4b2e7b
               Pieces:
                 - Size: 8
                   Op: null
@@ -6317,34 +6731,34 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 31
+    - ID: 33
       Name: main.condStructDirect
-      OutOfLinePCRanges: [0x4b29e0..0x4b2a9a]
+      OutOfLinePCRanges: [0x4b2ee0..0x4b2f9a]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 121 StructureType main.condFields
           Locations:
-            - Range: 0x4b29e0..0x4b2a9a
+            - Range: 0x4b2ee0..0x4b2f9a
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b29e0..0x4b2a15
+            - Range: 0x4b2ee0..0x4b2f15
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4b2a15..0x4b2a1a
+            - Range: 0x4b2f15..0x4b2f1a
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
                 - Size: 8
                   Op: {CfaOffset: 88}
-            - Range: 0x4b2a1a..0x4b2a9a
+            - Range: 0x4b2f1a..0x4b2f9a
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
@@ -6353,134 +6767,36 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 32
+    - ID: 34
       Name: main.condNullPtr
-      OutOfLinePCRanges: [0x4b2aa0..0x4b2ba6]
+      OutOfLinePCRanges: [0x4b2fa0..0x4b30a6]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 99 PointerType *int
           Locations:
-            - Range: 0x4b2aa0..0x4b2b00
+            - Range: 0x4b2fa0..0x4b3000
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4b2b00..0x4b2ba6
+            - Range: 0x4b3000..0x4b30a6
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b2aa0..0x4b2b05
+            - Range: 0x4b2fa0..0x4b3005
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4b2b05..0x4b2b08
+            - Range: 0x4b3005..0x4b3008
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4b2b08..0x4b2ba6
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 33
-      Name: main.condNullSlice
-      OutOfLinePCRanges: [0x4b2bc0..0x4b2d25]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 107 GoSliceHeaderType []int
-          Locations:
-            - Range: 0x4b2bc0..0x4b2c52
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4b2c52..0x4b2c57
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 0}
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-            - Range: 0x4b2c57..0x4b2c5a
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 0}
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-            - Range: 0x4b2c5a..0x4b2d25
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 0}
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x4b2bc0..0x4b2c5f
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-            - Range: 0x4b2c5f..0x4b2d25
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 24}
-                - Size: 8
-                  Op: {CfaOffset: 32}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 34
-      Name: main.condNullMap
-      OutOfLinePCRanges: [0x4b2d40..0x4b2e46]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 111 GoMapType map[string]int
-          Locations:
-            - Range: 0x4b2d40..0x4b2da0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4b2da0..0x4b2e46
-              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x4b2d40..0x4b2da5
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4b2da5..0x4b2da8
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-            - Range: 0x4b2da8..0x4b2e46
+            - Range: 0x4b3008..0x4b30a6
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -6490,87 +6806,95 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 35
-      Name: main.condNullIface
-      OutOfLinePCRanges: [0x4b2e60..0x4b2fae]
+      Name: main.condNullSlice
+      OutOfLinePCRanges: [0x4b30c0..0x4b3225]
       InlinePCRanges: []
       Variables:
-        - Name: i
-          Type: 13 GoInterfaceType error
+        - Name: s
+          Type: 107 GoSliceHeaderType []int
           Locations:
-            - Range: 0x4b2e60..0x4b2eec
+            - Range: 0x4b30c0..0x4b3152
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4b2eec..0x4b2ef1
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4b3152..0x4b3157
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0x4b2ef1..0x4b2fae
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x4b3157..0x4b315a
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x4b315a..0x4b3225
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 0}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b2e60..0x4b2ef4
+            - Range: 0x4b30c0..0x4b315f
               Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x4b2ef4..0x4b2ef9
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+            - Range: 0x4b315f..0x4b3225
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 16}
-                - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0x4b2ef9..0x4b2fae
-              Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 16}
-                - Size: 8
-                  Op: {CfaOffset: 24}
+                  Op: {CfaOffset: 32}
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 36
-      Name: main.condNullUnsafePtr
-      OutOfLinePCRanges: [0x4b2fc0..0x4b30c6]
+      Name: main.condNullMap
+      OutOfLinePCRanges: [0x4b3240..0x4b3346]
       InlinePCRanges: []
       Variables:
-        - Name: p
-          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: m
+          Type: 111 GoMapType map[string]int
           Locations:
-            - Range: 0x4b2fc0..0x4b3020
+            - Range: 0x4b3240..0x4b32a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4b3020..0x4b30c6
+            - Range: 0x4b32a0..0x4b3346
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b2fc0..0x4b3025
+            - Range: 0x4b3240..0x4b32a5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4b3025..0x4b3028
+            - Range: 0x4b32a5..0x4b32a8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4b3028..0x4b30c6
+            - Range: 0x4b32a8..0x4b3346
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -6580,41 +6904,49 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 37
-      Name: main.lenString
-      OutOfLinePCRanges: [0x4b3100..0x4b3237]
+      Name: main.condNullIface
+      OutOfLinePCRanges: [0x4b3360..0x4b34ae]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 9 GoStringHeaderType string
+        - Name: i
+          Type: 13 GoInterfaceType error
           Locations:
-            - Range: 0x4b3100..0x4b317b
+            - Range: 0x4b3360..0x4b33ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4b317b..0x4b3180
-              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x4b3180..0x4b3237
-              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
+            - Range: 0x4b33ec..0x4b33f1
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 0}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+            - Range: 0x4b33f1..0x4b34ae
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 0}
+                - Size: 8
+                  Op: {CfaOffset: 8}
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b3100..0x4b3183
+            - Range: 0x4b3360..0x4b33f4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x4b3183..0x4b3188
+            - Range: 0x4b33f4..0x4b33f9
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0x4b3188..0x4b3237
+            - Range: 0x4b33f9..0x4b34ae
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -6624,110 +6956,12 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 38
-      Name: main.lenSlice
-      OutOfLinePCRanges: [0x4b3240..0x4b338c]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 107 GoSliceHeaderType []int
-          Locations:
-            - Range: 0x4b3240..0x4b32ca
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4b32ca..0x4b32cf
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4b32cf..0x4b32d2
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4b32d2..0x4b338c
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: null
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x4b3240..0x4b32d7
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-            - Range: 0x4b32d7..0x4b338c
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 24}
-                - Size: 8
-                  Op: {CfaOffset: 32}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 39
-      Name: main.lenMap
-      OutOfLinePCRanges: [0x4b33a0..0x4b34ba]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 111 GoMapType map[string]int
-          Locations:
-            - Range: 0x4b33a0..0x4b3400
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4b3400..0x4b34ba
-              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x4b33a0..0x4b3405
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4b3405..0x4b3408
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-            - Range: 0x4b3408..0x4b34ba
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 40
-      Name: main.lenPtrString
+      Name: main.condNullUnsafePtr
       OutOfLinePCRanges: [0x4b34c0..0x4b35c6]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 95 PointerType *string
+        - Name: p
+          Type: 14 VoidPointerType unsafe.Pointer
           Locations:
             - Range: 0x4b34c0..0x4b3520
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -6759,72 +6993,178 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 41
-      Name: main.lenStructFields
-      OutOfLinePCRanges: [0x4b35e0..0x4b37b4]
+    - ID: 39
+      Name: main.lenString
+      OutOfLinePCRanges: [0x4b3600..0x4b3737]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 124 StructureType main.lenFields
-          Locations:
-            - Range: 0x4b35e0..0x4b37b4
-              Pieces: [{Size: 72, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
+        - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b35e0..0x4b36ad
+            - Range: 0x4b3600..0x4b367b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4b36ad..0x4b36b2
+            - Range: 0x4b367b..0x4b3680
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
+            - Range: 0x4b3680..0x4b3737
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4b3600..0x4b3683
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 72}
+                  Op: {RegNo: 2, Shift: 0}
                 - Size: 8
-                  Op: {CfaOffset: 80}
-            - Range: 0x4b36b2..0x4b37b4
+                  Op: {RegNo: 5, Shift: 0}
+            - Range: 0x4b3683..0x4b3688
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 72}
+                  Op: {CfaOffset: 16}
                 - Size: 8
-                  Op: {CfaOffset: 80}
+                  Op: {CfaOffset: 24}
+            - Range: 0x4b3688..0x4b3737
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 42
-      Name: main.lenPtrStructFields
-      OutOfLinePCRanges: [0x4b37c0..0x4b393c]
+    - ID: 40
+      Name: main.lenSlice
+      OutOfLinePCRanges: [0x4b3740..0x4b388c]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 126 PointerType *main.lenFields
+        - Name: s
+          Type: 107 GoSliceHeaderType []int
           Locations:
-            - Range: 0x4b37c0..0x4b3831
+            - Range: 0x4b3740..0x4b37ca
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4b37ca..0x4b37cf
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4b37cf..0x4b37d2
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4b37d2..0x4b388c
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: null
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4b3740..0x4b37d7
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+            - Range: 0x4b37d7..0x4b388c
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 24}
+                - Size: 8
+                  Op: {CfaOffset: 32}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 41
+      Name: main.lenMap
+      OutOfLinePCRanges: [0x4b38a0..0x4b39ba]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 111 GoMapType map[string]int
+          Locations:
+            - Range: 0x4b38a0..0x4b3900
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4b3831..0x4b393c
+            - Range: 0x4b3900..0x4b39ba
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b37c0..0x4b3836
+            - Range: 0x4b38a0..0x4b3905
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4b3836..0x4b3839
+            - Range: 0x4b3905..0x4b3908
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4b3839..0x4b393c
+            - Range: 0x4b3908..0x4b39ba
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 42
+      Name: main.lenPtrString
+      OutOfLinePCRanges: [0x4b39c0..0x4b3ac6]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 95 PointerType *string
+          Locations:
+            - Range: 0x4b39c0..0x4b3a20
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4b3a20..0x4b3ac6
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4b39c0..0x4b3a25
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4b3a25..0x4b3a28
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x4b3a28..0x4b3ac6
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -6834,35 +7174,71 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 43
-      Name: main.lenErrInt
-      OutOfLinePCRanges: [0x4b3940..0x4b3a5a]
+      Name: main.lenStructFields
+      OutOfLinePCRanges: [0x4b3ae0..0x4b3cb4]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 7 BaseType int
+          Type: 124 StructureType main.lenFields
           Locations:
-            - Range: 0x4b3940..0x4b39af
+            - Range: 0x4b3ae0..0x4b3cb4
+              Pieces: [{Size: 72, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4b3ae0..0x4b3bad
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x4b3bad..0x4b3bb2
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 72}
+                - Size: 8
+                  Op: {CfaOffset: 80}
+            - Range: 0x4b3bb2..0x4b3cb4
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 72}
+                - Size: 8
+                  Op: {CfaOffset: 80}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 44
+      Name: main.lenPtrStructFields
+      OutOfLinePCRanges: [0x4b3cc0..0x4b3e3c]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 126 PointerType *main.lenFields
+          Locations:
+            - Range: 0x4b3cc0..0x4b3d31
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4b39af..0x4b3a5a
+            - Range: 0x4b3d31..0x4b3e3c
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b3940..0x4b39b4
+            - Range: 0x4b3cc0..0x4b3d36
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4b39b4..0x4b39b7
+            - Range: 0x4b3d36..0x4b3d39
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4b39b7..0x4b3a5a
+            - Range: 0x4b3d39..0x4b3e3c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -6871,34 +7247,72 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 44
+    - ID: 45
+      Name: main.lenErrInt
+      OutOfLinePCRanges: [0x4b3e40..0x4b3f5a]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x4b3e40..0x4b3eaf
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4b3eaf..0x4b3f5a
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4b3e40..0x4b3eb4
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4b3eb4..0x4b3eb7
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x4b3eb7..0x4b3f5a
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 46
       Name: main.lenErrStruct
-      OutOfLinePCRanges: [0x4b3a60..0x4b3b9d]
+      OutOfLinePCRanges: [0x4b3f60..0x4b409d]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 121 StructureType main.condFields
           Locations:
-            - Range: 0x4b3a60..0x4b3b9d
+            - Range: 0x4b3f60..0x4b409d
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b3a60..0x4b3af1
+            - Range: 0x4b3f60..0x4b3ff1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4b3af1..0x4b3af6
+            - Range: 0x4b3ff1..0x4b3ff6
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
                 - Size: 8
                   Op: {CfaOffset: 88}
-            - Range: 0x4b3af6..0x4b3b9d
+            - Range: 0x4b3ff6..0x4b409d
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
@@ -6907,28 +7321,28 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 45
+    - ID: 47
       Name: main.indexNilPtrSlice
-      OutOfLinePCRanges: [0x4b3ba0..0x4b3c5c]
+      OutOfLinePCRanges: [0x4b40a0..0x4b415c]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 126 PointerType *main.lenFields
           Locations:
-            - Range: 0x4b3ba0..0x4b3bf5
+            - Range: 0x4b40a0..0x4b40f5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b3ba0..0x4b3bf8
+            - Range: 0x4b40a0..0x4b40f8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4b3bf8..0x4b3bfd
+            - Range: 0x4b40f8..0x4b40fd
               Pieces:
                 - Size: 8
                   Op: null
@@ -6937,60 +7351,60 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 46
+    - ID: 48
       Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
-      OutOfLinePCRanges: [0x4b3c60..0x4b3e57]
+      OutOfLinePCRanges: [0x4b4160..0x4b4357]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 127 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
           Locations:
-            - Range: 0x4b3c60..0x4b3e44
+            - Range: 0x4b4160..0x4b4344
               Pieces: []
-            - Range: 0x4b3e44..0x4b3e45
+            - Range: 0x4b4344..0x4b4345
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4b3e45..0x4b3e57
+            - Range: 0x4b4345..0x4b4357
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 47
+    - ID: 49
       Name: main.bigArrayArg
-      OutOfLinePCRanges: [0x4b3e60..0x4b3eea]
+      OutOfLinePCRanges: [0x4b4360..0x4b43ea]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 132 ArrayType [131072]int64
           Locations:
-            - Range: 0x4b3e60..0x4b3eea
+            - Range: 0x4b4360..0x4b43ea
               Pieces: [{Size: 1048576, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 48
+    - ID: 50
       Name: main.bigArrayStructArg
-      OutOfLinePCRanges: [0x4b3f00..0x4b3f91]
+      OutOfLinePCRanges: [0x4b4400..0x4b4491]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 133 PointerType *main.bigArrayStruct
           Locations:
-            - Range: 0x4b3f00..0x4b3f23
+            - Range: 0x4b4400..0x4b4423
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4b3f23..0x4b3f91
+            - Range: 0x4b4423..0x4b4491
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 49
+    - ID: 51
       Name: main.structSliceArg
-      OutOfLinePCRanges: [0x4b3fa0..0x4b407c]
+      OutOfLinePCRanges: [0x4b44a0..0x4b457c]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 135 GoSliceHeaderType []main.indexMemberStruct
           Locations:
-            - Range: 0x4b3fa0..0x4b3fd9
+            - Range: 0x4b44a0..0x4b44d9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6998,7 +7412,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4b3fd9..0x4b3fde
+            - Range: 0x4b44d9..0x4b44de
               Pieces:
                 - Size: 8
                   Op: null
@@ -7006,7 +7420,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4b4037..0x4b403a
+            - Range: 0x4b4537..0x4b453a
               Pieces:
                 - Size: 8
                   Op: null
@@ -7014,7 +7428,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4b403a..0x4b407c
+            - Range: 0x4b453a..0x4b457c
               Pieces:
                 - Size: 8
                   Op: null
@@ -7027,129 +7441,19 @@ Subprograms:
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b3fa0..0x4b3fde
+            - Range: 0x4b44a0..0x4b44de
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
-            - Range: 0x4b3fde..0x4b4035
+            - Range: 0x4b44de..0x4b4535
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: {CfaOffset: 32}
-            - Range: 0x4b4035..0x4b407c
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 50
-      Name: main.structArrayArg
-      OutOfLinePCRanges: [0x4b4080..0x4b4134]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 138 ArrayType [2]main.indexMemberStruct
-          Locations:
-            - Range: 0x4b4080..0x4b4134
-              Pieces: [{Size: 64, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x4b4080..0x4b40b2
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4b40b2..0x4b40b7
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 64}
-                - Size: 8
-                  Op: {CfaOffset: 72}
-            - Range: 0x4b40b7..0x4b4134
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 64}
-                - Size: 8
-                  Op: {CfaOffset: 72}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 51
-      Name: main.ptrStructSliceArg
-      OutOfLinePCRanges: [0x4b4140..0x4b4225]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 139 GoSliceHeaderType []*main.indexMemberStruct
-          Locations:
-            - Range: 0x4b4140..0x4b417a
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4b417a..0x4b417c
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: null
-            - Range: 0x4b417c..0x4b4185
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: null
-            - Range: 0x4b41de..0x4b41e1
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4b41e1..0x4b4225
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: null
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x4b4140..0x4b4185
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-            - Range: 0x4b4185..0x4b41dc
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 24}
-                - Size: 8
-                  Op: {CfaOffset: 32}
-            - Range: 0x4b41dc..0x4b4225
+            - Range: 0x4b4535..0x4b457c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -7159,33 +7463,143 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 52
+      Name: main.structArrayArg
+      OutOfLinePCRanges: [0x4b4580..0x4b4634]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 138 ArrayType [2]main.indexMemberStruct
+          Locations:
+            - Range: 0x4b4580..0x4b4634
+              Pieces: [{Size: 64, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4b4580..0x4b45b2
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x4b45b2..0x4b45b7
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 64}
+                - Size: 8
+                  Op: {CfaOffset: 72}
+            - Range: 0x4b45b7..0x4b4634
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 64}
+                - Size: 8
+                  Op: {CfaOffset: 72}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 53
+      Name: main.ptrStructSliceArg
+      OutOfLinePCRanges: [0x4b4640..0x4b4725]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 139 GoSliceHeaderType []*main.indexMemberStruct
+          Locations:
+            - Range: 0x4b4640..0x4b467a
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4b467a..0x4b467c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: null
+            - Range: 0x4b467c..0x4b4685
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: null
+            - Range: 0x4b46de..0x4b46e1
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4b46e1..0x4b4725
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: null
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4b4640..0x4b4685
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+            - Range: 0x4b4685..0x4b46dc
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 24}
+                - Size: 8
+                  Op: {CfaOffset: 32}
+            - Range: 0x4b46dc..0x4b4725
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 54
       Name: main.ptrStructArrayArg
-      OutOfLinePCRanges: [0x4b4240..0x4b42e9]
+      OutOfLinePCRanges: [0x4b4740..0x4b47e9]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 141 ArrayType [2]*main.indexMemberStruct
           Locations:
-            - Range: 0x4b4240..0x4b42e9
+            - Range: 0x4b4740..0x4b47e9
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b4240..0x4b426f
+            - Range: 0x4b4740..0x4b476f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4b426f..0x4b4274
+            - Range: 0x4b476f..0x4b4774
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0x4b4274..0x4b42e9
+            - Range: 0x4b4774..0x4b47e9
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -7194,36 +7608,36 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 53
+    - ID: 55
       Name: main.indexMemberWrapperArg
-      OutOfLinePCRanges: [0x4b4300..0x4b43e5]
+      OutOfLinePCRanges: [0x4b4800..0x4b48e5]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 142 PointerType *main.indexMemberWrapper
           Locations:
-            - Range: 0x4b4300..0x4b4338
+            - Range: 0x4b4800..0x4b4838
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4b4338..0x4b43e5
+            - Range: 0x4b4838..0x4b48e5
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b4300..0x4b4336
+            - Range: 0x4b4800..0x4b4836
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4b4336..0x4b433d
+            - Range: 0x4b4836..0x4b483d
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4b433d..0x4b43e5
+            - Range: 0x4b483d..0x4b48e5
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -7232,261 +7646,261 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 54
+    - ID: 56
       Name: main.mapIndexIntKey
-      OutOfLinePCRanges: [0x4b4400..0x4b4456]
+      OutOfLinePCRanges: [0x4b4900..0x4b4956]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 144 GoMapType map[int]string
           Locations:
-            - Range: 0x4b4400..0x4b442d
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 55
-      Name: main.mapIndexStringKey
-      OutOfLinePCRanges: [0x4b4460..0x4b44b6]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 111 GoMapType map[string]int
-          Locations:
-            - Range: 0x4b4460..0x4b448d
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 56
-      Name: main.mapIndexLargeMap
-      OutOfLinePCRanges: [0x4b44c0..0x4b4530]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 111 GoMapType map[string]int
-          Locations:
-            - Range: 0x4b44c0..0x4b44e3
+            - Range: 0x4b4900..0x4b492d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 57
-      Name: main.mapIndexMissing
-      OutOfLinePCRanges: [0x4b4540..0x4b4596]
+      Name: main.mapIndexStringKey
+      OutOfLinePCRanges: [0x4b4960..0x4b49b6]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 111 GoMapType map[string]int
           Locations:
-            - Range: 0x4b4540..0x4b456d
+            - Range: 0x4b4960..0x4b498d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 58
-      Name: main.mapIndexKeyLen8
-      OutOfLinePCRanges: [0x4b46c0..0x4b4730]
+      Name: main.mapIndexLargeMap
+      OutOfLinePCRanges: [0x4b49c0..0x4b4a30]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 111 GoMapType map[string]int
           Locations:
-            - Range: 0x4b46c0..0x4b46e3
+            - Range: 0x4b49c0..0x4b49e3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 59
-      Name: main.mapIndexKeyLen24
-      OutOfLinePCRanges: [0x4b4740..0x4b47b0]
+      Name: main.mapIndexMissing
+      OutOfLinePCRanges: [0x4b4a40..0x4b4a96]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 111 GoMapType map[string]int
           Locations:
-            - Range: 0x4b4740..0x4b4763
+            - Range: 0x4b4a40..0x4b4a6d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 60
-      Name: main.mapIndexKeyLen48
-      OutOfLinePCRanges: [0x4b47c0..0x4b4830]
+      Name: main.mapIndexKeyLen8
+      OutOfLinePCRanges: [0x4b4bc0..0x4b4c30]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 111 GoMapType map[string]int
           Locations:
-            - Range: 0x4b47c0..0x4b47e3
+            - Range: 0x4b4bc0..0x4b4be3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 61
-      Name: main.mapIndexKeyLen96
-      OutOfLinePCRanges: [0x4b4840..0x4b48b0]
+      Name: main.mapIndexKeyLen24
+      OutOfLinePCRanges: [0x4b4c40..0x4b4cb0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 111 GoMapType map[string]int
           Locations:
-            - Range: 0x4b4840..0x4b4863
+            - Range: 0x4b4c40..0x4b4c63
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 62
-      Name: main.mapIndexKeyLen200
-      OutOfLinePCRanges: [0x4b48c0..0x4b4930]
+      Name: main.mapIndexKeyLen48
+      OutOfLinePCRanges: [0x4b4cc0..0x4b4d30]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 111 GoMapType map[string]int
           Locations:
-            - Range: 0x4b48c0..0x4b48e3
+            - Range: 0x4b4cc0..0x4b4ce3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 63
-      Name: main.mapIndexStructVal
-      OutOfLinePCRanges: [0x4b4940..0x4b49be]
+      Name: main.mapIndexKeyLen96
+      OutOfLinePCRanges: [0x4b4d40..0x4b4db0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 149 GoMapType map[string]main.indexMemberStruct
+          Type: 111 GoMapType map[string]int
           Locations:
-            - Range: 0x4b4940..0x4b496a
+            - Range: 0x4b4d40..0x4b4d63
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 64
-      Name: main.mapIndexPtrStructVal
-      OutOfLinePCRanges: [0x4b49c0..0x4b4a45]
+      Name: main.mapIndexKeyLen200
+      OutOfLinePCRanges: [0x4b4dc0..0x4b4e30]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 154 GoMapType map[string]*main.indexMemberStruct
+          Type: 111 GoMapType map[string]int
           Locations:
-            - Range: 0x4b49c0..0x4b49ea
+            - Range: 0x4b4dc0..0x4b4de3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 65
-      Name: main.mapIndexEmptyKey
-      OutOfLinePCRanges: [0x4b4a60..0x4b4adc]
+      Name: main.mapIndexStructVal
+      OutOfLinePCRanges: [0x4b4e40..0x4b4ebe]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 111 GoMapType map[string]int
+          Type: 149 GoMapType map[string]main.indexMemberStruct
           Locations:
-            - Range: 0x4b4a60..0x4b4a82
+            - Range: 0x4b4e40..0x4b4e6a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 66
-      Name: main.mapIndexKeyLen16
-      OutOfLinePCRanges: [0x4b4ae0..0x4b4b50]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 111 GoMapType map[string]int
-          Locations:
-            - Range: 0x4b4ae0..0x4b4b03
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 67
-      Name: main.mapIndexKeyLen17
-      OutOfLinePCRanges: [0x4b4b60..0x4b4bd0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 111 GoMapType map[string]int
-          Locations:
-            - Range: 0x4b4b60..0x4b4b83
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 68
-      Name: main.mapIndexBoolKey
-      OutOfLinePCRanges: [0x4b4be0..0x4b4c36]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 159 GoMapType map[bool]int
-          Locations:
-            - Range: 0x4b4be0..0x4b4c0d
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 69
-      Name: main.mapIndexZeroValue
-      OutOfLinePCRanges: [0x4b4c40..0x4b4c96]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 111 GoMapType map[string]int
-          Locations:
-            - Range: 0x4b4c40..0x4b4c6d
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 70
-      Name: main.mapIndexNilPtrVal
-      OutOfLinePCRanges: [0x4b4ca0..0x4b4cf6]
+      Name: main.mapIndexPtrStructVal
+      OutOfLinePCRanges: [0x4b4ec0..0x4b4f45]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 154 GoMapType map[string]*main.indexMemberStruct
           Locations:
-            - Range: 0x4b4ca0..0x4b4ccd
+            - Range: 0x4b4ec0..0x4b4eea
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 67
+      Name: main.mapIndexEmptyKey
+      OutOfLinePCRanges: [0x4b4f60..0x4b4fdc]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 111 GoMapType map[string]int
+          Locations:
+            - Range: 0x4b4f60..0x4b4f82
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 68
+      Name: main.mapIndexKeyLen16
+      OutOfLinePCRanges: [0x4b4fe0..0x4b5050]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 111 GoMapType map[string]int
+          Locations:
+            - Range: 0x4b4fe0..0x4b5003
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 69
+      Name: main.mapIndexKeyLen17
+      OutOfLinePCRanges: [0x4b5060..0x4b50d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 111 GoMapType map[string]int
+          Locations:
+            - Range: 0x4b5060..0x4b5083
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 70
+      Name: main.mapIndexBoolKey
+      OutOfLinePCRanges: [0x4b50e0..0x4b5136]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 159 GoMapType map[bool]int
+          Locations:
+            - Range: 0x4b50e0..0x4b510d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 71
-      Name: main.mapIndexLargeValue
-      OutOfLinePCRanges: [0x4b4d00..0x4b4d7e]
+      Name: main.mapIndexZeroValue
+      OutOfLinePCRanges: [0x4b5140..0x4b5196]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 164 GoMapType map[string]main.largeValueStruct
+          Type: 111 GoMapType map[string]int
           Locations:
-            - Range: 0x4b4d00..0x4b4d25
+            - Range: 0x4b5140..0x4b516d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 72
+      Name: main.mapIndexNilPtrVal
+      OutOfLinePCRanges: [0x4b51a0..0x4b51f6]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 154 GoMapType map[string]*main.indexMemberStruct
+          Locations:
+            - Range: 0x4b51a0..0x4b51cd
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 73
+      Name: main.mapIndexLargeValue
+      OutOfLinePCRanges: [0x4b5200..0x4b527e]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 164 GoMapType map[string]main.largeValueStruct
+          Locations:
+            - Range: 0x4b5200..0x4b5225
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 74
       Name: main.condMultiReturn
-      OutOfLinePCRanges: [0x4b4e00..0x4b4ed4]
+      OutOfLinePCRanges: [0x4b5300..0x4b53d4]
       InlinePCRanges: []
       Variables:
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b4e00..0x4b4e49
+            - Range: 0x4b5300..0x4b5349
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4b4e49..0x4b4e4e
+            - Range: 0x4b5349..0x4b534e
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0x4b4e4e..0x4b4ed4
+            - Range: 0x4b534e..0x4b53d4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -7497,51 +7911,51 @@ Subprograms:
         - Name: r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4b4e00..0x4b4eac
+            - Range: 0x4b5300..0x4b53ac
               Pieces: []
-            - Range: 0x4b4eac..0x4b4ead
+            - Range: 0x4b53ac..0x4b53ad
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4b4ead..0x4b4ed4
+            - Range: 0x4b53ad..0x4b53d4
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: r1
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b4e00..0x4b4eac
+            - Range: 0x4b5300..0x4b53ac
               Pieces: []
-            - Range: 0x4b4eac..0x4b4ead
+            - Range: 0x4b53ac..0x4b53ad
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4b4ead..0x4b4ed4
+            - Range: 0x4b53ad..0x4b53d4
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 73
+    - ID: 75
       Name: main.genericIdentity[go.shape.string]
-      OutOfLinePCRanges: [0x4b4ee0..0x4b4f7d]
+      OutOfLinePCRanges: [0x4b53e0..0x4b547d]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 169 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x4b4ee0..0x4b4f09
+            - Range: 0x4b53e0..0x4b5409
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4b4f09..0x4b4f0e
+            - Range: 0x4b5409..0x4b540e
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4b4f0e..0x4b4f7d
+            - Range: 0x4b540e..0x4b547d
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -7552,68 +7966,68 @@ Subprograms:
         - Name: ~r0
           Type: 169 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x4b4ee0..0x4b4f4f
+            - Range: 0x4b53e0..0x4b544f
               Pieces: []
-            - Range: 0x4b4f4f..0x4b4f50
+            - Range: 0x4b544f..0x4b5450
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4b4f50..0x4b4f7d
+            - Range: 0x4b5450..0x4b547d
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 74
+    - ID: 76
       Name: main.genericIdentity[go.shape.int]
-      OutOfLinePCRanges: [0x4b4f80..0x4b4ffe]
+      OutOfLinePCRanges: [0x4b5480..0x4b54fe]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 170 BaseType go.shape.int
           Locations:
-            - Range: 0x4b4f80..0x4b4fa6
+            - Range: 0x4b5480..0x4b54a6
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x4b4fa6..0x4b4ffe
+            - Range: 0x4b54a6..0x4b54fe
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 170 BaseType go.shape.int
           Locations:
-            - Range: 0x4b4f80..0x4b4fdd
+            - Range: 0x4b5480..0x4b54dd
               Pieces: []
-            - Range: 0x4b4fdd..0x4b4fde
+            - Range: 0x4b54dd..0x4b54de
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4b4fde..0x4b4ffe
+            - Range: 0x4b54de..0x4b54fe
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 75
+    - ID: 77
       Name: main.inlined
-      OutOfLinePCRanges: [0x4b1780..0x4b17e2]
+      OutOfLinePCRanges: [0x4b19c0..0x4b1a22]
       InlinePCRanges:
         - Ranges: [0x4af17b..0x4af1bc]
-          RootRanges: [0x4aefe0..0x4b1459]
+          RootRanges: [0x4aefe0..0x4b1699]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
             - Range: 0x4af17b..0x4af1bc
               Pieces: []
-            - Range: 0x4b1780..0x4b1799
+            - Range: 0x4b19c0..0x4b19d9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 76
+    - ID: 78
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x4af3c6..0x4af405]
-          RootRanges: [0x4aefe0..0x4b1459]
+          RootRanges: [0x4aefe0..0x4b1699]
       Variables:
         - Name: ptr
           Type: 171 PointerType *****int
@@ -7623,12 +8037,12 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 77
+    - ID: 79
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x4af410..0x4af44a]
-          RootRanges: [0x4aefe0..0x4b1459]
+          RootRanges: [0x4aefe0..0x4b1699]
       Variables:
         - Name: ptr
           Type: 173 PointerType **int
@@ -7638,17 +8052,17 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 78
+    - ID: 80
       Name: main.(*methodValueReceiver).inlinedMethod
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x4b500d..0x4b5010]
-          RootRanges: [0x4b5000..0x4b5022]
+        - Ranges: [0x4b550d..0x4b5510]
+          RootRanges: [0x4b5500..0x4b5522]
       Variables:
         - Name: m
           Type: 174 PointerType *main.methodValueReceiver
           Locations:
-            - Range: 0x4b500d..0x4b5022
+            - Range: 0x4b550d..0x4b5522
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7658,28 +8072,28 @@ Types:
       ID: 171
       Name: '*****int'
       ByteSize: 8
-      GoRuntimeType: 38336
+      GoRuntimeType: 38368
       GoKind: 22
       Pointee: 172 PointerType ****int
     - __kind: PointerType
       ID: 172
       Name: '****int'
       ByteSize: 8
-      GoRuntimeType: 38272
+      GoRuntimeType: 38304
       GoKind: 22
       Pointee: 330 PointerType ***int
     - __kind: PointerType
       ID: 330
       Name: '***int'
       ByteSize: 8
-      GoRuntimeType: 38208
+      GoRuntimeType: 38240
       GoKind: 22
       Pointee: 173 PointerType **int
     - __kind: PointerType
       ID: 173
       Name: '**int'
       ByteSize: 8
-      GoRuntimeType: 38144
+      GoRuntimeType: 38176
       GoKind: 22
       Pointee: 99 PointerType *int
     - __kind: PointerType
@@ -7764,7 +8178,7 @@ Types:
       ID: 125
       Name: '*[]int'
       ByteSize: 8
-      GoRuntimeType: 38080
+      GoRuntimeType: 38112
       GoKind: 22
       Pointee: 107 GoSliceHeaderType []int
     - __kind: PointerType
@@ -7781,7 +8195,7 @@ Types:
       ID: 39
       Name: '*[]runtime.ancestorInfo'
       ByteSize: 8
-      GoRuntimeType: 43392
+      GoRuntimeType: 43424
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
@@ -7803,35 +8217,35 @@ Types:
       ID: 11
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 32224
+      GoRuntimeType: 32256
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
       ID: 102
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 31136
+      GoRuntimeType: 31168
       GoKind: 22
       Pointee: 13 GoInterfaceType error
     - __kind: PointerType
       ID: 283
       Name: '*errors.errorString'
       ByteSize: 8
-      GoRuntimeType: 63072
+      GoRuntimeType: 63200
       GoKind: 22
       Pointee: 284 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
       ID: 104
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 32096
+      GoRuntimeType: 32128
       GoKind: 22
       Pointee: 18 BaseType float32
     - __kind: PointerType
       ID: 98
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 32160
+      GoRuntimeType: 32192
       GoKind: 22
       Pointee: 15 BaseType float64
     - __kind: PointerType
@@ -7843,56 +8257,56 @@ Types:
       ID: 99
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 31776
+      GoRuntimeType: 31808
       GoKind: 22
       Pointee: 7 BaseType int
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 31520
+      GoRuntimeType: 31552
       GoKind: 22
       Pointee: 10 BaseType int32
     - __kind: PointerType
       ID: 100
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 31648
+      GoRuntimeType: 31680
       GoKind: 22
       Pointee: 12 BaseType int64
     - __kind: PointerType
       ID: 323
       Name: '*internal/abi.Type'
       ByteSize: 8
-      GoRuntimeType: 142400
+      GoRuntimeType: 142528
       GoKind: 22
       Pointee: 324 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
       ID: 291
       Name: '*internal/bisect.parseError'
       ByteSize: 8
-      GoRuntimeType: 66336
+      GoRuntimeType: 66464
       GoKind: 22
       Pointee: 292 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
       ID: 319
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 80864
+      GoRuntimeType: 80992
       GoKind: 22
       Pointee: 320 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 317
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
-      GoRuntimeType: 80736
+      GoRuntimeType: 80864
       GoKind: 22
       Pointee: 318 StructureType internal/poll.errNetClosing
     - __kind: PointerType
       ID: 290
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
-      GoRuntimeType: 66144
+      GoRuntimeType: 66272
       GoKind: 22
       Pointee: 280 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
@@ -7904,42 +8318,42 @@ Types:
       ID: 309
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
-      GoRuntimeType: 73440
+      GoRuntimeType: 73568
       GoKind: 22
       Pointee: 310 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
       ID: 315
       Name: '*io/fs.PathError'
       ByteSize: 8
-      GoRuntimeType: 80608
+      GoRuntimeType: 80736
       GoKind: 22
       Pointee: 316 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
       ID: 133
       Name: '*main.bigArrayStruct'
       ByteSize: 8
-      GoRuntimeType: 29536
+      GoRuntimeType: 29568
       GoKind: 22
       Pointee: 134 StructureType main.bigArrayStruct
     - __kind: PointerType
       ID: 203
       Name: '*main.bigStruct'
       ByteSize: 8
-      GoRuntimeType: 29408
+      GoRuntimeType: 29440
       GoKind: 22
       Pointee: 204 StructureType main.bigStruct
     - __kind: PointerType
       ID: 123
       Name: '*main.condFields'
       ByteSize: 8
-      GoRuntimeType: 29152
+      GoRuntimeType: 29184
       GoKind: 22
       Pointee: 121 StructureType main.condFields
     - __kind: PointerType
       ID: 136
       Name: '*main.indexMemberStruct'
       ByteSize: 8
-      GoRuntimeType: 29344
+      GoRuntimeType: 29376
       GoKind: 22
       Pointee: 137 StructureType main.indexMemberStruct
     - __kind: PointerType
@@ -7952,14 +8366,14 @@ Types:
       ID: 262
       Name: '*main.largeValueStruct'
       ByteSize: 8
-      GoRuntimeType: 29472
+      GoRuntimeType: 29504
       GoKind: 22
       Pointee: 263 StructureType main.largeValueStruct
     - __kind: PointerType
       ID: 126
       Name: '*main.lenFields'
       ByteSize: 8
-      GoRuntimeType: 29216
+      GoRuntimeType: 29248
       GoKind: 22
       Pointee: 124 StructureType main.lenFields
     - __kind: PointerType
@@ -8062,77 +8476,77 @@ Types:
       ID: 311
       Name: '*os.SyscallError'
       ByteSize: 8
-      GoRuntimeType: 77664
+      GoRuntimeType: 77792
       GoKind: 22
       Pointee: 312 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 285
       Name: '*reflect.ValueError'
       ByteSize: 8
-      GoRuntimeType: 63936
+      GoRuntimeType: 64064
       GoKind: 22
       Pointee: 286 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
       ID: 303
       Name: '*runtime.PanicNilError'
       ByteSize: 8
-      GoRuntimeType: 70752
+      GoRuntimeType: 70880
       GoKind: 22
       Pointee: 304 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
       ID: 307
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
-      GoRuntimeType: 72544
+      GoRuntimeType: 72672
       GoKind: 22
       Pointee: 308 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
       ByteSize: 8
-      GoRuntimeType: 32416
+      GoRuntimeType: 32448
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._defer
     - __kind: PointerType
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 89280
+      GoRuntimeType: 89408
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 305
       Name: '*runtime.boundsError'
       ByteSize: 8
-      GoRuntimeType: 70880
+      GoRuntimeType: 71008
       GoKind: 22
       Pointee: 306 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 65
       Name: '*runtime.cgoCallers'
       ByteSize: 8
-      GoRuntimeType: 33056
+      GoRuntimeType: 33088
       GoKind: 22
       Pointee: 66 UnresolvedPointeeType runtime.cgoCallers
     - __kind: PointerType
       ID: 47
       Name: '*runtime.coro'
       ByteSize: 8
-      GoRuntimeType: 33120
+      GoRuntimeType: 33152
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
       ID: 313
       Name: '*runtime.errorAddressString'
       ByteSize: 8
-      GoRuntimeType: 80096
+      GoRuntimeType: 80224
       GoKind: 22
       Pointee: 314 StructureType runtime.errorAddressString
     - __kind: PointerType
       ID: 301
       Name: '*runtime.errorString'
       ByteSize: 8
-      GoRuntimeType: 70368
+      GoRuntimeType: 70496
       GoKind: 22
       Pointee: 293 GoStringHeaderType runtime.errorString
     - __kind: PointerType
@@ -8144,28 +8558,28 @@ Types:
       ID: 55
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 64800
+      GoRuntimeType: 64928
       GoKind: 22
       Pointee: 22 StructureType runtime.g
     - __kind: PointerType
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 89920
+      GoRuntimeType: 90048
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
       ID: 64
       Name: '*runtime.p'
       ByteSize: 8
-      GoRuntimeType: 71904
+      GoRuntimeType: 72032
       GoKind: 22
       Pointee: 182 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 302
       Name: '*runtime.plainError'
       ByteSize: 8
-      GoRuntimeType: 70496
+      GoRuntimeType: 70624
       GoKind: 22
       Pointee: 296 GoStringHeaderType runtime.plainError
     - __kind: PointerType
@@ -8177,49 +8591,49 @@ Types:
       ID: 41
       Name: '*runtime.sudog'
       ByteSize: 8
-      GoRuntimeType: 33760
+      GoRuntimeType: 33792
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType runtime.sudog
     - __kind: PointerType
       ID: 49
       Name: '*runtime.synctestBubble'
       ByteSize: 8
-      GoRuntimeType: 102528
+      GoRuntimeType: 102656
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
       ID: 287
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
-      GoRuntimeType: 65472
+      GoRuntimeType: 65600
       GoKind: 22
       Pointee: 288 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 134560
+      GoRuntimeType: 134688
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 79
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 108736
+      GoRuntimeType: 108864
       GoKind: 22
       Pointee: 80 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 299
       Name: '*strconv.NumError'
       ByteSize: 8
-      GoRuntimeType: 69472
+      GoRuntimeType: 69600
       GoKind: 22
       Pointee: 300 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 95
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 31200
+      GoRuntimeType: 31232
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
@@ -8231,7 +8645,7 @@ Types:
       ID: 322
       Name: '*syscall.Errno'
       ByteSize: 8
-      GoRuntimeType: 90880
+      GoRuntimeType: 91008
       GoKind: 22
       Pointee: 321 BaseType syscall.Errno
     - __kind: PointerType
@@ -8283,7 +8697,7 @@ Types:
       ID: 289
       Name: '*time.fileSizeError'
       ByteSize: 8
-      GoRuntimeType: 65664
+      GoRuntimeType: 65792
       GoKind: 22
       Pointee: 277 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
@@ -8295,46 +8709,46 @@ Types:
       ID: 105
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 31840
+      GoRuntimeType: 31872
       GoKind: 22
       Pointee: 17 BaseType uint
     - __kind: PointerType
       ID: 106
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 31456
+      GoRuntimeType: 31488
       GoKind: 22
       Pointee: 6 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 31584
+      GoRuntimeType: 31616
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 101
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 31712
+      GoRuntimeType: 31744
       GoKind: 22
       Pointee: 8 BaseType uint64
     - __kind: PointerType
       ID: 5
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 31328
+      GoRuntimeType: 31360
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 19
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 31904
+      GoRuntimeType: 31936
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 677
+      ID: 686
       Name: Probe[main.(*methodValueReceiver).inlinedMethod]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8346,12 +8760,12 @@ Types:
             Type: 174 PointerType *main.methodValueReceiver
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: m}
+                  Variable: {subprogram: 80, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 675
+      ID: 684
       Name: Probe[main.PointerChainArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -8363,7 +8777,7 @@ Types:
             Type: 171 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: ptr}
+                  Variable: {subprogram: 78, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -8374,12 +8788,12 @@ Types:
             Type: 171 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: ptr}
+                  Variable: {subprogram: 78, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 676
+      ID: 685
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8391,12 +8805,12 @@ Types:
             Type: 173 PointerType **int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: ptr}
+                  Variable: {subprogram: 79, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 587
+      ID: 596
       Name: Probe[main.bigArrayArg]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8408,12 +8822,12 @@ Types:
             Type: 12 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: s}
+                  Variable: {subprogram: 49, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 589
+      ID: 598
       Name: Probe[main.bigArrayArg]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8425,18 +8839,18 @@ Types:
             Type: 12 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: s}
+                  Variable: {subprogram: 49, index: 0, name: s}
                   Offset: 1048568
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 588
+      ID: 597
       Name: Probe[main.bigArrayArg]Return
     - __kind: EventRootType
-      ID: 590
+      ID: 599
       Name: Probe[main.bigArrayArg]Return
     - __kind: EventRootType
-      ID: 591
+      ID: 600
       Name: Probe[main.bigArrayStructArg]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8448,7 +8862,7 @@ Types:
             Type: 12 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: s}
+                  Variable: {subprogram: 50, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -8456,7 +8870,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 592
+      ID: 601
       Name: Probe[main.bigArrayStructArg]Return
     - __kind: EventRootType
       ID: 374
@@ -8887,6 +9301,85 @@ Types:
       ID: 381
       Name: Probe[main.condInt8]Return
     - __kind: EventRootType
+      ID: 485
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 486
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 487
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 488
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 489
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 490
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 491
+      Name: Probe[main.condLineMixed]Line
+      ByteSize: 131
+      ExprStatusArraySize: 2
+      Expressions:
+        - Name: s
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: b
+          Offset: 18
+          Kind: local
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 1
+          DictIndex: -1
+        - Name: x
+          Offset: 19
+          Kind: local
+          Expression:
+            Type: 121 StructureType main.condFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 80
+          DictIndex: -1
+        - Name: p
+          Offset: 99
+          Kind: local
+          Expression:
+            Type: 123 PointerType *main.condFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 3, name: p}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: ss
+          Offset: 107
+          Kind: local
+          Expression:
+            Type: 107 GoSliceHeaderType []int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 4, name: ss}
+                  Offset: 0
+                  ByteSize: 24
+          DictIndex: -1
+    - __kind: EventRootType
       ID: 480
       Name: Probe[main.condLine]Line
       ByteSize: 25
@@ -8934,6 +9427,62 @@ Types:
     - __kind: EventRootType
       ID: 482
       Name: Probe[main.condLine]Line
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 483
+      Name: Probe[main.condLine]Line
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: "n"
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 0, name: "n"}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: tag
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: result
+          Offset: 25
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 2, name: result}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 484
+      Name: Probe[main.condLine]Line
       ByteSize: 25
       ExprStatusArraySize: 1
       Expressions:
@@ -8960,10 +9509,10 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 667
+      ID: 676
       Name: Probe[main.condMultiReturn]
     - __kind: EventRootType
-      ID: 668
+      ID: 677
       Name: Probe[main.condMultiReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -8975,7 +9524,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 1, name: r0}
+                  Variable: {subprogram: 74, index: 1, name: r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -8986,7 +9535,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 2, name: r1}
+                  Variable: {subprogram: 74, index: 2, name: r1}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -9082,7 +9631,7 @@ Types:
       ID: 469
       Name: Probe[main.condNilPtrStruct]Return
     - __kind: EventRootType
-      ID: 489
+      ID: 498
       Name: Probe[main.condNullIface]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -9094,76 +9643,16 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 35, index: 1, name: tag}
+                  Variable: {subprogram: 37, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 490
+      ID: 499
       Name: Probe[main.condNullIface]Return
     - __kind: EventRootType
-      ID: 487
+      ID: 496
       Name: Probe[main.condNullMap]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 34, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 488
-      Name: Probe[main.condNullMap]Return
-    - __kind: EventRootType
-      ID: 483
-      Name: Probe[main.condNullPtr]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 32, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 484
-      Name: Probe[main.condNullPtr]Return
-    - __kind: EventRootType
-      ID: 485
-      Name: Probe[main.condNullSlice]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 33, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 486
-      Name: Probe[main.condNullSlice]Return
-    - __kind: EventRootType
-      ID: 491
-      Name: Probe[main.condNullUnsafePtr]
       ByteSize: 17
       ExprStatusArraySize: 1
       Expressions:
@@ -9179,7 +9668,67 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
+      ID: 497
+      Name: Probe[main.condNullMap]Return
+    - __kind: EventRootType
       ID: 492
+      Name: Probe[main.condNullPtr]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 493
+      Name: Probe[main.condNullPtr]Return
+    - __kind: EventRootType
+      ID: 494
+      Name: Probe[main.condNullSlice]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 495
+      Name: Probe[main.condNullSlice]Return
+    - __kind: EventRootType
+      ID: 500
+      Name: Probe[main.condNullUnsafePtr]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 501
       Name: Probe[main.condNullUnsafePtr]Return
     - __kind: EventRootType
       ID: 476
@@ -9991,7 +10540,7 @@ Types:
       ID: 403
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 671
+      ID: 680
       Name: Probe[main.genericIdentity[go.shape.int]]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10004,12 +10553,12 @@ Types:
             Type: 170 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: x}
+                  Variable: {subprogram: 76, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 672
+      ID: 681
       Name: Probe[main.genericIdentity[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10022,12 +10571,12 @@ Types:
             Type: 170 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 1, name: ~r0}
+                  Variable: {subprogram: 76, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 669
+      ID: 678
       Name: Probe[main.genericIdentity[go.shape.string]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -10040,12 +10589,12 @@ Types:
             Type: 169 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: x}
+                  Variable: {subprogram: 75, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 670
+      ID: 679
       Name: Probe[main.genericIdentity[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -10058,12 +10607,12 @@ Types:
             Type: 169 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 1, name: ~r0}
+                  Variable: {subprogram: 75, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 613
+      ID: 622
       Name: Probe[main.indexMemberWrapperArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -10075,7 +10624,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
+                  Variable: {subprogram: 55, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10086,7 +10635,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 615
+      ID: 624
       Name: Probe[main.indexMemberWrapperArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10098,7 +10647,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
+                  Variable: {subprogram: 55, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10109,7 +10658,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 617
+      ID: 626
       Name: Probe[main.indexMemberWrapperArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -10121,7 +10670,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
+                  Variable: {subprogram: 55, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10135,7 +10684,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 619
+      ID: 628
       Name: Probe[main.indexMemberWrapperArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10147,7 +10696,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
+                  Variable: {subprogram: 55, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10161,19 +10710,19 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 614
+      ID: 623
       Name: Probe[main.indexMemberWrapperArg]Return
     - __kind: EventRootType
-      ID: 616
+      ID: 625
       Name: Probe[main.indexMemberWrapperArg]Return
     - __kind: EventRootType
-      ID: 618
+      ID: 627
       Name: Probe[main.indexMemberWrapperArg]Return
     - __kind: EventRootType
-      ID: 620
+      ID: 629
       Name: Probe[main.indexMemberWrapperArg]Return
     - __kind: EventRootType
-      ID: 579
+      ID: 588
       Name: Probe[main.indexNilPtrSlice]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10185,7 +10734,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: x}
+                  Variable: {subprogram: 47, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10198,7 +10747,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 581
+      ID: 590
       Name: Probe[main.indexNilPtrSlice]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10210,12 +10759,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 1, name: tag}
+                  Variable: {subprogram: 47, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 583
+      ID: 592
       Name: Probe[main.indexNilPtrSlice]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10227,7 +10776,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: x}
+                  Variable: {subprogram: 47, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10240,16 +10789,16 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 580
+      ID: 589
       Name: Probe[main.indexNilPtrSlice]Return
     - __kind: EventRootType
-      ID: 582
+      ID: 591
       Name: Probe[main.indexNilPtrSlice]Return
     - __kind: EventRootType
-      ID: 584
+      ID: 593
       Name: Probe[main.indexNilPtrSlice]Return
     - __kind: EventRootType
-      ID: 673
+      ID: 682
       Name: Probe[main.inlined]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10261,12 +10810,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: x}
+                  Variable: {subprogram: 77, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 674
+      ID: 683
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
       ID: 331
@@ -10479,7 +11028,7 @@ Types:
       ID: 352
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 571
+      ID: 580
       Name: Probe[main.lenErrInt]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -10491,7 +11040,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: x}
+                  Variable: {subprogram: 45, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -10502,21 +11051,21 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 1, name: tag}
+                  Variable: {subprogram: 45, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 573
+      ID: 582
       Name: Probe[main.lenErrInt]
     - __kind: EventRootType
-      ID: 572
+      ID: 581
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 574
+      ID: 583
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 575
+      ID: 584
       Name: Probe[main.lenErrStruct]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -10528,7 +11077,7 @@ Types:
             Type: 121 StructureType main.condFields
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: x}
+                  Variable: {subprogram: 46, index: 0, name: x}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -10539,21 +11088,21 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 1, name: tag}
+                  Variable: {subprogram: 46, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 577
+      ID: 586
       Name: Probe[main.lenErrStruct]
     - __kind: EventRootType
-      ID: 576
+      ID: 585
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 578
+      ID: 587
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 525
+      ID: 534
       Name: Probe[main.lenMap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10565,12 +11114,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Variable: {subprogram: 41, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 527
+      ID: 536
       Name: Probe[main.lenMap]
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -10582,7 +11131,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: m}
+                  Variable: {subprogram: 41, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10596,7 +11145,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 529
+      ID: 538
       Name: Probe[main.lenMap]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10608,845 +11157,16 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: m}
+                  Variable: {subprogram: 41, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
                   Bias: 0
                   ByteSize: 8
           DictIndex: -1
-    - __kind: EventRootType
-      ID: 531
-      Name: Probe[main.lenMap]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 533
-      Name: Probe[main.lenMap]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(m)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 8 BaseType uint64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 0
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 535
-      Name: Probe[main.lenMap]
-      ByteSize: 25
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 111 GoMapType map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-          DictIndex: -1
-        - Name: tag
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 526
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 528
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 530
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 532
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 534
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 536
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 537
-      Name: Probe[main.lenPtrString]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(s)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 539
-      Name: Probe[main.lenPtrString]
-      ByteSize: 25
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 95 PointerType *string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 8
-          DictIndex: -1
-        - Name: tag
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 538
-      Name: Probe[main.lenPtrString]Return
     - __kind: EventRootType
       ID: 540
-      Name: Probe[main.lenPtrString]Return
-    - __kind: EventRootType
-      ID: 561
-      Name: Probe[main.lenPtrStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: items_0
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 16
-                  ByteSize: 16
-                - __kind: SliceBoundsCheckOp
-                  Index: 0
-                - __kind: DereferenceOp
-                  Bias: 0
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 563
-      Name: Probe[main.lenPtrStructFields]
-      ByteSize: 25
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 126 PointerType *main.lenFields
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-          DictIndex: -1
-        - Name: tag
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 565
-      Name: Probe[main.lenPtrStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.Dict)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 8 BaseType uint64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 40
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 0
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 567
-      Name: Probe[main.lenPtrStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.Items)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 24
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 569
-      Name: Probe[main.lenPtrStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.S)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 562
-      Name: Probe[main.lenPtrStructFields]Return
-    - __kind: EventRootType
-      ID: 564
-      Name: Probe[main.lenPtrStructFields]Return
-    - __kind: EventRootType
-      ID: 566
-      Name: Probe[main.lenPtrStructFields]Return
-    - __kind: EventRootType
-      ID: 568
-      Name: Probe[main.lenPtrStructFields]Return
-    - __kind: EventRootType
-      ID: 570
-      Name: Probe[main.lenPtrStructFields]Return
-    - __kind: EventRootType
-      ID: 513
-      Name: Probe[main.lenSlice]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 515
-      Name: Probe[main.lenSlice]
-      ByteSize: 2
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: isEmpty(s)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-                - __kind: ExprPushOffsetOp
-                  ByteSize: 8
-                - __kind: ExprLoadLiteralOp
-                  Data: AAAAAAAAAAA=
-                - __kind: ExprCmpEqBaseOp
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 517
-      Name: Probe[main.lenSlice]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s_len
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 519
-      Name: Probe[main.lenSlice]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 521
-      Name: Probe[main.lenSlice]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(s)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 523
-      Name: Probe[main.lenSlice]
-      ByteSize: 41
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 107 GoSliceHeaderType []int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 24
-          DictIndex: -1
-        - Name: tag
-          Offset: 25
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 514
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 516
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 518
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 520
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 522
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 524
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 493
-      Name: Probe[main.lenString]
-      ByteSize: 33
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-        - Name: tag
-          Offset: 17
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 495
-      Name: Probe[main.lenString]
-      ByteSize: 2
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s_len_eq_5
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-                - __kind: ExprPushOffsetOp
-                  ByteSize: 8
-                - __kind: ExprLoadLiteralOp
-                  Data: BQAAAAAAAAA=
-                - __kind: ExprCmpEqBaseOp
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 497
-      Name: Probe[main.lenString]
-      ByteSize: 2
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(s) == 5
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-                - __kind: ExprPushOffsetOp
-                  ByteSize: 8
-                - __kind: ExprLoadLiteralOp
-                  Data: BQAAAAAAAAA=
-                - __kind: ExprCmpEqBaseOp
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 499
-      Name: Probe[main.lenString]
-      ByteSize: 2
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s_isEmpty
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-                - __kind: ExprPushOffsetOp
-                  ByteSize: 8
-                - __kind: ExprLoadLiteralOp
-                  Data: AAAAAAAAAAA=
-                - __kind: ExprCmpEqBaseOp
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 501
-      Name: Probe[main.lenString]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 503
-      Name: Probe[main.lenString]
-      ByteSize: 2
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: isEmpty(s)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-                - __kind: ExprPushOffsetOp
-                  ByteSize: 8
-                - __kind: ExprLoadLiteralOp
-                  Data: AAAAAAAAAAA=
-                - __kind: ExprCmpEqBaseOp
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 505
-      Name: Probe[main.lenString]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s_len
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 507
-      Name: Probe[main.lenString]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 509
-      Name: Probe[main.lenString]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(s)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 511
-      Name: Probe[main.lenString]
-      ByteSize: 33
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-        - Name: tag
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 494
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 496
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 498
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 500
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 502
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 504
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 506
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 508
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 510
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 512
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 541
-      Name: Probe[main.lenStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: items_2
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 16
-                  ByteSize: 16
-                - __kind: SliceBoundsCheckOp
-                  Index: 2
-                - __kind: DereferenceOp
-                  Bias: 16
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 543
-      Name: Probe[main.lenStructFields]
-      ByteSize: 89
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 124 StructureType main.lenFields
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 72
-          DictIndex: -1
-        - Name: tag
-          Offset: 73
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 545
-      Name: Probe[main.lenStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.Dict)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 8 BaseType uint64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 40
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 0
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 547
-      Name: Probe[main.lenStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.PtrSlice)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 56
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 549
-      Name: Probe[main.lenStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.PtrStr)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 48
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 551
-      Name: Probe[main.lenStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.Items)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 24
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 553
-      Name: Probe[main.lenStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.S)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 555
-      Name: Probe[main.lenStructFields]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 557
-      Name: Probe[main.lenStructFields]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 559
-      Name: Probe[main.lenStructFields]
+      Name: Probe[main.lenMap]
       ByteSize: 17
       ExprStatusArraySize: 1
       Expressions:
@@ -11463,33 +11183,862 @@ Types:
           DictIndex: -1
     - __kind: EventRootType
       ID: 542
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenMap]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(m)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 41, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+          DictIndex: -1
     - __kind: EventRootType
       ID: 544
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenMap]
+      ByteSize: 25
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 111 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 41, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 41, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 535
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 537
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 539
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 541
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 543
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 545
+      Name: Probe[main.lenMap]Return
     - __kind: EventRootType
       ID: 546
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenPtrString]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 42, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+          DictIndex: -1
     - __kind: EventRootType
       ID: 548
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenPtrString]
+      ByteSize: 25
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 95 PointerType *string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 42, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 42, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 547
+      Name: Probe[main.lenPtrString]Return
+    - __kind: EventRootType
+      ID: 549
+      Name: Probe[main.lenPtrString]Return
+    - __kind: EventRootType
+      ID: 570
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: items_0
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 16
+                  ByteSize: 16
+                - __kind: SliceBoundsCheckOp
+                  Index: 0
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 572
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 25
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 126 PointerType *main.lenFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 574
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.Dict)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 40
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 576
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.Items)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 24
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 578
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.S)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 571
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 573
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 575
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 577
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 579
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 522
+      Name: Probe[main.lenSlice]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 524
+      Name: Probe[main.lenSlice]
+      ByteSize: 2
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: isEmpty(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 526
+      Name: Probe[main.lenSlice]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s_len
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 528
+      Name: Probe[main.lenSlice]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 530
+      Name: Probe[main.lenSlice]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 532
+      Name: Probe[main.lenSlice]
+      ByteSize: 41
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 107 GoSliceHeaderType []int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+          DictIndex: -1
+        - Name: tag
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 523
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 525
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 527
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 529
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 531
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 533
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 502
+      Name: Probe[main.lenString]
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: tag
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 504
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s_len_eq_5
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 506
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(s) == 5
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 508
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s_isEmpty
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 510
+      Name: Probe[main.lenString]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 512
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: isEmpty(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 514
+      Name: Probe[main.lenString]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s_len
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 516
+      Name: Probe[main.lenString]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 518
+      Name: Probe[main.lenString]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 520
+      Name: Probe[main.lenString]
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: tag
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 503
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 505
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 507
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 509
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 511
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 513
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 515
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 517
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 519
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 521
+      Name: Probe[main.lenString]Return
     - __kind: EventRootType
       ID: 550
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: items_2
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 16
+                  ByteSize: 16
+                - __kind: SliceBoundsCheckOp
+                  Index: 2
+                - __kind: DereferenceOp
+                  Bias: 16
+                  ByteSize: 8
+          DictIndex: -1
     - __kind: EventRootType
       ID: 552
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenStructFields]
+      ByteSize: 89
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 124 StructureType main.lenFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 72
+          DictIndex: -1
+        - Name: tag
+          Offset: 73
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
     - __kind: EventRootType
       ID: 554
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.Dict)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 40
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+          DictIndex: -1
     - __kind: EventRootType
       ID: 556
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.PtrSlice)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 56
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+          DictIndex: -1
     - __kind: EventRootType
       ID: 558
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.PtrStr)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 48
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+          DictIndex: -1
     - __kind: EventRootType
       ID: 560
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.Items)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 24
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 562
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.S)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 8
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 564
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 566
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 568
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 551
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 553
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 555
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 557
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 559
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 561
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 563
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 565
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 567
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 569
       Name: Probe[main.lenStructFields]Return
     - __kind: EventRootType
       ID: 372
@@ -11523,7 +12072,7 @@ Types:
       ID: 373
       Name: Probe[main.mapArg]Return
     - __kind: EventRootType
-      ID: 657
+      ID: 666
       Name: Probe[main.mapIndexBoolKey]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11535,7 +12084,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11562,7 +12111,7 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 659
+      ID: 668
       Name: Probe[main.mapIndexBoolKey]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11574,7 +12123,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11601,13 +12150,13 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 658
+      ID: 667
+      Name: Probe[main.mapIndexBoolKey]Return
+    - __kind: EventRootType
+      ID: 669
       Name: Probe[main.mapIndexBoolKey]Return
     - __kind: EventRootType
       ID: 660
-      Name: Probe[main.mapIndexBoolKey]Return
-    - __kind: EventRootType
-      ID: 651
       Name: Probe[main.mapIndexEmptyKey]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11619,7 +12168,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11646,10 +12195,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 652
+      ID: 661
       Name: Probe[main.mapIndexEmptyKey]Return
     - __kind: EventRootType
-      ID: 621
+      ID: 630
       Name: Probe[main.mapIndexIntKey]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -11661,7 +12210,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: m}
+                  Variable: {subprogram: 56, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11688,10 +12237,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 622
+      ID: 631
       Name: Probe[main.mapIndexIntKey]Return
     - __kind: EventRootType
-      ID: 653
+      ID: 662
       Name: Probe[main.mapIndexKeyLen16]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11703,7 +12252,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11730,10 +12279,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 654
+      ID: 663
       Name: Probe[main.mapIndexKeyLen16]Return
     - __kind: EventRootType
-      ID: 655
+      ID: 664
       Name: Probe[main.mapIndexKeyLen17]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11745,7 +12294,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11772,10 +12321,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 656
+      ID: 665
       Name: Probe[main.mapIndexKeyLen17]Return
     - __kind: EventRootType
-      ID: 641
+      ID: 650
       Name: Probe[main.mapIndexKeyLen200]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11787,7 +12336,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
+                  Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11814,10 +12363,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 642
+      ID: 651
       Name: Probe[main.mapIndexKeyLen200]Return
     - __kind: EventRootType
-      ID: 635
+      ID: 644
       Name: Probe[main.mapIndexKeyLen24]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11829,7 +12378,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
+                  Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11856,10 +12405,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 636
+      ID: 645
       Name: Probe[main.mapIndexKeyLen24]Return
     - __kind: EventRootType
-      ID: 637
+      ID: 646
       Name: Probe[main.mapIndexKeyLen48]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11871,7 +12420,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
+                  Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11898,10 +12447,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 638
+      ID: 647
       Name: Probe[main.mapIndexKeyLen48]Return
     - __kind: EventRootType
-      ID: 633
+      ID: 642
       Name: Probe[main.mapIndexKeyLen8]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11913,7 +12462,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
+                  Variable: {subprogram: 60, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11940,10 +12489,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 634
+      ID: 643
       Name: Probe[main.mapIndexKeyLen8]Return
     - __kind: EventRootType
-      ID: 639
+      ID: 648
       Name: Probe[main.mapIndexKeyLen96]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11955,7 +12504,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11982,10 +12531,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 640
+      ID: 649
       Name: Probe[main.mapIndexKeyLen96]Return
     - __kind: EventRootType
-      ID: 629
+      ID: 638
       Name: Probe[main.mapIndexLargeMap]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11997,7 +12546,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: m}
+                  Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12024,10 +12573,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 630
+      ID: 639
       Name: Probe[main.mapIndexLargeMap]Return
     - __kind: EventRootType
-      ID: 665
+      ID: 674
       Name: Probe[main.mapIndexLargeValue]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12039,7 +12588,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12069,10 +12618,10 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 666
+      ID: 675
       Name: Probe[main.mapIndexLargeValue]Return
     - __kind: EventRootType
-      ID: 631
+      ID: 640
       Name: Probe[main.mapIndexMissing]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12084,7 +12633,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
+                  Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12111,10 +12660,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 632
+      ID: 641
       Name: Probe[main.mapIndexMissing]Return
     - __kind: EventRootType
-      ID: 663
+      ID: 672
       Name: Probe[main.mapIndexNilPtrVal]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12126,7 +12675,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 72, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12156,10 +12705,10 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 664
+      ID: 673
       Name: Probe[main.mapIndexNilPtrVal]Return
     - __kind: EventRootType
-      ID: 647
+      ID: 656
       Name: Probe[main.mapIndexPtrStructVal]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12171,7 +12720,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12201,7 +12750,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 649
+      ID: 658
       Name: Probe[main.mapIndexPtrStructVal]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12213,7 +12762,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12243,13 +12792,13 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 648
+      ID: 657
       Name: Probe[main.mapIndexPtrStructVal]Return
     - __kind: EventRootType
-      ID: 650
+      ID: 659
       Name: Probe[main.mapIndexPtrStructVal]Return
     - __kind: EventRootType
-      ID: 623
+      ID: 632
       Name: Probe[main.mapIndexStringKey]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12261,7 +12810,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12288,10 +12837,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 625
+      ID: 634
       Name: Probe[main.mapIndexStringKey]
     - __kind: EventRootType
-      ID: 627
+      ID: 636
       Name: Probe[main.mapIndexStringKey]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12303,7 +12852,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12330,16 +12879,16 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 624
+      ID: 633
       Name: Probe[main.mapIndexStringKey]Return
     - __kind: EventRootType
-      ID: 626
+      ID: 635
       Name: Probe[main.mapIndexStringKey]Return
     - __kind: EventRootType
-      ID: 628
+      ID: 637
       Name: Probe[main.mapIndexStringKey]Return
     - __kind: EventRootType
-      ID: 643
+      ID: 652
       Name: Probe[main.mapIndexStructVal]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12351,7 +12900,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12378,7 +12927,7 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 645
+      ID: 654
       Name: Probe[main.mapIndexStructVal]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12390,7 +12939,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12417,13 +12966,13 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 644
+      ID: 653
       Name: Probe[main.mapIndexStructVal]Return
     - __kind: EventRootType
-      ID: 646
+      ID: 655
       Name: Probe[main.mapIndexStructVal]Return
     - __kind: EventRootType
-      ID: 661
+      ID: 670
       Name: Probe[main.mapIndexZeroValue]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12435,7 +12984,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12462,7 +13011,7 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 662
+      ID: 671
       Name: Probe[main.mapIndexZeroValue]Return
     - __kind: EventRootType
       ID: 376
@@ -12471,7 +13020,7 @@ Types:
       ID: 377
       Name: Probe[main.noArgs]Return
     - __kind: EventRootType
-      ID: 609
+      ID: 618
       Name: Probe[main.ptrStructArrayArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12483,7 +13032,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: s}
+                  Variable: {subprogram: 54, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12491,7 +13040,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 611
+      ID: 620
       Name: Probe[main.ptrStructArrayArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12503,7 +13052,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: s}
+                  Variable: {subprogram: 54, index: 0, name: s}
                   Offset: 8
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12511,13 +13060,13 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 610
+      ID: 619
       Name: Probe[main.ptrStructArrayArg]Return
     - __kind: EventRootType
-      ID: 612
+      ID: 621
       Name: Probe[main.ptrStructArrayArg]Return
     - __kind: EventRootType
-      ID: 605
+      ID: 614
       Name: Probe[main.ptrStructSliceArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12529,7 +13078,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: s}
+                  Variable: {subprogram: 53, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -12542,7 +13091,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 607
+      ID: 616
       Name: Probe[main.ptrStructSliceArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12554,7 +13103,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: s}
+                  Variable: {subprogram: 53, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -12567,10 +13116,10 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 606
+      ID: 615
       Name: Probe[main.ptrStructSliceArg]Return
     - __kind: EventRootType
-      ID: 608
+      ID: 617
       Name: Probe[main.ptrStructSliceArg]Return
     - __kind: EventRootType
       ID: 333
@@ -12732,7 +13281,7 @@ Types:
       ID: 366
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 601
+      ID: 610
       Name: Probe[main.structArrayArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12744,12 +13293,12 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: s}
+                  Variable: {subprogram: 52, index: 0, name: s}
                   Offset: 0
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 603
+      ID: 612
       Name: Probe[main.structArrayArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12761,18 +13310,18 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: s}
+                  Variable: {subprogram: 52, index: 0, name: s}
                   Offset: 40
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
+      ID: 611
+      Name: Probe[main.structArrayArg]Return
+    - __kind: EventRootType
+      ID: 613
+      Name: Probe[main.structArrayArg]Return
+    - __kind: EventRootType
       ID: 602
-      Name: Probe[main.structArrayArg]Return
-    - __kind: EventRootType
-      ID: 604
-      Name: Probe[main.structArrayArg]Return
-    - __kind: EventRootType
-      ID: 593
       Name: Probe[main.structSliceArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12784,7 +13333,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: s}
+                  Variable: {subprogram: 51, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -12794,7 +13343,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 595
+      ID: 604
       Name: Probe[main.structSliceArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12806,7 +13355,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: s}
+                  Variable: {subprogram: 51, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -12816,7 +13365,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 597
+      ID: 606
       Name: Probe[main.structSliceArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12828,12 +13377,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 1, name: tag}
+                  Variable: {subprogram: 51, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 599
+      ID: 608
       Name: Probe[main.structSliceArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12845,7 +13394,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: s}
+                  Variable: {subprogram: 51, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -12855,22 +13404,22 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
+      ID: 603
+      Name: Probe[main.structSliceArg]Return
+    - __kind: EventRootType
+      ID: 605
+      Name: Probe[main.structSliceArg]Return
+    - __kind: EventRootType
+      ID: 607
+      Name: Probe[main.structSliceArg]Return
+    - __kind: EventRootType
+      ID: 609
+      Name: Probe[main.structSliceArg]Return
+    - __kind: EventRootType
       ID: 594
-      Name: Probe[main.structSliceArg]Return
-    - __kind: EventRootType
-      ID: 596
-      Name: Probe[main.structSliceArg]Return
-    - __kind: EventRootType
-      ID: 598
-      Name: Probe[main.structSliceArg]Return
-    - __kind: EventRootType
-      ID: 600
-      Name: Probe[main.structSliceArg]Return
-    - __kind: EventRootType
-      ID: 585
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 586
+      ID: 595
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12882,7 +13431,7 @@ Types:
             Type: 127 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: ~r0}
+                  Variable: {subprogram: 48, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -12890,7 +13439,7 @@ Types:
       ID: 92
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 58048
+      GoRuntimeType: 58176
       GoKind: 17
       Count: 10
       HasCount: true
@@ -12899,7 +13448,7 @@ Types:
       ID: 328
       Name: '[128]uint8'
       ByteSize: 128
-      GoRuntimeType: 51424
+      GoRuntimeType: 51456
       GoKind: 17
       Count: 128
       HasCount: true
@@ -12908,7 +13457,7 @@ Types:
       ID: 132
       Name: '[131072]int64'
       ByteSize: 1048576
-      GoRuntimeType: 52096
+      GoRuntimeType: 52128
       GoKind: 17
       Count: 131072
       HasCount: true
@@ -12917,7 +13466,7 @@ Types:
       ID: 329
       Name: '[256]uint8'
       ByteSize: 256
-      GoRuntimeType: 51712
+      GoRuntimeType: 51744
       GoKind: 17
       Count: 256
       HasCount: true
@@ -12934,7 +13483,7 @@ Types:
       ID: 78
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 57664
+      GoRuntimeType: 57792
       GoKind: 17
       Count: 2
       HasCount: true
@@ -12943,7 +13492,7 @@ Types:
       ID: 77
       Name: '[2][2]*runtime.traceBuf'
       ByteSize: 32
-      GoRuntimeType: 57760
+      GoRuntimeType: 57888
       GoKind: 17
       Count: 2
       HasCount: true
@@ -12952,7 +13501,7 @@ Types:
       ID: 84
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 57952
+      GoRuntimeType: 58080
       GoKind: 17
       Count: 2
       HasCount: true
@@ -12969,7 +13518,7 @@ Types:
       ID: 54
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 53728
+      GoRuntimeType: 53856
       GoKind: 17
       Count: 2
       HasCount: true
@@ -12978,7 +13527,7 @@ Types:
       ID: 90
       Name: '[32]uint64'
       ByteSize: 256
-      GoRuntimeType: 60256
+      GoRuntimeType: 60384
       GoKind: 17
       Count: 32
       HasCount: true
@@ -12987,7 +13536,7 @@ Types:
       ID: 68
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 57472
+      GoRuntimeType: 57600
       GoKind: 17
       Count: 32
       HasCount: true
@@ -12996,7 +13545,7 @@ Types:
       ID: 108
       Name: '[3]int'
       ByteSize: 24
-      GoRuntimeType: 50848
+      GoRuntimeType: 50880
       GoKind: 17
       Count: 3
       HasCount: true
@@ -13005,7 +13554,7 @@ Types:
       ID: 122
       Name: '[3]int16'
       ByteSize: 6
-      GoRuntimeType: 50560
+      GoRuntimeType: 50592
       GoKind: 17
       Count: 3
       HasCount: true
@@ -13014,7 +13563,7 @@ Types:
       ID: 53
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 56896
+      GoRuntimeType: 57024
       GoKind: 17
       Count: 3
       HasCount: true
@@ -13023,7 +13572,7 @@ Types:
       ID: 110
       Name: '[3]string'
       ByteSize: 48
-      GoRuntimeType: 50944
+      GoRuntimeType: 50976
       GoKind: 17
       Count: 3
       HasCount: true
@@ -13032,7 +13581,7 @@ Types:
       ID: 91
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 59392
+      GoRuntimeType: 59520
       GoKind: 17
       Count: 4
       HasCount: true
@@ -13041,7 +13590,7 @@ Types:
       ID: 58
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 56224
+      GoRuntimeType: 56352
       GoKind: 17
       Count: 6
       HasCount: true
@@ -13050,7 +13599,7 @@ Types:
       ID: 85
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 57856
+      GoRuntimeType: 57984
       GoKind: 17
       Count: 8
       HasCount: true
@@ -13081,7 +13630,7 @@ Types:
       ID: 62
       Name: '[]*runtime.p'
       ByteSize: 24
-      GoRuntimeType: 42944
+      GoRuntimeType: 42976
       GoKind: 23
       RawFields:
         - Name: array
@@ -13158,7 +13707,7 @@ Types:
       ID: 107
       Name: '[]int'
       ByteSize: 24
-      GoRuntimeType: 41344
+      GoRuntimeType: 41376
       GoKind: 23
       RawFields:
         - Name: array
@@ -13261,7 +13810,7 @@ Types:
       ID: 109
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 41600
+      GoRuntimeType: 41632
       GoKind: 23
       RawFields:
         - Name: array
@@ -13284,7 +13833,7 @@ Types:
       ID: 38
       Name: '[]uint8'
       ByteSize: 24
-      GoRuntimeType: 40960
+      GoRuntimeType: 40992
       GoKind: 23
       RawFields:
         - Name: array
@@ -13307,7 +13856,7 @@ Types:
       ID: 43
       Name: '[]uintptr'
       ByteSize: 24
-      GoRuntimeType: 41472
+      GoRuntimeType: 41504
       GoKind: 23
       RawFields:
         - Name: array
@@ -13330,25 +13879,25 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 46688
+      GoRuntimeType: 46720
       GoKind: 1
     - __kind: BaseType
       ID: 97
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 46496
+      GoRuntimeType: 46528
       GoKind: 16
     - __kind: BaseType
       ID: 96
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 46432
+      GoRuntimeType: 46464
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 13
       Name: error
       ByteSize: 16
-      GoRuntimeType: 70240
+      GoRuntimeType: 70368
       GoKind: 20
       RawFields:
         - Name: tab
@@ -13365,25 +13914,25 @@ Types:
       ID: 18
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 46560
+      GoRuntimeType: 46592
       GoKind: 13
     - __kind: BaseType
       ID: 15
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 46624
+      GoRuntimeType: 46656
       GoKind: 14
     - __kind: GoSubroutineType
       ID: 59
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 39040
+      GoRuntimeType: 39072
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 73
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 62624
+      GoRuntimeType: 62752
       GoKind: 19
     - __kind: BaseType
       ID: 170
@@ -13538,31 +14087,31 @@ Types:
       ID: 7
       Name: int
       ByteSize: 8
-      GoRuntimeType: 46240
+      GoRuntimeType: 46272
       GoKind: 2
     - __kind: BaseType
       ID: 103
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 45856
+      GoRuntimeType: 45888
       GoKind: 4
     - __kind: BaseType
       ID: 10
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 45984
+      GoRuntimeType: 46016
       GoKind: 5
     - __kind: BaseType
       ID: 12
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 46112
+      GoRuntimeType: 46144
       GoKind: 6
     - __kind: BaseType
       ID: 16
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 45728
+      GoRuntimeType: 45760
       GoKind: 3
     - __kind: UnresolvedPointeeType
       ID: 324
@@ -13576,7 +14125,7 @@ Types:
       ID: 89
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 125344
+      GoRuntimeType: 125472
       GoKind: 25
       RawFields:
         - Name: buf
@@ -13601,14 +14150,14 @@ Types:
     - __kind: StructureType
       ID: 318
       Name: internal/poll.errNetClosing
-      GoRuntimeType: 100000
+      GoRuntimeType: 100128
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 81376
+      GoRuntimeType: 81504
       GoKind: 25
       RawFields:
         - Name: u
@@ -13618,7 +14167,7 @@ Types:
       ID: 71
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 111808
+      GoRuntimeType: 111936
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -13634,7 +14183,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 100800
+      GoRuntimeType: 100928
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -13647,7 +14196,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 100640
+      GoRuntimeType: 100768
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -13660,7 +14209,7 @@ Types:
       ID: 76
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 100960
+      GoRuntimeType: 101088
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -13672,20 +14221,20 @@ Types:
     - __kind: StructureType
       ID: 72
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 68544
+      GoRuntimeType: 68672
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 33
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 68448
+      GoRuntimeType: 68576
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
       ID: 280
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
-      GoRuntimeType: 61376
+      GoRuntimeType: 61504
       GoKind: 24
       RawFields:
         - Name: str
@@ -13704,7 +14253,7 @@ Types:
       ID: 310
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
-      GoRuntimeType: 103328
+      GoRuntimeType: 103456
       GoKind: 25
       RawFields:
         - Name: typ
@@ -13718,14 +14267,14 @@ Types:
       ID: 274
       Name: main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 77024
+      GoRuntimeType: 77152
       GoKind: 25
       RawFields: [{Name: a, Offset: 0, Type: 7 BaseType int}]
     - __kind: StructureType
       ID: 134
       Name: main.bigArrayStruct
       ByteSize: 1048584
-      GoRuntimeType: 92640
+      GoRuntimeType: 92768
       GoKind: 25
       RawFields:
         - Name: tag
@@ -13738,7 +14287,7 @@ Types:
       ID: 204
       Name: main.bigStruct
       ByteSize: 184
-      GoRuntimeType: 133088
+      GoRuntimeType: 133216
       GoKind: 25
       RawFields:
         - Name: Field1
@@ -13769,7 +14318,7 @@ Types:
       ID: 121
       Name: main.condFields
       ByteSize: 80
-      GoRuntimeType: 140704
+      GoRuntimeType: 140832
       GoKind: 25
       RawFields:
         - Name: I8
@@ -13815,7 +14364,7 @@ Types:
       ID: 137
       Name: main.indexMemberStruct
       ByteSize: 32
-      GoRuntimeType: 105088
+      GoRuntimeType: 105216
       GoKind: 25
       RawFields:
         - Name: Val
@@ -13846,7 +14395,7 @@ Types:
       ID: 263
       Name: main.largeValueStruct
       ByteSize: 264
-      GoRuntimeType: 92480
+      GoRuntimeType: 92608
       GoKind: 25
       RawFields:
         - Name: Pad
@@ -13859,7 +14408,7 @@ Types:
       ID: 124
       Name: main.lenFields
       ByteSize: 72
-      GoRuntimeType: 127232
+      GoRuntimeType: 127360
       GoKind: 25
       RawFields:
         - Name: S
@@ -14205,70 +14754,70 @@ Types:
       ID: 159
       Name: map[bool]int
       ByteSize: 8
-      GoRuntimeType: 74592
+      GoRuntimeType: 74720
       GoKind: 21
       HeaderType: 161 GoSwissMapHeaderType map<bool,int>
     - __kind: GoMapType
       ID: 213
       Name: map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 74720
+      GoRuntimeType: 74848
       GoKind: 21
       HeaderType: 215 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 144
       Name: map[int]string
       ByteSize: 8
-      GoRuntimeType: 74848
+      GoRuntimeType: 74976
       GoKind: 21
       HeaderType: 146 GoSwissMapHeaderType map<int,string>
     - __kind: GoMapType
       ID: 154
       Name: map[string]*main.indexMemberStruct
       ByteSize: 8
-      GoRuntimeType: 74976
+      GoRuntimeType: 75104
       GoKind: 21
       HeaderType: 156 GoSwissMapHeaderType map<string,*main.indexMemberStruct>
     - __kind: GoMapType
       ID: 111
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 74464
+      GoRuntimeType: 74592
       GoKind: 21
       HeaderType: 113 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 116
       Name: map[string]main.bigStruct
       ByteSize: 8
-      GoRuntimeType: 75104
+      GoRuntimeType: 75232
       GoKind: 21
       HeaderType: 118 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: GoMapType
       ID: 149
       Name: map[string]main.indexMemberStruct
       ByteSize: 8
-      GoRuntimeType: 75232
+      GoRuntimeType: 75360
       GoKind: 21
       HeaderType: 151 GoSwissMapHeaderType map<string,main.indexMemberStruct>
     - __kind: GoMapType
       ID: 164
       Name: map[string]main.largeValueStruct
       ByteSize: 8
-      GoRuntimeType: 75360
+      GoRuntimeType: 75488
       GoKind: 21
       HeaderType: 166 GoSwissMapHeaderType map<string,main.largeValueStruct>
     - __kind: GoMapType
       ID: 127
       Name: map[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 75616
+      GoRuntimeType: 75744
       GoKind: 21
       HeaderType: 129 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: ArrayType
       ID: 252
       Name: noalg.[8]struct { key bool; elem int }
       ByteSize: 128
-      GoRuntimeType: 51040
+      GoRuntimeType: 51072
       GoKind: 17
       Count: 8
       HasCount: true
@@ -14277,7 +14826,7 @@ Types:
       ID: 272
       Name: noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
       ByteSize: 128
-      GoRuntimeType: 51136
+      GoRuntimeType: 51168
       GoKind: 17
       Count: 8
       HasCount: true
@@ -14286,7 +14835,7 @@ Types:
       ID: 228
       Name: noalg.[8]struct { key int; elem string }
       ByteSize: 192
-      GoRuntimeType: 51232
+      GoRuntimeType: 51264
       GoKind: 17
       Count: 8
       HasCount: true
@@ -14295,7 +14844,7 @@ Types:
       ID: 201
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
-      GoRuntimeType: 51520
+      GoRuntimeType: 51552
       GoKind: 17
       Count: 8
       HasCount: true
@@ -14304,7 +14853,7 @@ Types:
       ID: 244
       Name: noalg.[8]struct { key string; elem *main.indexMemberStruct }
       ByteSize: 192
-      GoRuntimeType: 51328
+      GoRuntimeType: 51360
       GoKind: 17
       Count: 8
       HasCount: true
@@ -14313,7 +14862,7 @@ Types:
       ID: 260
       Name: noalg.[8]struct { key string; elem *main.largeValueStruct }
       ByteSize: 192
-      GoRuntimeType: 51808
+      GoRuntimeType: 51840
       GoKind: 17
       Count: 8
       HasCount: true
@@ -14322,7 +14871,7 @@ Types:
       ID: 193
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 50656
+      GoRuntimeType: 50688
       GoKind: 17
       Count: 8
       HasCount: true
@@ -14331,7 +14880,7 @@ Types:
       ID: 236
       Name: noalg.[8]struct { key string; elem main.indexMemberStruct }
       ByteSize: 384
-      GoRuntimeType: 51616
+      GoRuntimeType: 51648
       GoKind: 17
       Count: 8
       HasCount: true
@@ -14340,7 +14889,7 @@ Types:
       ID: 211
       Name: noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
       ByteSize: 128
-      GoRuntimeType: 52000
+      GoRuntimeType: 52032
       GoKind: 17
       Count: 8
       HasCount: true
@@ -14349,7 +14898,7 @@ Types:
       ID: 251
       Name: noalg.map.group[bool]int
       ByteSize: 136
-      GoRuntimeType: 83040
+      GoRuntimeType: 83168
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14362,7 +14911,7 @@ Types:
       ID: 271
       Name: noalg.map.group[int]main.aStructNotUsedAsAnArgument
       ByteSize: 136
-      GoRuntimeType: 83296
+      GoRuntimeType: 83424
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14375,7 +14924,7 @@ Types:
       ID: 227
       Name: noalg.map.group[int]string
       ByteSize: 200
-      GoRuntimeType: 83552
+      GoRuntimeType: 83680
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14388,7 +14937,7 @@ Types:
       ID: 243
       Name: noalg.map.group[string]*main.indexMemberStruct
       ByteSize: 200
-      GoRuntimeType: 83808
+      GoRuntimeType: 83936
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14401,7 +14950,7 @@ Types:
       ID: 192
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 82784
+      GoRuntimeType: 82912
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14414,7 +14963,7 @@ Types:
       ID: 200
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
-      GoRuntimeType: 84064
+      GoRuntimeType: 84192
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14427,7 +14976,7 @@ Types:
       ID: 235
       Name: noalg.map.group[string]main.indexMemberStruct
       ByteSize: 392
-      GoRuntimeType: 84320
+      GoRuntimeType: 84448
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14440,7 +14989,7 @@ Types:
       ID: 259
       Name: noalg.map.group[string]main.largeValueStruct
       ByteSize: 200
-      GoRuntimeType: 84576
+      GoRuntimeType: 84704
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14453,7 +15002,7 @@ Types:
       ID: 210
       Name: noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 136
-      GoRuntimeType: 85088
+      GoRuntimeType: 85216
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14466,7 +15015,7 @@ Types:
       ID: 253
       Name: noalg.struct { key bool; elem int }
       ByteSize: 16
-      GoRuntimeType: 82912
+      GoRuntimeType: 83040
       GoKind: 25
       RawFields:
         - Name: key
@@ -14479,7 +15028,7 @@ Types:
       ID: 273
       Name: noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
       ByteSize: 16
-      GoRuntimeType: 83168
+      GoRuntimeType: 83296
       GoKind: 25
       RawFields:
         - Name: key
@@ -14492,7 +15041,7 @@ Types:
       ID: 229
       Name: noalg.struct { key int; elem string }
       ByteSize: 24
-      GoRuntimeType: 83424
+      GoRuntimeType: 83552
       GoKind: 25
       RawFields:
         - Name: key
@@ -14505,7 +15054,7 @@ Types:
       ID: 202
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
-      GoRuntimeType: 83936
+      GoRuntimeType: 84064
       GoKind: 25
       RawFields:
         - Name: key
@@ -14518,7 +15067,7 @@ Types:
       ID: 245
       Name: noalg.struct { key string; elem *main.indexMemberStruct }
       ByteSize: 24
-      GoRuntimeType: 83680
+      GoRuntimeType: 83808
       GoKind: 25
       RawFields:
         - Name: key
@@ -14531,7 +15080,7 @@ Types:
       ID: 261
       Name: noalg.struct { key string; elem *main.largeValueStruct }
       ByteSize: 24
-      GoRuntimeType: 84448
+      GoRuntimeType: 84576
       GoKind: 25
       RawFields:
         - Name: key
@@ -14544,7 +15093,7 @@ Types:
       ID: 194
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 82656
+      GoRuntimeType: 82784
       GoKind: 25
       RawFields:
         - Name: key
@@ -14557,7 +15106,7 @@ Types:
       ID: 237
       Name: noalg.struct { key string; elem main.indexMemberStruct }
       ByteSize: 48
-      GoRuntimeType: 84192
+      GoRuntimeType: 84320
       GoKind: 25
       RawFields:
         - Name: key
@@ -14570,7 +15119,7 @@ Types:
       ID: 212
       Name: noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
       ByteSize: 16
-      GoRuntimeType: 84960
+      GoRuntimeType: 85088
       GoKind: 25
       RawFields:
         - Name: key
@@ -14607,7 +15156,7 @@ Types:
       ID: 306
       Name: runtime.boundsError
       ByteSize: 24
-      GoRuntimeType: 126240
+      GoRuntimeType: 126368
       GoKind: 25
       RawFields:
         - Name: x
@@ -14626,7 +15175,7 @@ Types:
       ID: 325
       Name: runtime.boundsErrorCode
       ByteSize: 1
-      GoRuntimeType: 46816
+      GoRuntimeType: 46848
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 66
@@ -14639,14 +15188,14 @@ Types:
     - __kind: StructureType
       ID: 87
       Name: runtime.dlogPerM
-      GoRuntimeType: 67680
+      GoRuntimeType: 67808
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 314
       Name: runtime.errorAddressString
       ByteSize: 24
-      GoRuntimeType: 118336
+      GoRuntimeType: 118464
       GoKind: 25
       RawFields:
         - Name: msg
@@ -14659,7 +15208,7 @@ Types:
       ID: 293
       Name: runtime.errorString
       ByteSize: 16
-      GoRuntimeType: 67104
+      GoRuntimeType: 67232
       GoKind: 24
       RawFields:
         - Name: str
@@ -14678,7 +15227,7 @@ Types:
       ID: 22
       Name: runtime.g
       ByteSize: 440
-      GoRuntimeType: 155776
+      GoRuntimeType: 155904
       GoKind: 25
       RawFields:
         - Name: stack
@@ -14868,7 +15417,7 @@ Types:
       ID: 51
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 79840
+      GoRuntimeType: 79968
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -14878,7 +15427,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 48
-      GoRuntimeType: 128768
+      GoRuntimeType: 128896
       GoKind: 25
       RawFields:
         - Name: sp
@@ -14903,7 +15452,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 97920
+      GoRuntimeType: 98048
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -14916,7 +15465,7 @@ Types:
       ID: 56
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 117184
+      GoRuntimeType: 117312
       GoKind: 25
       RawFields:
         - Name: stack
@@ -14935,13 +15484,13 @@ Types:
       ID: 31
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 61088
+      GoRuntimeType: 61216
       GoKind: 12
     - __kind: StructureType
       ID: 93
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 97760
+      GoRuntimeType: 97888
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -14954,7 +15503,7 @@ Types:
       ID: 81
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 129536
+      GoRuntimeType: 129664
       GoKind: 25
       RawFields:
         - Name: fn
@@ -14979,13 +15528,13 @@ Types:
       ID: 94
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 60992
+      GoRuntimeType: 61120
       GoKind: 2
     - __kind: StructureType
       ID: 29
       Name: runtime.m
       ByteSize: 1816
-      GoRuntimeType: 159072
+      GoRuntimeType: 159200
       GoKind: 25
       RawFields:
         - Name: g0
@@ -15205,7 +15754,7 @@ Types:
       ID: 70
       Name: runtime.mLockProfile
       ByteSize: 56
-      GoRuntimeType: 129280
+      GoRuntimeType: 129408
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -15230,7 +15779,7 @@ Types:
       ID: 88
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 124224
+      GoRuntimeType: 124352
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -15252,7 +15801,7 @@ Types:
       ID: 75
       Name: runtime.mTraceState
       ByteSize: 56
-      GoRuntimeType: 124000
+      GoRuntimeType: 124128
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -15274,7 +15823,7 @@ Types:
       ID: 69
       Name: runtime.mWaitList
       ByteSize: 16
-      GoRuntimeType: 97440
+      GoRuntimeType: 97568
       GoKind: 25
       RawFields:
         - Name: next
@@ -15287,13 +15836,13 @@ Types:
       ID: 37
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 60704
+      GoRuntimeType: 60832
       GoKind: 12
     - __kind: StructureType
       ID: 67
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 79584
+      GoRuntimeType: 79712
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
@@ -15304,7 +15853,7 @@ Types:
       ID: 83
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 97600
+      GoRuntimeType: 97728
       GoKind: 25
       RawFields:
         - Name: entries
@@ -15317,7 +15866,7 @@ Types:
       ID: 86
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 118144
+      GoRuntimeType: 118272
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -15336,7 +15885,7 @@ Types:
       ID: 296
       Name: runtime.plainError
       ByteSize: 16
-      GoRuntimeType: 67200
+      GoRuntimeType: 67328
       GoKind: 24
       RawFields:
         - Name: str
@@ -15355,13 +15904,13 @@ Types:
       ID: 60
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 60896
+      GoRuntimeType: 61024
       GoKind: 12
     - __kind: ArrayType
       ID: 57
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 64320
+      GoRuntimeType: 64448
       GoKind: 17
       Count: 2
       HasCount: true
@@ -15370,7 +15919,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 95680
+      GoRuntimeType: 95808
       GoKind: 25
       RawFields:
         - Name: lo
@@ -15391,7 +15940,7 @@ Types:
       ID: 288
       Name: runtime.synctestDeadlockError
       ByteSize: 24
-      GoRuntimeType: 104928
+      GoRuntimeType: 105056
       GoKind: 25
       RawFields:
         - Name: reason
@@ -15404,7 +15953,7 @@ Types:
       ID: 61
       Name: runtime.throwType
       ByteSize: 4
-      GoRuntimeType: 46944
+      GoRuntimeType: 46976
       GoKind: 10
     - __kind: UnresolvedPointeeType
       ID: 45
@@ -15414,7 +15963,7 @@ Types:
       ID: 74
       Name: runtime.traceBlockReason
       ByteSize: 1
-      GoRuntimeType: 47008
+      GoRuntimeType: 47040
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 80
@@ -15424,7 +15973,7 @@ Types:
       ID: 52
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 96640
+      GoRuntimeType: 96768
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -15437,12 +15986,12 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 82400
+      GoRuntimeType: 82528
       GoKind: 8
     - __kind: StructureType
       ID: 82
       Name: runtime.winlibcall
-      GoRuntimeType: 67584
+      GoRuntimeType: 67712
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -15453,7 +16002,7 @@ Types:
       ID: 9
       Name: string
       ByteSize: 16
-      GoRuntimeType: 45664
+      GoRuntimeType: 45696
       GoKind: 24
       RawFields:
         - Name: str
@@ -15472,7 +16021,7 @@ Types:
       ID: 321
       Name: syscall.Errno
       ByteSize: 8
-      GoRuntimeType: 82528
+      GoRuntimeType: 82656
       GoKind: 12
     - __kind: StructureType
       ID: 248
@@ -15694,7 +16243,7 @@ Types:
       ID: 277
       Name: time.fileSizeError
       ByteSize: 16
-      GoRuntimeType: 61184
+      GoRuntimeType: 61312
       GoKind: 24
       RawFields:
         - Name: str
@@ -15713,45 +16262,45 @@ Types:
       ID: 17
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 46304
+      GoRuntimeType: 46336
       GoKind: 7
     - __kind: BaseType
       ID: 6
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 45920
+      GoRuntimeType: 45952
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 46048
+      GoRuntimeType: 46080
       GoKind: 10
     - __kind: BaseType
       ID: 8
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 46176
+      GoRuntimeType: 46208
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 45792
+      GoRuntimeType: 45824
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 46368
+      GoRuntimeType: 46400
       GoKind: 12
     - __kind: VoidPointerType
       ID: 14
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 46752
+      GoRuntimeType: 46784
       GoKind: 26
-MaxTypeID: 677
+MaxTypeID: 686
 Issues:
     - probe_definition:
         id: condCompound_eq_of_eq
@@ -16060,6 +16609,26 @@ Issues:
         Kind: 7
         Message: condition variable "x" not available at any event
     - probe_definition:
+        id: condLineReturn_cond_return
+        version: 0
+        type: LOG_PROBE
+        where:
+            methodName: main.condLineReturn
+            sourceFile: main.go
+            lines: ["571"]
+        tags: ['issue:ConditionVariableUnavailable']
+        when:
+            dsl: '@return == 14'
+            json: {eq: [{ref: '@return'}, 14]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: matched
+        segments: [matched]
+        captureSnapshot: false
+      issue:
+        Kind: 7
+        Message: condition variable "@return" not found
+    - probe_definition:
         id: condNull_int_vs_null
         version: 0
         type: LOG_PROBE
@@ -16147,8 +16716,8 @@ Issues:
       issue:
         Kind: 3
         Message: probe kind ProbeKindSpan is not supported
-GoModuledataInfo: {FirstModuledataAddr: "0x59a3a0", TypesOffset: 296}
-GoMapHashInfo: {UseAeshashAddr: "0x5c3dca", AeskeyschedAddr: "0x5c4460"}
+GoModuledataInfo: {FirstModuledataAddr: "0x59b3a0", TypesOffset: 296}
+GoMapHashInfo: {UseAeshashAddr: "0x5c4dca", AeskeyschedAddr: "0x5c5460"}
 CommonTypes:
     G: 22 StructureType runtime.g
     M: 29 StructureType runtime.m

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.26rc1.yaml
@@ -9,10 +9,10 @@ Probes:
       segments: ['ptr: ', {json: {ref: ptr}, dsl: ptr}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 76}
+        - subprogram: {subprogram: 78}
           events:
             - Kind: Entry
-              Type: 682 EventRootType Probe[main.PointerChainArg]
+              Type: 691 EventRootType Probe[main.PointerChainArg]
               InjectionPoints: [{PC: "0x4c2b38", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -32,10 +32,10 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 77}
+        - subprogram: {subprogram: 79}
           events:
             - Kind: Entry
-              Type: 683 EventRootType Probe[main.PointerSmallChainArg]
+              Type: 692 EventRootType Probe[main.PointerSmallChainArg]
               InjectionPoints: [{PC: "0x4c2b7d", Frameless: false}]
               Condition: null
     - id: bigMapArg
@@ -50,11 +50,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 381 EventRootType Probe[main.bigMapArg]
-              InjectionPoints: [{PC: "0x4c4f8a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c51ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 382 EventRootType Probe[main.bigMapArg]Return
-              InjectionPoints: [{PC: "0x4c4fdf", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c523f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 'm: {m}'
@@ -78,7 +78,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 427 EventRootType Probe[main.condBool]
-              InjectionPoints: [{PC: "0x4c57ea", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5a4a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -95,7 +95,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 428 EventRootType Probe[main.condBool]Return
-              InjectionPoints: [{PC: "0x4c585c", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5abc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -119,7 +119,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 429 EventRootType Probe[main.condBool]
-              InjectionPoints: [{PC: "0x4c57ea", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5a4a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -136,7 +136,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 430 EventRootType Probe[main.condBool]Return
-              InjectionPoints: [{PC: "0x4c585c", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5abc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -159,11 +159,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 431 EventRootType Probe[main.condBool]
-              InjectionPoints: [{PC: "0x4c57ea", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5a4a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 432 EventRootType Probe[main.condBool]Return
-              InjectionPoints: [{PC: "0x4c585c", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5abc", Frameless: false}]
               Condition: null
     - id: condCompound_and
       version: 0
@@ -188,7 +188,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 477 EventRootType Probe[main.condReturnAndLocal]
-              InjectionPoints: [{PC: "0x4c5cca", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5f2a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -220,7 +220,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 478 EventRootType Probe[main.condReturnAndLocal]Return
-              InjectionPoints: [{PC: "0x4c5d3b", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5f9b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: a == 1 && b == 1 [a={a}, b={b}]
@@ -262,7 +262,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 447 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0x4c596e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5bce", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -292,7 +292,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 448 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0x4c5a70", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5cd0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x.S == "world" && tag == "match" [x.S={x.S}, tag={tag}]
@@ -314,7 +314,7 @@ Probes:
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["519"]
+        lines: ["547"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -338,7 +338,7 @@ Probes:
           events:
             - Kind: Line
               Type: 487 EventRootType Probe[main.condLine]Line
-              InjectionPoints: [{PC: "0x4c5e41", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c60a1", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -412,7 +412,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 449 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0x4c596e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5bce", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -460,7 +460,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 450 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0x4c5a70", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5cd0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: (x.I32 == 300 || x.I32 == 999) && !isEmpty(x.S) [x.I32={x.I32}, x.S={x.S}, tag={tag}]
@@ -502,7 +502,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 433 EventRootType Probe[main.condBool]
-              InjectionPoints: [{PC: "0x4c57ea", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5a4a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -520,7 +520,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 434 EventRootType Probe[main.condBool]Return
-              InjectionPoints: [{PC: "0x4c585c", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5abc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '!x [x={x}, tag={tag}]'
@@ -559,7 +559,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 393 EventRootType Probe[main.condInt32]
-              InjectionPoints: [{PC: "0x4c51ea", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c544a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -591,7 +591,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 394 EventRootType Probe[main.condInt32]Return
-              InjectionPoints: [{PC: "0x4c525c", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c54bc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x == 42 || x == 100 [x={x}, tag={tag}]
@@ -629,16 +629,16 @@ Probes:
         - ']'
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 500 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4c67d3", Frameless: false}]
+              Type: 509 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4c6cf3", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 37, index: 1, name: tag}
+                      Variable: {subprogram: 39, index: 1, name: tag}
                       Offset: 0
                       ByteSize: 16
                     - __kind: ExprReadStringOp
@@ -650,7 +650,7 @@ Probes:
                       Cond: true
                       Target: 1
                     - __kind: LocationOp
-                      Variable: {subprogram: 37, index: 0, name: s}
+                      Variable: {subprogram: 39, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -664,8 +664,8 @@ Probes:
                       ID: 1
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 501 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4c68bc", Frameless: false}]
+              Type: 510 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4c6ddc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag == "match" || !isEmpty(s) [s={s}, tag={tag}]
@@ -703,20 +703,20 @@ Probes:
         - ']'
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 72}
+        - subprogram: {subprogram: 74}
           events:
             - Kind: Entry
-              Type: 674 EventRootType Probe[main.condMultiReturn]
-              InjectionPoints: [{PC: "0x4c850e", Frameless: false}]
+              Type: 683 EventRootType Probe[main.condMultiReturn]
+              InjectionPoints: [{PC: "0x4c8a2e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 675 EventRootType Probe[main.condMultiReturn]Return
-              InjectionPoints: [{PC: "0x4c85b2", Frameless: false}]
+              Type: 684 EventRootType Probe[main.condMultiReturn]Return
+              InjectionPoints: [{PC: "0x4c8ad2", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 72, index: 1, name: r0}
+                      Variable: {subprogram: 74, index: 1, name: r0}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -729,7 +729,7 @@ Probes:
                       Cond: false
                       Target: 1
                     - __kind: LocationOp
-                      Variable: {subprogram: 72, index: 2, name: r1}
+                      Variable: {subprogram: 74, index: 2, name: r1}
                       Offset: 0
                       ByteSize: 16
                     - __kind: ExprReadStringOp
@@ -777,7 +777,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 469 EventRootType Probe[main.condNilPtrStruct]
-              InjectionPoints: [{PC: "0x4c5c0e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5e6e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -811,7 +811,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 470 EventRootType Probe[main.condNilPtrStruct]Return
-              InjectionPoints: [{PC: "0x4c5c8f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5eef", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag == "nilptr" && x.I32 == 300 [tag={tag}]
@@ -845,7 +845,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 471 EventRootType Probe[main.condNilPtrStruct]
-              InjectionPoints: [{PC: "0x4c5c0e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5e6e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -879,7 +879,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 472 EventRootType Probe[main.condNilPtrStruct]Return
-              InjectionPoints: [{PC: "0x4c5c8f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5eef", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag == "nilptr" || x.I32 == 300 [tag={tag}]
@@ -903,11 +903,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 423 EventRootType Probe[main.condFloat32]
-              InjectionPoints: [{PC: "0x4c566e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c58ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 424 EventRootType Probe[main.condFloat32]Return
-              InjectionPoints: [{PC: "0x4c56e5", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5945", Frameless: false}]
               Condition: null
     - id: condFloat64_nocond
       version: 0
@@ -922,11 +922,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 425 EventRootType Probe[main.condFloat64]
-              InjectionPoints: [{PC: "0x4c572e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c598e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 426 EventRootType Probe[main.condFloat64]Return
-              InjectionPoints: [{PC: "0x4c57a5", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5a05", Frameless: false}]
               Condition: null
     - id: condInt16_cond
       version: 0
@@ -942,7 +942,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 389 EventRootType Probe[main.condInt16]
-              InjectionPoints: [{PC: "0x4c512a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c538a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -959,7 +959,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 390 EventRootType Probe[main.condInt16]Return
-              InjectionPoints: [{PC: "0x4c519c", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c53fc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -982,11 +982,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 391 EventRootType Probe[main.condInt16]
-              InjectionPoints: [{PC: "0x4c512a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c538a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 392 EventRootType Probe[main.condInt16]Return
-              InjectionPoints: [{PC: "0x4c519c", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c53fc", Frameless: false}]
               Condition: null
     - id: condInt32_cond
       version: 0
@@ -1002,7 +1002,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 395 EventRootType Probe[main.condInt32]
-              InjectionPoints: [{PC: "0x4c51ea", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c544a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1019,7 +1019,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 396 EventRootType Probe[main.condInt32]Return
-              InjectionPoints: [{PC: "0x4c525c", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c54bc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1046,7 +1046,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 397 EventRootType Probe[main.condInt32]
-              InjectionPoints: [{PC: "0x4c51ea", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c544a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1063,7 +1063,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 398 EventRootType Probe[main.condInt32]Return
-              InjectionPoints: [{PC: "0x4c525c", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c54bc", Frameless: false}]
               Condition: null
     - id: condInt32_nocond
       version: 0
@@ -1078,11 +1078,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 399 EventRootType Probe[main.condInt32]
-              InjectionPoints: [{PC: "0x4c51ea", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c544a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 400 EventRootType Probe[main.condInt32]Return
-              InjectionPoints: [{PC: "0x4c525c", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c54bc", Frameless: false}]
               Condition: null
     - id: condInt64_cond
       version: 0
@@ -1098,7 +1098,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 401 EventRootType Probe[main.condInt64]
-              InjectionPoints: [{PC: "0x4c52aa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c550a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1115,7 +1115,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 402 EventRootType Probe[main.condInt64]Return
-              InjectionPoints: [{PC: "0x4c531c", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c557c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1138,11 +1138,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 403 EventRootType Probe[main.condInt64]
-              InjectionPoints: [{PC: "0x4c52aa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c550a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 404 EventRootType Probe[main.condInt64]Return
-              InjectionPoints: [{PC: "0x4c531c", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c557c", Frameless: false}]
               Condition: null
     - id: condInt8_cond
       version: 0
@@ -1158,7 +1158,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 385 EventRootType Probe[main.condInt8]
-              InjectionPoints: [{PC: "0x4c506a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c52ca", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1175,7 +1175,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 386 EventRootType Probe[main.condInt8]Return
-              InjectionPoints: [{PC: "0x4c50dc", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c533c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1198,11 +1198,257 @@ Probes:
           events:
             - Kind: Entry
               Type: 387 EventRootType Probe[main.condInt8]
-              InjectionPoints: [{PC: "0x4c506a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c52ca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 388 EventRootType Probe[main.condInt8]Return
-              InjectionPoints: [{PC: "0x4c50dc", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c533c", Frameless: false}]
+              Condition: null
+    - id: condLineMixed_cond_bool
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when: {dsl: b == true, json: {eq: [{ref: b}, true]}}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 492 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0x4c61b1", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 1, name: b}
+                      Offset: 0
+                      ByteSize: 1
+                    - __kind: ExprPushOffsetOp
+                      ByteSize: 1
+                    - __kind: ExprLoadLiteralOp
+                      Data: AQ==
+                    - __kind: ExprCmpEqBaseOp
+                      ByteSize: 1
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_isEmpty_slice
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when: {dsl: isEmpty(ss), json: {isEmpty: {ref: ss}}}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 493 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0x4c61b1", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 4, name: ss}
+                      Offset: 8
+                      ByteSize: 8
+                    - __kind: ExprPushOffsetOp
+                      ByteSize: 8
+                    - __kind: ExprLoadLiteralOp
+                      Data: AAAAAAAAAAA=
+                    - __kind: ExprCmpEqBaseOp
+                      ByteSize: 8
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_len_string
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when:
+        dsl: len(s) == 5
+        json: {eq: [{len: {ref: s}}, 5]}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 494 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0x4c61b1", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 0, name: s}
+                      Offset: 8
+                      ByteSize: 8
+                    - __kind: ExprPushOffsetOp
+                      ByteSize: 8
+                    - __kind: ExprLoadLiteralOp
+                      Data: BQAAAAAAAAA=
+                    - __kind: ExprCmpEqBaseOp
+                      ByteSize: 8
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_ptrstruct_field
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when:
+        dsl: p.S == "world"
+        json: {eq: [{getmember: [{ref: p}, S]}, world]}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 495 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0x4c61b1", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 3, name: p}
+                      Offset: 0
+                      ByteSize: 8
+                    - __kind: DereferenceOp
+                      Bias: 56
+                      ByteSize: 16
+                    - __kind: ExprReadStringOp
+                      MaxLen: 255
+                    - __kind: ExprLoadLiteralOp
+                      Data: BQAAAHdvcmxk
+                    - __kind: ExprCmpEqStringOp
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_string
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when:
+        dsl: s == "hello"
+        json: {eq: [{ref: s}, hello]}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 496 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0x4c61b1", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 0, name: s}
+                      Offset: 0
+                      ByteSize: 16
+                    - __kind: ExprReadStringOp
+                      MaxLen: 255
+                    - __kind: ExprLoadLiteralOp
+                      Data: BQAAAGhlbGxv
+                    - __kind: ExprCmpEqStringOp
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_struct_field
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when:
+        dsl: x.I32 == 300
+        json: {eq: [{getmember: [{ref: x}, I32]}, 300]}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 497 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0x4c61b1", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 2, name: x}
+                      Offset: 4
+                      ByteSize: 4
+                    - __kind: ExprPushOffsetOp
+                      ByteSize: 4
+                    - __kind: ExprLoadLiteralOp
+                      Data: LAEAAA==
+                    - __kind: ExprCmpEqBaseOp
+                      ByteSize: 4
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_nocond
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 498 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0x4c61b1", Frameless: false}]
               Condition: null
     - id: condLine_cond
       version: 0
@@ -1210,7 +1456,7 @@ Probes:
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["519"]
+        lines: ["547"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -1227,7 +1473,7 @@ Probes:
           events:
             - Kind: Line
               Type: 488 EventRootType Probe[main.condLine]Line
-              InjectionPoints: [{PC: "0x4c5e41", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c60a1", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1242,13 +1488,58 @@ Probes:
                     - __kind: ExprCmpEqBaseOp
                       ByteSize: 8
                     - __kind: ConditionCheckOp
-    - id: condLine_nocond
+    - id: condLine_local_cond
       version: 0
       type: LOG_PROBE
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["519"]
+        lines: ["548"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+        - issue:ConditionVariableUnavailable@arch=arm64,toolchain=go1.23.11
+        - issue:ConditionVariableUnavailable@arch=amd64,toolchain=go1.23.11
+      when: {dsl: result == 14, json: {eq: [{ref: result}, 14]}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 28}
+          events:
+            - Kind: Line
+              Type: 489 EventRootType Probe[main.condLine]Line
+              InjectionPoints: [{PC: "0x4c60a4", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 28, index: 2, name: result}
+                      Offset: 0
+                      ByteSize: 8
+                    - __kind: ExprPushOffsetOp
+                      ByteSize: 8
+                    - __kind: ExprLoadLiteralOp
+                      Data: DgAAAAAAAAA=
+                    - __kind: ExprCmpEqBaseOp
+                      ByteSize: 8
+                    - __kind: ConditionCheckOp
+          probeTemplate:
+            TemplateString: tag={tag}
+            Segments:
+                - tag=
+                - JSON: {Ref: tag}
+                  DSL: tag
+                  EventKind: Line
+                  EventExpressionIndex: 0
+    - id: condLine_local_nocond
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLine
+        sourceFile: main.go
+        lines: ["548"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -1260,8 +1551,29 @@ Probes:
         - subprogram: {subprogram: 28}
           events:
             - Kind: Line
-              Type: 489 EventRootType Probe[main.condLine]Line
-              InjectionPoints: [{PC: "0x4c5e41", Frameless: false}]
+              Type: 490 EventRootType Probe[main.condLine]Line
+              InjectionPoints: [{PC: "0x4c60a4", Frameless: false}]
+              Condition: null
+    - id: condLine_nocond
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLine
+        sourceFile: main.go
+        lines: ["547"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 28}
+          events:
+            - Kind: Line
+              Type: 491 EventRootType Probe[main.condLine]Line
+              InjectionPoints: [{PC: "0x4c60a1", Frameless: false}]
               Condition: null
     - id: condNilPtr_cond
       version: 0
@@ -1279,7 +1591,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 473 EventRootType Probe[main.condNilPtrStruct]
-              InjectionPoints: [{PC: "0x4c5c0e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5e6e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1299,7 +1611,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 474 EventRootType Probe[main.condNilPtrStruct]Return
-              InjectionPoints: [{PC: "0x4c5c8f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5eef", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: condNilPtr {tag}
@@ -1322,11 +1634,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 475 EventRootType Probe[main.condNilPtrStruct]
-              InjectionPoints: [{PC: "0x4c5c0e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5e6e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 476 EventRootType Probe[main.condNilPtrStruct]Return
-              InjectionPoints: [{PC: "0x4c5c8f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5eef", Frameless: false}]
               Condition: null
     - id: condNull_iface
       version: 0
@@ -1338,16 +1650,16 @@ Probes:
       segments: ['i == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 35}
+        - subprogram: {subprogram: 37}
           events:
             - Kind: Entry
-              Type: 496 EventRootType Probe[main.condNullIface]
-              InjectionPoints: [{PC: "0x4c652e", Frameless: false}]
+              Type: 505 EventRootType Probe[main.condNullIface]
+              InjectionPoints: [{PC: "0x4c6a4e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 35, index: 0, name: i}
+                      Variable: {subprogram: 37, index: 0, name: i}
                       Offset: 0
                       ByteSize: 16
                     - __kind: ExprPushOffsetOp
@@ -1358,8 +1670,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 497 EventRootType Probe[main.condNullIface]Return
-              InjectionPoints: [{PC: "0x4c6636", Frameless: false}]
+              Type: 506 EventRootType Probe[main.condNullIface]Return
+              InjectionPoints: [{PC: "0x4c6b56", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: i == nil [tag={tag}]
@@ -1380,16 +1692,16 @@ Probes:
       segments: ['m == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 34}
+        - subprogram: {subprogram: 36}
           events:
             - Kind: Entry
-              Type: 494 EventRootType Probe[main.condNullMap]
-              InjectionPoints: [{PC: "0x4c640e", Frameless: false}]
+              Type: 503 EventRootType Probe[main.condNullMap]
+              InjectionPoints: [{PC: "0x4c692e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 34, index: 0, name: m}
+                      Variable: {subprogram: 36, index: 0, name: m}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -1400,8 +1712,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 495 EventRootType Probe[main.condNullMap]Return
-              InjectionPoints: [{PC: "0x4c64da", Frameless: false}]
+              Type: 504 EventRootType Probe[main.condNullMap]Return
+              InjectionPoints: [{PC: "0x4c69fa", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: m == nil [tag={tag}]
@@ -1422,16 +1734,16 @@ Probes:
       segments: ['p == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 32}
+        - subprogram: {subprogram: 34}
           events:
             - Kind: Entry
-              Type: 490 EventRootType Probe[main.condNullPtr]
-              InjectionPoints: [{PC: "0x4c616e", Frameless: false}]
+              Type: 499 EventRootType Probe[main.condNullPtr]
+              InjectionPoints: [{PC: "0x4c668e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 32, index: 0, name: p}
+                      Variable: {subprogram: 34, index: 0, name: p}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -1442,8 +1754,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 491 EventRootType Probe[main.condNullPtr]Return
-              InjectionPoints: [{PC: "0x4c623a", Frameless: false}]
+              Type: 500 EventRootType Probe[main.condNullPtr]Return
+              InjectionPoints: [{PC: "0x4c675a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p == nil [tag={tag}]
@@ -1464,16 +1776,16 @@ Probes:
       segments: ['s == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 33}
+        - subprogram: {subprogram: 35}
           events:
             - Kind: Entry
-              Type: 492 EventRootType Probe[main.condNullSlice]
-              InjectionPoints: [{PC: "0x4c6293", Frameless: false}]
+              Type: 501 EventRootType Probe[main.condNullSlice]
+              InjectionPoints: [{PC: "0x4c67b3", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 33, index: 0, name: s}
+                      Variable: {subprogram: 35, index: 0, name: s}
                       Offset: 0
                       ByteSize: 24
                     - __kind: ExprPushOffsetOp
@@ -1484,8 +1796,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 493 EventRootType Probe[main.condNullSlice]Return
-              InjectionPoints: [{PC: "0x4c63a5", Frameless: false}]
+              Type: 502 EventRootType Probe[main.condNullSlice]Return
+              InjectionPoints: [{PC: "0x4c68c5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: s == nil [tag={tag}]
@@ -1506,16 +1818,16 @@ Probes:
       segments: ['p == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 36}
+        - subprogram: {subprogram: 38}
           events:
             - Kind: Entry
-              Type: 498 EventRootType Probe[main.condNullUnsafePtr]
-              InjectionPoints: [{PC: "0x4c668e", Frameless: false}]
+              Type: 507 EventRootType Probe[main.condNullUnsafePtr]
+              InjectionPoints: [{PC: "0x4c6bae", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 36, index: 0, name: p}
+                      Variable: {subprogram: 38, index: 0, name: p}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -1526,8 +1838,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 499 EventRootType Probe[main.condNullUnsafePtr]Return
-              InjectionPoints: [{PC: "0x4c675a", Frameless: false}]
+              Type: 508 EventRootType Probe[main.condNullUnsafePtr]Return
+              InjectionPoints: [{PC: "0x4c6c7a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p == nil [tag={tag}]
@@ -1552,7 +1864,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 483 EventRootType Probe[main.condOnly]
-              InjectionPoints: [{PC: "0x4c5d6a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5fca", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1569,7 +1881,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 484 EventRootType Probe[main.condOnly]Return
-              InjectionPoints: [{PC: "0x4c5ddc", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c603c", Frameless: false}]
               Condition: null
     - id: condOnly_nocond
       version: 0
@@ -1584,11 +1896,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 485 EventRootType Probe[main.condOnly]
-              InjectionPoints: [{PC: "0x4c5d6a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5fca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 486 EventRootType Probe[main.condOnly]Return
-              InjectionPoints: [{PC: "0x4c5ddc", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c603c", Frameless: false}]
               Condition: null
     - id: condPtrStruct_field_i32
       version: 0
@@ -1606,7 +1918,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 463 EventRootType Probe[main.condPtrStructArg]
-              InjectionPoints: [{PC: "0x4c5aae", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5d0e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1626,7 +1938,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 464 EventRootType Probe[main.condPtrStructArg]Return
-              InjectionPoints: [{PC: "0x4c5bb6", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5e16", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1652,7 +1964,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 465 EventRootType Probe[main.condPtrStructArg]
-              InjectionPoints: [{PC: "0x4c5aae", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5d0e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1671,7 +1983,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 466 EventRootType Probe[main.condPtrStructArg]Return
-              InjectionPoints: [{PC: "0x4c5bb6", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5e16", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1694,11 +2006,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 467 EventRootType Probe[main.condPtrStructArg]
-              InjectionPoints: [{PC: "0x4c5aae", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5d0e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 468 EventRootType Probe[main.condPtrStructArg]Return
-              InjectionPoints: [{PC: "0x4c5bb6", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5e16", Frameless: false}]
               Condition: null
     - id: condReturnAndLocal_cond_param
       version: 0
@@ -1714,7 +2026,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 479 EventRootType Probe[main.condReturnAndLocal]
-              InjectionPoints: [{PC: "0x4c5cca", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5f2a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1731,7 +2043,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 480 EventRootType Probe[main.condReturnAndLocal]Return
-              InjectionPoints: [{PC: "0x4c5d3b", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5f9b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: b={b}
@@ -1754,11 +2066,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 481 EventRootType Probe[main.condReturnAndLocal]
-              InjectionPoints: [{PC: "0x4c5cca", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5f2a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 482 EventRootType Probe[main.condReturnAndLocal]Return
-              InjectionPoints: [{PC: "0x4c5d3b", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5f9b", Frameless: false}]
               Condition: null
     - id: condString_cond
       version: 0
@@ -1776,7 +2088,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 435 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0x4c58ae", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5b0e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1792,7 +2104,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 436 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0x4c5925", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5b85", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1816,7 +2128,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 437 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0x4c58ae", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5b0e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1832,7 +2144,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 438 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0x4c5925", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5b85", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1860,11 +2172,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 439 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0x4c58ae", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5b0e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 440 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0x4c5925", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5b85", Frameless: false}]
               Condition: null
     - id: condString_eq_template
       version: 0
@@ -1882,11 +2194,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 441 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0x4c58ae", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5b0e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 442 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0x4c5925", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5b85", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: eq={x == "hello"}
@@ -1909,11 +2221,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 443 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0x4c58ae", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5b0e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 444 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0x4c5925", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5b85", Frameless: false}]
               Condition: null
     - id: condString_snapshot_with_cond
       version: 0
@@ -1931,7 +2243,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 445 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0x4c58ae", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5b0e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1947,7 +2259,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 446 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0x4c5925", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5b85", Frameless: false}]
               Condition: null
     - id: condStruct_cond_i32_capture_tag
       version: 0
@@ -1968,7 +2280,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 451 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0x4c596e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5bce", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1985,7 +2297,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 452 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0x4c5a70", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5cd0", Frameless: false}]
               Condition: null
     - id: condStruct_field_bool
       version: 0
@@ -2003,7 +2315,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 453 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0x4c596e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5bce", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2020,7 +2332,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 454 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0x4c5a70", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5cd0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2046,7 +2358,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 455 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0x4c596e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5bce", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2063,7 +2375,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 456 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0x4c5a70", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5cd0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2089,7 +2401,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 457 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0x4c596e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5bce", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2106,7 +2418,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 458 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0x4c5a70", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5cd0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2132,7 +2444,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 459 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0x4c596e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5bce", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2148,7 +2460,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 460 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0x4c5a70", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5cd0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2171,11 +2483,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 461 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0x4c596e", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5bce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 462 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0x4c5a70", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5cd0", Frameless: false}]
               Condition: null
     - id: condUint16_cond
       version: 0
@@ -2191,7 +2503,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 411 EventRootType Probe[main.condUint16]
-              InjectionPoints: [{PC: "0x4c542a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c568a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2208,7 +2520,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 412 EventRootType Probe[main.condUint16]Return
-              InjectionPoints: [{PC: "0x4c549c", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c56fc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2231,11 +2543,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 413 EventRootType Probe[main.condUint16]
-              InjectionPoints: [{PC: "0x4c542a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c568a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 414 EventRootType Probe[main.condUint16]Return
-              InjectionPoints: [{PC: "0x4c549c", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c56fc", Frameless: false}]
               Condition: null
     - id: condUint32_cond
       version: 0
@@ -2251,7 +2563,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 415 EventRootType Probe[main.condUint32]
-              InjectionPoints: [{PC: "0x4c54ea", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c574a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2268,7 +2580,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 416 EventRootType Probe[main.condUint32]Return
-              InjectionPoints: [{PC: "0x4c555c", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c57bc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2291,11 +2603,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 417 EventRootType Probe[main.condUint32]
-              InjectionPoints: [{PC: "0x4c54ea", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c574a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 418 EventRootType Probe[main.condUint32]Return
-              InjectionPoints: [{PC: "0x4c555c", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c57bc", Frameless: false}]
               Condition: null
     - id: condUint64_cond
       version: 0
@@ -2311,7 +2623,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 419 EventRootType Probe[main.condUint64]
-              InjectionPoints: [{PC: "0x4c55aa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c580a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2328,7 +2640,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 420 EventRootType Probe[main.condUint64]Return
-              InjectionPoints: [{PC: "0x4c561c", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c587c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2351,11 +2663,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 421 EventRootType Probe[main.condUint64]
-              InjectionPoints: [{PC: "0x4c55aa", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c580a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 422 EventRootType Probe[main.condUint64]Return
-              InjectionPoints: [{PC: "0x4c561c", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c587c", Frameless: false}]
               Condition: null
     - id: condUint8_cond
       version: 0
@@ -2371,7 +2683,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 405 EventRootType Probe[main.condUint8]
-              InjectionPoints: [{PC: "0x4c536a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c55ca", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2388,7 +2700,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 406 EventRootType Probe[main.condUint8]Return
-              InjectionPoints: [{PC: "0x4c53dc", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c563c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2412,7 +2724,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 407 EventRootType Probe[main.condUint8]
-              InjectionPoints: [{PC: "0x4c536a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c55ca", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2429,7 +2741,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 408 EventRootType Probe[main.condUint8]Return
-              InjectionPoints: [{PC: "0x4c53dc", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c563c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2452,11 +2764,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 409 EventRootType Probe[main.condUint8]
-              InjectionPoints: [{PC: "0x4c536a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c55ca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 410 EventRootType Probe[main.condUint8]Return
-              InjectionPoints: [{PC: "0x4c53dc", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c563c", Frameless: false}]
               Condition: null
     - id: genericIdentity
       version: 0
@@ -2466,25 +2778,25 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 73}
+        - subprogram: {subprogram: 75}
           events:
             - Kind: Entry
-              Type: 676 EventRootType Probe[main.genericIdentity[go.shape.string]]
-              InjectionPoints: [{PC: "0x4c85ea", Frameless: false}]
+              Type: 685 EventRootType Probe[main.genericIdentity[go.shape.string]]
+              InjectionPoints: [{PC: "0x4c8b0a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 677 EventRootType Probe[main.genericIdentity[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x4c864f", Frameless: false}]
+              Type: 686 EventRootType Probe[main.genericIdentity[go.shape.string]]Return
+              InjectionPoints: [{PC: "0x4c8b6f", Frameless: false}]
               Condition: null
-        - subprogram: {subprogram: 74}
+        - subprogram: {subprogram: 76}
           events:
             - Kind: Entry
-              Type: 678 EventRootType Probe[main.genericIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0x4c868a", Frameless: false}]
+              Type: 687 EventRootType Probe[main.genericIdentity[go.shape.int]]
+              InjectionPoints: [{PC: "0x4c8baa", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 679 EventRootType Probe[main.genericIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x4c86dd", Frameless: false}]
+              Type: 688 EventRootType Probe[main.genericIdentity[go.shape.int]]Return
+              InjectionPoints: [{PC: "0x4c8bfd", Frameless: false}]
               Condition: null
     - id: indexBigArrayStruct_last
       version: 0
@@ -2500,15 +2812,15 @@ Probes:
             dsl: s.data[131071]
             json: {index: [{getmember: [{ref: s}, data]}, 131071]}
       instances:
-        - subprogram: {subprogram: 48}
+        - subprogram: {subprogram: 50}
           events:
             - Kind: Entry
-              Type: 598 EventRootType Probe[main.bigArrayStructArg]
-              InjectionPoints: [{PC: "0x4c75ea", Frameless: false}]
+              Type: 607 EventRootType Probe[main.bigArrayStructArg]
+              InjectionPoints: [{PC: "0x4c7b0a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 599 EventRootType Probe[main.bigArrayStructArg]Return
-              InjectionPoints: [{PC: "0x4c7659", Frameless: false}]
+              Type: 608 EventRootType Probe[main.bigArrayStructArg]Return
+              InjectionPoints: [{PC: "0x4c7b79", Frameless: false}]
               Condition: null
     - id: indexBigArray_first
       version: 0
@@ -2522,15 +2834,15 @@ Probes:
         - name: s_0
           expr: {dsl: 's[0]', json: {index: [{ref: s}, 0]}}
       instances:
-        - subprogram: {subprogram: 47}
+        - subprogram: {subprogram: 49}
           events:
             - Kind: Entry
-              Type: 594 EventRootType Probe[main.bigArrayArg]
-              InjectionPoints: [{PC: "0x4c754a", Frameless: false}]
+              Type: 603 EventRootType Probe[main.bigArrayArg]
+              InjectionPoints: [{PC: "0x4c7a6a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 595 EventRootType Probe[main.bigArrayArg]Return
-              InjectionPoints: [{PC: "0x4c75b6", Frameless: false}]
+              Type: 604 EventRootType Probe[main.bigArrayArg]Return
+              InjectionPoints: [{PC: "0x4c7ad6", Frameless: false}]
               Condition: null
     - id: indexBigArray_last
       version: 0
@@ -2544,15 +2856,15 @@ Probes:
         - name: s_131071
           expr: {dsl: 's[131071]', json: {index: [{ref: s}, 131071]}}
       instances:
-        - subprogram: {subprogram: 47}
+        - subprogram: {subprogram: 49}
           events:
             - Kind: Entry
-              Type: 596 EventRootType Probe[main.bigArrayArg]
-              InjectionPoints: [{PC: "0x4c754a", Frameless: false}]
+              Type: 605 EventRootType Probe[main.bigArrayArg]
+              InjectionPoints: [{PC: "0x4c7a6a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 597 EventRootType Probe[main.bigArrayArg]Return
-              InjectionPoints: [{PC: "0x4c75b6", Frameless: false}]
+              Type: 606 EventRootType Probe[main.bigArrayArg]Return
+              InjectionPoints: [{PC: "0x4c7ad6", Frameless: false}]
               Condition: null
     - id: indexErr_array_oob_capture
       version: 0
@@ -2570,11 +2882,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 360 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0x4c4cca", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c4f2a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 361 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0x4c4d16", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c4f76", Frameless: false}]
               Condition: null
     - id: indexErr_array_oob_template
       version: 0
@@ -2589,11 +2901,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 362 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0x4c4cca", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c4f2a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 363 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0x4c4d16", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c4f76", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's[3]: {s[3]}'
@@ -2617,11 +2929,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 346 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0x4c4c4a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c4eaa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 347 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0x4c4c8f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c4eef", Frameless: false}]
               Condition: null
     - id: indexErr_slice_oob_cond
       version: 0
@@ -2639,7 +2951,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 348 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0x4c4c4a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c4eaa", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2661,7 +2973,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 349 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0x4c4c8f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c4eef", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: matched, Segments: [matched]}
     - id: indexErr_slice_oob_template
@@ -2677,11 +2989,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 350 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0x4c4c4a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c4eaa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 351 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0x4c4c8f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c4eef", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's[5]: {s[5]}'
@@ -2707,11 +3019,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 364 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0x4c4cca", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c4f2a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 365 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0x4c4d16", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c4f76", Frameless: false}]
               Condition: null
     - id: indexIntArray_cond
       version: 0
@@ -2729,7 +3041,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 366 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0x4c4cca", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c4f2a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2746,7 +3058,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 367 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0x4c4d16", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c4f76", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: matched, Segments: [matched]}
     - id: indexIntSlice_capture
@@ -2765,11 +3077,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 352 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0x4c4c4a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c4eaa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 353 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0x4c4c8f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c4eef", Frameless: false}]
               Condition: null
     - id: indexIntSlice_cond
       version: 0
@@ -2787,7 +3099,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 354 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0x4c4c4a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c4eaa", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2809,7 +3121,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 355 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0x4c4c8f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c4eef", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: matched, Segments: [matched]}
     - id: indexIntSlice_template
@@ -2825,11 +3137,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 356 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0x4c4c4a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c4eaa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 357 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0x4c4c8f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c4eef", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's[1]: {s[1]}'
@@ -2853,15 +3165,15 @@ Probes:
             dsl: s[0].Val
             json: {getmember: [{index: [{ref: s}, 0]}, Val]}
       instances:
-        - subprogram: {subprogram: 50}
+        - subprogram: {subprogram: 52}
           events:
             - Kind: Entry
-              Type: 608 EventRootType Probe[main.structArrayArg]
-              InjectionPoints: [{PC: "0x4c778e", Frameless: false}]
+              Type: 617 EventRootType Probe[main.structArrayArg]
+              InjectionPoints: [{PC: "0x4c7cae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 609 EventRootType Probe[main.structArrayArg]Return
-              InjectionPoints: [{PC: "0x4c7810", Frameless: false}]
+              Type: 618 EventRootType Probe[main.structArrayArg]Return
+              InjectionPoints: [{PC: "0x4c7d30", Frameless: false}]
               Condition: null
     - id: indexMember_arrayStruct_capture_string
       version: 0
@@ -2877,15 +3189,15 @@ Probes:
             dsl: s[1].Txt
             json: {getmember: [{index: [{ref: s}, 1]}, Txt]}
       instances:
-        - subprogram: {subprogram: 50}
+        - subprogram: {subprogram: 52}
           events:
             - Kind: Entry
-              Type: 610 EventRootType Probe[main.structArrayArg]
-              InjectionPoints: [{PC: "0x4c778e", Frameless: false}]
+              Type: 619 EventRootType Probe[main.structArrayArg]
+              InjectionPoints: [{PC: "0x4c7cae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 611 EventRootType Probe[main.structArrayArg]Return
-              InjectionPoints: [{PC: "0x4c7810", Frameless: false}]
+              Type: 620 EventRootType Probe[main.structArrayArg]Return
+              InjectionPoints: [{PC: "0x4c7d30", Frameless: false}]
               Condition: null
     - id: indexMember_ptrArrayStruct_capture_int
       version: 0
@@ -2901,15 +3213,15 @@ Probes:
             dsl: s[0].Val
             json: {getmember: [{index: [{ref: s}, 0]}, Val]}
       instances:
-        - subprogram: {subprogram: 52}
+        - subprogram: {subprogram: 54}
           events:
             - Kind: Entry
-              Type: 616 EventRootType Probe[main.ptrStructArrayArg]
-              InjectionPoints: [{PC: "0x4c794e", Frameless: false}]
+              Type: 625 EventRootType Probe[main.ptrStructArrayArg]
+              InjectionPoints: [{PC: "0x4c7e6e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 617 EventRootType Probe[main.ptrStructArrayArg]Return
-              InjectionPoints: [{PC: "0x4c79c7", Frameless: false}]
+              Type: 626 EventRootType Probe[main.ptrStructArrayArg]Return
+              InjectionPoints: [{PC: "0x4c7ee7", Frameless: false}]
               Condition: null
     - id: indexMember_ptrArrayStruct_capture_string
       version: 0
@@ -2925,15 +3237,15 @@ Probes:
             dsl: s[1].Txt
             json: {getmember: [{index: [{ref: s}, 1]}, Txt]}
       instances:
-        - subprogram: {subprogram: 52}
+        - subprogram: {subprogram: 54}
           events:
             - Kind: Entry
-              Type: 618 EventRootType Probe[main.ptrStructArrayArg]
-              InjectionPoints: [{PC: "0x4c794e", Frameless: false}]
+              Type: 627 EventRootType Probe[main.ptrStructArrayArg]
+              InjectionPoints: [{PC: "0x4c7e6e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 619 EventRootType Probe[main.ptrStructArrayArg]Return
-              InjectionPoints: [{PC: "0x4c79c7", Frameless: false}]
+              Type: 628 EventRootType Probe[main.ptrStructArrayArg]Return
+              InjectionPoints: [{PC: "0x4c7ee7", Frameless: false}]
               Condition: null
     - id: indexMember_ptrSliceStruct_capture_int
       version: 0
@@ -2949,15 +3261,15 @@ Probes:
             dsl: s[0].Val
             json: {getmember: [{index: [{ref: s}, 0]}, Val]}
       instances:
-        - subprogram: {subprogram: 51}
+        - subprogram: {subprogram: 53}
           events:
             - Kind: Entry
-              Type: 612 EventRootType Probe[main.ptrStructSliceArg]
-              InjectionPoints: [{PC: "0x4c784e", Frameless: false}]
+              Type: 621 EventRootType Probe[main.ptrStructSliceArg]
+              InjectionPoints: [{PC: "0x4c7d6e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 613 EventRootType Probe[main.ptrStructSliceArg]Return
-              InjectionPoints: [{PC: "0x4c78d6", Frameless: false}]
+              Type: 622 EventRootType Probe[main.ptrStructSliceArg]Return
+              InjectionPoints: [{PC: "0x4c7df6", Frameless: false}]
               Condition: null
     - id: indexMember_ptrSliceStruct_capture_string
       version: 0
@@ -2973,15 +3285,15 @@ Probes:
             dsl: s[1].Txt
             json: {getmember: [{index: [{ref: s}, 1]}, Txt]}
       instances:
-        - subprogram: {subprogram: 51}
+        - subprogram: {subprogram: 53}
           events:
             - Kind: Entry
-              Type: 614 EventRootType Probe[main.ptrStructSliceArg]
-              InjectionPoints: [{PC: "0x4c784e", Frameless: false}]
+              Type: 623 EventRootType Probe[main.ptrStructSliceArg]
+              InjectionPoints: [{PC: "0x4c7d6e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 615 EventRootType Probe[main.ptrStructSliceArg]Return
-              InjectionPoints: [{PC: "0x4c78d6", Frameless: false}]
+              Type: 624 EventRootType Probe[main.ptrStructSliceArg]Return
+              InjectionPoints: [{PC: "0x4c7df6", Frameless: false}]
               Condition: null
     - id: indexMember_sliceStruct_capture_int
       version: 0
@@ -2997,15 +3309,15 @@ Probes:
             dsl: s[0].Val
             json: {getmember: [{index: [{ref: s}, 0]}, Val]}
       instances:
-        - subprogram: {subprogram: 49}
+        - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 600 EventRootType Probe[main.structSliceArg]
-              InjectionPoints: [{PC: "0x4c768e", Frameless: false}]
+              Type: 609 EventRootType Probe[main.structSliceArg]
+              InjectionPoints: [{PC: "0x4c7bae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 601 EventRootType Probe[main.structSliceArg]Return
-              InjectionPoints: [{PC: "0x4c7716", Frameless: false}]
+              Type: 610 EventRootType Probe[main.structSliceArg]Return
+              InjectionPoints: [{PC: "0x4c7c36", Frameless: false}]
               Condition: null
     - id: indexMember_sliceStruct_capture_string
       version: 0
@@ -3021,15 +3333,15 @@ Probes:
             dsl: s[1].Txt
             json: {getmember: [{index: [{ref: s}, 1]}, Txt]}
       instances:
-        - subprogram: {subprogram: 49}
+        - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 602 EventRootType Probe[main.structSliceArg]
-              InjectionPoints: [{PC: "0x4c768e", Frameless: false}]
+              Type: 611 EventRootType Probe[main.structSliceArg]
+              InjectionPoints: [{PC: "0x4c7bae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 603 EventRootType Probe[main.structSliceArg]Return
-              InjectionPoints: [{PC: "0x4c7716", Frameless: false}]
+              Type: 612 EventRootType Probe[main.structSliceArg]Return
+              InjectionPoints: [{PC: "0x4c7c36", Frameless: false}]
               Condition: null
     - id: indexMember_sliceStruct_cond
       version: 0
@@ -3044,16 +3356,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 49}
+        - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 604 EventRootType Probe[main.structSliceArg]
-              InjectionPoints: [{PC: "0x4c768e", Frameless: false}]
+              Type: 613 EventRootType Probe[main.structSliceArg]
+              InjectionPoints: [{PC: "0x4c7bae", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 49, index: 0, name: s}
+                      Variable: {subprogram: 51, index: 0, name: s}
                       Offset: 0
                       ByteSize: 16
                     - __kind: SliceBoundsCheckOp
@@ -3069,8 +3381,8 @@ Probes:
                       ByteSize: 4
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 605 EventRootType Probe[main.structSliceArg]Return
-              InjectionPoints: [{PC: "0x4c7716", Frameless: false}]
+              Type: 614 EventRootType Probe[main.structSliceArg]Return
+              InjectionPoints: [{PC: "0x4c7c36", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -3092,15 +3404,15 @@ Probes:
           dsl: s[0].Val
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 49}
+        - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 606 EventRootType Probe[main.structSliceArg]
-              InjectionPoints: [{PC: "0x4c768e", Frameless: false}]
+              Type: 615 EventRootType Probe[main.structSliceArg]
+              InjectionPoints: [{PC: "0x4c7bae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 607 EventRootType Probe[main.structSliceArg]Return
-              InjectionPoints: [{PC: "0x4c7716", Frameless: false}]
+              Type: 616 EventRootType Probe[main.structSliceArg]Return
+              InjectionPoints: [{PC: "0x4c7c36", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: s[0].Val={s[0].Val}
@@ -3127,15 +3439,15 @@ Probes:
             json:
                 getmember: [{index: [{getmember: [{ref: s}, Arr]}, 0]}, Val]
       instances:
-        - subprogram: {subprogram: 53}
+        - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 620 EventRootType Probe[main.indexMemberWrapperArg]
-              InjectionPoints: [{PC: "0x4c7a0e", Frameless: false}]
+              Type: 629 EventRootType Probe[main.indexMemberWrapperArg]
+              InjectionPoints: [{PC: "0x4c7f2e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 621 EventRootType Probe[main.indexMemberWrapperArg]Return
-              InjectionPoints: [{PC: "0x4c7ab6", Frameless: false}]
+              Type: 630 EventRootType Probe[main.indexMemberWrapperArg]Return
+              InjectionPoints: [{PC: "0x4c7fd6", Frameless: false}]
               Condition: null
     - id: indexMember_wrapper_arr_capture_1
       version: 0
@@ -3152,15 +3464,15 @@ Probes:
             json:
                 getmember: [{index: [{getmember: [{ref: s}, Arr]}, 1]}, Txt]
       instances:
-        - subprogram: {subprogram: 53}
+        - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 622 EventRootType Probe[main.indexMemberWrapperArg]
-              InjectionPoints: [{PC: "0x4c7a0e", Frameless: false}]
+              Type: 631 EventRootType Probe[main.indexMemberWrapperArg]
+              InjectionPoints: [{PC: "0x4c7f2e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 623 EventRootType Probe[main.indexMemberWrapperArg]Return
-              InjectionPoints: [{PC: "0x4c7ab6", Frameless: false}]
+              Type: 632 EventRootType Probe[main.indexMemberWrapperArg]Return
+              InjectionPoints: [{PC: "0x4c7fd6", Frameless: false}]
               Condition: null
     - id: indexMember_wrapper_ptrArr_capture
       version: 0
@@ -3177,15 +3489,15 @@ Probes:
             json:
                 getmember: [{index: [{getmember: [{ref: s}, PtrArr]}, 0]}, Val]
       instances:
-        - subprogram: {subprogram: 53}
+        - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 624 EventRootType Probe[main.indexMemberWrapperArg]
-              InjectionPoints: [{PC: "0x4c7a0e", Frameless: false}]
+              Type: 633 EventRootType Probe[main.indexMemberWrapperArg]
+              InjectionPoints: [{PC: "0x4c7f2e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 625 EventRootType Probe[main.indexMemberWrapperArg]Return
-              InjectionPoints: [{PC: "0x4c7ab6", Frameless: false}]
+              Type: 634 EventRootType Probe[main.indexMemberWrapperArg]Return
+              InjectionPoints: [{PC: "0x4c7fd6", Frameless: false}]
               Condition: null
     - id: indexMember_wrapper_ptrArr_capture_1
       version: 0
@@ -3202,15 +3514,15 @@ Probes:
             json:
                 getmember: [{index: [{getmember: [{ref: s}, PtrArr]}, 1]}, Txt]
       instances:
-        - subprogram: {subprogram: 53}
+        - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 626 EventRootType Probe[main.indexMemberWrapperArg]
-              InjectionPoints: [{PC: "0x4c7a0e", Frameless: false}]
+              Type: 635 EventRootType Probe[main.indexMemberWrapperArg]
+              InjectionPoints: [{PC: "0x4c7f2e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 627 EventRootType Probe[main.indexMemberWrapperArg]Return
-              InjectionPoints: [{PC: "0x4c7ab6", Frameless: false}]
+              Type: 636 EventRootType Probe[main.indexMemberWrapperArg]Return
+              InjectionPoints: [{PC: "0x4c7fd6", Frameless: false}]
               Condition: null
     - id: indexNilPtr_capture
       version: 0
@@ -3226,15 +3538,15 @@ Probes:
             dsl: x.Items[0]
             json: {index: [{getmember: [{ref: x}, Items]}, 0]}
       instances:
-        - subprogram: {subprogram: 45}
+        - subprogram: {subprogram: 47}
           events:
             - Kind: Entry
-              Type: 586 EventRootType Probe[main.indexNilPtrSlice]
-              InjectionPoints: [{PC: "0x4c728e", Frameless: false}]
+              Type: 595 EventRootType Probe[main.indexNilPtrSlice]
+              InjectionPoints: [{PC: "0x4c77ae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 587 EventRootType Probe[main.indexNilPtrSlice]Return
-              InjectionPoints: [{PC: "0x4c730f", Frameless: false}]
+              Type: 596 EventRootType Probe[main.indexNilPtrSlice]Return
+              InjectionPoints: [{PC: "0x4c782f", Frameless: false}]
               Condition: null
     - id: indexNilPtr_cond
       version: 0
@@ -3249,16 +3561,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 45}
+        - subprogram: {subprogram: 47}
           events:
             - Kind: Entry
-              Type: 588 EventRootType Probe[main.indexNilPtrSlice]
-              InjectionPoints: [{PC: "0x4c728e", Frameless: false}]
+              Type: 597 EventRootType Probe[main.indexNilPtrSlice]
+              InjectionPoints: [{PC: "0x4c77ae", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 45, index: 0, name: x}
+                      Variable: {subprogram: 47, index: 0, name: x}
                       Offset: 0
                       ByteSize: 8
                     - __kind: DereferenceOp
@@ -3277,8 +3589,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 589 EventRootType Probe[main.indexNilPtrSlice]Return
-              InjectionPoints: [{PC: "0x4c730f", Frameless: false}]
+              Type: 598 EventRootType Probe[main.indexNilPtrSlice]Return
+              InjectionPoints: [{PC: "0x4c782f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -3300,15 +3612,15 @@ Probes:
           dsl: x.Items[0]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 45}
+        - subprogram: {subprogram: 47}
           events:
             - Kind: Entry
-              Type: 590 EventRootType Probe[main.indexNilPtrSlice]
-              InjectionPoints: [{PC: "0x4c728e", Frameless: false}]
+              Type: 599 EventRootType Probe[main.indexNilPtrSlice]
+              InjectionPoints: [{PC: "0x4c77ae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 591 EventRootType Probe[main.indexNilPtrSlice]Return
-              InjectionPoints: [{PC: "0x4c730f", Frameless: false}]
+              Type: 600 EventRootType Probe[main.indexNilPtrSlice]Return
+              InjectionPoints: [{PC: "0x4c782f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 'items[0]: {x.Items[0]}'
@@ -3334,15 +3646,15 @@ Probes:
             dsl: x.Items[0]
             json: {index: [{getmember: [{ref: x}, Items]}, 0]}
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 568 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0x4c6e93", Frameless: false}]
+              Type: 577 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0x4c73b3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 569 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0x4c6fcb", Frameless: false}]
+              Type: 578 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0x4c74eb", Frameless: false}]
               Condition: null
     - id: indexStringArray_capture
       version: 0
@@ -3360,11 +3672,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 374 EventRootType Probe[main.stringArrayArg]
-              InjectionPoints: [{PC: "0x4c4dca", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c502a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 375 EventRootType Probe[main.stringArrayArg]Return
-              InjectionPoints: [{PC: "0x4c4e16", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5076", Frameless: false}]
               Condition: null
     - id: indexStringSlice_capture
       version: 0
@@ -3382,11 +3694,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 370 EventRootType Probe[main.stringSliceArg]
-              InjectionPoints: [{PC: "0x4c4d4a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c4faa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 371 EventRootType Probe[main.stringSliceArg]Return
-              InjectionPoints: [{PC: "0x4c4d8f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c4fef", Frameless: false}]
               Condition: null
     - id: indexStructSliceField_capture
       version: 0
@@ -3402,15 +3714,15 @@ Probes:
             dsl: x.Items[2]
             json: {index: [{getmember: [{ref: x}, Items]}, 2]}
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 548 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4c6cb3", Frameless: false}]
+              Type: 557 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4c71d3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 549 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4c6e39", Frameless: false}]
+              Type: 558 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4c7359", Frameless: false}]
               Condition: null
     - id: inlined
       version: 0
@@ -3421,19 +3733,19 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 75}
+        - subprogram: {subprogram: 77}
           events:
             - Kind: Entry
-              Type: 680 EventRootType Probe[main.inlined]
+              Type: 689 EventRootType Probe[main.inlined]
               InjectionPoints:
                 - PC: "0x4c2846"
                   Frameless: false
-                - PC: "0x4c4e6a"
+                - PC: "0x4c50ca"
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 681 EventRootType Probe[main.inlined]Return
-              InjectionPoints: [{PC: "0x4c4eaa", Frameless: false}]
+              Type: 690 EventRootType Probe[main.inlined]Return
+              InjectionPoints: [{PC: "0x4c510a", Frameless: false}]
               Condition: null
     - id: inlinedMethod
       version: 0
@@ -3443,11 +3755,11 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 78}
+        - subprogram: {subprogram: 80}
           events:
             - Kind: Entry
-              Type: 684 EventRootType Probe[main.(*methodValueReceiver).inlinedMethod]
-              InjectionPoints: [{PC: "0x4c8704", Frameless: true}]
+              Type: 693 EventRootType Probe[main.(*methodValueReceiver).inlinedMethod]
+              InjectionPoints: [{PC: "0x4c8c24", Frameless: true}]
               Condition: null
     - id: intArg
       version: 0
@@ -3461,11 +3773,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 338 EventRootType Probe[main.intArg]
-              InjectionPoints: [{PC: "0x4c4b4a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c4daa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 339 EventRootType Probe[main.intArg]Return
-              InjectionPoints: [{PC: "0x4c4b8a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c4dea", Frameless: false}]
               Condition: null
     - id: intArrayArg
       version: 0
@@ -3479,11 +3791,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 368 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0x4c4cca", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c4f2a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 369 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0x4c4d16", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c4f76", Frameless: false}]
               Condition: null
     - id: intArrayArgFrameless
       version: 0
@@ -3497,7 +3809,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 378 EventRootType Probe[main.stringArrayArgFrameless]
-              InjectionPoints: [{PC: "0x4c4e40", Frameless: true}]
+              InjectionPoints: [{PC: "0x4c50a0", Frameless: true}]
               Condition: null
     - id: intSliceArg
       version: 0
@@ -3511,11 +3823,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 358 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0x4c4c4a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c4eaa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 359 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0x4c4c8f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c4eef", Frameless: false}]
               Condition: null
     - id: lenErrInt_nocond
       version: 0
@@ -3526,15 +3838,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 43}
+        - subprogram: {subprogram: 45}
           events:
             - Kind: Entry
-              Type: 578 EventRootType Probe[main.lenErrInt]
-              InjectionPoints: [{PC: "0x4c7013", Frameless: false}]
+              Type: 587 EventRootType Probe[main.lenErrInt]
+              InjectionPoints: [{PC: "0x4c7533", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 579 EventRootType Probe[main.lenErrInt]Return
-              InjectionPoints: [{PC: "0x4c70ee", Frameless: false}]
+              Type: 588 EventRootType Probe[main.lenErrInt]Return
+              InjectionPoints: [{PC: "0x4c760e", Frameless: false}]
               Condition: null
     - id: lenErrStruct_nocond
       version: 0
@@ -3545,15 +3857,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 44}
+        - subprogram: {subprogram: 46}
           events:
             - Kind: Entry
-              Type: 582 EventRootType Probe[main.lenErrStruct]
-              InjectionPoints: [{PC: "0x4c7133", Frameless: false}]
+              Type: 591 EventRootType Probe[main.lenErrStruct]
+              InjectionPoints: [{PC: "0x4c7653", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 583 EventRootType Probe[main.lenErrStruct]Return
-              InjectionPoints: [{PC: "0x4c724f", Frameless: false}]
+              Type: 592 EventRootType Probe[main.lenErrStruct]Return
+              InjectionPoints: [{PC: "0x4c776f", Frameless: false}]
               Condition: null
     - id: lenErr_int
       version: 0
@@ -3564,15 +3876,15 @@ Probes:
       segments: [len=, {json: {len: {ref: x}}, dsl: len(x)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 43}
+        - subprogram: {subprogram: 45}
           events:
             - Kind: Entry
-              Type: 580 EventRootType Probe[main.lenErrInt]
-              InjectionPoints: [{PC: "0x4c7013", Frameless: false}]
+              Type: 589 EventRootType Probe[main.lenErrInt]
+              InjectionPoints: [{PC: "0x4c7533", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 581 EventRootType Probe[main.lenErrInt]Return
-              InjectionPoints: [{PC: "0x4c70ee", Frameless: false}]
+              Type: 590 EventRootType Probe[main.lenErrInt]Return
+              InjectionPoints: [{PC: "0x4c760e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x)}
@@ -3589,15 +3901,15 @@ Probes:
       segments: [len=, {json: {len: {ref: x}}, dsl: len(x)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 44}
+        - subprogram: {subprogram: 46}
           events:
             - Kind: Entry
-              Type: 584 EventRootType Probe[main.lenErrStruct]
-              InjectionPoints: [{PC: "0x4c7133", Frameless: false}]
+              Type: 593 EventRootType Probe[main.lenErrStruct]
+              InjectionPoints: [{PC: "0x4c7653", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 585 EventRootType Probe[main.lenErrStruct]Return
-              InjectionPoints: [{PC: "0x4c724f", Frameless: false}]
+              Type: 594 EventRootType Probe[main.lenErrStruct]Return
+              InjectionPoints: [{PC: "0x4c776f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x)}
@@ -3615,16 +3927,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 532 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0x4c6a6e", Frameless: false}]
+              Type: 541 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0x4c6f8e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 39, index: 0, name: m}
+                      Variable: {subprogram: 41, index: 0, name: m}
                       Offset: 0
                       ByteSize: 8
                     - __kind: DereferenceOp
@@ -3638,8 +3950,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 533 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0x4c6b4e", Frameless: false}]
+              Type: 542 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0x4c706e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -3661,15 +3973,15 @@ Probes:
           dsl: isEmpty(m)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 534 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0x4c6a6e", Frameless: false}]
+              Type: 543 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0x4c6f8e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 535 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0x4c6b4e", Frameless: false}]
+              Type: 544 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0x4c706e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: empty={isEmpty(m)}
@@ -3691,15 +4003,15 @@ Probes:
         - name: m_len
           expr: {dsl: len(m), json: {len: {ref: m}}}
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 536 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0x4c6a6e", Frameless: false}]
+              Type: 545 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0x4c6f8e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 537 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0x4c6b4e", Frameless: false}]
+              Type: 546 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0x4c706e", Frameless: false}]
               Condition: null
     - id: lenMap_len_eq_cond
       version: 0
@@ -3713,16 +4025,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 538 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0x4c6a6e", Frameless: false}]
+              Type: 547 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0x4c6f8e", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 39, index: 0, name: m}
+                      Variable: {subprogram: 41, index: 0, name: m}
                       Offset: 0
                       ByteSize: 8
                     - __kind: DereferenceOp
@@ -3736,8 +4048,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 539 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0x4c6b4e", Frameless: false}]
+              Type: 548 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0x4c706e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -3756,15 +4068,15 @@ Probes:
       segments: [len=, {json: {len: {ref: m}}, dsl: len(m)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 540 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0x4c6a6e", Frameless: false}]
+              Type: 549 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0x4c6f8e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 541 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0x4c6b4e", Frameless: false}]
+              Type: 550 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0x4c706e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(m)}
@@ -3783,15 +4095,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 542 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0x4c6a6e", Frameless: false}]
+              Type: 551 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0x4c6f8e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 543 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0x4c6b4e", Frameless: false}]
+              Type: 552 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0x4c706e", Frameless: false}]
               Condition: null
     - id: lenPtrString_len_template
       version: 0
@@ -3802,15 +4114,15 @@ Probes:
       segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 40}
+        - subprogram: {subprogram: 42}
           events:
             - Kind: Entry
-              Type: 544 EventRootType Probe[main.lenPtrString]
-              InjectionPoints: [{PC: "0x4c6b8e", Frameless: false}]
+              Type: 553 EventRootType Probe[main.lenPtrString]
+              InjectionPoints: [{PC: "0x4c70ae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 545 EventRootType Probe[main.lenPtrString]Return
-              InjectionPoints: [{PC: "0x4c6c5a", Frameless: false}]
+              Type: 554 EventRootType Probe[main.lenPtrString]Return
+              InjectionPoints: [{PC: "0x4c717a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(s)}
@@ -3829,15 +4141,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 40}
+        - subprogram: {subprogram: 42}
           events:
             - Kind: Entry
-              Type: 546 EventRootType Probe[main.lenPtrString]
-              InjectionPoints: [{PC: "0x4c6b8e", Frameless: false}]
+              Type: 555 EventRootType Probe[main.lenPtrString]
+              InjectionPoints: [{PC: "0x4c70ae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 547 EventRootType Probe[main.lenPtrString]Return
-              InjectionPoints: [{PC: "0x4c6c5a", Frameless: false}]
+              Type: 556 EventRootType Probe[main.lenPtrString]Return
+              InjectionPoints: [{PC: "0x4c717a", Frameless: false}]
               Condition: null
     - id: lenPtrStructFields_nocond
       version: 0
@@ -3848,15 +4160,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 570 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0x4c6e93", Frameless: false}]
+              Type: 579 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0x4c73b3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 571 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0x4c6fcb", Frameless: false}]
+              Type: 580 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0x4c74eb", Frameless: false}]
               Condition: null
     - id: lenPtrStruct_field_map
       version: 0
@@ -3870,15 +4182,15 @@ Probes:
           dsl: len(x.Dict)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 572 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0x4c6e93", Frameless: false}]
+              Type: 581 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0x4c73b3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 573 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0x4c6fcb", Frameless: false}]
+              Type: 582 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0x4c74eb", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.Dict)}
@@ -3900,15 +4212,15 @@ Probes:
           dsl: len(x.Items)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 574 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0x4c6e93", Frameless: false}]
+              Type: 583 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0x4c73b3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 575 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0x4c6fcb", Frameless: false}]
+              Type: 584 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0x4c74eb", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.Items)}
@@ -3930,15 +4242,15 @@ Probes:
           dsl: len(x.S)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 576 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0x4c6e93", Frameless: false}]
+              Type: 585 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0x4c73b3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 577 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0x4c6fcb", Frameless: false}]
+              Type: 586 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0x4c74eb", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.S)}
@@ -3958,16 +4270,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 520 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0x4c6913", Frameless: false}]
+              Type: 529 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0x4c6e33", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 38, index: 0, name: s}
+                      Variable: {subprogram: 40, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -3978,8 +4290,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 521 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0x4c6a09", Frameless: false}]
+              Type: 530 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0x4c6f29", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4001,15 +4313,15 @@ Probes:
           dsl: isEmpty(s)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 522 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0x4c6913", Frameless: false}]
+              Type: 531 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0x4c6e33", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 523 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0x4c6a09", Frameless: false}]
+              Type: 532 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0x4c6f29", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: empty={isEmpty(s)}
@@ -4031,15 +4343,15 @@ Probes:
         - name: s_len
           expr: {dsl: len(s), json: {len: {ref: s}}}
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 524 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0x4c6913", Frameless: false}]
+              Type: 533 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0x4c6e33", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 525 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0x4c6a09", Frameless: false}]
+              Type: 534 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0x4c6f29", Frameless: false}]
               Condition: null
     - id: lenSlice_len_eq_cond
       version: 0
@@ -4053,16 +4365,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 526 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0x4c6913", Frameless: false}]
+              Type: 535 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0x4c6e33", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 38, index: 0, name: s}
+                      Variable: {subprogram: 40, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4073,8 +4385,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 527 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0x4c6a09", Frameless: false}]
+              Type: 536 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0x4c6f29", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4093,15 +4405,15 @@ Probes:
       segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 528 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0x4c6913", Frameless: false}]
+              Type: 537 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0x4c6e33", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 529 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0x4c6a09", Frameless: false}]
+              Type: 538 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0x4c6f29", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(s)}
@@ -4120,15 +4432,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 530 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0x4c6913", Frameless: false}]
+              Type: 539 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0x4c6e33", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 531 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0x4c6a09", Frameless: false}]
+              Type: 540 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0x4c6f29", Frameless: false}]
               Condition: null
     - id: lenString_eq_capture
       version: 0
@@ -4144,15 +4456,15 @@ Probes:
             dsl: len(s) == 5
             json: {eq: [{len: {ref: s}}, 5]}
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 502 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4c67d3", Frameless: false}]
+              Type: 511 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4c6cf3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 503 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4c68bc", Frameless: false}]
+              Type: 512 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4c6ddc", Frameless: false}]
               Condition: null
     - id: lenString_eq_template
       version: 0
@@ -4166,15 +4478,15 @@ Probes:
           dsl: len(s) == 5
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 504 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4c67d3", Frameless: false}]
+              Type: 513 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4c6cf3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 505 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4c68bc", Frameless: false}]
+              Type: 514 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4c6ddc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: eq={len(s) == 5}
@@ -4196,15 +4508,15 @@ Probes:
         - name: s_isEmpty
           expr: {dsl: isEmpty(s), json: {isEmpty: {ref: s}}}
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 506 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4c67d3", Frameless: false}]
+              Type: 515 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4c6cf3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 507 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4c68bc", Frameless: false}]
+              Type: 516 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4c6ddc", Frameless: false}]
               Condition: null
     - id: lenString_isEmpty_cond
       version: 0
@@ -4216,16 +4528,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 508 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4c67d3", Frameless: false}]
+              Type: 517 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4c6cf3", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 37, index: 0, name: s}
+                      Variable: {subprogram: 39, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4236,8 +4548,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 509 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4c68bc", Frameless: false}]
+              Type: 518 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4c6ddc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4259,15 +4571,15 @@ Probes:
           dsl: isEmpty(s)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 510 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4c67d3", Frameless: false}]
+              Type: 519 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4c6cf3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 511 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4c68bc", Frameless: false}]
+              Type: 520 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4c6ddc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: empty={isEmpty(s)}
@@ -4289,15 +4601,15 @@ Probes:
         - name: s_len
           expr: {dsl: len(s), json: {len: {ref: s}}}
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 512 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4c67d3", Frameless: false}]
+              Type: 521 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4c6cf3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 513 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4c68bc", Frameless: false}]
+              Type: 522 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4c6ddc", Frameless: false}]
               Condition: null
     - id: lenString_len_eq_cond
       version: 0
@@ -4311,16 +4623,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 514 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4c67d3", Frameless: false}]
+              Type: 523 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4c6cf3", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 37, index: 0, name: s}
+                      Variable: {subprogram: 39, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4331,8 +4643,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 515 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4c68bc", Frameless: false}]
+              Type: 524 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4c6ddc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4351,15 +4663,15 @@ Probes:
       segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 516 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4c67d3", Frameless: false}]
+              Type: 525 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4c6cf3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 517 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4c68bc", Frameless: false}]
+              Type: 526 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4c6ddc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(s)}
@@ -4378,15 +4690,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 518 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0x4c67d3", Frameless: false}]
+              Type: 527 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0x4c6cf3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 519 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0x4c68bc", Frameless: false}]
+              Type: 528 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0x4c6ddc", Frameless: false}]
               Condition: null
     - id: lenStructFields_nocond
       version: 0
@@ -4397,15 +4709,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 550 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4c6cb3", Frameless: false}]
+              Type: 559 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4c71d3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 551 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4c6e39", Frameless: false}]
+              Type: 560 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4c7359", Frameless: false}]
               Condition: null
     - id: lenStruct_field_map
       version: 0
@@ -4419,15 +4731,15 @@ Probes:
           dsl: len(x.Dict)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 552 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4c6cb3", Frameless: false}]
+              Type: 561 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4c71d3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 553 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4c6e39", Frameless: false}]
+              Type: 562 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4c7359", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.Dict)}
@@ -4449,15 +4761,15 @@ Probes:
           dsl: len(x.PtrSlice)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 554 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4c6cb3", Frameless: false}]
+              Type: 563 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4c71d3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 555 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4c6e39", Frameless: false}]
+              Type: 564 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4c7359", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.PtrSlice)}
@@ -4479,15 +4791,15 @@ Probes:
           dsl: len(x.PtrStr)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 556 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4c6cb3", Frameless: false}]
+              Type: 565 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4c71d3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 557 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4c6e39", Frameless: false}]
+              Type: 566 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4c7359", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.PtrStr)}
@@ -4509,15 +4821,15 @@ Probes:
           dsl: len(x.Items)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 558 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4c6cb3", Frameless: false}]
+              Type: 567 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4c71d3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 559 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4c6e39", Frameless: false}]
+              Type: 568 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4c7359", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.Items)}
@@ -4539,15 +4851,15 @@ Probes:
           dsl: len(x.S)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 560 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4c6cb3", Frameless: false}]
+              Type: 569 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4c71d3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 561 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4c6e39", Frameless: false}]
+              Type: 570 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4c7359", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.S)}
@@ -4569,16 +4881,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 562 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4c6cb3", Frameless: false}]
+              Type: 571 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4c71d3", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 41, index: 0, name: x}
+                      Variable: {subprogram: 43, index: 0, name: x}
                       Offset: 40
                       ByteSize: 8
                     - __kind: DereferenceOp
@@ -4592,8 +4904,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 563 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4c6e39", Frameless: false}]
+              Type: 572 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4c7359", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4615,16 +4927,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 564 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4c6cb3", Frameless: false}]
+              Type: 573 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4c71d3", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 41, index: 0, name: x}
+                      Variable: {subprogram: 43, index: 0, name: x}
                       Offset: 24
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4635,8 +4947,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 565 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4c6e39", Frameless: false}]
+              Type: 574 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4c7359", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4658,16 +4970,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 566 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0x4c6cb3", Frameless: false}]
+              Type: 575 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0x4c71d3", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 41, index: 0, name: x}
+                      Variable: {subprogram: 43, index: 0, name: x}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4678,8 +4990,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 567 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0x4c6e39", Frameless: false}]
+              Type: 576 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0x4c7359", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4701,11 +5013,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 340 EventRootType Probe[main.stringArg]
-              InjectionPoints: [{PC: "0x4c4bca", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c4e2a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 341 EventRootType Probe[main.stringArg]Return
-              InjectionPoints: [{PC: "0x4c4c0f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c4e6f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's: {s}'
@@ -4727,11 +5039,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 342 EventRootType Probe[main.stringArg]
-              InjectionPoints: [{PC: "0x4c4bca", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c4e2a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 343 EventRootType Probe[main.stringArg]Return
-              InjectionPoints: [{PC: "0x4c4c0f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c4e6f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 'x: {x}'
@@ -4751,11 +5063,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 379 EventRootType Probe[main.mapArg]
-              InjectionPoints: [{PC: "0x4c4f2a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c518a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 380 EventRootType Probe[main.mapArg]Return
-              InjectionPoints: [{PC: "0x4c4f5f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c51bf", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 'm: {m}'
@@ -4780,15 +5092,15 @@ Probes:
         - name: false_val
           expr: {dsl: 'm[false]', json: {index: [{ref: m}, false]}}
       instances:
-        - subprogram: {subprogram: 68}
+        - subprogram: {subprogram: 70}
           events:
             - Kind: Entry
-              Type: 664 EventRootType Probe[main.mapIndexBoolKey]
-              InjectionPoints: [{PC: "0x4c82ea", Frameless: false}]
+              Type: 673 EventRootType Probe[main.mapIndexBoolKey]
+              InjectionPoints: [{PC: "0x4c880a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 665 EventRootType Probe[main.mapIndexBoolKey]Return
-              InjectionPoints: [{PC: "0x4c831f", Frameless: false}]
+              Type: 674 EventRootType Probe[main.mapIndexBoolKey]Return
+              InjectionPoints: [{PC: "0x4c883f", Frameless: false}]
               Condition: null
     - id: mapIndex_boolKey_true
       version: 0
@@ -4805,15 +5117,15 @@ Probes:
         - name: true_val
           expr: {dsl: 'm[true]', json: {index: [{ref: m}, true]}}
       instances:
-        - subprogram: {subprogram: 68}
+        - subprogram: {subprogram: 70}
           events:
             - Kind: Entry
-              Type: 666 EventRootType Probe[main.mapIndexBoolKey]
-              InjectionPoints: [{PC: "0x4c82ea", Frameless: false}]
+              Type: 675 EventRootType Probe[main.mapIndexBoolKey]
+              InjectionPoints: [{PC: "0x4c880a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 667 EventRootType Probe[main.mapIndexBoolKey]Return
-              InjectionPoints: [{PC: "0x4c831f", Frameless: false}]
+              Type: 676 EventRootType Probe[main.mapIndexBoolKey]Return
+              InjectionPoints: [{PC: "0x4c883f", Frameless: false}]
               Condition: null
     - id: mapIndex_emptyKey_capture
       version: 0
@@ -4830,15 +5142,15 @@ Probes:
         - name: empty_val
           expr: {dsl: 'm[""]', json: {index: [{ref: m}, ""]}}
       instances:
-        - subprogram: {subprogram: 65}
+        - subprogram: {subprogram: 67}
           events:
             - Kind: Entry
-              Type: 658 EventRootType Probe[main.mapIndexEmptyKey]
-              InjectionPoints: [{PC: "0x4c816a", Frameless: false}]
+              Type: 667 EventRootType Probe[main.mapIndexEmptyKey]
+              InjectionPoints: [{PC: "0x4c868a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 659 EventRootType Probe[main.mapIndexEmptyKey]Return
-              InjectionPoints: [{PC: "0x4c81c5", Frameless: false}]
+              Type: 668 EventRootType Probe[main.mapIndexEmptyKey]Return
+              InjectionPoints: [{PC: "0x4c86e5", Frameless: false}]
               Condition: null
     - id: mapIndex_intKey_capture
       version: 0
@@ -4855,15 +5167,15 @@ Probes:
         - name: m_2
           expr: {dsl: 'm[2]', json: {index: [{ref: m}, 2]}}
       instances:
-        - subprogram: {subprogram: 54}
+        - subprogram: {subprogram: 56}
           events:
             - Kind: Entry
-              Type: 628 EventRootType Probe[main.mapIndexIntKey]
-              InjectionPoints: [{PC: "0x4c7b0a", Frameless: false}]
+              Type: 637 EventRootType Probe[main.mapIndexIntKey]
+              InjectionPoints: [{PC: "0x4c802a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 629 EventRootType Probe[main.mapIndexIntKey]Return
-              InjectionPoints: [{PC: "0x4c7b3f", Frameless: false}]
+              Type: 638 EventRootType Probe[main.mapIndexIntKey]Return
+              InjectionPoints: [{PC: "0x4c805f", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen16
       version: 0
@@ -4882,15 +5194,15 @@ Probes:
             dsl: m["000000000000002a"]
             json: {index: [{ref: m}, 000000000000002a]}
       instances:
-        - subprogram: {subprogram: 66}
+        - subprogram: {subprogram: 68}
           events:
             - Kind: Entry
-              Type: 660 EventRootType Probe[main.mapIndexKeyLen16]
-              InjectionPoints: [{PC: "0x4c81ea", Frameless: false}]
+              Type: 669 EventRootType Probe[main.mapIndexKeyLen16]
+              InjectionPoints: [{PC: "0x4c870a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 661 EventRootType Probe[main.mapIndexKeyLen16]Return
-              InjectionPoints: [{PC: "0x4c8239", Frameless: false}]
+              Type: 670 EventRootType Probe[main.mapIndexKeyLen16]Return
+              InjectionPoints: [{PC: "0x4c8759", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen17
       version: 0
@@ -4909,15 +5221,15 @@ Probes:
             dsl: m["0000000000000002a"]
             json: {index: [{ref: m}, 0000000000000002a]}
       instances:
-        - subprogram: {subprogram: 67}
+        - subprogram: {subprogram: 69}
           events:
             - Kind: Entry
-              Type: 662 EventRootType Probe[main.mapIndexKeyLen17]
-              InjectionPoints: [{PC: "0x4c826a", Frameless: false}]
+              Type: 671 EventRootType Probe[main.mapIndexKeyLen17]
+              InjectionPoints: [{PC: "0x4c878a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 663 EventRootType Probe[main.mapIndexKeyLen17]Return
-              InjectionPoints: [{PC: "0x4c82b9", Frameless: false}]
+              Type: 672 EventRootType Probe[main.mapIndexKeyLen17]Return
+              InjectionPoints: [{PC: "0x4c87d9", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen200
       version: 0
@@ -4939,15 +5251,15 @@ Probes:
                     - ref: m
                     - 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002a
       instances:
-        - subprogram: {subprogram: 62}
+        - subprogram: {subprogram: 64}
           events:
             - Kind: Entry
-              Type: 648 EventRootType Probe[main.mapIndexKeyLen200]
-              InjectionPoints: [{PC: "0x4c7fca", Frameless: false}]
+              Type: 657 EventRootType Probe[main.mapIndexKeyLen200]
+              InjectionPoints: [{PC: "0x4c84ea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 649 EventRootType Probe[main.mapIndexKeyLen200]Return
-              InjectionPoints: [{PC: "0x4c8019", Frameless: false}]
+              Type: 658 EventRootType Probe[main.mapIndexKeyLen200]Return
+              InjectionPoints: [{PC: "0x4c8539", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen24
       version: 0
@@ -4966,15 +5278,15 @@ Probes:
             dsl: m["00000000000000000000002a"]
             json: {index: [{ref: m}, 00000000000000000000002a]}
       instances:
-        - subprogram: {subprogram: 59}
+        - subprogram: {subprogram: 61}
           events:
             - Kind: Entry
-              Type: 642 EventRootType Probe[main.mapIndexKeyLen24]
-              InjectionPoints: [{PC: "0x4c7e4a", Frameless: false}]
+              Type: 651 EventRootType Probe[main.mapIndexKeyLen24]
+              InjectionPoints: [{PC: "0x4c836a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 643 EventRootType Probe[main.mapIndexKeyLen24]Return
-              InjectionPoints: [{PC: "0x4c7e99", Frameless: false}]
+              Type: 652 EventRootType Probe[main.mapIndexKeyLen24]Return
+              InjectionPoints: [{PC: "0x4c83b9", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen48
       version: 0
@@ -4996,15 +5308,15 @@ Probes:
                     - ref: m
                     - 00000000000000000000000000000000000000000000002a
       instances:
-        - subprogram: {subprogram: 60}
+        - subprogram: {subprogram: 62}
           events:
             - Kind: Entry
-              Type: 644 EventRootType Probe[main.mapIndexKeyLen48]
-              InjectionPoints: [{PC: "0x4c7eca", Frameless: false}]
+              Type: 653 EventRootType Probe[main.mapIndexKeyLen48]
+              InjectionPoints: [{PC: "0x4c83ea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 645 EventRootType Probe[main.mapIndexKeyLen48]Return
-              InjectionPoints: [{PC: "0x4c7f19", Frameless: false}]
+              Type: 654 EventRootType Probe[main.mapIndexKeyLen48]Return
+              InjectionPoints: [{PC: "0x4c8439", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen8
       version: 0
@@ -5023,15 +5335,15 @@ Probes:
             dsl: m["0000002a"]
             json: {index: [{ref: m}, 0000002a]}
       instances:
-        - subprogram: {subprogram: 58}
+        - subprogram: {subprogram: 60}
           events:
             - Kind: Entry
-              Type: 640 EventRootType Probe[main.mapIndexKeyLen8]
-              InjectionPoints: [{PC: "0x4c7dca", Frameless: false}]
+              Type: 649 EventRootType Probe[main.mapIndexKeyLen8]
+              InjectionPoints: [{PC: "0x4c82ea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 641 EventRootType Probe[main.mapIndexKeyLen8]Return
-              InjectionPoints: [{PC: "0x4c7e19", Frameless: false}]
+              Type: 650 EventRootType Probe[main.mapIndexKeyLen8]Return
+              InjectionPoints: [{PC: "0x4c8339", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen96
       version: 0
@@ -5053,15 +5365,15 @@ Probes:
                     - ref: m
                     - 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002a
       instances:
-        - subprogram: {subprogram: 61}
+        - subprogram: {subprogram: 63}
           events:
             - Kind: Entry
-              Type: 646 EventRootType Probe[main.mapIndexKeyLen96]
-              InjectionPoints: [{PC: "0x4c7f4a", Frameless: false}]
+              Type: 655 EventRootType Probe[main.mapIndexKeyLen96]
+              InjectionPoints: [{PC: "0x4c846a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 647 EventRootType Probe[main.mapIndexKeyLen96]Return
-              InjectionPoints: [{PC: "0x4c7f99", Frameless: false}]
+              Type: 656 EventRootType Probe[main.mapIndexKeyLen96]Return
+              InjectionPoints: [{PC: "0x4c84b9", Frameless: false}]
               Condition: null
     - id: mapIndex_largeMap_capture
       version: 0
@@ -5080,15 +5392,15 @@ Probes:
             dsl: m["key42"]
             json: {index: [{ref: m}, key42]}
       instances:
-        - subprogram: {subprogram: 56}
+        - subprogram: {subprogram: 58}
           events:
             - Kind: Entry
-              Type: 636 EventRootType Probe[main.mapIndexLargeMap]
-              InjectionPoints: [{PC: "0x4c7bca", Frameless: false}]
+              Type: 645 EventRootType Probe[main.mapIndexLargeMap]
+              InjectionPoints: [{PC: "0x4c80ea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 637 EventRootType Probe[main.mapIndexLargeMap]Return
-              InjectionPoints: [{PC: "0x4c7c19", Frameless: false}]
+              Type: 646 EventRootType Probe[main.mapIndexLargeMap]Return
+              InjectionPoints: [{PC: "0x4c8139", Frameless: false}]
               Condition: null
     - id: mapIndex_largeValue_capture
       version: 0
@@ -5107,15 +5419,15 @@ Probes:
             dsl: m["k"].Val
             json: {getmember: [{index: [{ref: m}, k]}, Val]}
       instances:
-        - subprogram: {subprogram: 71}
+        - subprogram: {subprogram: 73}
           events:
             - Kind: Entry
-              Type: 672 EventRootType Probe[main.mapIndexLargeValue]
-              InjectionPoints: [{PC: "0x4c840a", Frameless: false}]
+              Type: 681 EventRootType Probe[main.mapIndexLargeValue]
+              InjectionPoints: [{PC: "0x4c892a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 673 EventRootType Probe[main.mapIndexLargeValue]Return
-              InjectionPoints: [{PC: "0x4c8467", Frameless: false}]
+              Type: 682 EventRootType Probe[main.mapIndexLargeValue]Return
+              InjectionPoints: [{PC: "0x4c8987", Frameless: false}]
               Condition: null
     - id: mapIndex_missing_capture
       version: 0
@@ -5134,15 +5446,15 @@ Probes:
             dsl: m["missing"]
             json: {index: [{ref: m}, missing]}
       instances:
-        - subprogram: {subprogram: 57}
+        - subprogram: {subprogram: 59}
           events:
             - Kind: Entry
-              Type: 638 EventRootType Probe[main.mapIndexMissing]
-              InjectionPoints: [{PC: "0x4c7c4a", Frameless: false}]
+              Type: 647 EventRootType Probe[main.mapIndexMissing]
+              InjectionPoints: [{PC: "0x4c816a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 639 EventRootType Probe[main.mapIndexMissing]Return
-              InjectionPoints: [{PC: "0x4c7c7f", Frameless: false}]
+              Type: 648 EventRootType Probe[main.mapIndexMissing]Return
+              InjectionPoints: [{PC: "0x4c819f", Frameless: false}]
               Condition: null
     - id: mapIndex_nilPtrVal_capture
       version: 0
@@ -5161,15 +5473,15 @@ Probes:
             dsl: m["nil_key"].Val
             json: {getmember: [{index: [{ref: m}, nil_key]}, Val]}
       instances:
-        - subprogram: {subprogram: 70}
+        - subprogram: {subprogram: 72}
           events:
             - Kind: Entry
-              Type: 670 EventRootType Probe[main.mapIndexNilPtrVal]
-              InjectionPoints: [{PC: "0x4c83aa", Frameless: false}]
+              Type: 679 EventRootType Probe[main.mapIndexNilPtrVal]
+              InjectionPoints: [{PC: "0x4c88ca", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 671 EventRootType Probe[main.mapIndexNilPtrVal]Return
-              InjectionPoints: [{PC: "0x4c83df", Frameless: false}]
+              Type: 680 EventRootType Probe[main.mapIndexNilPtrVal]Return
+              InjectionPoints: [{PC: "0x4c88ff", Frameless: false}]
               Condition: null
     - id: mapIndex_ptrStructVal_capture_int
       version: 0
@@ -5188,15 +5500,15 @@ Probes:
             dsl: m["x"].Val
             json: {getmember: [{index: [{ref: m}, x]}, Val]}
       instances:
-        - subprogram: {subprogram: 64}
+        - subprogram: {subprogram: 66}
           events:
             - Kind: Entry
-              Type: 654 EventRootType Probe[main.mapIndexPtrStructVal]
-              InjectionPoints: [{PC: "0x4c80ca", Frameless: false}]
+              Type: 663 EventRootType Probe[main.mapIndexPtrStructVal]
+              InjectionPoints: [{PC: "0x4c85ea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 655 EventRootType Probe[main.mapIndexPtrStructVal]Return
-              InjectionPoints: [{PC: "0x4c812a", Frameless: false}]
+              Type: 664 EventRootType Probe[main.mapIndexPtrStructVal]Return
+              InjectionPoints: [{PC: "0x4c864a", Frameless: false}]
               Condition: null
     - id: mapIndex_ptrStructVal_capture_string
       version: 0
@@ -5215,15 +5527,15 @@ Probes:
             dsl: m["y"].Txt
             json: {getmember: [{index: [{ref: m}, "y"]}, Txt]}
       instances:
-        - subprogram: {subprogram: 64}
+        - subprogram: {subprogram: 66}
           events:
             - Kind: Entry
-              Type: 656 EventRootType Probe[main.mapIndexPtrStructVal]
-              InjectionPoints: [{PC: "0x4c80ca", Frameless: false}]
+              Type: 665 EventRootType Probe[main.mapIndexPtrStructVal]
+              InjectionPoints: [{PC: "0x4c85ea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 657 EventRootType Probe[main.mapIndexPtrStructVal]Return
-              InjectionPoints: [{PC: "0x4c812a", Frameless: false}]
+              Type: 666 EventRootType Probe[main.mapIndexPtrStructVal]Return
+              InjectionPoints: [{PC: "0x4c864a", Frameless: false}]
               Condition: null
     - id: mapIndex_stringKey_capture
       version: 0
@@ -5242,15 +5554,15 @@ Probes:
             dsl: m["beta"]
             json: {index: [{ref: m}, beta]}
       instances:
-        - subprogram: {subprogram: 55}
+        - subprogram: {subprogram: 57}
           events:
             - Kind: Entry
-              Type: 630 EventRootType Probe[main.mapIndexStringKey]
-              InjectionPoints: [{PC: "0x4c7b6a", Frameless: false}]
+              Type: 639 EventRootType Probe[main.mapIndexStringKey]
+              InjectionPoints: [{PC: "0x4c808a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 631 EventRootType Probe[main.mapIndexStringKey]Return
-              InjectionPoints: [{PC: "0x4c7b9f", Frameless: false}]
+              Type: 640 EventRootType Probe[main.mapIndexStringKey]Return
+              InjectionPoints: [{PC: "0x4c80bf", Frameless: false}]
               Condition: null
     - id: mapIndex_stringKey_cond
       version: 0
@@ -5267,16 +5579,16 @@ Probes:
       segments: [matched]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 55}
+        - subprogram: {subprogram: 57}
           events:
             - Kind: Entry
-              Type: 632 EventRootType Probe[main.mapIndexStringKey]
-              InjectionPoints: [{PC: "0x4c7b6a", Frameless: false}]
+              Type: 641 EventRootType Probe[main.mapIndexStringKey]
+              InjectionPoints: [{PC: "0x4c808a", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 55, index: 0, name: m}
+                      Variable: {subprogram: 57, index: 0, name: m}
                       Offset: 0
                       ByteSize: 8
                     - __kind: DereferenceOp
@@ -5309,8 +5621,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 633 EventRootType Probe[main.mapIndexStringKey]Return
-              InjectionPoints: [{PC: "0x4c7b9f", Frameless: false}]
+              Type: 642 EventRootType Probe[main.mapIndexStringKey]Return
+              InjectionPoints: [{PC: "0x4c80bf", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: matched, Segments: [matched]}
     - id: mapIndex_stringKey_template
@@ -5328,15 +5640,15 @@ Probes:
           dsl: m["beta"]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 55}
+        - subprogram: {subprogram: 57}
           events:
             - Kind: Entry
-              Type: 634 EventRootType Probe[main.mapIndexStringKey]
-              InjectionPoints: [{PC: "0x4c7b6a", Frameless: false}]
+              Type: 643 EventRootType Probe[main.mapIndexStringKey]
+              InjectionPoints: [{PC: "0x4c808a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 635 EventRootType Probe[main.mapIndexStringKey]Return
-              InjectionPoints: [{PC: "0x4c7b9f", Frameless: false}]
+              Type: 644 EventRootType Probe[main.mapIndexStringKey]Return
+              InjectionPoints: [{PC: "0x4c80bf", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: beta={m["beta"]}
@@ -5363,15 +5675,15 @@ Probes:
             dsl: m["a"].Val
             json: {getmember: [{index: [{ref: m}, a]}, Val]}
       instances:
-        - subprogram: {subprogram: 63}
+        - subprogram: {subprogram: 65}
           events:
             - Kind: Entry
-              Type: 650 EventRootType Probe[main.mapIndexStructVal]
-              InjectionPoints: [{PC: "0x4c804a", Frameless: false}]
+              Type: 659 EventRootType Probe[main.mapIndexStructVal]
+              InjectionPoints: [{PC: "0x4c856a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 651 EventRootType Probe[main.mapIndexStructVal]Return
-              InjectionPoints: [{PC: "0x4c80a7", Frameless: false}]
+              Type: 660 EventRootType Probe[main.mapIndexStructVal]Return
+              InjectionPoints: [{PC: "0x4c85c7", Frameless: false}]
               Condition: null
     - id: mapIndex_structVal_capture_string
       version: 0
@@ -5390,15 +5702,15 @@ Probes:
             dsl: m["b"].Txt
             json: {getmember: [{index: [{ref: m}, b]}, Txt]}
       instances:
-        - subprogram: {subprogram: 63}
+        - subprogram: {subprogram: 65}
           events:
             - Kind: Entry
-              Type: 652 EventRootType Probe[main.mapIndexStructVal]
-              InjectionPoints: [{PC: "0x4c804a", Frameless: false}]
+              Type: 661 EventRootType Probe[main.mapIndexStructVal]
+              InjectionPoints: [{PC: "0x4c856a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 653 EventRootType Probe[main.mapIndexStructVal]Return
-              InjectionPoints: [{PC: "0x4c80a7", Frameless: false}]
+              Type: 662 EventRootType Probe[main.mapIndexStructVal]Return
+              InjectionPoints: [{PC: "0x4c85c7", Frameless: false}]
               Condition: null
     - id: mapIndex_zeroValue_capture
       version: 0
@@ -5417,15 +5729,15 @@ Probes:
             dsl: m["zero"]
             json: {index: [{ref: m}, zero]}
       instances:
-        - subprogram: {subprogram: 69}
+        - subprogram: {subprogram: 71}
           events:
             - Kind: Entry
-              Type: 668 EventRootType Probe[main.mapIndexZeroValue]
-              InjectionPoints: [{PC: "0x4c834a", Frameless: false}]
+              Type: 677 EventRootType Probe[main.mapIndexZeroValue]
+              InjectionPoints: [{PC: "0x4c886a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 669 EventRootType Probe[main.mapIndexZeroValue]Return
-              InjectionPoints: [{PC: "0x4c837f", Frameless: false}]
+              Type: 678 EventRootType Probe[main.mapIndexZeroValue]Return
+              InjectionPoints: [{PC: "0x4c889f", Frameless: false}]
               Condition: null
     - id: noArgs
       version: 0
@@ -5439,11 +5751,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 383 EventRootType Probe[main.noArgs]
-              InjectionPoints: [{PC: "0x4c500a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c526a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 384 EventRootType Probe[main.noArgs]Return
-              InjectionPoints: [{PC: "0x4c5046", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c52a6", Frameless: false}]
               Condition: null
     - id: stringArg
       version: 0
@@ -5457,11 +5769,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 344 EventRootType Probe[main.stringArg]
-              InjectionPoints: [{PC: "0x4c4bca", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c4e2a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 345 EventRootType Probe[main.stringArg]Return
-              InjectionPoints: [{PC: "0x4c4c0f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c4e6f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's: {s}'
@@ -5483,11 +5795,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 376 EventRootType Probe[main.stringArrayArg]
-              InjectionPoints: [{PC: "0x4c4dca", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c502a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 377 EventRootType Probe[main.stringArrayArg]Return
-              InjectionPoints: [{PC: "0x4c4e16", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c5076", Frameless: false}]
               Condition: null
     - id: stringSliceArg
       version: 0
@@ -5501,11 +5813,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 372 EventRootType Probe[main.stringSliceArg]
-              InjectionPoints: [{PC: "0x4c4d4a", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c4faa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 373 EventRootType Probe[main.stringSliceArg]Return
-              InjectionPoints: [{PC: "0x4c4d8f", Frameless: false}]
+              InjectionPoints: [{PC: "0x4c4fef", Frameless: false}]
               Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
       version: 0
@@ -5516,39 +5828,39 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 46}
+        - subprogram: {subprogram: 48}
           events:
             - Kind: Entry
-              Type: 592 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
-              InjectionPoints: [{PC: "0x4c7356", Frameless: false}]
+              Type: 601 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+              InjectionPoints: [{PC: "0x4c7876", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 593 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
-              InjectionPoints: [{PC: "0x4c7520", Frameless: false}]
+              Type: 602 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+              InjectionPoints: [{PC: "0x4c7a40", Frameless: false}]
               Condition: null
 Subprograms:
     - ID: 1
       Name: main.intArg
-      OutOfLinePCRanges: [0x4c4b40..0x4c4ba2]
+      OutOfLinePCRanges: [0x4c4da0..0x4c4e02]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4c4b40..0x4c4b59
+            - Range: 0x4c4da0..0x4c4db9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 2
       Name: main.stringArg
-      OutOfLinePCRanges: [0x4c4bc0..0x4c4c31]
+      OutOfLinePCRanges: [0x4c4e20..0x4c4e91]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c4bc0..0x4c4bde
+            - Range: 0x4c4e20..0x4c4e3e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -5559,13 +5871,13 @@ Subprograms:
       DictRegister: null
     - ID: 3
       Name: main.intSliceArg
-      OutOfLinePCRanges: [0x4c4c40..0x4c4cba]
+      OutOfLinePCRanges: [0x4c4ea0..0x4c4f1a]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 112 GoSliceHeaderType []int
           Locations:
-            - Range: 0x4c4c40..0x4c4c5e
+            - Range: 0x4c4ea0..0x4c4ebe
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -5578,26 +5890,26 @@ Subprograms:
       DictRegister: null
     - ID: 4
       Name: main.intArrayArg
-      OutOfLinePCRanges: [0x4c4cc0..0x4c4d27]
+      OutOfLinePCRanges: [0x4c4f20..0x4c4f87]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 113 ArrayType [3]int
           Locations:
-            - Range: 0x4c4cc0..0x4c4d27
+            - Range: 0x4c4f20..0x4c4f87
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 5
       Name: main.stringSliceArg
-      OutOfLinePCRanges: [0x4c4d40..0x4c4dba]
+      OutOfLinePCRanges: [0x4c4fa0..0x4c501a]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 114 GoSliceHeaderType []string
           Locations:
-            - Range: 0x4c4d40..0x4c4d5e
+            - Range: 0x4c4fa0..0x4c4fbe
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -5610,86 +5922,86 @@ Subprograms:
       DictRegister: null
     - ID: 6
       Name: main.stringArrayArg
-      OutOfLinePCRanges: [0x4c4dc0..0x4c4e27]
+      OutOfLinePCRanges: [0x4c5020..0x4c5087]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 115 ArrayType [3]string
           Locations:
-            - Range: 0x4c4dc0..0x4c4e27
+            - Range: 0x4c5020..0x4c5087
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 7
       Name: main.stringArrayArgFrameless
-      OutOfLinePCRanges: [0x4c4e40..0x4c4e41]
+      OutOfLinePCRanges: [0x4c50a0..0x4c50a1]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 115 ArrayType [3]string
           Locations:
-            - Range: 0x4c4e40..0x4c4e41
+            - Range: 0x4c50a0..0x4c50a1
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 8
       Name: main.mapArg
-      OutOfLinePCRanges: [0x4c4f20..0x4c4f76]
+      OutOfLinePCRanges: [0x4c5180..0x4c51d6]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 116 GoMapType map[string]int
           Locations:
-            - Range: 0x4c4f20..0x4c4f4d
+            - Range: 0x4c5180..0x4c51ad
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 9
       Name: main.bigMapArg
-      OutOfLinePCRanges: [0x4c4f80..0x4c4ff6]
+      OutOfLinePCRanges: [0x4c51e0..0x4c5256]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 121 GoMapType map[string]main.bigStruct
           Locations:
-            - Range: 0x4c4f80..0x4c4fa4
+            - Range: 0x4c51e0..0x4c5204
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4c4fa4..0x4c4ff6
+            - Range: 0x4c5204..0x4c5256
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 10
       Name: main.noArgs
-      OutOfLinePCRanges: [0x4c5000..0x4c5053]
+      OutOfLinePCRanges: [0x4c5260..0x4c52b3]
       InlinePCRanges: []
       Variables: []
       DictRegister: null
     - ID: 11
       Name: main.condInt8
-      OutOfLinePCRanges: [0x4c5060..0x4c5109]
+      OutOfLinePCRanges: [0x4c52c0..0x4c5369]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 20 BaseType int8
           Locations:
-            - Range: 0x4c5060..0x4c50a3
+            - Range: 0x4c52c0..0x4c5303
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c5060..0x4c50a6
+            - Range: 0x4c52c0..0x4c5306
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c50a6..0x4c50ab
+            - Range: 0x4c5306..0x4c530b
               Pieces:
                 - Size: 8
                   Op: null
@@ -5700,32 +6012,32 @@ Subprograms:
       DictRegister: null
     - ID: 12
       Name: main.condInt16
-      OutOfLinePCRanges: [0x4c5120..0x4c51ca]
+      OutOfLinePCRanges: [0x4c5380..0x4c542a]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 108 BaseType int16
           Locations:
-            - Range: 0x4c5120..0x4c514b
+            - Range: 0x4c5380..0x4c53ab
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c5120..0x4c513d
+            - Range: 0x4c5380..0x4c539d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c513d..0x4c514b
+            - Range: 0x4c539d..0x4c53ab
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4c514b..0x4c51ca
+            - Range: 0x4c53ab..0x4c542a
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -5736,32 +6048,32 @@ Subprograms:
       DictRegister: null
     - ID: 13
       Name: main.condInt32
-      OutOfLinePCRanges: [0x4c51e0..0x4c5288]
+      OutOfLinePCRanges: [0x4c5440..0x4c54e8]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType int32
           Locations:
-            - Range: 0x4c51e0..0x4c520b
+            - Range: 0x4c5440..0x4c546b
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c51e0..0x4c51fd
+            - Range: 0x4c5440..0x4c545d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c51fd..0x4c520b
+            - Range: 0x4c545d..0x4c546b
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4c520b..0x4c5288
+            - Range: 0x4c546b..0x4c54e8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -5772,32 +6084,32 @@ Subprograms:
       DictRegister: null
     - ID: 14
       Name: main.condInt64
-      OutOfLinePCRanges: [0x4c52a0..0x4c534a]
+      OutOfLinePCRanges: [0x4c5500..0x4c55aa]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType int64
           Locations:
-            - Range: 0x4c52a0..0x4c52cb
+            - Range: 0x4c5500..0x4c552b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c52a0..0x4c52bd
+            - Range: 0x4c5500..0x4c551d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c52bd..0x4c52cb
+            - Range: 0x4c551d..0x4c552b
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4c52cb..0x4c534a
+            - Range: 0x4c552b..0x4c55aa
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -5808,26 +6120,26 @@ Subprograms:
       DictRegister: null
     - ID: 15
       Name: main.condUint8
-      OutOfLinePCRanges: [0x4c5360..0x4c5409]
+      OutOfLinePCRanges: [0x4c55c0..0x4c5669]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x4c5360..0x4c53a3
+            - Range: 0x4c55c0..0x4c5603
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c5360..0x4c53a6
+            - Range: 0x4c55c0..0x4c5606
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c53a6..0x4c53ab
+            - Range: 0x4c5606..0x4c560b
               Pieces:
                 - Size: 8
                   Op: null
@@ -5838,32 +6150,32 @@ Subprograms:
       DictRegister: null
     - ID: 16
       Name: main.condUint16
-      OutOfLinePCRanges: [0x4c5420..0x4c54ca]
+      OutOfLinePCRanges: [0x4c5680..0x4c572a]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0x4c5420..0x4c544b
+            - Range: 0x4c5680..0x4c56ab
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c5420..0x4c543d
+            - Range: 0x4c5680..0x4c569d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c543d..0x4c544b
+            - Range: 0x4c569d..0x4c56ab
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4c544b..0x4c54ca
+            - Range: 0x4c56ab..0x4c572a
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -5874,32 +6186,32 @@ Subprograms:
       DictRegister: null
     - ID: 17
       Name: main.condUint32
-      OutOfLinePCRanges: [0x4c54e0..0x4c5588]
+      OutOfLinePCRanges: [0x4c5740..0x4c57e8]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x4c54e0..0x4c550b
+            - Range: 0x4c5740..0x4c576b
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c54e0..0x4c54fd
+            - Range: 0x4c5740..0x4c575d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c54fd..0x4c550b
+            - Range: 0x4c575d..0x4c576b
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4c550b..0x4c5588
+            - Range: 0x4c576b..0x4c57e8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -5910,32 +6222,32 @@ Subprograms:
       DictRegister: null
     - ID: 18
       Name: main.condUint64
-      OutOfLinePCRanges: [0x4c55a0..0x4c564a]
+      OutOfLinePCRanges: [0x4c5800..0x4c58aa]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x4c55a0..0x4c55cb
+            - Range: 0x4c5800..0x4c582b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c55a0..0x4c55bd
+            - Range: 0x4c5800..0x4c581d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c55bd..0x4c55cb
+            - Range: 0x4c581d..0x4c582b
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4c55cb..0x4c564a
+            - Range: 0x4c582b..0x4c58aa
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -5946,32 +6258,32 @@ Subprograms:
       DictRegister: null
     - ID: 19
       Name: main.condFloat32
-      OutOfLinePCRanges: [0x4c5660..0x4c571a]
+      OutOfLinePCRanges: [0x4c58c0..0x4c597a]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType float32
           Locations:
-            - Range: 0x4c5660..0x4c5693
+            - Range: 0x4c58c0..0x4c58f3
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c5660..0x4c568e
+            - Range: 0x4c58c0..0x4c58ee
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4c568e..0x4c5693
+            - Range: 0x4c58ee..0x4c58f3
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4c5693..0x4c571a
+            - Range: 0x4c58f3..0x4c597a
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -5982,32 +6294,32 @@ Subprograms:
       DictRegister: null
     - ID: 20
       Name: main.condFloat64
-      OutOfLinePCRanges: [0x4c5720..0x4c57da]
+      OutOfLinePCRanges: [0x4c5980..0x4c5a3a]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType float64
           Locations:
-            - Range: 0x4c5720..0x4c5754
+            - Range: 0x4c5980..0x4c59b4
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c5720..0x4c574f
+            - Range: 0x4c5980..0x4c59af
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4c574f..0x4c5754
+            - Range: 0x4c59af..0x4c59b4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4c5754..0x4c57da
+            - Range: 0x4c59b4..0x4c5a3a
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -6018,26 +6330,26 @@ Subprograms:
       DictRegister: null
     - ID: 21
       Name: main.condBool
-      OutOfLinePCRanges: [0x4c57e0..0x4c5889]
+      OutOfLinePCRanges: [0x4c5a40..0x4c5ae9]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x4c57e0..0x4c5823
+            - Range: 0x4c5a40..0x4c5a83
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c57e0..0x4c5826
+            - Range: 0x4c5a40..0x4c5a86
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c5826..0x4c582b
+            - Range: 0x4c5a86..0x4c5a8b
               Pieces:
                 - Size: 8
                   Op: null
@@ -6048,13 +6360,13 @@ Subprograms:
       DictRegister: null
     - ID: 22
       Name: main.condString
-      OutOfLinePCRanges: [0x4c58a0..0x4c595e]
+      OutOfLinePCRanges: [0x4c5b00..0x4c5bbe]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c58a0..0x4c58d4
+            - Range: 0x4c5b00..0x4c5b34
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6065,19 +6377,19 @@ Subprograms:
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c58a0..0x4c58c6
+            - Range: 0x4c5b00..0x4c5b26
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x4c58c6..0x4c58d4
+            - Range: 0x4c5b26..0x4c5b34
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0x4c58d4..0x4c595e
+            - Range: 0x4c5b34..0x4c5bbe
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -6088,32 +6400,32 @@ Subprograms:
       DictRegister: null
     - ID: 23
       Name: main.condStructArg
-      OutOfLinePCRanges: [0x4c5960..0x4c5a94]
+      OutOfLinePCRanges: [0x4c5bc0..0x4c5cf4]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 126 StructureType main.condFields
           Locations:
-            - Range: 0x4c5960..0x4c5a94
+            - Range: 0x4c5bc0..0x4c5cf4
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c5960..0x4c59a6
+            - Range: 0x4c5bc0..0x4c5c06
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4c59a6..0x4c59ab
+            - Range: 0x4c5c06..0x4c5c0b
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
                 - Size: 8
                   Op: {CfaOffset: 88}
-            - Range: 0x4c59ab..0x4c5a94
+            - Range: 0x4c5c0b..0x4c5cf4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
@@ -6124,34 +6436,34 @@ Subprograms:
       DictRegister: null
     - ID: 24
       Name: main.condPtrStructArg
-      OutOfLinePCRanges: [0x4c5aa0..0x4c5be5]
+      OutOfLinePCRanges: [0x4c5d00..0x4c5e45]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 128 PointerType *main.condFields
           Locations:
-            - Range: 0x4c5aa0..0x4c5aea
+            - Range: 0x4c5d00..0x4c5d4a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4c5aea..0x4c5be5
+            - Range: 0x4c5d4a..0x4c5e45
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c5aa0..0x4c5acf
+            - Range: 0x4c5d00..0x4c5d2f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c5acf..0x4c5aef
+            - Range: 0x4c5d2f..0x4c5d4f
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4c5aef..0x4c5be5
+            - Range: 0x4c5d4f..0x4c5e45
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -6162,26 +6474,26 @@ Subprograms:
       DictRegister: null
     - ID: 25
       Name: main.condNilPtrStruct
-      OutOfLinePCRanges: [0x4c5c00..0x4c5cbd]
+      OutOfLinePCRanges: [0x4c5e60..0x4c5f1d]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 128 PointerType *main.condFields
           Locations:
-            - Range: 0x4c5c00..0x4c5c56
+            - Range: 0x4c5e60..0x4c5eb6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c5c00..0x4c5c59
+            - Range: 0x4c5e60..0x4c5eb9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c5c59..0x4c5c5e
+            - Range: 0x4c5eb9..0x4c5ebe
               Pieces:
                 - Size: 8
                   Op: null
@@ -6192,72 +6504,72 @@ Subprograms:
       DictRegister: null
     - ID: 26
       Name: main.condReturnAndLocal
-      OutOfLinePCRanges: [0x4c5cc0..0x4c5d5f]
+      OutOfLinePCRanges: [0x4c5f20..0x4c5fbf]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4c5cc0..0x4c5cd1
+            - Range: 0x4c5f20..0x4c5f31
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4c5cc0..0x4c5d05
+            - Range: 0x4c5f20..0x4c5f65
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4c5cc0..0x4c5d3b
+            - Range: 0x4c5f20..0x4c5f9b
               Pieces: []
-            - Range: 0x4c5d3b..0x4c5d3c
+            - Range: 0x4c5f9b..0x4c5f9c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4c5d3c..0x4c5d5f
+            - Range: 0x4c5f9c..0x4c5fbf
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: sum
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4c5cd1..0x4c5d05
+            - Range: 0x4c5f31..0x4c5f65
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4c5d05..0x4c5d5f
+            - Range: 0x4c5f65..0x4c5fbf
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 27
       Name: main.condOnly
-      OutOfLinePCRanges: [0x4c5d60..0x4c5e0a]
+      OutOfLinePCRanges: [0x4c5fc0..0x4c606a]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4c5d60..0x4c5d8b
+            - Range: 0x4c5fc0..0x4c5feb
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c5d60..0x4c5d7d
+            - Range: 0x4c5fc0..0x4c5fdd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c5d7d..0x4c5d8b
+            - Range: 0x4c5fdd..0x4c5feb
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4c5d8b..0x4c5e0a
+            - Range: 0x4c5feb..0x4c606a
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -6268,34 +6580,34 @@ Subprograms:
       DictRegister: null
     - ID: 28
       Name: main.condLine
-      OutOfLinePCRanges: [0x4c5e20..0x4c5ef9]
+      OutOfLinePCRanges: [0x4c6080..0x4c6159]
       InlinePCRanges: []
       Variables:
         - Name: "n"
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4c5e20..0x4c5e44
+            - Range: 0x4c6080..0x4c60a4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4c5e44..0x4c5ef9
+            - Range: 0x4c60a4..0x4c6159
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c5e20..0x4c5e49
+            - Range: 0x4c6080..0x4c60a9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c5e49..0x4c5e5c
+            - Range: 0x4c60a9..0x4c60bc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4c5e5c..0x4c5ef9
+            - Range: 0x4c60bc..0x4c6159
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -6306,20 +6618,122 @@ Subprograms:
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4c5e44..0x4c5e5c
+            - Range: 0x4c60a4..0x4c60bc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 29
+      Name: main.condLineMixed
+      OutOfLinePCRanges: [0x4c6160..0x4c6393]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4c6160..0x4c61e0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x4c61e0..0x4c61e5
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 80}
+                - Size: 8
+                  Op: {CfaOffset: 88}
+            - Range: 0x4c61e5..0x4c6393
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 80}
+                - Size: 8
+                  Op: {CfaOffset: 88}
+          Role: Parameter
+          DictIndex: -1
+        - Name: b
+          Type: 4 BaseType bool
+          Locations:
+            - Range: 0x4c6160..0x4c61b6
+              Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0x4c61b6..0x4c6393
+              Pieces: [{Size: 1, Op: {CfaOffset: 96}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: x
+          Type: 126 StructureType main.condFields
+          Locations:
+            - Range: 0x4c6160..0x4c6393
+              Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: p
+          Type: 128 PointerType *main.condFields
+          Locations:
+            - Range: 0x4c6160..0x4c61e5
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+            - Range: 0x4c61e5..0x4c6393
+              Pieces: [{Size: 8, Op: {CfaOffset: 104}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: ss
+          Type: 112 GoSliceHeaderType []int
+          Locations:
+            - Range: 0x4c6160..0x4c61e5
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+            - Range: 0x4c61e5..0x4c6393
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 112}
+                - Size: 8
+                  Op: {CfaOffset: 120}
+                - Size: 8
+                  Op: {CfaOffset: 128}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 30
+      Name: main.condLineReturn
+      OutOfLinePCRanges: [0x4c63a0..0x4c6412]
+      InlinePCRanges: []
+      Variables:
+        - Name: "n"
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x4c63a0..0x4c63b1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations: [{Range: 0x4c63a0..0x4c6412, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: doubled
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x4c63b1..0x4c63c5
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4c63c5..0x4c6412
+              Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
+          Role: Local
+          DictIndex: -1
+      DictRegister: null
+    - ID: 31
       Name: main.condSliceArg
-      OutOfLinePCRanges: [0x4c5f00..0x4c5fc7]
+      OutOfLinePCRanges: [0x4c6420..0x4c64e7]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 112 GoSliceHeaderType []int
           Locations:
-            - Range: 0x4c5f00..0x4c5f34
+            - Range: 0x4c6420..0x4c6454
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6332,13 +6746,13 @@ Subprograms:
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c5f00..0x4c5f34
+            - Range: 0x4c6420..0x4c6454
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
-            - Range: 0x4c5f34..0x4c5fc7
+            - Range: 0x4c6454..0x4c64e7
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
@@ -6347,28 +6761,28 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 30
+    - ID: 32
       Name: main.condMapArg
-      OutOfLinePCRanges: [0x4c5fe0..0x4c607c]
+      OutOfLinePCRanges: [0x4c6500..0x4c659c]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 116 GoMapType map[string]int
           Locations:
-            - Range: 0x4c5fe0..0x4c6015
+            - Range: 0x4c6500..0x4c6535
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c5fe0..0x4c6018
+            - Range: 0x4c6500..0x4c6538
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c6018..0x4c601d
+            - Range: 0x4c6538..0x4c653d
               Pieces:
                 - Size: 8
                   Op: null
@@ -6377,237 +6791,49 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 31
+    - ID: 33
       Name: main.condStructDirect
-      OutOfLinePCRanges: [0x4c6080..0x4c6145]
+      OutOfLinePCRanges: [0x4c65a0..0x4c6665]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 126 StructureType main.condFields
           Locations:
-            - Range: 0x4c6080..0x4c6145
+            - Range: 0x4c65a0..0x4c6665
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c6080..0x4c60b7
+            - Range: 0x4c65a0..0x4c65d7
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4c60b7..0x4c60bc
+            - Range: 0x4c65d7..0x4c65dc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
                 - Size: 8
                   Op: {CfaOffset: 88}
-            - Range: 0x4c60bc..0x4c6145
+            - Range: 0x4c65dc..0x4c6665
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
                 - Size: 8
                   Op: {CfaOffset: 88}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 32
-      Name: main.condNullPtr
-      OutOfLinePCRanges: [0x4c6160..0x4c6269]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 104 PointerType *int
-          Locations:
-            - Range: 0x4c6160..0x4c61c0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4c61c0..0x4c6269
-              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x4c6160..0x4c61c5
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c61c5..0x4c61c8
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-            - Range: 0x4c61c8..0x4c6269
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 33
-      Name: main.condNullSlice
-      OutOfLinePCRanges: [0x4c6280..0x4c63ea]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 112 GoSliceHeaderType []int
-          Locations:
-            - Range: 0x4c6280..0x4c6312
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c6312..0x4c6317
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 0}
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-            - Range: 0x4c6317..0x4c631a
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 0}
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-            - Range: 0x4c631a..0x4c63ea
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 0}
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x4c6280..0x4c631f
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-            - Range: 0x4c631f..0x4c63ea
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 24}
-                - Size: 8
-                  Op: {CfaOffset: 32}
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 34
-      Name: main.condNullMap
-      OutOfLinePCRanges: [0x4c6400..0x4c6509]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 116 GoMapType map[string]int
-          Locations:
-            - Range: 0x4c6400..0x4c6460
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4c6460..0x4c6509
-              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x4c6400..0x4c6465
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c6465..0x4c6468
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-            - Range: 0x4c6468..0x4c6509
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 35
-      Name: main.condNullIface
-      OutOfLinePCRanges: [0x4c6520..0x4c666e]
-      InlinePCRanges: []
-      Variables:
-        - Name: i
-          Type: 15 GoInterfaceType error
-          Locations:
-            - Range: 0x4c6520..0x4c65ab
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4c65ab..0x4c65b0
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 0}
-                - Size: 8
-                  Op: {CfaOffset: 8}
-            - Range: 0x4c65b0..0x4c666e
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 0}
-                - Size: 8
-                  Op: {CfaOffset: 8}
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x4c6520..0x4c65b3
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-            - Range: 0x4c65b3..0x4c65b8
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 16}
-                - Size: 8
-                  Op: {CfaOffset: 24}
-            - Range: 0x4c65b8..0x4c666e
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 16}
-                - Size: 8
-                  Op: {CfaOffset: 24}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 36
-      Name: main.condNullUnsafePtr
+      Name: main.condNullPtr
       OutOfLinePCRanges: [0x4c6680..0x4c6789]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 16 VoidPointerType unsafe.Pointer
+          Type: 104 PointerType *int
           Locations:
             - Range: 0x4c6680..0x4c66e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -6639,42 +6865,148 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 37
-      Name: main.lenString
-      OutOfLinePCRanges: [0x4c67c0..0x4c68f7]
+    - ID: 35
+      Name: main.condNullSlice
+      OutOfLinePCRanges: [0x4c67a0..0x4c690a]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 9 GoStringHeaderType string
+          Type: 112 GoSliceHeaderType []int
           Locations:
-            - Range: 0x4c67c0..0x4c683b
+            - Range: 0x4c67a0..0x4c6832
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4c683b..0x4c6840
-              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x4c6840..0x4c68f7
-              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4c6832..0x4c6837
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 0}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x4c6837..0x4c683a
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 0}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x4c683a..0x4c690a
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 0}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c67c0..0x4c6843
+            - Range: 0x4c67a0..0x4c683f
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+            - Range: 0x4c683f..0x4c690a
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 24}
+                - Size: 8
+                  Op: {CfaOffset: 32}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 36
+      Name: main.condNullMap
+      OutOfLinePCRanges: [0x4c6920..0x4c6a29]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 116 GoMapType map[string]int
+          Locations:
+            - Range: 0x4c6920..0x4c6980
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4c6980..0x4c6a29
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4c6920..0x4c6985
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4c6985..0x4c6988
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x4c6988..0x4c6a29
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 37
+      Name: main.condNullIface
+      OutOfLinePCRanges: [0x4c6a40..0x4c6b8e]
+      InlinePCRanges: []
+      Variables:
+        - Name: i
+          Type: 15 GoInterfaceType error
+          Locations:
+            - Range: 0x4c6a40..0x4c6acb
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x4c6acb..0x4c6ad0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 0}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+            - Range: 0x4c6ad0..0x4c6b8e
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 0}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4c6a40..0x4c6ad3
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x4c6843..0x4c6848
+            - Range: 0x4c6ad3..0x4c6ad8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0x4c6848..0x4c68f7
+            - Range: 0x4c6ad8..0x4c6b8e
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -6684,14 +7016,96 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 38
+      Name: main.condNullUnsafePtr
+      OutOfLinePCRanges: [0x4c6ba0..0x4c6ca9]
+      InlinePCRanges: []
+      Variables:
+        - Name: p
+          Type: 16 VoidPointerType unsafe.Pointer
+          Locations:
+            - Range: 0x4c6ba0..0x4c6c00
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4c6c00..0x4c6ca9
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4c6ba0..0x4c6c05
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4c6c05..0x4c6c08
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x4c6c08..0x4c6ca9
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 39
+      Name: main.lenString
+      OutOfLinePCRanges: [0x4c6ce0..0x4c6e17]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4c6ce0..0x4c6d5b
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x4c6d5b..0x4c6d60
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
+            - Range: 0x4c6d60..0x4c6e17
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4c6ce0..0x4c6d63
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+            - Range: 0x4c6d63..0x4c6d68
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0x4c6d68..0x4c6e17
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 40
       Name: main.lenSlice
-      OutOfLinePCRanges: [0x4c6900..0x4c6a4e]
+      OutOfLinePCRanges: [0x4c6e20..0x4c6f6e]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 112 GoSliceHeaderType []int
           Locations:
-            - Range: 0x4c6900..0x4c698a
+            - Range: 0x4c6e20..0x4c6eaa
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6699,7 +7113,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c698a..0x4c698f
+            - Range: 0x4c6eaa..0x4c6eaf
               Pieces:
                 - Size: 8
                   Op: null
@@ -6707,7 +7121,7 @@ Subprograms:
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c698f..0x4c6992
+            - Range: 0x4c6eaf..0x4c6eb2
               Pieces:
                 - Size: 8
                   Op: null
@@ -6715,7 +7129,7 @@ Subprograms:
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c6992..0x4c6a4e
+            - Range: 0x4c6eb2..0x4c6f6e
               Pieces:
                 - Size: 8
                   Op: null
@@ -6728,13 +7142,13 @@ Subprograms:
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c6900..0x4c6997
+            - Range: 0x4c6e20..0x4c6eb7
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
-            - Range: 0x4c6997..0x4c6a4e
+            - Range: 0x4c6eb7..0x4c6f6e
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
@@ -6743,36 +7157,36 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 39
+    - ID: 41
       Name: main.lenMap
-      OutOfLinePCRanges: [0x4c6a60..0x4c6b7c]
+      OutOfLinePCRanges: [0x4c6f80..0x4c709c]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 116 GoMapType map[string]int
           Locations:
-            - Range: 0x4c6a60..0x4c6ac0
+            - Range: 0x4c6f80..0x4c6fe0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4c6ac0..0x4c6b7c
+            - Range: 0x4c6fe0..0x4c709c
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c6a60..0x4c6ac5
+            - Range: 0x4c6f80..0x4c6fe5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c6ac5..0x4c6ac8
+            - Range: 0x4c6fe5..0x4c6fe8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4c6ac8..0x4c6b7c
+            - Range: 0x4c6fe8..0x4c709c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -6781,110 +7195,36 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 40
+    - ID: 42
       Name: main.lenPtrString
-      OutOfLinePCRanges: [0x4c6b80..0x4c6c89]
+      OutOfLinePCRanges: [0x4c70a0..0x4c71a9]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 101 PointerType *string
           Locations:
-            - Range: 0x4c6b80..0x4c6be0
+            - Range: 0x4c70a0..0x4c7100
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4c6be0..0x4c6c89
+            - Range: 0x4c7100..0x4c71a9
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c6b80..0x4c6be5
+            - Range: 0x4c70a0..0x4c7105
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c6be5..0x4c6be8
+            - Range: 0x4c7105..0x4c7108
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4c6be8..0x4c6c89
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 41
-      Name: main.lenStructFields
-      OutOfLinePCRanges: [0x4c6ca0..0x4c6e65]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 129 StructureType main.lenFields
-          Locations:
-            - Range: 0x4c6ca0..0x4c6e65
-              Pieces: [{Size: 72, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x4c6ca0..0x4c6d55
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4c6d55..0x4c6d5a
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 72}
-                - Size: 8
-                  Op: {CfaOffset: 80}
-            - Range: 0x4c6d5a..0x4c6e65
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 72}
-                - Size: 8
-                  Op: {CfaOffset: 80}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 42
-      Name: main.lenPtrStructFields
-      OutOfLinePCRanges: [0x4c6e80..0x4c6ffc]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 131 PointerType *main.lenFields
-          Locations:
-            - Range: 0x4c6e80..0x4c6ef1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4c6ef1..0x4c6ffc
-              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x4c6e80..0x4c6ef6
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c6ef6..0x4c6ef9
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-            - Range: 0x4c6ef9..0x4c6ffc
+            - Range: 0x4c7108..0x4c71a9
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -6894,35 +7234,71 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 43
-      Name: main.lenErrInt
-      OutOfLinePCRanges: [0x4c7000..0x4c711c]
+      Name: main.lenStructFields
+      OutOfLinePCRanges: [0x4c71c0..0x4c7385]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 7 BaseType int
+          Type: 129 StructureType main.lenFields
           Locations:
-            - Range: 0x4c7000..0x4c706f
+            - Range: 0x4c71c0..0x4c7385
+              Pieces: [{Size: 72, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4c71c0..0x4c7275
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x4c7275..0x4c727a
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 72}
+                - Size: 8
+                  Op: {CfaOffset: 80}
+            - Range: 0x4c727a..0x4c7385
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 72}
+                - Size: 8
+                  Op: {CfaOffset: 80}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 44
+      Name: main.lenPtrStructFields
+      OutOfLinePCRanges: [0x4c73a0..0x4c751c]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 131 PointerType *main.lenFields
+          Locations:
+            - Range: 0x4c73a0..0x4c7411
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4c706f..0x4c711c
+            - Range: 0x4c7411..0x4c751c
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c7000..0x4c7074
+            - Range: 0x4c73a0..0x4c7416
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c7074..0x4c7077
+            - Range: 0x4c7416..0x4c7419
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4c7077..0x4c711c
+            - Range: 0x4c7419..0x4c751c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -6931,34 +7307,72 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 44
+    - ID: 45
+      Name: main.lenErrInt
+      OutOfLinePCRanges: [0x4c7520..0x4c763c]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x4c7520..0x4c758f
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4c758f..0x4c763c
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4c7520..0x4c7594
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4c7594..0x4c7597
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x4c7597..0x4c763c
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 46
       Name: main.lenErrStruct
-      OutOfLinePCRanges: [0x4c7120..0x4c7276]
+      OutOfLinePCRanges: [0x4c7640..0x4c7796]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 126 StructureType main.condFields
           Locations:
-            - Range: 0x4c7120..0x4c7276
+            - Range: 0x4c7640..0x4c7796
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c7120..0x4c71c9
+            - Range: 0x4c7640..0x4c76e9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4c71c9..0x4c71ce
+            - Range: 0x4c76e9..0x4c76ee
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
                 - Size: 8
                   Op: {CfaOffset: 88}
-            - Range: 0x4c71ce..0x4c7276
+            - Range: 0x4c76ee..0x4c7796
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
@@ -6967,28 +7381,28 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 45
+    - ID: 47
       Name: main.indexNilPtrSlice
-      OutOfLinePCRanges: [0x4c7280..0x4c733d]
+      OutOfLinePCRanges: [0x4c77a0..0x4c785d]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 131 PointerType *main.lenFields
           Locations:
-            - Range: 0x4c7280..0x4c72d6
+            - Range: 0x4c77a0..0x4c77f6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c7280..0x4c72d9
+            - Range: 0x4c77a0..0x4c77f9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c72d9..0x4c72de
+            - Range: 0x4c77f9..0x4c77fe
               Pieces:
                 - Size: 8
                   Op: null
@@ -6997,60 +7411,60 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 46
+    - ID: 48
       Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
-      OutOfLinePCRanges: [0x4c7340..0x4c7533]
+      OutOfLinePCRanges: [0x4c7860..0x4c7a53]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 132 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
           Locations:
-            - Range: 0x4c7340..0x4c7520
+            - Range: 0x4c7860..0x4c7a40
               Pieces: []
-            - Range: 0x4c7520..0x4c7521
+            - Range: 0x4c7a40..0x4c7a41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4c7521..0x4c7533
+            - Range: 0x4c7a41..0x4c7a53
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 47
+    - ID: 49
       Name: main.bigArrayArg
-      OutOfLinePCRanges: [0x4c7540..0x4c75ca]
+      OutOfLinePCRanges: [0x4c7a60..0x4c7aea]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 137 ArrayType [131072]int64
           Locations:
-            - Range: 0x4c7540..0x4c75ca
+            - Range: 0x4c7a60..0x4c7aea
               Pieces: [{Size: 1048576, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 48
+    - ID: 50
       Name: main.bigArrayStructArg
-      OutOfLinePCRanges: [0x4c75e0..0x4c7673]
+      OutOfLinePCRanges: [0x4c7b00..0x4c7b93]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 138 PointerType *main.bigArrayStruct
           Locations:
-            - Range: 0x4c75e0..0x4c7605
+            - Range: 0x4c7b00..0x4c7b25
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4c7605..0x4c7673
+            - Range: 0x4c7b25..0x4c7b93
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 49
+    - ID: 51
       Name: main.structSliceArg
-      OutOfLinePCRanges: [0x4c7680..0x4c7765]
+      OutOfLinePCRanges: [0x4c7ba0..0x4c7c85]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 140 GoSliceHeaderType []main.indexMemberStruct
           Locations:
-            - Range: 0x4c7680..0x4c76a1
+            - Range: 0x4c7ba0..0x4c7bc1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7058,7 +7472,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c76a1..0x4c76bb
+            - Range: 0x4c7bc1..0x4c7bdb
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7066,7 +7480,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x4c76bb..0x4c76c5
+            - Range: 0x4c7bdb..0x4c7be5
               Pieces:
                 - Size: 8
                   Op: null
@@ -7079,113 +7493,19 @@ Subprograms:
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c7680..0x4c76c5
+            - Range: 0x4c7ba0..0x4c7be5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
-            - Range: 0x4c76c5..0x4c771c
+            - Range: 0x4c7be5..0x4c7c3c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: {CfaOffset: 32}
-            - Range: 0x4c771c..0x4c7765
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 50
-      Name: main.structArrayArg
-      OutOfLinePCRanges: [0x4c7780..0x4c7834]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 143 ArrayType [2]main.indexMemberStruct
-          Locations:
-            - Range: 0x4c7780..0x4c7834
-              Pieces: [{Size: 64, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x4c7780..0x4c77b4
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4c77b4..0x4c77b9
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 64}
-                - Size: 8
-                  Op: {CfaOffset: 72}
-            - Range: 0x4c77b9..0x4c7834
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 64}
-                - Size: 8
-                  Op: {CfaOffset: 72}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 51
-      Name: main.ptrStructSliceArg
-      OutOfLinePCRanges: [0x4c7840..0x4c7925]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 144 GoSliceHeaderType []*main.indexMemberStruct
-          Locations:
-            - Range: 0x4c7840..0x4c7861
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c7861..0x4c787e
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: null
-            - Range: 0x4c787e..0x4c7885
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: null
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x4c7840..0x4c7885
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-            - Range: 0x4c7885..0x4c78dc
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 24}
-                - Size: 8
-                  Op: {CfaOffset: 32}
-            - Range: 0x4c78dc..0x4c7925
+            - Range: 0x4c7c3c..0x4c7c85
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -7195,33 +7515,127 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 52
+      Name: main.structArrayArg
+      OutOfLinePCRanges: [0x4c7ca0..0x4c7d54]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 143 ArrayType [2]main.indexMemberStruct
+          Locations:
+            - Range: 0x4c7ca0..0x4c7d54
+              Pieces: [{Size: 64, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4c7ca0..0x4c7cd4
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x4c7cd4..0x4c7cd9
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 64}
+                - Size: 8
+                  Op: {CfaOffset: 72}
+            - Range: 0x4c7cd9..0x4c7d54
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 64}
+                - Size: 8
+                  Op: {CfaOffset: 72}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 53
+      Name: main.ptrStructSliceArg
+      OutOfLinePCRanges: [0x4c7d60..0x4c7e45]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 144 GoSliceHeaderType []*main.indexMemberStruct
+          Locations:
+            - Range: 0x4c7d60..0x4c7d81
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4c7d81..0x4c7d9e
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: null
+            - Range: 0x4c7d9e..0x4c7da5
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: null
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4c7d60..0x4c7da5
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+            - Range: 0x4c7da5..0x4c7dfc
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 24}
+                - Size: 8
+                  Op: {CfaOffset: 32}
+            - Range: 0x4c7dfc..0x4c7e45
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 54
       Name: main.ptrStructArrayArg
-      OutOfLinePCRanges: [0x4c7940..0x4c79eb]
+      OutOfLinePCRanges: [0x4c7e60..0x4c7f0b]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 146 ArrayType [2]*main.indexMemberStruct
           Locations:
-            - Range: 0x4c7940..0x4c79eb
+            - Range: 0x4c7e60..0x4c7f0b
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c7940..0x4c7971
+            - Range: 0x4c7e60..0x4c7e91
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4c7971..0x4c7976
+            - Range: 0x4c7e91..0x4c7e96
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0x4c7976..0x4c79eb
+            - Range: 0x4c7e96..0x4c7f0b
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -7230,36 +7644,36 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 53
+    - ID: 55
       Name: main.indexMemberWrapperArg
-      OutOfLinePCRanges: [0x4c7a00..0x4c7ae5]
+      OutOfLinePCRanges: [0x4c7f20..0x4c8005]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 147 PointerType *main.indexMemberWrapper
           Locations:
-            - Range: 0x4c7a00..0x4c7a39
+            - Range: 0x4c7f20..0x4c7f59
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4c7a39..0x4c7ae5
+            - Range: 0x4c7f59..0x4c8005
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c7a00..0x4c7a26
+            - Range: 0x4c7f20..0x4c7f46
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c7a26..0x4c7a3e
+            - Range: 0x4c7f46..0x4c7f5e
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4c7a3e..0x4c7ae5
+            - Range: 0x4c7f5e..0x4c8005
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -7268,261 +7682,261 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 54
+    - ID: 56
       Name: main.mapIndexIntKey
-      OutOfLinePCRanges: [0x4c7b00..0x4c7b56]
+      OutOfLinePCRanges: [0x4c8020..0x4c8076]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 149 GoMapType map[int]string
           Locations:
-            - Range: 0x4c7b00..0x4c7b2d
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 55
-      Name: main.mapIndexStringKey
-      OutOfLinePCRanges: [0x4c7b60..0x4c7bb6]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 116 GoMapType map[string]int
-          Locations:
-            - Range: 0x4c7b60..0x4c7b8d
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 56
-      Name: main.mapIndexLargeMap
-      OutOfLinePCRanges: [0x4c7bc0..0x4c7c30]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 116 GoMapType map[string]int
-          Locations:
-            - Range: 0x4c7bc0..0x4c7be3
+            - Range: 0x4c8020..0x4c804d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 57
-      Name: main.mapIndexMissing
-      OutOfLinePCRanges: [0x4c7c40..0x4c7c96]
+      Name: main.mapIndexStringKey
+      OutOfLinePCRanges: [0x4c8080..0x4c80d6]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 116 GoMapType map[string]int
           Locations:
-            - Range: 0x4c7c40..0x4c7c6d
+            - Range: 0x4c8080..0x4c80ad
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 58
-      Name: main.mapIndexKeyLen8
-      OutOfLinePCRanges: [0x4c7dc0..0x4c7e30]
+      Name: main.mapIndexLargeMap
+      OutOfLinePCRanges: [0x4c80e0..0x4c8150]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 116 GoMapType map[string]int
           Locations:
-            - Range: 0x4c7dc0..0x4c7de3
+            - Range: 0x4c80e0..0x4c8103
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 59
-      Name: main.mapIndexKeyLen24
-      OutOfLinePCRanges: [0x4c7e40..0x4c7eb0]
+      Name: main.mapIndexMissing
+      OutOfLinePCRanges: [0x4c8160..0x4c81b6]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 116 GoMapType map[string]int
           Locations:
-            - Range: 0x4c7e40..0x4c7e63
+            - Range: 0x4c8160..0x4c818d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 60
-      Name: main.mapIndexKeyLen48
-      OutOfLinePCRanges: [0x4c7ec0..0x4c7f30]
+      Name: main.mapIndexKeyLen8
+      OutOfLinePCRanges: [0x4c82e0..0x4c8350]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 116 GoMapType map[string]int
           Locations:
-            - Range: 0x4c7ec0..0x4c7ee3
+            - Range: 0x4c82e0..0x4c8303
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 61
-      Name: main.mapIndexKeyLen96
-      OutOfLinePCRanges: [0x4c7f40..0x4c7fb0]
+      Name: main.mapIndexKeyLen24
+      OutOfLinePCRanges: [0x4c8360..0x4c83d0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 116 GoMapType map[string]int
           Locations:
-            - Range: 0x4c7f40..0x4c7f63
+            - Range: 0x4c8360..0x4c8383
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 62
-      Name: main.mapIndexKeyLen200
-      OutOfLinePCRanges: [0x4c7fc0..0x4c8030]
+      Name: main.mapIndexKeyLen48
+      OutOfLinePCRanges: [0x4c83e0..0x4c8450]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 116 GoMapType map[string]int
           Locations:
-            - Range: 0x4c7fc0..0x4c7fe3
+            - Range: 0x4c83e0..0x4c8403
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 63
-      Name: main.mapIndexStructVal
-      OutOfLinePCRanges: [0x4c8040..0x4c80be]
+      Name: main.mapIndexKeyLen96
+      OutOfLinePCRanges: [0x4c8460..0x4c84d0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 154 GoMapType map[string]main.indexMemberStruct
+          Type: 116 GoMapType map[string]int
           Locations:
-            - Range: 0x4c8040..0x4c806a
+            - Range: 0x4c8460..0x4c8483
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 64
-      Name: main.mapIndexPtrStructVal
-      OutOfLinePCRanges: [0x4c80c0..0x4c8145]
+      Name: main.mapIndexKeyLen200
+      OutOfLinePCRanges: [0x4c84e0..0x4c8550]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 159 GoMapType map[string]*main.indexMemberStruct
+          Type: 116 GoMapType map[string]int
           Locations:
-            - Range: 0x4c80c0..0x4c80ea
+            - Range: 0x4c84e0..0x4c8503
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 65
-      Name: main.mapIndexEmptyKey
-      OutOfLinePCRanges: [0x4c8160..0x4c81dc]
+      Name: main.mapIndexStructVal
+      OutOfLinePCRanges: [0x4c8560..0x4c85de]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 116 GoMapType map[string]int
+          Type: 154 GoMapType map[string]main.indexMemberStruct
           Locations:
-            - Range: 0x4c8160..0x4c8182
+            - Range: 0x4c8560..0x4c858a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 66
-      Name: main.mapIndexKeyLen16
-      OutOfLinePCRanges: [0x4c81e0..0x4c8250]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 116 GoMapType map[string]int
-          Locations:
-            - Range: 0x4c81e0..0x4c8203
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 67
-      Name: main.mapIndexKeyLen17
-      OutOfLinePCRanges: [0x4c8260..0x4c82d0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 116 GoMapType map[string]int
-          Locations:
-            - Range: 0x4c8260..0x4c8283
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 68
-      Name: main.mapIndexBoolKey
-      OutOfLinePCRanges: [0x4c82e0..0x4c8336]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 164 GoMapType map[bool]int
-          Locations:
-            - Range: 0x4c82e0..0x4c830d
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 69
-      Name: main.mapIndexZeroValue
-      OutOfLinePCRanges: [0x4c8340..0x4c8396]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 116 GoMapType map[string]int
-          Locations:
-            - Range: 0x4c8340..0x4c836d
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 70
-      Name: main.mapIndexNilPtrVal
-      OutOfLinePCRanges: [0x4c83a0..0x4c83f6]
+      Name: main.mapIndexPtrStructVal
+      OutOfLinePCRanges: [0x4c85e0..0x4c8665]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 159 GoMapType map[string]*main.indexMemberStruct
           Locations:
-            - Range: 0x4c83a0..0x4c83cd
+            - Range: 0x4c85e0..0x4c860a
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 67
+      Name: main.mapIndexEmptyKey
+      OutOfLinePCRanges: [0x4c8680..0x4c86fc]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 116 GoMapType map[string]int
+          Locations:
+            - Range: 0x4c8680..0x4c86a2
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 68
+      Name: main.mapIndexKeyLen16
+      OutOfLinePCRanges: [0x4c8700..0x4c8770]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 116 GoMapType map[string]int
+          Locations:
+            - Range: 0x4c8700..0x4c8723
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 69
+      Name: main.mapIndexKeyLen17
+      OutOfLinePCRanges: [0x4c8780..0x4c87f0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 116 GoMapType map[string]int
+          Locations:
+            - Range: 0x4c8780..0x4c87a3
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 70
+      Name: main.mapIndexBoolKey
+      OutOfLinePCRanges: [0x4c8800..0x4c8856]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 164 GoMapType map[bool]int
+          Locations:
+            - Range: 0x4c8800..0x4c882d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 71
-      Name: main.mapIndexLargeValue
-      OutOfLinePCRanges: [0x4c8400..0x4c847e]
+      Name: main.mapIndexZeroValue
+      OutOfLinePCRanges: [0x4c8860..0x4c88b6]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 169 GoMapType map[string]main.largeValueStruct
+          Type: 116 GoMapType map[string]int
           Locations:
-            - Range: 0x4c8400..0x4c8425
+            - Range: 0x4c8860..0x4c888d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 72
+      Name: main.mapIndexNilPtrVal
+      OutOfLinePCRanges: [0x4c88c0..0x4c8916]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 159 GoMapType map[string]*main.indexMemberStruct
+          Locations:
+            - Range: 0x4c88c0..0x4c88ed
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 73
+      Name: main.mapIndexLargeValue
+      OutOfLinePCRanges: [0x4c8920..0x4c899e]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 169 GoMapType map[string]main.largeValueStruct
+          Locations:
+            - Range: 0x4c8920..0x4c8945
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 74
       Name: main.condMultiReturn
-      OutOfLinePCRanges: [0x4c8500..0x4c85d6]
+      OutOfLinePCRanges: [0x4c8a20..0x4c8af6]
       InlinePCRanges: []
       Variables:
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c8500..0x4c854a
+            - Range: 0x4c8a20..0x4c8a6a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4c854a..0x4c854f
+            - Range: 0x4c8a6a..0x4c8a6f
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0x4c854f..0x4c85d6
+            - Range: 0x4c8a6f..0x4c8af6
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -7533,51 +7947,51 @@ Subprograms:
         - Name: r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4c8500..0x4c85b2
+            - Range: 0x4c8a20..0x4c8ad2
               Pieces: []
-            - Range: 0x4c85b2..0x4c85b3
+            - Range: 0x4c8ad2..0x4c8ad3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4c85b3..0x4c85d6
+            - Range: 0x4c8ad3..0x4c8af6
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: r1
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c8500..0x4c85b2
+            - Range: 0x4c8a20..0x4c8ad2
               Pieces: []
-            - Range: 0x4c85b2..0x4c85b3
+            - Range: 0x4c8ad2..0x4c8ad3
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c85b3..0x4c85d6
+            - Range: 0x4c8ad3..0x4c8af6
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 73
+    - ID: 75
       Name: main.genericIdentity[go.shape.string]
-      OutOfLinePCRanges: [0x4c85e0..0x4c867d]
+      OutOfLinePCRanges: [0x4c8b00..0x4c8b9d]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 174 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x4c85e0..0x4c8609
+            - Range: 0x4c8b00..0x4c8b29
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c8609..0x4c860e
+            - Range: 0x4c8b29..0x4c8b2e
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4c860e..0x4c867d
+            - Range: 0x4c8b2e..0x4c8b9d
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -7588,68 +8002,68 @@ Subprograms:
         - Name: ~r0
           Type: 174 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x4c85e0..0x4c864f
+            - Range: 0x4c8b00..0x4c8b6f
               Pieces: []
-            - Range: 0x4c864f..0x4c8650
+            - Range: 0x4c8b6f..0x4c8b70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4c8650..0x4c867d
+            - Range: 0x4c8b70..0x4c8b9d
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 74
+    - ID: 76
       Name: main.genericIdentity[go.shape.int]
-      OutOfLinePCRanges: [0x4c8680..0x4c86fe]
+      OutOfLinePCRanges: [0x4c8ba0..0x4c8c1e]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 175 BaseType go.shape.int
           Locations:
-            - Range: 0x4c8680..0x4c86a6
+            - Range: 0x4c8ba0..0x4c8bc6
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x4c86a6..0x4c86fe
+            - Range: 0x4c8bc6..0x4c8c1e
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 175 BaseType go.shape.int
           Locations:
-            - Range: 0x4c8680..0x4c86dd
+            - Range: 0x4c8ba0..0x4c8bfd
               Pieces: []
-            - Range: 0x4c86dd..0x4c86de
+            - Range: 0x4c8bfd..0x4c8bfe
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4c86de..0x4c86fe
+            - Range: 0x4c8bfe..0x4c8c1e
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 75
+    - ID: 77
       Name: main.inlined
-      OutOfLinePCRanges: [0x4c4e60..0x4c4ec2]
+      OutOfLinePCRanges: [0x4c50c0..0x4c5122]
       InlinePCRanges:
         - Ranges: [0x4c2846..0x4c2887]
-          RootRanges: [0x4c2680..0x4c4b3f]
+          RootRanges: [0x4c2680..0x4c4d9f]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
             - Range: 0x4c2846..0x4c2887
               Pieces: []
-            - Range: 0x4c4e60..0x4c4e79
+            - Range: 0x4c50c0..0x4c50d9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 76
+    - ID: 78
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x4c2b38..0x4c2b72]
-          RootRanges: [0x4c2680..0x4c4b3f]
+          RootRanges: [0x4c2680..0x4c4d9f]
       Variables:
         - Name: ptr
           Type: 176 PointerType *****int
@@ -7659,12 +8073,12 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 77
+    - ID: 79
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x4c2b7d..0x4c2bb7]
-          RootRanges: [0x4c2680..0x4c4b3f]
+          RootRanges: [0x4c2680..0x4c4d9f]
       Variables:
         - Name: ptr
           Type: 178 PointerType **int
@@ -7674,17 +8088,17 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 78
+    - ID: 80
       Name: main.(*methodValueReceiver).inlinedMethod
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x4c8704..0x4c8707]
-          RootRanges: [0x4c8700..0x4c8708]
+        - Ranges: [0x4c8c24..0x4c8c27]
+          RootRanges: [0x4c8c20..0x4c8c28]
       Variables:
         - Name: m
           Type: 179 PointerType *main.methodValueReceiver
           Locations:
-            - Range: 0x4c8704..0x4c8708
+            - Range: 0x4c8c24..0x4c8c28
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7853,7 +8267,7 @@ Types:
       ID: 289
       Name: '*errors.errorString'
       ByteSize: 8
-      GoRuntimeType: 66784
+      GoRuntimeType: 66880
       GoKind: 22
       Pointee: 290 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
@@ -7900,42 +8314,42 @@ Types:
       ID: 330
       Name: '*internal/abi.Type'
       ByteSize: 8
-      GoRuntimeType: 149728
+      GoRuntimeType: 149824
       GoKind: 22
       Pointee: 331 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
       ID: 298
       Name: '*internal/bisect.parseError'
       ByteSize: 8
-      GoRuntimeType: 70336
+      GoRuntimeType: 70432
       GoKind: 22
       Pointee: 299 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
       ID: 326
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 85376
+      GoRuntimeType: 85472
       GoKind: 22
       Pointee: 327 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 324
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
-      GoRuntimeType: 85248
+      GoRuntimeType: 85344
       GoKind: 22
       Pointee: 325 StructureType internal/poll.errNetClosing
     - __kind: PointerType
       ID: 99
       Name: '*internal/runtime/atomic.Pointer[runtime.m]'
       ByteSize: 8
-      GoRuntimeType: 109888
+      GoRuntimeType: 109984
       GoKind: 22
       Pointee: 100 UnresolvedPointeeType internal/runtime/atomic.Pointer[runtime.m]
     - __kind: PointerType
       ID: 297
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
-      GoRuntimeType: 70144
+      GoRuntimeType: 70240
       GoKind: 22
       Pointee: 286 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
@@ -7947,21 +8361,21 @@ Types:
       ID: 316
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
-      GoRuntimeType: 77568
+      GoRuntimeType: 77664
       GoKind: 22
       Pointee: 317 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
       ID: 296
       Name: '*internal/strconv.Error'
       ByteSize: 8
-      GoRuntimeType: 69856
+      GoRuntimeType: 69952
       GoKind: 22
       Pointee: 285 BaseType internal/strconv.Error
     - __kind: PointerType
       ID: 322
       Name: '*io/fs.PathError'
       ByteSize: 8
-      GoRuntimeType: 85120
+      GoRuntimeType: 85216
       GoKind: 22
       Pointee: 323 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
@@ -8112,28 +8526,28 @@ Types:
       ID: 318
       Name: '*os.SyscallError'
       ByteSize: 8
-      GoRuntimeType: 81792
+      GoRuntimeType: 81888
       GoKind: 22
       Pointee: 319 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 291
       Name: '*reflect.ValueError'
       ByteSize: 8
-      GoRuntimeType: 67648
+      GoRuntimeType: 67744
       GoKind: 22
       Pointee: 292 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
       ID: 310
       Name: '*runtime.PanicNilError'
       ByteSize: 8
-      GoRuntimeType: 76032
+      GoRuntimeType: 76128
       GoKind: 22
       Pointee: 311 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
       ID: 314
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
-      GoRuntimeType: 76672
+      GoRuntimeType: 76768
       GoKind: 22
       Pointee: 315 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
@@ -8147,14 +8561,14 @@ Types:
       ID: 25
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 93760
+      GoRuntimeType: 93856
       GoKind: 22
       Pointee: 26 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 312
       Name: '*runtime.boundsError'
       ByteSize: 8
-      GoRuntimeType: 76160
+      GoRuntimeType: 76256
       GoKind: 22
       Pointee: 313 StructureType runtime.boundsError
     - __kind: PointerType
@@ -8175,14 +8589,14 @@ Types:
       ID: 320
       Name: '*runtime.errorAddressString'
       ByteSize: 8
-      GoRuntimeType: 84608
+      GoRuntimeType: 84704
       GoKind: 22
       Pointee: 321 StructureType runtime.errorAddressString
     - __kind: PointerType
       ID: 308
       Name: '*runtime.errorString'
       ByteSize: 8
-      GoRuntimeType: 74368
+      GoRuntimeType: 74464
       GoKind: 22
       Pointee: 300 GoStringHeaderType runtime.errorString
     - __kind: PointerType
@@ -8194,28 +8608,28 @@ Types:
       ID: 59
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 83328
+      GoRuntimeType: 83424
       GoKind: 22
       Pointee: 23 StructureType runtime.g
     - __kind: PointerType
       ID: 29
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 94400
+      GoRuntimeType: 94496
       GoKind: 22
       Pointee: 30 StructureType runtime.m
     - __kind: PointerType
       ID: 68
       Name: '*runtime.p'
       ByteSize: 8
-      GoRuntimeType: 75776
+      GoRuntimeType: 75872
       GoKind: 22
       Pointee: 187 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 309
       Name: '*runtime.plainError'
       ByteSize: 8
-      GoRuntimeType: 74496
+      GoRuntimeType: 74592
       GoKind: 22
       Pointee: 303 GoStringHeaderType runtime.plainError
     - __kind: PointerType
@@ -8234,28 +8648,28 @@ Types:
       ID: 50
       Name: '*runtime.synctestBubble'
       ByteSize: 8
-      GoRuntimeType: 107648
+      GoRuntimeType: 107744
       GoKind: 22
       Pointee: 51 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
       ID: 293
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
-      GoRuntimeType: 69376
+      GoRuntimeType: 69472
       GoKind: 22
       Pointee: 294 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 45
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 142272
+      GoRuntimeType: 142368
       GoKind: 22
       Pointee: 46 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 83
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 115264
+      GoRuntimeType: 115360
       GoKind: 22
       Pointee: 84 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
@@ -8269,7 +8683,7 @@ Types:
       ID: 306
       Name: '*strconv.NumError'
       ByteSize: 8
-      GoRuntimeType: 73472
+      GoRuntimeType: 73568
       GoKind: 22
       Pointee: 307 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
@@ -8288,7 +8702,7 @@ Types:
       ID: 329
       Name: '*syscall.Errno'
       ByteSize: 8
-      GoRuntimeType: 95360
+      GoRuntimeType: 95456
       GoKind: 22
       Pointee: 328 BaseType syscall.Errno
     - __kind: PointerType
@@ -8340,7 +8754,7 @@ Types:
       ID: 295
       Name: '*time.fileSizeError'
       ByteSize: 8
-      GoRuntimeType: 69568
+      GoRuntimeType: 69664
       GoKind: 22
       Pointee: 282 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
@@ -8391,7 +8805,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 684
+      ID: 693
       Name: Probe[main.(*methodValueReceiver).inlinedMethod]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8403,12 +8817,12 @@ Types:
             Type: 179 PointerType *main.methodValueReceiver
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: m}
+                  Variable: {subprogram: 80, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 682
+      ID: 691
       Name: Probe[main.PointerChainArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -8420,7 +8834,7 @@ Types:
             Type: 176 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: ptr}
+                  Variable: {subprogram: 78, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -8431,12 +8845,12 @@ Types:
             Type: 176 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: ptr}
+                  Variable: {subprogram: 78, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 683
+      ID: 692
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8448,12 +8862,12 @@ Types:
             Type: 178 PointerType **int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: ptr}
+                  Variable: {subprogram: 79, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 594
+      ID: 603
       Name: Probe[main.bigArrayArg]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8465,12 +8879,12 @@ Types:
             Type: 12 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: s}
+                  Variable: {subprogram: 49, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 596
+      ID: 605
       Name: Probe[main.bigArrayArg]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8482,18 +8896,18 @@ Types:
             Type: 12 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: s}
+                  Variable: {subprogram: 49, index: 0, name: s}
                   Offset: 1048568
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 595
+      ID: 604
       Name: Probe[main.bigArrayArg]Return
     - __kind: EventRootType
-      ID: 597
+      ID: 606
       Name: Probe[main.bigArrayArg]Return
     - __kind: EventRootType
-      ID: 598
+      ID: 607
       Name: Probe[main.bigArrayStructArg]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8505,7 +8919,7 @@ Types:
             Type: 12 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: s}
+                  Variable: {subprogram: 50, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -8513,7 +8927,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 599
+      ID: 608
       Name: Probe[main.bigArrayStructArg]Return
     - __kind: EventRootType
       ID: 381
@@ -8944,6 +9358,85 @@ Types:
       ID: 388
       Name: Probe[main.condInt8]Return
     - __kind: EventRootType
+      ID: 492
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 493
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 494
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 495
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 496
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 497
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 498
+      Name: Probe[main.condLineMixed]Line
+      ByteSize: 131
+      ExprStatusArraySize: 2
+      Expressions:
+        - Name: s
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: b
+          Offset: 18
+          Kind: local
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 1
+          DictIndex: -1
+        - Name: x
+          Offset: 19
+          Kind: local
+          Expression:
+            Type: 126 StructureType main.condFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 80
+          DictIndex: -1
+        - Name: p
+          Offset: 99
+          Kind: local
+          Expression:
+            Type: 128 PointerType *main.condFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 3, name: p}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: ss
+          Offset: 107
+          Kind: local
+          Expression:
+            Type: 112 GoSliceHeaderType []int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 4, name: ss}
+                  Offset: 0
+                  ByteSize: 24
+          DictIndex: -1
+    - __kind: EventRootType
       ID: 487
       Name: Probe[main.condLine]Line
       ByteSize: 25
@@ -8991,6 +9484,62 @@ Types:
     - __kind: EventRootType
       ID: 489
       Name: Probe[main.condLine]Line
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 490
+      Name: Probe[main.condLine]Line
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: "n"
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 0, name: "n"}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: tag
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: result
+          Offset: 25
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 2, name: result}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 491
+      Name: Probe[main.condLine]Line
       ByteSize: 25
       ExprStatusArraySize: 1
       Expressions:
@@ -9017,10 +9566,10 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 674
+      ID: 683
       Name: Probe[main.condMultiReturn]
     - __kind: EventRootType
-      ID: 675
+      ID: 684
       Name: Probe[main.condMultiReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -9032,7 +9581,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 1, name: r0}
+                  Variable: {subprogram: 74, index: 1, name: r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -9043,7 +9592,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 2, name: r1}
+                  Variable: {subprogram: 74, index: 2, name: r1}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -9139,7 +9688,7 @@ Types:
       ID: 476
       Name: Probe[main.condNilPtrStruct]Return
     - __kind: EventRootType
-      ID: 496
+      ID: 505
       Name: Probe[main.condNullIface]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -9151,76 +9700,16 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 35, index: 1, name: tag}
+                  Variable: {subprogram: 37, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 497
+      ID: 506
       Name: Probe[main.condNullIface]Return
     - __kind: EventRootType
-      ID: 494
+      ID: 503
       Name: Probe[main.condNullMap]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 34, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 495
-      Name: Probe[main.condNullMap]Return
-    - __kind: EventRootType
-      ID: 490
-      Name: Probe[main.condNullPtr]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 32, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 491
-      Name: Probe[main.condNullPtr]Return
-    - __kind: EventRootType
-      ID: 492
-      Name: Probe[main.condNullSlice]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 33, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 493
-      Name: Probe[main.condNullSlice]Return
-    - __kind: EventRootType
-      ID: 498
-      Name: Probe[main.condNullUnsafePtr]
       ByteSize: 17
       ExprStatusArraySize: 1
       Expressions:
@@ -9236,7 +9725,67 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
+      ID: 504
+      Name: Probe[main.condNullMap]Return
+    - __kind: EventRootType
       ID: 499
+      Name: Probe[main.condNullPtr]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 500
+      Name: Probe[main.condNullPtr]Return
+    - __kind: EventRootType
+      ID: 501
+      Name: Probe[main.condNullSlice]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 502
+      Name: Probe[main.condNullSlice]Return
+    - __kind: EventRootType
+      ID: 507
+      Name: Probe[main.condNullUnsafePtr]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 508
       Name: Probe[main.condNullUnsafePtr]Return
     - __kind: EventRootType
       ID: 483
@@ -10048,7 +10597,7 @@ Types:
       ID: 410
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 678
+      ID: 687
       Name: Probe[main.genericIdentity[go.shape.int]]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10061,12 +10610,12 @@ Types:
             Type: 175 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: x}
+                  Variable: {subprogram: 76, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 679
+      ID: 688
       Name: Probe[main.genericIdentity[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10079,12 +10628,12 @@ Types:
             Type: 175 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 1, name: ~r0}
+                  Variable: {subprogram: 76, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 676
+      ID: 685
       Name: Probe[main.genericIdentity[go.shape.string]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -10097,12 +10646,12 @@ Types:
             Type: 174 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: x}
+                  Variable: {subprogram: 75, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 677
+      ID: 686
       Name: Probe[main.genericIdentity[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -10115,12 +10664,12 @@ Types:
             Type: 174 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 1, name: ~r0}
+                  Variable: {subprogram: 75, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 620
+      ID: 629
       Name: Probe[main.indexMemberWrapperArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -10132,7 +10681,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
+                  Variable: {subprogram: 55, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10143,7 +10692,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 622
+      ID: 631
       Name: Probe[main.indexMemberWrapperArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10155,7 +10704,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
+                  Variable: {subprogram: 55, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10166,7 +10715,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 624
+      ID: 633
       Name: Probe[main.indexMemberWrapperArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -10178,7 +10727,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
+                  Variable: {subprogram: 55, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10192,7 +10741,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 626
+      ID: 635
       Name: Probe[main.indexMemberWrapperArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10204,7 +10753,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
+                  Variable: {subprogram: 55, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10218,19 +10767,19 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 621
+      ID: 630
       Name: Probe[main.indexMemberWrapperArg]Return
     - __kind: EventRootType
-      ID: 623
+      ID: 632
       Name: Probe[main.indexMemberWrapperArg]Return
     - __kind: EventRootType
-      ID: 625
+      ID: 634
       Name: Probe[main.indexMemberWrapperArg]Return
     - __kind: EventRootType
-      ID: 627
+      ID: 636
       Name: Probe[main.indexMemberWrapperArg]Return
     - __kind: EventRootType
-      ID: 586
+      ID: 595
       Name: Probe[main.indexNilPtrSlice]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10242,7 +10791,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: x}
+                  Variable: {subprogram: 47, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10255,7 +10804,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 588
+      ID: 597
       Name: Probe[main.indexNilPtrSlice]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10267,12 +10816,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 1, name: tag}
+                  Variable: {subprogram: 47, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 590
+      ID: 599
       Name: Probe[main.indexNilPtrSlice]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10284,7 +10833,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: x}
+                  Variable: {subprogram: 47, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10297,16 +10846,16 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 587
+      ID: 596
       Name: Probe[main.indexNilPtrSlice]Return
     - __kind: EventRootType
-      ID: 589
+      ID: 598
       Name: Probe[main.indexNilPtrSlice]Return
     - __kind: EventRootType
-      ID: 591
+      ID: 600
       Name: Probe[main.indexNilPtrSlice]Return
     - __kind: EventRootType
-      ID: 680
+      ID: 689
       Name: Probe[main.inlined]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10318,12 +10867,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: x}
+                  Variable: {subprogram: 77, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 681
+      ID: 690
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
       ID: 338
@@ -10536,7 +11085,7 @@ Types:
       ID: 359
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 578
+      ID: 587
       Name: Probe[main.lenErrInt]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -10548,7 +11097,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: x}
+                  Variable: {subprogram: 45, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -10559,21 +11108,21 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 1, name: tag}
+                  Variable: {subprogram: 45, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 580
+      ID: 589
       Name: Probe[main.lenErrInt]
     - __kind: EventRootType
-      ID: 579
+      ID: 588
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 581
+      ID: 590
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 582
+      ID: 591
       Name: Probe[main.lenErrStruct]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -10585,7 +11134,7 @@ Types:
             Type: 126 StructureType main.condFields
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: x}
+                  Variable: {subprogram: 46, index: 0, name: x}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -10596,21 +11145,21 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 1, name: tag}
+                  Variable: {subprogram: 46, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 584
+      ID: 593
       Name: Probe[main.lenErrStruct]
     - __kind: EventRootType
-      ID: 583
+      ID: 592
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 585
+      ID: 594
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 532
+      ID: 541
       Name: Probe[main.lenMap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10622,12 +11171,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Variable: {subprogram: 41, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 534
+      ID: 543
       Name: Probe[main.lenMap]
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -10639,7 +11188,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: m}
+                  Variable: {subprogram: 41, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10653,7 +11202,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 536
+      ID: 545
       Name: Probe[main.lenMap]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10665,845 +11214,16 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: m}
+                  Variable: {subprogram: 41, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
                   Bias: 0
                   ByteSize: 8
           DictIndex: -1
-    - __kind: EventRootType
-      ID: 538
-      Name: Probe[main.lenMap]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 540
-      Name: Probe[main.lenMap]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(m)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 8 BaseType uint64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 0
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 542
-      Name: Probe[main.lenMap]
-      ByteSize: 25
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 116 GoMapType map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-          DictIndex: -1
-        - Name: tag
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 533
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 535
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 537
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 539
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 541
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 543
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 544
-      Name: Probe[main.lenPtrString]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(s)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 546
-      Name: Probe[main.lenPtrString]
-      ByteSize: 25
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 101 PointerType *string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 8
-          DictIndex: -1
-        - Name: tag
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 545
-      Name: Probe[main.lenPtrString]Return
     - __kind: EventRootType
       ID: 547
-      Name: Probe[main.lenPtrString]Return
-    - __kind: EventRootType
-      ID: 568
-      Name: Probe[main.lenPtrStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: items_0
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 16
-                  ByteSize: 16
-                - __kind: SliceBoundsCheckOp
-                  Index: 0
-                - __kind: DereferenceOp
-                  Bias: 0
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 570
-      Name: Probe[main.lenPtrStructFields]
-      ByteSize: 25
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 131 PointerType *main.lenFields
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-          DictIndex: -1
-        - Name: tag
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 572
-      Name: Probe[main.lenPtrStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.Dict)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 8 BaseType uint64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 40
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 0
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 574
-      Name: Probe[main.lenPtrStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.Items)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 24
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 576
-      Name: Probe[main.lenPtrStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.S)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 569
-      Name: Probe[main.lenPtrStructFields]Return
-    - __kind: EventRootType
-      ID: 571
-      Name: Probe[main.lenPtrStructFields]Return
-    - __kind: EventRootType
-      ID: 573
-      Name: Probe[main.lenPtrStructFields]Return
-    - __kind: EventRootType
-      ID: 575
-      Name: Probe[main.lenPtrStructFields]Return
-    - __kind: EventRootType
-      ID: 577
-      Name: Probe[main.lenPtrStructFields]Return
-    - __kind: EventRootType
-      ID: 520
-      Name: Probe[main.lenSlice]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 522
-      Name: Probe[main.lenSlice]
-      ByteSize: 2
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: isEmpty(s)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-                - __kind: ExprPushOffsetOp
-                  ByteSize: 8
-                - __kind: ExprLoadLiteralOp
-                  Data: AAAAAAAAAAA=
-                - __kind: ExprCmpEqBaseOp
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 524
-      Name: Probe[main.lenSlice]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s_len
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 526
-      Name: Probe[main.lenSlice]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 528
-      Name: Probe[main.lenSlice]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(s)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 530
-      Name: Probe[main.lenSlice]
-      ByteSize: 41
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 112 GoSliceHeaderType []int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 24
-          DictIndex: -1
-        - Name: tag
-          Offset: 25
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 521
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 523
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 525
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 527
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 529
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 531
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 500
-      Name: Probe[main.lenString]
-      ByteSize: 33
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-        - Name: tag
-          Offset: 17
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 502
-      Name: Probe[main.lenString]
-      ByteSize: 2
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s_len_eq_5
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-                - __kind: ExprPushOffsetOp
-                  ByteSize: 8
-                - __kind: ExprLoadLiteralOp
-                  Data: BQAAAAAAAAA=
-                - __kind: ExprCmpEqBaseOp
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 504
-      Name: Probe[main.lenString]
-      ByteSize: 2
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(s) == 5
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-                - __kind: ExprPushOffsetOp
-                  ByteSize: 8
-                - __kind: ExprLoadLiteralOp
-                  Data: BQAAAAAAAAA=
-                - __kind: ExprCmpEqBaseOp
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 506
-      Name: Probe[main.lenString]
-      ByteSize: 2
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s_isEmpty
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-                - __kind: ExprPushOffsetOp
-                  ByteSize: 8
-                - __kind: ExprLoadLiteralOp
-                  Data: AAAAAAAAAAA=
-                - __kind: ExprCmpEqBaseOp
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 508
-      Name: Probe[main.lenString]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 510
-      Name: Probe[main.lenString]
-      ByteSize: 2
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: isEmpty(s)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-                - __kind: ExprPushOffsetOp
-                  ByteSize: 8
-                - __kind: ExprLoadLiteralOp
-                  Data: AAAAAAAAAAA=
-                - __kind: ExprCmpEqBaseOp
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 512
-      Name: Probe[main.lenString]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s_len
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 514
-      Name: Probe[main.lenString]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 516
-      Name: Probe[main.lenString]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(s)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 518
-      Name: Probe[main.lenString]
-      ByteSize: 33
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-        - Name: tag
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 501
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 503
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 505
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 507
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 509
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 511
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 513
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 515
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 517
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 519
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 548
-      Name: Probe[main.lenStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: items_2
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 16
-                  ByteSize: 16
-                - __kind: SliceBoundsCheckOp
-                  Index: 2
-                - __kind: DereferenceOp
-                  Bias: 16
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 550
-      Name: Probe[main.lenStructFields]
-      ByteSize: 89
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 129 StructureType main.lenFields
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 72
-          DictIndex: -1
-        - Name: tag
-          Offset: 73
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 552
-      Name: Probe[main.lenStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.Dict)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 8 BaseType uint64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 40
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 0
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 554
-      Name: Probe[main.lenStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.PtrSlice)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 56
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 556
-      Name: Probe[main.lenStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.PtrStr)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 48
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 558
-      Name: Probe[main.lenStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.Items)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 24
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 560
-      Name: Probe[main.lenStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.S)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 562
-      Name: Probe[main.lenStructFields]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 564
-      Name: Probe[main.lenStructFields]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 566
-      Name: Probe[main.lenStructFields]
+      Name: Probe[main.lenMap]
       ByteSize: 17
       ExprStatusArraySize: 1
       Expressions:
@@ -11520,33 +11240,862 @@ Types:
           DictIndex: -1
     - __kind: EventRootType
       ID: 549
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenMap]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(m)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 41, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+          DictIndex: -1
     - __kind: EventRootType
       ID: 551
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenMap]
+      ByteSize: 25
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 116 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 41, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 41, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 542
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 544
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 546
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 548
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 550
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 552
+      Name: Probe[main.lenMap]Return
     - __kind: EventRootType
       ID: 553
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenPtrString]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 42, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+          DictIndex: -1
     - __kind: EventRootType
       ID: 555
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenPtrString]
+      ByteSize: 25
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 101 PointerType *string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 42, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 42, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 554
+      Name: Probe[main.lenPtrString]Return
+    - __kind: EventRootType
+      ID: 556
+      Name: Probe[main.lenPtrString]Return
+    - __kind: EventRootType
+      ID: 577
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: items_0
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 16
+                  ByteSize: 16
+                - __kind: SliceBoundsCheckOp
+                  Index: 0
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 579
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 25
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 131 PointerType *main.lenFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 581
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.Dict)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 40
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 583
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.Items)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 24
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 585
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.S)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 578
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 580
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 582
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 584
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 586
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 529
+      Name: Probe[main.lenSlice]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 531
+      Name: Probe[main.lenSlice]
+      ByteSize: 2
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: isEmpty(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 533
+      Name: Probe[main.lenSlice]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s_len
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 535
+      Name: Probe[main.lenSlice]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 537
+      Name: Probe[main.lenSlice]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 539
+      Name: Probe[main.lenSlice]
+      ByteSize: 41
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 112 GoSliceHeaderType []int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+          DictIndex: -1
+        - Name: tag
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 530
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 532
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 534
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 536
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 538
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 540
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 509
+      Name: Probe[main.lenString]
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: tag
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 511
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s_len_eq_5
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 513
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(s) == 5
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 515
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s_isEmpty
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 517
+      Name: Probe[main.lenString]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 519
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: isEmpty(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 521
+      Name: Probe[main.lenString]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s_len
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 523
+      Name: Probe[main.lenString]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 525
+      Name: Probe[main.lenString]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 527
+      Name: Probe[main.lenString]
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: tag
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 510
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 512
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 514
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 516
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 518
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 520
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 522
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 524
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 526
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 528
+      Name: Probe[main.lenString]Return
     - __kind: EventRootType
       ID: 557
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: items_2
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 16
+                  ByteSize: 16
+                - __kind: SliceBoundsCheckOp
+                  Index: 2
+                - __kind: DereferenceOp
+                  Bias: 16
+                  ByteSize: 8
+          DictIndex: -1
     - __kind: EventRootType
       ID: 559
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenStructFields]
+      ByteSize: 89
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 129 StructureType main.lenFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 72
+          DictIndex: -1
+        - Name: tag
+          Offset: 73
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
     - __kind: EventRootType
       ID: 561
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.Dict)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 40
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+          DictIndex: -1
     - __kind: EventRootType
       ID: 563
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.PtrSlice)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 56
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+          DictIndex: -1
     - __kind: EventRootType
       ID: 565
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.PtrStr)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 48
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+          DictIndex: -1
     - __kind: EventRootType
       ID: 567
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.Items)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 24
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 569
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.S)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 8
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 571
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 573
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 575
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 558
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 560
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 562
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 564
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 566
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 568
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 570
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 572
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 574
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 576
       Name: Probe[main.lenStructFields]Return
     - __kind: EventRootType
       ID: 379
@@ -11580,7 +12129,7 @@ Types:
       ID: 380
       Name: Probe[main.mapArg]Return
     - __kind: EventRootType
-      ID: 664
+      ID: 673
       Name: Probe[main.mapIndexBoolKey]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11592,7 +12141,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11619,7 +12168,7 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 666
+      ID: 675
       Name: Probe[main.mapIndexBoolKey]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11631,7 +12180,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11658,13 +12207,13 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 665
+      ID: 674
+      Name: Probe[main.mapIndexBoolKey]Return
+    - __kind: EventRootType
+      ID: 676
       Name: Probe[main.mapIndexBoolKey]Return
     - __kind: EventRootType
       ID: 667
-      Name: Probe[main.mapIndexBoolKey]Return
-    - __kind: EventRootType
-      ID: 658
       Name: Probe[main.mapIndexEmptyKey]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11676,7 +12225,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11703,10 +12252,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 659
+      ID: 668
       Name: Probe[main.mapIndexEmptyKey]Return
     - __kind: EventRootType
-      ID: 628
+      ID: 637
       Name: Probe[main.mapIndexIntKey]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -11718,7 +12267,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: m}
+                  Variable: {subprogram: 56, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11745,10 +12294,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 629
+      ID: 638
       Name: Probe[main.mapIndexIntKey]Return
     - __kind: EventRootType
-      ID: 660
+      ID: 669
       Name: Probe[main.mapIndexKeyLen16]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11760,7 +12309,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11787,10 +12336,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 661
+      ID: 670
       Name: Probe[main.mapIndexKeyLen16]Return
     - __kind: EventRootType
-      ID: 662
+      ID: 671
       Name: Probe[main.mapIndexKeyLen17]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11802,7 +12351,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11829,10 +12378,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 663
+      ID: 672
       Name: Probe[main.mapIndexKeyLen17]Return
     - __kind: EventRootType
-      ID: 648
+      ID: 657
       Name: Probe[main.mapIndexKeyLen200]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11844,7 +12393,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
+                  Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11871,10 +12420,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 649
+      ID: 658
       Name: Probe[main.mapIndexKeyLen200]Return
     - __kind: EventRootType
-      ID: 642
+      ID: 651
       Name: Probe[main.mapIndexKeyLen24]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11886,7 +12435,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
+                  Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11913,10 +12462,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 643
+      ID: 652
       Name: Probe[main.mapIndexKeyLen24]Return
     - __kind: EventRootType
-      ID: 644
+      ID: 653
       Name: Probe[main.mapIndexKeyLen48]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11928,7 +12477,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
+                  Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11955,10 +12504,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 645
+      ID: 654
       Name: Probe[main.mapIndexKeyLen48]Return
     - __kind: EventRootType
-      ID: 640
+      ID: 649
       Name: Probe[main.mapIndexKeyLen8]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11970,7 +12519,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
+                  Variable: {subprogram: 60, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11997,10 +12546,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 641
+      ID: 650
       Name: Probe[main.mapIndexKeyLen8]Return
     - __kind: EventRootType
-      ID: 646
+      ID: 655
       Name: Probe[main.mapIndexKeyLen96]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12012,7 +12561,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12039,10 +12588,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 647
+      ID: 656
       Name: Probe[main.mapIndexKeyLen96]Return
     - __kind: EventRootType
-      ID: 636
+      ID: 645
       Name: Probe[main.mapIndexLargeMap]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12054,7 +12603,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: m}
+                  Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12081,10 +12630,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 637
+      ID: 646
       Name: Probe[main.mapIndexLargeMap]Return
     - __kind: EventRootType
-      ID: 672
+      ID: 681
       Name: Probe[main.mapIndexLargeValue]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12096,7 +12645,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12126,10 +12675,10 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 673
+      ID: 682
       Name: Probe[main.mapIndexLargeValue]Return
     - __kind: EventRootType
-      ID: 638
+      ID: 647
       Name: Probe[main.mapIndexMissing]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12141,7 +12690,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
+                  Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12168,10 +12717,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 639
+      ID: 648
       Name: Probe[main.mapIndexMissing]Return
     - __kind: EventRootType
-      ID: 670
+      ID: 679
       Name: Probe[main.mapIndexNilPtrVal]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12183,7 +12732,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 72, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12213,10 +12762,10 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 671
+      ID: 680
       Name: Probe[main.mapIndexNilPtrVal]Return
     - __kind: EventRootType
-      ID: 654
+      ID: 663
       Name: Probe[main.mapIndexPtrStructVal]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12228,7 +12777,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12258,7 +12807,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 656
+      ID: 665
       Name: Probe[main.mapIndexPtrStructVal]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12270,7 +12819,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12300,13 +12849,13 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 655
+      ID: 664
       Name: Probe[main.mapIndexPtrStructVal]Return
     - __kind: EventRootType
-      ID: 657
+      ID: 666
       Name: Probe[main.mapIndexPtrStructVal]Return
     - __kind: EventRootType
-      ID: 630
+      ID: 639
       Name: Probe[main.mapIndexStringKey]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12318,7 +12867,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12345,10 +12894,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 632
+      ID: 641
       Name: Probe[main.mapIndexStringKey]
     - __kind: EventRootType
-      ID: 634
+      ID: 643
       Name: Probe[main.mapIndexStringKey]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12360,7 +12909,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12387,16 +12936,16 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 631
+      ID: 640
       Name: Probe[main.mapIndexStringKey]Return
     - __kind: EventRootType
-      ID: 633
+      ID: 642
       Name: Probe[main.mapIndexStringKey]Return
     - __kind: EventRootType
-      ID: 635
+      ID: 644
       Name: Probe[main.mapIndexStringKey]Return
     - __kind: EventRootType
-      ID: 650
+      ID: 659
       Name: Probe[main.mapIndexStructVal]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12408,7 +12957,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12435,7 +12984,7 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 652
+      ID: 661
       Name: Probe[main.mapIndexStructVal]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12447,7 +12996,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12474,13 +13023,13 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 651
+      ID: 660
       Name: Probe[main.mapIndexStructVal]Return
     - __kind: EventRootType
-      ID: 653
+      ID: 662
       Name: Probe[main.mapIndexStructVal]Return
     - __kind: EventRootType
-      ID: 668
+      ID: 677
       Name: Probe[main.mapIndexZeroValue]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12492,7 +13041,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12519,7 +13068,7 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 669
+      ID: 678
       Name: Probe[main.mapIndexZeroValue]Return
     - __kind: EventRootType
       ID: 383
@@ -12528,7 +13077,7 @@ Types:
       ID: 384
       Name: Probe[main.noArgs]Return
     - __kind: EventRootType
-      ID: 616
+      ID: 625
       Name: Probe[main.ptrStructArrayArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12540,7 +13089,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: s}
+                  Variable: {subprogram: 54, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12548,7 +13097,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 618
+      ID: 627
       Name: Probe[main.ptrStructArrayArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12560,7 +13109,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: s}
+                  Variable: {subprogram: 54, index: 0, name: s}
                   Offset: 8
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12568,13 +13117,13 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 617
+      ID: 626
       Name: Probe[main.ptrStructArrayArg]Return
     - __kind: EventRootType
-      ID: 619
+      ID: 628
       Name: Probe[main.ptrStructArrayArg]Return
     - __kind: EventRootType
-      ID: 612
+      ID: 621
       Name: Probe[main.ptrStructSliceArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12586,7 +13135,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: s}
+                  Variable: {subprogram: 53, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -12599,7 +13148,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 614
+      ID: 623
       Name: Probe[main.ptrStructSliceArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12611,7 +13160,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: s}
+                  Variable: {subprogram: 53, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -12624,10 +13173,10 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 613
+      ID: 622
       Name: Probe[main.ptrStructSliceArg]Return
     - __kind: EventRootType
-      ID: 615
+      ID: 624
       Name: Probe[main.ptrStructSliceArg]Return
     - __kind: EventRootType
       ID: 340
@@ -12789,7 +13338,7 @@ Types:
       ID: 373
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 608
+      ID: 617
       Name: Probe[main.structArrayArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12801,12 +13350,12 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: s}
+                  Variable: {subprogram: 52, index: 0, name: s}
                   Offset: 0
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 610
+      ID: 619
       Name: Probe[main.structArrayArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12818,18 +13367,18 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: s}
+                  Variable: {subprogram: 52, index: 0, name: s}
                   Offset: 40
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
+      ID: 618
+      Name: Probe[main.structArrayArg]Return
+    - __kind: EventRootType
+      ID: 620
+      Name: Probe[main.structArrayArg]Return
+    - __kind: EventRootType
       ID: 609
-      Name: Probe[main.structArrayArg]Return
-    - __kind: EventRootType
-      ID: 611
-      Name: Probe[main.structArrayArg]Return
-    - __kind: EventRootType
-      ID: 600
       Name: Probe[main.structSliceArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12841,7 +13390,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: s}
+                  Variable: {subprogram: 51, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -12851,7 +13400,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 602
+      ID: 611
       Name: Probe[main.structSliceArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12863,7 +13412,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: s}
+                  Variable: {subprogram: 51, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -12873,7 +13422,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 604
+      ID: 613
       Name: Probe[main.structSliceArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12885,12 +13434,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 1, name: tag}
+                  Variable: {subprogram: 51, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 606
+      ID: 615
       Name: Probe[main.structSliceArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12902,7 +13451,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: s}
+                  Variable: {subprogram: 51, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -12912,22 +13461,22 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
+      ID: 610
+      Name: Probe[main.structSliceArg]Return
+    - __kind: EventRootType
+      ID: 612
+      Name: Probe[main.structSliceArg]Return
+    - __kind: EventRootType
+      ID: 614
+      Name: Probe[main.structSliceArg]Return
+    - __kind: EventRootType
+      ID: 616
+      Name: Probe[main.structSliceArg]Return
+    - __kind: EventRootType
       ID: 601
-      Name: Probe[main.structSliceArg]Return
-    - __kind: EventRootType
-      ID: 603
-      Name: Probe[main.structSliceArg]Return
-    - __kind: EventRootType
-      ID: 605
-      Name: Probe[main.structSliceArg]Return
-    - __kind: EventRootType
-      ID: 607
-      Name: Probe[main.structSliceArg]Return
-    - __kind: EventRootType
-      ID: 592
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 593
+      ID: 602
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12939,7 +13488,7 @@ Types:
             Type: 132 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: ~r0}
+                  Variable: {subprogram: 48, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -12947,7 +13496,7 @@ Types:
       ID: 95
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 58016
+      GoRuntimeType: 58112
       GoKind: 17
       Count: 10
       HasCount: true
@@ -12991,7 +13540,7 @@ Types:
       ID: 82
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 60992
+      GoRuntimeType: 61088
       GoKind: 17
       Count: 2
       HasCount: true
@@ -13000,7 +13549,7 @@ Types:
       ID: 81
       Name: '[2][2]*runtime.traceBuf'
       ByteSize: 32
-      GoRuntimeType: 61088
+      GoRuntimeType: 61184
       GoKind: 17
       Count: 2
       HasCount: true
@@ -13009,7 +13558,7 @@ Types:
       ID: 87
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 61280
+      GoRuntimeType: 61376
       GoKind: 17
       Count: 2
       HasCount: true
@@ -13026,7 +13575,7 @@ Types:
       ID: 58
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 59360
+      GoRuntimeType: 59456
       GoKind: 17
       Count: 2
       HasCount: true
@@ -13035,7 +13584,7 @@ Types:
       ID: 93
       Name: '[32]uint64'
       ByteSize: 256
-      GoRuntimeType: 63584
+      GoRuntimeType: 63680
       GoKind: 17
       Count: 32
       HasCount: true
@@ -13044,7 +13593,7 @@ Types:
       ID: 73
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 57920
+      GoRuntimeType: 58016
       GoKind: 17
       Count: 32
       HasCount: true
@@ -13071,7 +13620,7 @@ Types:
       ID: 57
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 59264
+      GoRuntimeType: 59360
       GoKind: 17
       Count: 3
       HasCount: true
@@ -13089,7 +13638,7 @@ Types:
       ID: 94
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 62720
+      GoRuntimeType: 62816
       GoKind: 17
       Count: 4
       HasCount: true
@@ -13098,7 +13647,7 @@ Types:
       ID: 62
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 57824
+      GoRuntimeType: 57920
       GoKind: 17
       Count: 6
       HasCount: true
@@ -13107,7 +13656,7 @@ Types:
       ID: 88
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 61184
+      GoRuntimeType: 61280
       GoKind: 17
       Count: 8
       HasCount: true
@@ -13405,7 +13954,7 @@ Types:
       ID: 15
       Name: error
       ByteSize: 16
-      GoRuntimeType: 74240
+      GoRuntimeType: 74336
       GoKind: 20
       RawFields:
         - Name: tab
@@ -13440,7 +13989,7 @@ Types:
       ID: 78
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 65952
+      GoRuntimeType: 66048
       GoKind: 19
     - __kind: BaseType
       ID: 175
@@ -13639,7 +14188,7 @@ Types:
       ID: 92
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 131904
+      GoRuntimeType: 132000
       GoKind: 25
       RawFields:
         - Name: buf
@@ -13664,14 +14213,14 @@ Types:
     - __kind: StructureType
       ID: 325
       Name: internal/poll.errNetClosing
-      GoRuntimeType: 105120
+      GoRuntimeType: 105216
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 36
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 85888
+      GoRuntimeType: 85984
       GoKind: 25
       RawFields:
         - Name: u
@@ -13681,7 +14230,7 @@ Types:
       ID: 76
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 117952
+      GoRuntimeType: 118048
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -13701,7 +14250,7 @@ Types:
       ID: 33
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 105920
+      GoRuntimeType: 106016
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -13714,7 +14263,7 @@ Types:
       ID: 37
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 105760
+      GoRuntimeType: 105856
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -13726,20 +14275,20 @@ Types:
     - __kind: StructureType
       ID: 77
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 72544
+      GoRuntimeType: 72640
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 34
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 72448
+      GoRuntimeType: 72544
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
       ID: 286
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
-      GoRuntimeType: 64800
+      GoRuntimeType: 64896
       GoKind: 24
       RawFields:
         - Name: str
@@ -13758,7 +14307,7 @@ Types:
       ID: 317
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
-      GoRuntimeType: 108768
+      GoRuntimeType: 108864
       GoKind: 25
       RawFields:
         - Name: typ
@@ -13768,7 +14317,7 @@ Types:
       ID: 285
       Name: internal/strconv.Error
       ByteSize: 8
-      GoRuntimeType: 64704
+      GoRuntimeType: 64800
       GoKind: 2
     - __kind: UnresolvedPointeeType
       ID: 323
@@ -13778,14 +14327,14 @@ Types:
       ID: 279
       Name: main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 81152
+      GoRuntimeType: 81248
       GoKind: 25
       RawFields: [{Name: a, Offset: 0, Type: 7 BaseType int}]
     - __kind: StructureType
       ID: 139
       Name: main.bigArrayStruct
       ByteSize: 1048584
-      GoRuntimeType: 97120
+      GoRuntimeType: 97216
       GoKind: 25
       RawFields:
         - Name: tag
@@ -13798,7 +14347,7 @@ Types:
       ID: 209
       Name: main.bigStruct
       ByteSize: 184
-      GoRuntimeType: 140512
+      GoRuntimeType: 140608
       GoKind: 25
       RawFields:
         - Name: Field1
@@ -13829,7 +14378,7 @@ Types:
       ID: 126
       Name: main.condFields
       ByteSize: 80
-      GoRuntimeType: 148064
+      GoRuntimeType: 148160
       GoKind: 25
       RawFields:
         - Name: I8
@@ -13875,7 +14424,7 @@ Types:
       ID: 142
       Name: main.indexMemberStruct
       ByteSize: 32
-      GoRuntimeType: 110848
+      GoRuntimeType: 110944
       GoKind: 25
       RawFields:
         - Name: Val
@@ -13906,7 +14455,7 @@ Types:
       ID: 268
       Name: main.largeValueStruct
       ByteSize: 264
-      GoRuntimeType: 96960
+      GoRuntimeType: 97056
       GoKind: 25
       RawFields:
         - Name: Pad
@@ -13919,7 +14468,7 @@ Types:
       ID: 129
       Name: main.lenFields
       ByteSize: 72
-      GoRuntimeType: 133792
+      GoRuntimeType: 133888
       GoKind: 25
       RawFields:
         - Name: S
@@ -14265,63 +14814,63 @@ Types:
       ID: 164
       Name: map[bool]int
       ByteSize: 8
-      GoRuntimeType: 78720
+      GoRuntimeType: 78816
       GoKind: 21
       HeaderType: 166 GoSwissMapHeaderType map<bool,int>
     - __kind: GoMapType
       ID: 218
       Name: map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 78848
+      GoRuntimeType: 78944
       GoKind: 21
       HeaderType: 220 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 149
       Name: map[int]string
       ByteSize: 8
-      GoRuntimeType: 78976
+      GoRuntimeType: 79072
       GoKind: 21
       HeaderType: 151 GoSwissMapHeaderType map<int,string>
     - __kind: GoMapType
       ID: 159
       Name: map[string]*main.indexMemberStruct
       ByteSize: 8
-      GoRuntimeType: 79104
+      GoRuntimeType: 79200
       GoKind: 21
       HeaderType: 161 GoSwissMapHeaderType map<string,*main.indexMemberStruct>
     - __kind: GoMapType
       ID: 116
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 78592
+      GoRuntimeType: 78688
       GoKind: 21
       HeaderType: 118 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 121
       Name: map[string]main.bigStruct
       ByteSize: 8
-      GoRuntimeType: 79232
+      GoRuntimeType: 79328
       GoKind: 21
       HeaderType: 123 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: GoMapType
       ID: 154
       Name: map[string]main.indexMemberStruct
       ByteSize: 8
-      GoRuntimeType: 79360
+      GoRuntimeType: 79456
       GoKind: 21
       HeaderType: 156 GoSwissMapHeaderType map<string,main.indexMemberStruct>
     - __kind: GoMapType
       ID: 169
       Name: map[string]main.largeValueStruct
       ByteSize: 8
-      GoRuntimeType: 79488
+      GoRuntimeType: 79584
       GoKind: 21
       HeaderType: 171 GoSwissMapHeaderType map<string,main.largeValueStruct>
     - __kind: GoMapType
       ID: 132
       Name: map[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 79744
+      GoRuntimeType: 79840
       GoKind: 21
       HeaderType: 134 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: ArrayType
@@ -14409,7 +14958,7 @@ Types:
       ID: 256
       Name: noalg.map.group[bool]int
       ByteSize: 136
-      GoRuntimeType: 87552
+      GoRuntimeType: 87648
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14422,7 +14971,7 @@ Types:
       ID: 276
       Name: noalg.map.group[int]main.aStructNotUsedAsAnArgument
       ByteSize: 136
-      GoRuntimeType: 87808
+      GoRuntimeType: 87904
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14435,7 +14984,7 @@ Types:
       ID: 232
       Name: noalg.map.group[int]string
       ByteSize: 200
-      GoRuntimeType: 88064
+      GoRuntimeType: 88160
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14448,7 +14997,7 @@ Types:
       ID: 248
       Name: noalg.map.group[string]*main.indexMemberStruct
       ByteSize: 200
-      GoRuntimeType: 88320
+      GoRuntimeType: 88416
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14461,7 +15010,7 @@ Types:
       ID: 197
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 87296
+      GoRuntimeType: 87392
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14474,7 +15023,7 @@ Types:
       ID: 205
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
-      GoRuntimeType: 88576
+      GoRuntimeType: 88672
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14487,7 +15036,7 @@ Types:
       ID: 240
       Name: noalg.map.group[string]main.indexMemberStruct
       ByteSize: 392
-      GoRuntimeType: 88832
+      GoRuntimeType: 88928
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14500,7 +15049,7 @@ Types:
       ID: 264
       Name: noalg.map.group[string]main.largeValueStruct
       ByteSize: 200
-      GoRuntimeType: 89088
+      GoRuntimeType: 89184
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14513,7 +15062,7 @@ Types:
       ID: 215
       Name: noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 136
-      GoRuntimeType: 89600
+      GoRuntimeType: 89696
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14526,7 +15075,7 @@ Types:
       ID: 258
       Name: noalg.struct { key bool; elem int }
       ByteSize: 16
-      GoRuntimeType: 87424
+      GoRuntimeType: 87520
       GoKind: 25
       RawFields:
         - Name: key
@@ -14539,7 +15088,7 @@ Types:
       ID: 278
       Name: noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
       ByteSize: 16
-      GoRuntimeType: 87680
+      GoRuntimeType: 87776
       GoKind: 25
       RawFields:
         - Name: key
@@ -14552,7 +15101,7 @@ Types:
       ID: 234
       Name: noalg.struct { key int; elem string }
       ByteSize: 24
-      GoRuntimeType: 87936
+      GoRuntimeType: 88032
       GoKind: 25
       RawFields:
         - Name: key
@@ -14565,7 +15114,7 @@ Types:
       ID: 207
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
-      GoRuntimeType: 88448
+      GoRuntimeType: 88544
       GoKind: 25
       RawFields:
         - Name: key
@@ -14578,7 +15127,7 @@ Types:
       ID: 250
       Name: noalg.struct { key string; elem *main.indexMemberStruct }
       ByteSize: 24
-      GoRuntimeType: 88192
+      GoRuntimeType: 88288
       GoKind: 25
       RawFields:
         - Name: key
@@ -14591,7 +15140,7 @@ Types:
       ID: 266
       Name: noalg.struct { key string; elem *main.largeValueStruct }
       ByteSize: 24
-      GoRuntimeType: 88960
+      GoRuntimeType: 89056
       GoKind: 25
       RawFields:
         - Name: key
@@ -14604,7 +15153,7 @@ Types:
       ID: 199
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 87168
+      GoRuntimeType: 87264
       GoKind: 25
       RawFields:
         - Name: key
@@ -14617,7 +15166,7 @@ Types:
       ID: 242
       Name: noalg.struct { key string; elem main.indexMemberStruct }
       ByteSize: 48
-      GoRuntimeType: 88704
+      GoRuntimeType: 88800
       GoKind: 25
       RawFields:
         - Name: key
@@ -14630,7 +15179,7 @@ Types:
       ID: 217
       Name: noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
       ByteSize: 16
-      GoRuntimeType: 89472
+      GoRuntimeType: 89568
       GoKind: 25
       RawFields:
         - Name: key
@@ -14667,7 +15216,7 @@ Types:
       ID: 313
       Name: runtime.boundsError
       ByteSize: 24
-      GoRuntimeType: 132800
+      GoRuntimeType: 132896
       GoKind: 25
       RawFields:
         - Name: x
@@ -14693,14 +15242,14 @@ Types:
     - __kind: StructureType
       ID: 90
       Name: runtime.dlogPerM
-      GoRuntimeType: 71680
+      GoRuntimeType: 71776
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 321
       Name: runtime.errorAddressString
       ByteSize: 24
-      GoRuntimeType: 124480
+      GoRuntimeType: 124576
       GoKind: 25
       RawFields:
         - Name: msg
@@ -14713,7 +15262,7 @@ Types:
       ID: 300
       Name: runtime.errorString
       ByteSize: 16
-      GoRuntimeType: 71104
+      GoRuntimeType: 71200
       GoKind: 24
       RawFields:
         - Name: str
@@ -14732,7 +15281,7 @@ Types:
       ID: 23
       Name: runtime.g
       ByteSize: 456
-      GoRuntimeType: 164768
+      GoRuntimeType: 164864
       GoKind: 25
       RawFields:
         - Name: stack
@@ -14934,7 +15483,7 @@ Types:
       ID: 55
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 83200
+      GoRuntimeType: 83296
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -14944,7 +15493,7 @@ Types:
       ID: 31
       Name: runtime.gobuf
       ByteSize: 48
-      GoRuntimeType: 135328
+      GoRuntimeType: 135424
       GoKind: 25
       RawFields:
         - Name: sp
@@ -14969,7 +15518,7 @@ Types:
       ID: 47
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 100640
+      GoRuntimeType: 100736
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -14982,7 +15531,7 @@ Types:
       ID: 60
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 123328
+      GoRuntimeType: 123424
       GoKind: 25
       RawFields:
         - Name: stack
@@ -15001,13 +15550,13 @@ Types:
       ID: 32
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 64032
+      GoRuntimeType: 64128
       GoKind: 12
     - __kind: StructureType
       ID: 96
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 103040
+      GoRuntimeType: 103136
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -15020,7 +15569,7 @@ Types:
       ID: 72
       Name: runtime.listNodeManual
       ByteSize: 16
-      GoRuntimeType: 102240
+      GoRuntimeType: 102336
       GoKind: 25
       RawFields:
         - Name: prev
@@ -15033,13 +15582,13 @@ Types:
       ID: 97
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 64416
+      GoRuntimeType: 64512
       GoKind: 2
     - __kind: StructureType
       ID: 30
       Name: runtime.m
       ByteSize: 1824
-      GoRuntimeType: 170048
+      GoRuntimeType: 170144
       GoKind: 25
       RawFields:
         - Name: g0
@@ -15268,7 +15817,7 @@ Types:
       ID: 75
       Name: runtime.mLockProfile
       ByteSize: 56
-      GoRuntimeType: 135840
+      GoRuntimeType: 135936
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -15293,7 +15842,7 @@ Types:
       ID: 91
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 131232
+      GoRuntimeType: 131328
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -15315,7 +15864,7 @@ Types:
       ID: 80
       Name: runtime.mTraceState
       ByteSize: 72
-      GoRuntimeType: 136096
+      GoRuntimeType: 136192
       GoKind: 25
       RawFields:
         - Name: writing
@@ -15340,7 +15889,7 @@ Types:
       ID: 74
       Name: runtime.mWaitList
       ByteSize: 16
-      GoRuntimeType: 102720
+      GoRuntimeType: 102816
       GoKind: 25
       RawFields:
         - Name: next
@@ -15353,7 +15902,7 @@ Types:
       ID: 98
       Name: runtime.mWeakPointer
       ByteSize: 8
-      GoRuntimeType: 108128
+      GoRuntimeType: 108224
       GoKind: 25
       RawFields:
         - Name: m
@@ -15363,13 +15912,13 @@ Types:
       ID: 38
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 64128
+      GoRuntimeType: 64224
       GoKind: 12
     - __kind: StructureType
       ID: 71
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 84224
+      GoRuntimeType: 84320
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
@@ -15380,7 +15929,7 @@ Types:
       ID: 86
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 102880
+      GoRuntimeType: 102976
       GoKind: 25
       RawFields:
         - Name: entries
@@ -15393,7 +15942,7 @@ Types:
       ID: 89
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 124288
+      GoRuntimeType: 124384
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -15412,7 +15961,7 @@ Types:
       ID: 303
       Name: runtime.plainError
       ByteSize: 16
-      GoRuntimeType: 71200
+      GoRuntimeType: 71296
       GoKind: 24
       RawFields:
         - Name: str
@@ -15431,13 +15980,13 @@ Types:
       ID: 64
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 64320
+      GoRuntimeType: 64416
       GoKind: 12
     - __kind: ArrayType
       ID: 61
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 67936
+      GoRuntimeType: 68032
       GoKind: 17
       Count: 2
       HasCount: true
@@ -15446,7 +15995,7 @@ Types:
       ID: 24
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 99360
+      GoRuntimeType: 99456
       GoKind: 25
       RawFields:
         - Name: lo
@@ -15467,7 +16016,7 @@ Types:
       ID: 294
       Name: runtime.synctestDeadlockError
       ByteSize: 24
-      GoRuntimeType: 110688
+      GoRuntimeType: 110784
       GoKind: 25
       RawFields:
         - Name: reason
@@ -15500,7 +16049,7 @@ Types:
       ID: 56
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 100960
+      GoRuntimeType: 101056
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -15513,19 +16062,19 @@ Types:
       ID: 35
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 110368
+      GoRuntimeType: 110464
       GoKind: 8
     - __kind: StructureType
       ID: 85
       Name: runtime.winlibcall
-      GoRuntimeType: 71584
+      GoRuntimeType: 71680
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 52
       Name: runtime.xRegPerG
       ByteSize: 8
-      GoRuntimeType: 83072
+      GoRuntimeType: 83168
       GoKind: 25
       RawFields:
         - Name: state
@@ -15562,7 +16111,7 @@ Types:
       ID: 328
       Name: syscall.Errno
       ByteSize: 8
-      GoRuntimeType: 87040
+      GoRuntimeType: 87136
       GoKind: 12
     - __kind: StructureType
       ID: 253
@@ -15784,7 +16333,7 @@ Types:
       ID: 282
       Name: time.fileSizeError
       ByteSize: 16
-      GoRuntimeType: 64512
+      GoRuntimeType: 64608
       GoKind: 24
       RawFields:
         - Name: str
@@ -15841,7 +16390,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 49248
       GoKind: 26
-MaxTypeID: 684
+MaxTypeID: 693
 Issues:
     - probe_definition:
         id: condCompound_eq_of_eq
@@ -16149,6 +16698,26 @@ Issues:
       issue:
         Kind: 7
         Message: condition variable "x" not available at any event
+    - probe_definition:
+        id: condLineReturn_cond_return
+        version: 0
+        type: LOG_PROBE
+        where:
+            methodName: main.condLineReturn
+            sourceFile: main.go
+            lines: ["571"]
+        tags: ['issue:ConditionVariableUnavailable']
+        when:
+            dsl: '@return == 14'
+            json: {eq: [{ref: '@return'}, 14]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: matched
+        segments: [matched]
+        captureSnapshot: false
+      issue:
+        Kind: 7
+        Message: condition variable "@return" not found
     - probe_definition:
         id: condNull_int_vs_null
         version: 0

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
@@ -9,10 +9,10 @@ Probes:
       segments: ['ptr: ', {json: {ref: ptr}, dsl: ptr}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 76}
+        - subprogram: {subprogram: 78}
           events:
             - Kind: Entry
-              Type: 611 EventRootType Probe[main.PointerChainArg]
+              Type: 619 EventRootType Probe[main.PointerChainArg]
               InjectionPoints: [{PC: "0xb6034", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -32,10 +32,10 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 77}
+        - subprogram: {subprogram: 79}
           events:
             - Kind: Entry
-              Type: 612 EventRootType Probe[main.PointerSmallChainArg]
+              Type: 620 EventRootType Probe[main.PointerSmallChainArg]
               InjectionPoints: [{PC: "0xb607c", Frameless: false}]
               Condition: null
     - id: bigMapArg
@@ -50,11 +50,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 312 EventRootType Probe[main.bigMapArg]
-              InjectionPoints: [{PC: "0xb85d0", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8810", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 313 EventRootType Probe[main.bigMapArg]Return
-              InjectionPoints: [{PC: "0xb8644", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8884", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 'm: {m}'
@@ -78,7 +78,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 358 EventRootType Probe[main.condBool]
-              InjectionPoints: [{PC: "0xb8dd8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9018", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -95,7 +95,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 359 EventRootType Probe[main.condBool]Return
-              InjectionPoints: [{PC: "0xb8e40", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9080", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -119,7 +119,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 360 EventRootType Probe[main.condBool]
-              InjectionPoints: [{PC: "0xb8dd8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9018", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -136,7 +136,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 361 EventRootType Probe[main.condBool]Return
-              InjectionPoints: [{PC: "0xb8e40", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9080", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -159,11 +159,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 362 EventRootType Probe[main.condBool]
-              InjectionPoints: [{PC: "0xb8dd8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9018", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 363 EventRootType Probe[main.condBool]Return
-              InjectionPoints: [{PC: "0xb8e40", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9080", Frameless: false}]
               Condition: null
     - id: condCompound_and
       version: 0
@@ -188,7 +188,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 408 EventRootType Probe[main.condReturnAndLocal]
-              InjectionPoints: [{PC: "0xb9258", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9498", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -220,7 +220,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 409 EventRootType Probe[main.condReturnAndLocal]Return
-              InjectionPoints: [{PC: "0xb92b8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb94f8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: a == 1 && b == 1 [a={a}, b={b}]
@@ -262,7 +262,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 378 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0xb8f4c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb918c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -292,7 +292,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 379 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0xb9020", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9260", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x.S == "world" && tag == "match" [x.S={x.S}, tag={tag}]
@@ -314,7 +314,7 @@ Probes:
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["519"]
+        lines: ["547"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -338,7 +338,7 @@ Probes:
           events:
             - Kind: Line
               Type: 418 EventRootType Probe[main.condLine]Line
-              InjectionPoints: [{PC: "0xb93b4", Frameless: false}]
+              InjectionPoints: [{PC: "0xb95f4", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -412,7 +412,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 380 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0xb8f4c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb918c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -460,7 +460,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 381 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0xb9020", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9260", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: (x.I32 == 300 || x.I32 == 999) && !isEmpty(x.S) [x.I32={x.I32}, x.S={x.S}, tag={tag}]
@@ -502,7 +502,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 364 EventRootType Probe[main.condBool]
-              InjectionPoints: [{PC: "0xb8dd8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9018", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -520,7 +520,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 365 EventRootType Probe[main.condBool]Return
-              InjectionPoints: [{PC: "0xb8e40", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9080", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '!x [x={x}, tag={tag}]'
@@ -559,7 +559,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 324 EventRootType Probe[main.condInt32]
-              InjectionPoints: [{PC: "0xb8858", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8a98", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -591,7 +591,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 325 EventRootType Probe[main.condInt32]Return
-              InjectionPoints: [{PC: "0xb88b8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8af8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x == 42 || x == 100 [x={x}, tag={tag}]
@@ -629,16 +629,16 @@ Probes:
         - ']'
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 431 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xb9bec", Frameless: false}]
+              Type: 439 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xba05c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 37, index: 1, name: tag}
+                      Variable: {subprogram: 39, index: 1, name: tag}
                       Offset: 0
                       ByteSize: 16
                     - __kind: ExprReadStringOp
@@ -650,7 +650,7 @@ Probes:
                       Cond: true
                       Target: 1
                     - __kind: LocationOp
-                      Variable: {subprogram: 37, index: 0, name: s}
+                      Variable: {subprogram: 39, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -664,8 +664,8 @@ Probes:
                       ID: 1
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 432 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xb9ca0", Frameless: false}]
+              Type: 440 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xba110", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag == "match" || !isEmpty(s) [s={s}, tag={tag}]
@@ -703,20 +703,20 @@ Probes:
         - ']'
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 72}
+        - subprogram: {subprogram: 74}
           events:
             - Kind: Entry
-              Type: 603 EventRootType Probe[main.condMultiReturn]
-              InjectionPoints: [{PC: "0xbb798", Frameless: false}]
+              Type: 611 EventRootType Probe[main.condMultiReturn]
+              InjectionPoints: [{PC: "0xbbc08", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 604 EventRootType Probe[main.condMultiReturn]Return
-              InjectionPoints: [{PC: "0xbb824", Frameless: false}]
+              Type: 612 EventRootType Probe[main.condMultiReturn]Return
+              InjectionPoints: [{PC: "0xbbc94", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 72, index: 1, name: r0}
+                      Variable: {subprogram: 74, index: 1, name: r0}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -729,7 +729,7 @@ Probes:
                       Cond: false
                       Target: 1
                     - __kind: LocationOp
-                      Variable: {subprogram: 72, index: 2, name: r1}
+                      Variable: {subprogram: 74, index: 2, name: r1}
                       Offset: 0
                       ByteSize: 16
                     - __kind: ExprReadStringOp
@@ -777,7 +777,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 400 EventRootType Probe[main.condNilPtrStruct]
-              InjectionPoints: [{PC: "0xb9198", Frameless: false}]
+              InjectionPoints: [{PC: "0xb93d8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -811,7 +811,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 401 EventRootType Probe[main.condNilPtrStruct]Return
-              InjectionPoints: [{PC: "0xb920c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb944c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag == "nilptr" && x.I32 == 300 [tag={tag}]
@@ -845,7 +845,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 402 EventRootType Probe[main.condNilPtrStruct]
-              InjectionPoints: [{PC: "0xb9198", Frameless: false}]
+              InjectionPoints: [{PC: "0xb93d8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -879,7 +879,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 403 EventRootType Probe[main.condNilPtrStruct]Return
-              InjectionPoints: [{PC: "0xb920c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb944c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag == "nilptr" || x.I32 == 300 [tag={tag}]
@@ -903,11 +903,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 354 EventRootType Probe[main.condFloat32]
-              InjectionPoints: [{PC: "0xb8c78", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8eb8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 355 EventRootType Probe[main.condFloat32]Return
-              InjectionPoints: [{PC: "0xb8ce0", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8f20", Frameless: false}]
               Condition: null
     - id: condFloat64_nocond
       version: 0
@@ -922,11 +922,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 356 EventRootType Probe[main.condFloat64]
-              InjectionPoints: [{PC: "0xb8d28", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8f68", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 357 EventRootType Probe[main.condFloat64]Return
-              InjectionPoints: [{PC: "0xb8d90", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8fd0", Frameless: false}]
               Condition: null
     - id: condInt16_cond
       version: 0
@@ -942,7 +942,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 320 EventRootType Probe[main.condInt16]
-              InjectionPoints: [{PC: "0xb87a8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb89e8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -959,7 +959,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 321 EventRootType Probe[main.condInt16]Return
-              InjectionPoints: [{PC: "0xb8808", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8a48", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -982,11 +982,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 322 EventRootType Probe[main.condInt16]
-              InjectionPoints: [{PC: "0xb87a8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb89e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 323 EventRootType Probe[main.condInt16]Return
-              InjectionPoints: [{PC: "0xb8808", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8a48", Frameless: false}]
               Condition: null
     - id: condInt32_cond
       version: 0
@@ -1002,7 +1002,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 326 EventRootType Probe[main.condInt32]
-              InjectionPoints: [{PC: "0xb8858", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8a98", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1019,7 +1019,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 327 EventRootType Probe[main.condInt32]Return
-              InjectionPoints: [{PC: "0xb88b8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8af8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1046,7 +1046,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 328 EventRootType Probe[main.condInt32]
-              InjectionPoints: [{PC: "0xb8858", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8a98", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1063,7 +1063,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 329 EventRootType Probe[main.condInt32]Return
-              InjectionPoints: [{PC: "0xb88b8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8af8", Frameless: false}]
               Condition: null
     - id: condInt32_nocond
       version: 0
@@ -1078,11 +1078,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 330 EventRootType Probe[main.condInt32]
-              InjectionPoints: [{PC: "0xb8858", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8a98", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 331 EventRootType Probe[main.condInt32]Return
-              InjectionPoints: [{PC: "0xb88b8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8af8", Frameless: false}]
               Condition: null
     - id: condInt64_cond
       version: 0
@@ -1098,7 +1098,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 332 EventRootType Probe[main.condInt64]
-              InjectionPoints: [{PC: "0xb8908", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8b48", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1115,7 +1115,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 333 EventRootType Probe[main.condInt64]Return
-              InjectionPoints: [{PC: "0xb8968", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8ba8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1138,11 +1138,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 334 EventRootType Probe[main.condInt64]
-              InjectionPoints: [{PC: "0xb8908", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8b48", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 335 EventRootType Probe[main.condInt64]Return
-              InjectionPoints: [{PC: "0xb8968", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8ba8", Frameless: false}]
               Condition: null
     - id: condInt8_cond
       version: 0
@@ -1158,7 +1158,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 316 EventRootType Probe[main.condInt8]
-              InjectionPoints: [{PC: "0xb86f8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8938", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1175,7 +1175,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 317 EventRootType Probe[main.condInt8]Return
-              InjectionPoints: [{PC: "0xb8760", Frameless: false}]
+              InjectionPoints: [{PC: "0xb89a0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1198,11 +1198,257 @@ Probes:
           events:
             - Kind: Entry
               Type: 318 EventRootType Probe[main.condInt8]
-              InjectionPoints: [{PC: "0xb86f8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8938", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 319 EventRootType Probe[main.condInt8]Return
-              InjectionPoints: [{PC: "0xb8760", Frameless: false}]
+              InjectionPoints: [{PC: "0xb89a0", Frameless: false}]
+              Condition: null
+    - id: condLineMixed_cond_bool
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when: {dsl: b == true, json: {eq: [{ref: b}, true]}}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 422 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0xb96d8", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 1, name: b}
+                      Offset: 0
+                      ByteSize: 1
+                    - __kind: ExprPushOffsetOp
+                      ByteSize: 1
+                    - __kind: ExprLoadLiteralOp
+                      Data: AQ==
+                    - __kind: ExprCmpEqBaseOp
+                      ByteSize: 1
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_isEmpty_slice
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when: {dsl: isEmpty(ss), json: {isEmpty: {ref: ss}}}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 423 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0xb96d8", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 4, name: ss}
+                      Offset: 8
+                      ByteSize: 8
+                    - __kind: ExprPushOffsetOp
+                      ByteSize: 8
+                    - __kind: ExprLoadLiteralOp
+                      Data: AAAAAAAAAAA=
+                    - __kind: ExprCmpEqBaseOp
+                      ByteSize: 8
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_len_string
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when:
+        dsl: len(s) == 5
+        json: {eq: [{len: {ref: s}}, 5]}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 424 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0xb96d8", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 0, name: s}
+                      Offset: 8
+                      ByteSize: 8
+                    - __kind: ExprPushOffsetOp
+                      ByteSize: 8
+                    - __kind: ExprLoadLiteralOp
+                      Data: BQAAAAAAAAA=
+                    - __kind: ExprCmpEqBaseOp
+                      ByteSize: 8
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_ptrstruct_field
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when:
+        dsl: p.S == "world"
+        json: {eq: [{getmember: [{ref: p}, S]}, world]}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 425 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0xb96d8", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 3, name: p}
+                      Offset: 0
+                      ByteSize: 8
+                    - __kind: DereferenceOp
+                      Bias: 56
+                      ByteSize: 16
+                    - __kind: ExprReadStringOp
+                      MaxLen: 255
+                    - __kind: ExprLoadLiteralOp
+                      Data: BQAAAHdvcmxk
+                    - __kind: ExprCmpEqStringOp
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_string
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when:
+        dsl: s == "hello"
+        json: {eq: [{ref: s}, hello]}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 426 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0xb96d8", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 0, name: s}
+                      Offset: 0
+                      ByteSize: 16
+                    - __kind: ExprReadStringOp
+                      MaxLen: 255
+                    - __kind: ExprLoadLiteralOp
+                      Data: BQAAAGhlbGxv
+                    - __kind: ExprCmpEqStringOp
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_struct_field
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when:
+        dsl: x.I32 == 300
+        json: {eq: [{getmember: [{ref: x}, I32]}, 300]}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 427 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0xb96d8", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 2, name: x}
+                      Offset: 4
+                      ByteSize: 4
+                    - __kind: ExprPushOffsetOp
+                      ByteSize: 4
+                    - __kind: ExprLoadLiteralOp
+                      Data: LAEAAA==
+                    - __kind: ExprCmpEqBaseOp
+                      ByteSize: 4
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_nocond
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 428 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0xb96d8", Frameless: false}]
               Condition: null
     - id: condLine_cond
       version: 0
@@ -1210,7 +1456,7 @@ Probes:
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["519"]
+        lines: ["547"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -1227,7 +1473,7 @@ Probes:
           events:
             - Kind: Line
               Type: 419 EventRootType Probe[main.condLine]Line
-              InjectionPoints: [{PC: "0xb93b4", Frameless: false}]
+              InjectionPoints: [{PC: "0xb95f4", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1242,13 +1488,13 @@ Probes:
                     - __kind: ExprCmpEqBaseOp
                       ByteSize: 8
                     - __kind: ConditionCheckOp
-    - id: condLine_nocond
+    - id: condLine_local_nocond
       version: 0
       type: LOG_PROBE
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["519"]
+        lines: ["548"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -1261,7 +1507,28 @@ Probes:
           events:
             - Kind: Line
               Type: 420 EventRootType Probe[main.condLine]Line
-              InjectionPoints: [{PC: "0xb93b4", Frameless: false}]
+              InjectionPoints: [{PC: "0xb95f8", Frameless: false}]
+              Condition: null
+    - id: condLine_nocond
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLine
+        sourceFile: main.go
+        lines: ["547"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 28}
+          events:
+            - Kind: Line
+              Type: 421 EventRootType Probe[main.condLine]Line
+              InjectionPoints: [{PC: "0xb95f4", Frameless: false}]
               Condition: null
     - id: condNilPtr_cond
       version: 0
@@ -1279,7 +1546,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 404 EventRootType Probe[main.condNilPtrStruct]
-              InjectionPoints: [{PC: "0xb9198", Frameless: false}]
+              InjectionPoints: [{PC: "0xb93d8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1299,7 +1566,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 405 EventRootType Probe[main.condNilPtrStruct]Return
-              InjectionPoints: [{PC: "0xb920c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb944c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: condNilPtr {tag}
@@ -1322,11 +1589,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 406 EventRootType Probe[main.condNilPtrStruct]
-              InjectionPoints: [{PC: "0xb9198", Frameless: false}]
+              InjectionPoints: [{PC: "0xb93d8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 407 EventRootType Probe[main.condNilPtrStruct]Return
-              InjectionPoints: [{PC: "0xb920c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb944c", Frameless: false}]
               Condition: null
     - id: condNull_iface
       version: 0
@@ -1338,16 +1605,16 @@ Probes:
       segments: ['i == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 35}
+        - subprogram: {subprogram: 37}
           events:
             - Kind: Entry
-              Type: 427 EventRootType Probe[main.condNullIface]
-              InjectionPoints: [{PC: "0xb99bc", Frameless: false}]
+              Type: 435 EventRootType Probe[main.condNullIface]
+              InjectionPoints: [{PC: "0xb9e2c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 35, index: 0, name: i}
+                      Variable: {subprogram: 37, index: 0, name: i}
                       Offset: 0
                       ByteSize: 16
                     - __kind: ExprPushOffsetOp
@@ -1358,8 +1625,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 428 EventRootType Probe[main.condNullIface]Return
-              InjectionPoints: [{PC: "0xb9a7c", Frameless: false}]
+              Type: 436 EventRootType Probe[main.condNullIface]Return
+              InjectionPoints: [{PC: "0xb9eec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: i == nil [tag={tag}]
@@ -1380,16 +1647,16 @@ Probes:
       segments: ['m == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 34}
+        - subprogram: {subprogram: 36}
           events:
             - Kind: Entry
-              Type: 425 EventRootType Probe[main.condNullMap]
-              InjectionPoints: [{PC: "0xb98bc", Frameless: false}]
+              Type: 433 EventRootType Probe[main.condNullMap]
+              InjectionPoints: [{PC: "0xb9d2c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 34, index: 0, name: m}
+                      Variable: {subprogram: 36, index: 0, name: m}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -1400,8 +1667,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 426 EventRootType Probe[main.condNullMap]Return
-              InjectionPoints: [{PC: "0xb9964", Frameless: false}]
+              Type: 434 EventRootType Probe[main.condNullMap]Return
+              InjectionPoints: [{PC: "0xb9dd4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: m == nil [tag={tag}]
@@ -1422,16 +1689,16 @@ Probes:
       segments: ['p == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 32}
+        - subprogram: {subprogram: 34}
           events:
             - Kind: Entry
-              Type: 421 EventRootType Probe[main.condNullPtr]
-              InjectionPoints: [{PC: "0xb968c", Frameless: false}]
+              Type: 429 EventRootType Probe[main.condNullPtr]
+              InjectionPoints: [{PC: "0xb9afc", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 32, index: 0, name: p}
+                      Variable: {subprogram: 34, index: 0, name: p}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -1442,8 +1709,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 422 EventRootType Probe[main.condNullPtr]Return
-              InjectionPoints: [{PC: "0xb9734", Frameless: false}]
+              Type: 430 EventRootType Probe[main.condNullPtr]Return
+              InjectionPoints: [{PC: "0xb9ba4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p == nil [tag={tag}]
@@ -1464,16 +1731,16 @@ Probes:
       segments: ['s == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 33}
+        - subprogram: {subprogram: 35}
           events:
             - Kind: Entry
-              Type: 423 EventRootType Probe[main.condNullSlice]
-              InjectionPoints: [{PC: "0xb978c", Frameless: false}]
+              Type: 431 EventRootType Probe[main.condNullSlice]
+              InjectionPoints: [{PC: "0xb9bfc", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 33, index: 0, name: s}
+                      Variable: {subprogram: 35, index: 0, name: s}
                       Offset: 0
                       ByteSize: 24
                     - __kind: ExprPushOffsetOp
@@ -1484,8 +1751,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 424 EventRootType Probe[main.condNullSlice]Return
-              InjectionPoints: [{PC: "0xb9858", Frameless: false}]
+              Type: 432 EventRootType Probe[main.condNullSlice]Return
+              InjectionPoints: [{PC: "0xb9cc8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: s == nil [tag={tag}]
@@ -1506,16 +1773,16 @@ Probes:
       segments: ['p == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 36}
+        - subprogram: {subprogram: 38}
           events:
             - Kind: Entry
-              Type: 429 EventRootType Probe[main.condNullUnsafePtr]
-              InjectionPoints: [{PC: "0xb9adc", Frameless: false}]
+              Type: 437 EventRootType Probe[main.condNullUnsafePtr]
+              InjectionPoints: [{PC: "0xb9f4c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 36, index: 0, name: p}
+                      Variable: {subprogram: 38, index: 0, name: p}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -1526,8 +1793,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 430 EventRootType Probe[main.condNullUnsafePtr]Return
-              InjectionPoints: [{PC: "0xb9b84", Frameless: false}]
+              Type: 438 EventRootType Probe[main.condNullUnsafePtr]Return
+              InjectionPoints: [{PC: "0xb9ff4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p == nil [tag={tag}]
@@ -1552,7 +1819,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 414 EventRootType Probe[main.condOnly]
-              InjectionPoints: [{PC: "0xb92f8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9538", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1569,7 +1836,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 415 EventRootType Probe[main.condOnly]Return
-              InjectionPoints: [{PC: "0xb9358", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9598", Frameless: false}]
               Condition: null
     - id: condOnly_nocond
       version: 0
@@ -1584,11 +1851,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 416 EventRootType Probe[main.condOnly]
-              InjectionPoints: [{PC: "0xb92f8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9538", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 417 EventRootType Probe[main.condOnly]Return
-              InjectionPoints: [{PC: "0xb9358", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9598", Frameless: false}]
               Condition: null
     - id: condPtrStruct_field_i32
       version: 0
@@ -1606,7 +1873,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 394 EventRootType Probe[main.condPtrStructArg]
-              InjectionPoints: [{PC: "0xb906c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb92ac", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1626,7 +1893,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 395 EventRootType Probe[main.condPtrStructArg]Return
-              InjectionPoints: [{PC: "0xb9150", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9390", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1652,7 +1919,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 396 EventRootType Probe[main.condPtrStructArg]
-              InjectionPoints: [{PC: "0xb906c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb92ac", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1671,7 +1938,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 397 EventRootType Probe[main.condPtrStructArg]Return
-              InjectionPoints: [{PC: "0xb9150", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9390", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1694,11 +1961,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 398 EventRootType Probe[main.condPtrStructArg]
-              InjectionPoints: [{PC: "0xb906c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb92ac", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 399 EventRootType Probe[main.condPtrStructArg]Return
-              InjectionPoints: [{PC: "0xb9150", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9390", Frameless: false}]
               Condition: null
     - id: condReturnAndLocal_cond_param
       version: 0
@@ -1714,7 +1981,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 410 EventRootType Probe[main.condReturnAndLocal]
-              InjectionPoints: [{PC: "0xb9258", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9498", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1731,7 +1998,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 411 EventRootType Probe[main.condReturnAndLocal]Return
-              InjectionPoints: [{PC: "0xb92b8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb94f8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: b={b}
@@ -1754,11 +2021,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 412 EventRootType Probe[main.condReturnAndLocal]
-              InjectionPoints: [{PC: "0xb9258", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9498", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 413 EventRootType Probe[main.condReturnAndLocal]Return
-              InjectionPoints: [{PC: "0xb92b8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb94f8", Frameless: false}]
               Condition: null
     - id: condString_cond
       version: 0
@@ -1776,7 +2043,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 366 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0xb8e88", Frameless: false}]
+              InjectionPoints: [{PC: "0xb90c8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1792,7 +2059,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 367 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0xb8eec", Frameless: false}]
+              InjectionPoints: [{PC: "0xb912c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1816,7 +2083,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 368 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0xb8e88", Frameless: false}]
+              InjectionPoints: [{PC: "0xb90c8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1832,7 +2099,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 369 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0xb8eec", Frameless: false}]
+              InjectionPoints: [{PC: "0xb912c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1860,11 +2127,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 370 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0xb8e88", Frameless: false}]
+              InjectionPoints: [{PC: "0xb90c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 371 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0xb8eec", Frameless: false}]
+              InjectionPoints: [{PC: "0xb912c", Frameless: false}]
               Condition: null
     - id: condString_eq_template
       version: 0
@@ -1882,11 +2149,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 372 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0xb8e88", Frameless: false}]
+              InjectionPoints: [{PC: "0xb90c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 373 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0xb8eec", Frameless: false}]
+              InjectionPoints: [{PC: "0xb912c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: eq={x == "hello"}
@@ -1909,11 +2176,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 374 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0xb8e88", Frameless: false}]
+              InjectionPoints: [{PC: "0xb90c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 375 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0xb8eec", Frameless: false}]
+              InjectionPoints: [{PC: "0xb912c", Frameless: false}]
               Condition: null
     - id: condString_snapshot_with_cond
       version: 0
@@ -1931,7 +2198,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 376 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0xb8e88", Frameless: false}]
+              InjectionPoints: [{PC: "0xb90c8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1947,7 +2214,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 377 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0xb8eec", Frameless: false}]
+              InjectionPoints: [{PC: "0xb912c", Frameless: false}]
               Condition: null
     - id: condStruct_cond_i32_capture_tag
       version: 0
@@ -1968,7 +2235,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 382 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0xb8f4c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb918c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1985,7 +2252,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 383 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0xb9020", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9260", Frameless: false}]
               Condition: null
     - id: condStruct_field_bool
       version: 0
@@ -2003,7 +2270,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 384 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0xb8f4c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb918c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2020,7 +2287,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 385 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0xb9020", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9260", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2046,7 +2313,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 386 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0xb8f4c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb918c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2063,7 +2330,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 387 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0xb9020", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9260", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2089,7 +2356,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 388 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0xb8f4c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb918c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2106,7 +2373,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 389 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0xb9020", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9260", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2132,7 +2399,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 390 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0xb8f4c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb918c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2148,7 +2415,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 391 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0xb9020", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9260", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2171,11 +2438,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 392 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0xb8f4c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb918c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 393 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0xb9020", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9260", Frameless: false}]
               Condition: null
     - id: condUint16_cond
       version: 0
@@ -2191,7 +2458,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 342 EventRootType Probe[main.condUint16]
-              InjectionPoints: [{PC: "0xb8a68", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8ca8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2208,7 +2475,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 343 EventRootType Probe[main.condUint16]Return
-              InjectionPoints: [{PC: "0xb8ac8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8d08", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2231,11 +2498,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 344 EventRootType Probe[main.condUint16]
-              InjectionPoints: [{PC: "0xb8a68", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8ca8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 345 EventRootType Probe[main.condUint16]Return
-              InjectionPoints: [{PC: "0xb8ac8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8d08", Frameless: false}]
               Condition: null
     - id: condUint32_cond
       version: 0
@@ -2251,7 +2518,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 346 EventRootType Probe[main.condUint32]
-              InjectionPoints: [{PC: "0xb8b18", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8d58", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2268,7 +2535,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 347 EventRootType Probe[main.condUint32]Return
-              InjectionPoints: [{PC: "0xb8b78", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8db8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2291,11 +2558,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 348 EventRootType Probe[main.condUint32]
-              InjectionPoints: [{PC: "0xb8b18", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8d58", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 349 EventRootType Probe[main.condUint32]Return
-              InjectionPoints: [{PC: "0xb8b78", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8db8", Frameless: false}]
               Condition: null
     - id: condUint64_cond
       version: 0
@@ -2311,7 +2578,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 350 EventRootType Probe[main.condUint64]
-              InjectionPoints: [{PC: "0xb8bc8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8e08", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2328,7 +2595,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 351 EventRootType Probe[main.condUint64]Return
-              InjectionPoints: [{PC: "0xb8c28", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8e68", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2351,11 +2618,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 352 EventRootType Probe[main.condUint64]
-              InjectionPoints: [{PC: "0xb8bc8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8e08", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 353 EventRootType Probe[main.condUint64]Return
-              InjectionPoints: [{PC: "0xb8c28", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8e68", Frameless: false}]
               Condition: null
     - id: condUint8_cond
       version: 0
@@ -2371,7 +2638,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 336 EventRootType Probe[main.condUint8]
-              InjectionPoints: [{PC: "0xb89b8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8bf8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2388,7 +2655,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 337 EventRootType Probe[main.condUint8]Return
-              InjectionPoints: [{PC: "0xb8a20", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8c60", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2412,7 +2679,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 338 EventRootType Probe[main.condUint8]
-              InjectionPoints: [{PC: "0xb89b8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8bf8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2429,7 +2696,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 339 EventRootType Probe[main.condUint8]Return
-              InjectionPoints: [{PC: "0xb8a20", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8c60", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2452,11 +2719,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 340 EventRootType Probe[main.condUint8]
-              InjectionPoints: [{PC: "0xb89b8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8bf8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 341 EventRootType Probe[main.condUint8]Return
-              InjectionPoints: [{PC: "0xb8a20", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8c60", Frameless: false}]
               Condition: null
     - id: genericIdentity
       version: 0
@@ -2466,25 +2733,25 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 73}
+        - subprogram: {subprogram: 75}
           events:
             - Kind: Entry
-              Type: 605 EventRootType Probe[main.genericIdentity[go.shape.string]]
-              InjectionPoints: [{PC: "0xbb868", Frameless: false}]
+              Type: 613 EventRootType Probe[main.genericIdentity[go.shape.string]]
+              InjectionPoints: [{PC: "0xbbcd8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 606 EventRootType Probe[main.genericIdentity[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xbb8bc", Frameless: false}]
+              Type: 614 EventRootType Probe[main.genericIdentity[go.shape.string]]Return
+              InjectionPoints: [{PC: "0xbbd2c", Frameless: false}]
               Condition: null
-        - subprogram: {subprogram: 74}
+        - subprogram: {subprogram: 76}
           events:
             - Kind: Entry
-              Type: 607 EventRootType Probe[main.genericIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0xbb908", Frameless: false}]
+              Type: 615 EventRootType Probe[main.genericIdentity[go.shape.int]]
+              InjectionPoints: [{PC: "0xbbd78", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 608 EventRootType Probe[main.genericIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xbb950", Frameless: false}]
+              Type: 616 EventRootType Probe[main.genericIdentity[go.shape.int]]Return
+              InjectionPoints: [{PC: "0xbbdc0", Frameless: false}]
               Condition: null
     - id: indexBigArrayStruct_last
       version: 0
@@ -2500,15 +2767,15 @@ Probes:
             dsl: s.data[131071]
             json: {index: [{getmember: [{ref: s}, data]}, 131071]}
       instances:
-        - subprogram: {subprogram: 48}
+        - subprogram: {subprogram: 50}
           events:
             - Kind: Entry
-              Type: 529 EventRootType Probe[main.bigArrayStructArg]
-              InjectionPoints: [{PC: "0xba7f8", Frameless: false}]
+              Type: 537 EventRootType Probe[main.bigArrayStructArg]
+              InjectionPoints: [{PC: "0xbac68", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 530 EventRootType Probe[main.bigArrayStructArg]Return
-              InjectionPoints: [{PC: "0xba85c", Frameless: false}]
+              Type: 538 EventRootType Probe[main.bigArrayStructArg]Return
+              InjectionPoints: [{PC: "0xbaccc", Frameless: false}]
               Condition: null
     - id: indexBigArray_first
       version: 0
@@ -2522,15 +2789,15 @@ Probes:
         - name: s_0
           expr: {dsl: 's[0]', json: {index: [{ref: s}, 0]}}
       instances:
-        - subprogram: {subprogram: 47}
+        - subprogram: {subprogram: 49}
           events:
             - Kind: Entry
-              Type: 525 EventRootType Probe[main.bigArrayArg]
-              InjectionPoints: [{PC: "0xba768", Frameless: false}]
+              Type: 533 EventRootType Probe[main.bigArrayArg]
+              InjectionPoints: [{PC: "0xbabd8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 526 EventRootType Probe[main.bigArrayArg]Return
-              InjectionPoints: [{PC: "0xba7c4", Frameless: false}]
+              Type: 534 EventRootType Probe[main.bigArrayArg]Return
+              InjectionPoints: [{PC: "0xbac34", Frameless: false}]
               Condition: null
     - id: indexBigArray_last
       version: 0
@@ -2544,15 +2811,15 @@ Probes:
         - name: s_131071
           expr: {dsl: 's[131071]', json: {index: [{ref: s}, 131071]}}
       instances:
-        - subprogram: {subprogram: 47}
+        - subprogram: {subprogram: 49}
           events:
             - Kind: Entry
-              Type: 527 EventRootType Probe[main.bigArrayArg]
-              InjectionPoints: [{PC: "0xba768", Frameless: false}]
+              Type: 535 EventRootType Probe[main.bigArrayArg]
+              InjectionPoints: [{PC: "0xbabd8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 528 EventRootType Probe[main.bigArrayArg]Return
-              InjectionPoints: [{PC: "0xba7c4", Frameless: false}]
+              Type: 536 EventRootType Probe[main.bigArrayArg]Return
+              InjectionPoints: [{PC: "0xbac34", Frameless: false}]
               Condition: null
     - id: indexErr_array_oob_capture
       version: 0
@@ -2570,11 +2837,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 291 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0xb82f8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8538", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 292 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0xb833c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb857c", Frameless: false}]
               Condition: null
     - id: indexErr_array_oob_template
       version: 0
@@ -2589,11 +2856,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 293 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0xb82f8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8538", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 294 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0xb833c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb857c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's[3]: {s[3]}'
@@ -2617,11 +2884,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 277 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0xb8268", Frameless: false}]
+              InjectionPoints: [{PC: "0xb84a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 278 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0xb82a4", Frameless: false}]
+              InjectionPoints: [{PC: "0xb84e4", Frameless: false}]
               Condition: null
     - id: indexErr_slice_oob_cond
       version: 0
@@ -2639,7 +2906,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 279 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0xb8268", Frameless: false}]
+              InjectionPoints: [{PC: "0xb84a8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2661,7 +2928,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 280 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0xb82a4", Frameless: false}]
+              InjectionPoints: [{PC: "0xb84e4", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: matched, Segments: [matched]}
     - id: indexErr_slice_oob_template
@@ -2677,11 +2944,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 281 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0xb8268", Frameless: false}]
+              InjectionPoints: [{PC: "0xb84a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 282 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0xb82a4", Frameless: false}]
+              InjectionPoints: [{PC: "0xb84e4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's[5]: {s[5]}'
@@ -2707,11 +2974,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 295 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0xb82f8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8538", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 296 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0xb833c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb857c", Frameless: false}]
               Condition: null
     - id: indexIntArray_cond
       version: 0
@@ -2729,7 +2996,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 297 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0xb82f8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8538", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2746,7 +3013,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 298 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0xb833c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb857c", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: matched, Segments: [matched]}
     - id: indexIntSlice_capture
@@ -2765,11 +3032,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 283 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0xb8268", Frameless: false}]
+              InjectionPoints: [{PC: "0xb84a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 284 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0xb82a4", Frameless: false}]
+              InjectionPoints: [{PC: "0xb84e4", Frameless: false}]
               Condition: null
     - id: indexIntSlice_cond
       version: 0
@@ -2787,7 +3054,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 285 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0xb8268", Frameless: false}]
+              InjectionPoints: [{PC: "0xb84a8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2809,7 +3076,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 286 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0xb82a4", Frameless: false}]
+              InjectionPoints: [{PC: "0xb84e4", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: matched, Segments: [matched]}
     - id: indexIntSlice_template
@@ -2825,11 +3092,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 287 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0xb8268", Frameless: false}]
+              InjectionPoints: [{PC: "0xb84a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 288 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0xb82a4", Frameless: false}]
+              InjectionPoints: [{PC: "0xb84e4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's[1]: {s[1]}'
@@ -2853,15 +3120,15 @@ Probes:
             dsl: s[0].Val
             json: {getmember: [{index: [{ref: s}, 0]}, Val]}
       instances:
-        - subprogram: {subprogram: 50}
+        - subprogram: {subprogram: 52}
           events:
             - Kind: Entry
-              Type: 539 EventRootType Probe[main.structArrayArg]
-              InjectionPoints: [{PC: "0xba978", Frameless: false}]
+              Type: 547 EventRootType Probe[main.structArrayArg]
+              InjectionPoints: [{PC: "0xbade8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 540 EventRootType Probe[main.structArrayArg]Return
-              InjectionPoints: [{PC: "0xba9e0", Frameless: false}]
+              Type: 548 EventRootType Probe[main.structArrayArg]Return
+              InjectionPoints: [{PC: "0xbae50", Frameless: false}]
               Condition: null
     - id: indexMember_arrayStruct_capture_string
       version: 0
@@ -2877,15 +3144,15 @@ Probes:
             dsl: s[1].Txt
             json: {getmember: [{index: [{ref: s}, 1]}, Txt]}
       instances:
-        - subprogram: {subprogram: 50}
+        - subprogram: {subprogram: 52}
           events:
             - Kind: Entry
-              Type: 541 EventRootType Probe[main.structArrayArg]
-              InjectionPoints: [{PC: "0xba978", Frameless: false}]
+              Type: 549 EventRootType Probe[main.structArrayArg]
+              InjectionPoints: [{PC: "0xbade8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 542 EventRootType Probe[main.structArrayArg]Return
-              InjectionPoints: [{PC: "0xba9e0", Frameless: false}]
+              Type: 550 EventRootType Probe[main.structArrayArg]Return
+              InjectionPoints: [{PC: "0xbae50", Frameless: false}]
               Condition: null
     - id: indexMember_ptrArrayStruct_capture_int
       version: 0
@@ -2901,15 +3168,15 @@ Probes:
             dsl: s[0].Val
             json: {getmember: [{index: [{ref: s}, 0]}, Val]}
       instances:
-        - subprogram: {subprogram: 52}
+        - subprogram: {subprogram: 54}
           events:
             - Kind: Entry
-              Type: 547 EventRootType Probe[main.ptrStructArrayArg]
-              InjectionPoints: [{PC: "0xbab08", Frameless: false}]
+              Type: 555 EventRootType Probe[main.ptrStructArrayArg]
+              InjectionPoints: [{PC: "0xbaf78", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 548 EventRootType Probe[main.ptrStructArrayArg]Return
-              InjectionPoints: [{PC: "0xbab74", Frameless: false}]
+              Type: 556 EventRootType Probe[main.ptrStructArrayArg]Return
+              InjectionPoints: [{PC: "0xbafe4", Frameless: false}]
               Condition: null
     - id: indexMember_ptrArrayStruct_capture_string
       version: 0
@@ -2925,15 +3192,15 @@ Probes:
             dsl: s[1].Txt
             json: {getmember: [{index: [{ref: s}, 1]}, Txt]}
       instances:
-        - subprogram: {subprogram: 52}
+        - subprogram: {subprogram: 54}
           events:
             - Kind: Entry
-              Type: 549 EventRootType Probe[main.ptrStructArrayArg]
-              InjectionPoints: [{PC: "0xbab08", Frameless: false}]
+              Type: 557 EventRootType Probe[main.ptrStructArrayArg]
+              InjectionPoints: [{PC: "0xbaf78", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 550 EventRootType Probe[main.ptrStructArrayArg]Return
-              InjectionPoints: [{PC: "0xbab74", Frameless: false}]
+              Type: 558 EventRootType Probe[main.ptrStructArrayArg]Return
+              InjectionPoints: [{PC: "0xbafe4", Frameless: false}]
               Condition: null
     - id: indexMember_ptrSliceStruct_capture_int
       version: 0
@@ -2949,15 +3216,15 @@ Probes:
             dsl: s[0].Val
             json: {getmember: [{index: [{ref: s}, 0]}, Val]}
       instances:
-        - subprogram: {subprogram: 51}
+        - subprogram: {subprogram: 53}
           events:
             - Kind: Entry
-              Type: 543 EventRootType Probe[main.ptrStructSliceArg]
-              InjectionPoints: [{PC: "0xbaa28", Frameless: false}]
+              Type: 551 EventRootType Probe[main.ptrStructSliceArg]
+              InjectionPoints: [{PC: "0xbae98", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 544 EventRootType Probe[main.ptrStructSliceArg]Return
-              InjectionPoints: [{PC: "0xbaaa0", Frameless: false}]
+              Type: 552 EventRootType Probe[main.ptrStructSliceArg]Return
+              InjectionPoints: [{PC: "0xbaf10", Frameless: false}]
               Condition: null
     - id: indexMember_ptrSliceStruct_capture_string
       version: 0
@@ -2973,15 +3240,15 @@ Probes:
             dsl: s[1].Txt
             json: {getmember: [{index: [{ref: s}, 1]}, Txt]}
       instances:
-        - subprogram: {subprogram: 51}
+        - subprogram: {subprogram: 53}
           events:
             - Kind: Entry
-              Type: 545 EventRootType Probe[main.ptrStructSliceArg]
-              InjectionPoints: [{PC: "0xbaa28", Frameless: false}]
+              Type: 553 EventRootType Probe[main.ptrStructSliceArg]
+              InjectionPoints: [{PC: "0xbae98", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 546 EventRootType Probe[main.ptrStructSliceArg]Return
-              InjectionPoints: [{PC: "0xbaaa0", Frameless: false}]
+              Type: 554 EventRootType Probe[main.ptrStructSliceArg]Return
+              InjectionPoints: [{PC: "0xbaf10", Frameless: false}]
               Condition: null
     - id: indexMember_sliceStruct_capture_int
       version: 0
@@ -2997,15 +3264,15 @@ Probes:
             dsl: s[0].Val
             json: {getmember: [{index: [{ref: s}, 0]}, Val]}
       instances:
-        - subprogram: {subprogram: 49}
+        - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 531 EventRootType Probe[main.structSliceArg]
-              InjectionPoints: [{PC: "0xba898", Frameless: false}]
+              Type: 539 EventRootType Probe[main.structSliceArg]
+              InjectionPoints: [{PC: "0xbad08", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 532 EventRootType Probe[main.structSliceArg]Return
-              InjectionPoints: [{PC: "0xba90c", Frameless: false}]
+              Type: 540 EventRootType Probe[main.structSliceArg]Return
+              InjectionPoints: [{PC: "0xbad7c", Frameless: false}]
               Condition: null
     - id: indexMember_sliceStruct_capture_string
       version: 0
@@ -3021,15 +3288,15 @@ Probes:
             dsl: s[1].Txt
             json: {getmember: [{index: [{ref: s}, 1]}, Txt]}
       instances:
-        - subprogram: {subprogram: 49}
+        - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 533 EventRootType Probe[main.structSliceArg]
-              InjectionPoints: [{PC: "0xba898", Frameless: false}]
+              Type: 541 EventRootType Probe[main.structSliceArg]
+              InjectionPoints: [{PC: "0xbad08", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 534 EventRootType Probe[main.structSliceArg]Return
-              InjectionPoints: [{PC: "0xba90c", Frameless: false}]
+              Type: 542 EventRootType Probe[main.structSliceArg]Return
+              InjectionPoints: [{PC: "0xbad7c", Frameless: false}]
               Condition: null
     - id: indexMember_sliceStruct_cond
       version: 0
@@ -3044,16 +3311,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 49}
+        - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 535 EventRootType Probe[main.structSliceArg]
-              InjectionPoints: [{PC: "0xba898", Frameless: false}]
+              Type: 543 EventRootType Probe[main.structSliceArg]
+              InjectionPoints: [{PC: "0xbad08", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 49, index: 0, name: s}
+                      Variable: {subprogram: 51, index: 0, name: s}
                       Offset: 0
                       ByteSize: 16
                     - __kind: SliceBoundsCheckOp
@@ -3069,8 +3336,8 @@ Probes:
                       ByteSize: 4
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 536 EventRootType Probe[main.structSliceArg]Return
-              InjectionPoints: [{PC: "0xba90c", Frameless: false}]
+              Type: 544 EventRootType Probe[main.structSliceArg]Return
+              InjectionPoints: [{PC: "0xbad7c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -3092,15 +3359,15 @@ Probes:
           dsl: s[0].Val
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 49}
+        - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 537 EventRootType Probe[main.structSliceArg]
-              InjectionPoints: [{PC: "0xba898", Frameless: false}]
+              Type: 545 EventRootType Probe[main.structSliceArg]
+              InjectionPoints: [{PC: "0xbad08", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 538 EventRootType Probe[main.structSliceArg]Return
-              InjectionPoints: [{PC: "0xba90c", Frameless: false}]
+              Type: 546 EventRootType Probe[main.structSliceArg]Return
+              InjectionPoints: [{PC: "0xbad7c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: s[0].Val={s[0].Val}
@@ -3127,15 +3394,15 @@ Probes:
             json:
                 getmember: [{index: [{getmember: [{ref: s}, Arr]}, 0]}, Val]
       instances:
-        - subprogram: {subprogram: 53}
+        - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 551 EventRootType Probe[main.indexMemberWrapperArg]
-              InjectionPoints: [{PC: "0xbabb8", Frameless: false}]
+              Type: 559 EventRootType Probe[main.indexMemberWrapperArg]
+              InjectionPoints: [{PC: "0xbb028", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 552 EventRootType Probe[main.indexMemberWrapperArg]Return
-              InjectionPoints: [{PC: "0xbac50", Frameless: false}]
+              Type: 560 EventRootType Probe[main.indexMemberWrapperArg]Return
+              InjectionPoints: [{PC: "0xbb0c0", Frameless: false}]
               Condition: null
     - id: indexMember_wrapper_arr_capture_1
       version: 0
@@ -3152,15 +3419,15 @@ Probes:
             json:
                 getmember: [{index: [{getmember: [{ref: s}, Arr]}, 1]}, Txt]
       instances:
-        - subprogram: {subprogram: 53}
+        - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 553 EventRootType Probe[main.indexMemberWrapperArg]
-              InjectionPoints: [{PC: "0xbabb8", Frameless: false}]
+              Type: 561 EventRootType Probe[main.indexMemberWrapperArg]
+              InjectionPoints: [{PC: "0xbb028", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 554 EventRootType Probe[main.indexMemberWrapperArg]Return
-              InjectionPoints: [{PC: "0xbac50", Frameless: false}]
+              Type: 562 EventRootType Probe[main.indexMemberWrapperArg]Return
+              InjectionPoints: [{PC: "0xbb0c0", Frameless: false}]
               Condition: null
     - id: indexMember_wrapper_ptrArr_capture
       version: 0
@@ -3177,15 +3444,15 @@ Probes:
             json:
                 getmember: [{index: [{getmember: [{ref: s}, PtrArr]}, 0]}, Val]
       instances:
-        - subprogram: {subprogram: 53}
+        - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 555 EventRootType Probe[main.indexMemberWrapperArg]
-              InjectionPoints: [{PC: "0xbabb8", Frameless: false}]
+              Type: 563 EventRootType Probe[main.indexMemberWrapperArg]
+              InjectionPoints: [{PC: "0xbb028", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 556 EventRootType Probe[main.indexMemberWrapperArg]Return
-              InjectionPoints: [{PC: "0xbac50", Frameless: false}]
+              Type: 564 EventRootType Probe[main.indexMemberWrapperArg]Return
+              InjectionPoints: [{PC: "0xbb0c0", Frameless: false}]
               Condition: null
     - id: indexMember_wrapper_ptrArr_capture_1
       version: 0
@@ -3202,15 +3469,15 @@ Probes:
             json:
                 getmember: [{index: [{getmember: [{ref: s}, PtrArr]}, 1]}, Txt]
       instances:
-        - subprogram: {subprogram: 53}
+        - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 557 EventRootType Probe[main.indexMemberWrapperArg]
-              InjectionPoints: [{PC: "0xbabb8", Frameless: false}]
+              Type: 565 EventRootType Probe[main.indexMemberWrapperArg]
+              InjectionPoints: [{PC: "0xbb028", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 558 EventRootType Probe[main.indexMemberWrapperArg]Return
-              InjectionPoints: [{PC: "0xbac50", Frameless: false}]
+              Type: 566 EventRootType Probe[main.indexMemberWrapperArg]Return
+              InjectionPoints: [{PC: "0xbb0c0", Frameless: false}]
               Condition: null
     - id: indexNilPtr_capture
       version: 0
@@ -3226,15 +3493,15 @@ Probes:
             dsl: x.Items[0]
             json: {index: [{getmember: [{ref: x}, Items]}, 0]}
       instances:
-        - subprogram: {subprogram: 45}
+        - subprogram: {subprogram: 47}
           events:
             - Kind: Entry
-              Type: 517 EventRootType Probe[main.indexNilPtrSlice]
-              InjectionPoints: [{PC: "0xba4f8", Frameless: false}]
+              Type: 525 EventRootType Probe[main.indexNilPtrSlice]
+              InjectionPoints: [{PC: "0xba968", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 518 EventRootType Probe[main.indexNilPtrSlice]Return
-              InjectionPoints: [{PC: "0xba56c", Frameless: false}]
+              Type: 526 EventRootType Probe[main.indexNilPtrSlice]Return
+              InjectionPoints: [{PC: "0xba9dc", Frameless: false}]
               Condition: null
     - id: indexNilPtr_cond
       version: 0
@@ -3249,16 +3516,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 45}
+        - subprogram: {subprogram: 47}
           events:
             - Kind: Entry
-              Type: 519 EventRootType Probe[main.indexNilPtrSlice]
-              InjectionPoints: [{PC: "0xba4f8", Frameless: false}]
+              Type: 527 EventRootType Probe[main.indexNilPtrSlice]
+              InjectionPoints: [{PC: "0xba968", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 45, index: 0, name: x}
+                      Variable: {subprogram: 47, index: 0, name: x}
                       Offset: 0
                       ByteSize: 8
                     - __kind: DereferenceOp
@@ -3277,8 +3544,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 520 EventRootType Probe[main.indexNilPtrSlice]Return
-              InjectionPoints: [{PC: "0xba56c", Frameless: false}]
+              Type: 528 EventRootType Probe[main.indexNilPtrSlice]Return
+              InjectionPoints: [{PC: "0xba9dc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -3300,15 +3567,15 @@ Probes:
           dsl: x.Items[0]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 45}
+        - subprogram: {subprogram: 47}
           events:
             - Kind: Entry
-              Type: 521 EventRootType Probe[main.indexNilPtrSlice]
-              InjectionPoints: [{PC: "0xba4f8", Frameless: false}]
+              Type: 529 EventRootType Probe[main.indexNilPtrSlice]
+              InjectionPoints: [{PC: "0xba968", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 522 EventRootType Probe[main.indexNilPtrSlice]Return
-              InjectionPoints: [{PC: "0xba56c", Frameless: false}]
+              Type: 530 EventRootType Probe[main.indexNilPtrSlice]Return
+              InjectionPoints: [{PC: "0xba9dc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 'items[0]: {x.Items[0]}'
@@ -3334,15 +3601,15 @@ Probes:
             dsl: x.Items[0]
             json: {index: [{getmember: [{ref: x}, Items]}, 0]}
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 499 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0xba18c", Frameless: false}]
+              Type: 507 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0xba5fc", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 500 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0xba284", Frameless: false}]
+              Type: 508 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0xba6f4", Frameless: false}]
               Condition: null
     - id: indexStringArray_capture
       version: 0
@@ -3360,11 +3627,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 305 EventRootType Probe[main.stringArrayArg]
-              InjectionPoints: [{PC: "0xb8408", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8648", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 306 EventRootType Probe[main.stringArrayArg]Return
-              InjectionPoints: [{PC: "0xb844c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb868c", Frameless: false}]
               Condition: null
     - id: indexStringSlice_capture
       version: 0
@@ -3382,11 +3649,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 301 EventRootType Probe[main.stringSliceArg]
-              InjectionPoints: [{PC: "0xb8378", Frameless: false}]
+              InjectionPoints: [{PC: "0xb85b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 302 EventRootType Probe[main.stringSliceArg]Return
-              InjectionPoints: [{PC: "0xb83b4", Frameless: false}]
+              InjectionPoints: [{PC: "0xb85f4", Frameless: false}]
               Condition: null
     - id: indexStructSliceField_capture
       version: 0
@@ -3402,15 +3669,15 @@ Probes:
             dsl: x.Items[2]
             json: {index: [{getmember: [{ref: x}, Items]}, 2]}
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 479 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xba02c", Frameless: false}]
+              Type: 487 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xba49c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 480 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xba140", Frameless: false}]
+              Type: 488 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xba5b0", Frameless: false}]
               Condition: null
     - id: inlined
       version: 0
@@ -3421,19 +3688,19 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 75}
+        - subprogram: {subprogram: 77}
           events:
             - Kind: Entry
-              Type: 609 EventRootType Probe[main.inlined]
+              Type: 617 EventRootType Probe[main.inlined]
               InjectionPoints:
                 - PC: "0xb5dd4"
                   Frameless: false
-                - PC: "0xb8498"
+                - PC: "0xb86d8"
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 610 EventRootType Probe[main.inlined]Return
-              InjectionPoints: [{PC: "0xb84d0", Frameless: false}]
+              Type: 618 EventRootType Probe[main.inlined]Return
+              InjectionPoints: [{PC: "0xb8710", Frameless: false}]
               Condition: null
     - id: inlinedMethod
       version: 0
@@ -3443,11 +3710,11 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 78}
+        - subprogram: {subprogram: 80}
           events:
             - Kind: Entry
-              Type: 613 EventRootType Probe[main.(*methodValueReceiver).inlinedMethod]
-              InjectionPoints: [{PC: "0xbb984", Frameless: true}]
+              Type: 621 EventRootType Probe[main.(*methodValueReceiver).inlinedMethod]
+              InjectionPoints: [{PC: "0xbbdf4", Frameless: true}]
               Condition: null
     - id: intArg
       version: 0
@@ -3461,11 +3728,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 269 EventRootType Probe[main.intArg]
-              InjectionPoints: [{PC: "0xb8178", Frameless: false}]
+              InjectionPoints: [{PC: "0xb83b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 270 EventRootType Probe[main.intArg]Return
-              InjectionPoints: [{PC: "0xb81b0", Frameless: false}]
+              InjectionPoints: [{PC: "0xb83f0", Frameless: false}]
               Condition: null
     - id: intArrayArg
       version: 0
@@ -3479,11 +3746,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 299 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0xb82f8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8538", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 300 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0xb833c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb857c", Frameless: false}]
               Condition: null
     - id: intArrayArgFrameless
       version: 0
@@ -3497,7 +3764,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 309 EventRootType Probe[main.stringArrayArgFrameless]
-              InjectionPoints: [{PC: "0xb8470", Frameless: true}]
+              InjectionPoints: [{PC: "0xb86b0", Frameless: true}]
               Condition: null
     - id: intSliceArg
       version: 0
@@ -3511,11 +3778,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 289 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0xb8268", Frameless: false}]
+              InjectionPoints: [{PC: "0xb84a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 290 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0xb82a4", Frameless: false}]
+              InjectionPoints: [{PC: "0xb84e4", Frameless: false}]
               Condition: null
     - id: lenErrInt_nocond
       version: 0
@@ -3526,15 +3793,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 43}
+        - subprogram: {subprogram: 45}
           events:
             - Kind: Entry
-              Type: 509 EventRootType Probe[main.lenErrInt]
-              InjectionPoints: [{PC: "0xba2dc", Frameless: false}]
+              Type: 517 EventRootType Probe[main.lenErrInt]
+              InjectionPoints: [{PC: "0xba74c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 510 EventRootType Probe[main.lenErrInt]Return
-              InjectionPoints: [{PC: "0xba390", Frameless: false}]
+              Type: 518 EventRootType Probe[main.lenErrInt]Return
+              InjectionPoints: [{PC: "0xba800", Frameless: false}]
               Condition: null
     - id: lenErrStruct_nocond
       version: 0
@@ -3545,15 +3812,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 44}
+        - subprogram: {subprogram: 46}
           events:
             - Kind: Entry
-              Type: 513 EventRootType Probe[main.lenErrStruct]
-              InjectionPoints: [{PC: "0xba3dc", Frameless: false}]
+              Type: 521 EventRootType Probe[main.lenErrStruct]
+              InjectionPoints: [{PC: "0xba84c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 514 EventRootType Probe[main.lenErrStruct]Return
-              InjectionPoints: [{PC: "0xba4ac", Frameless: false}]
+              Type: 522 EventRootType Probe[main.lenErrStruct]Return
+              InjectionPoints: [{PC: "0xba91c", Frameless: false}]
               Condition: null
     - id: lenErr_int
       version: 0
@@ -3564,15 +3831,15 @@ Probes:
       segments: [len=, {json: {len: {ref: x}}, dsl: len(x)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 43}
+        - subprogram: {subprogram: 45}
           events:
             - Kind: Entry
-              Type: 511 EventRootType Probe[main.lenErrInt]
-              InjectionPoints: [{PC: "0xba2dc", Frameless: false}]
+              Type: 519 EventRootType Probe[main.lenErrInt]
+              InjectionPoints: [{PC: "0xba74c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 512 EventRootType Probe[main.lenErrInt]Return
-              InjectionPoints: [{PC: "0xba390", Frameless: false}]
+              Type: 520 EventRootType Probe[main.lenErrInt]Return
+              InjectionPoints: [{PC: "0xba800", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x)}
@@ -3589,15 +3856,15 @@ Probes:
       segments: [len=, {json: {len: {ref: x}}, dsl: len(x)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 44}
+        - subprogram: {subprogram: 46}
           events:
             - Kind: Entry
-              Type: 515 EventRootType Probe[main.lenErrStruct]
-              InjectionPoints: [{PC: "0xba3dc", Frameless: false}]
+              Type: 523 EventRootType Probe[main.lenErrStruct]
+              InjectionPoints: [{PC: "0xba84c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 516 EventRootType Probe[main.lenErrStruct]Return
-              InjectionPoints: [{PC: "0xba4ac", Frameless: false}]
+              Type: 524 EventRootType Probe[main.lenErrStruct]Return
+              InjectionPoints: [{PC: "0xba91c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x)}
@@ -3615,16 +3882,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 463 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0xb9e1c", Frameless: false}]
+              Type: 471 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0xba28c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 39, index: 0, name: m}
+                      Variable: {subprogram: 41, index: 0, name: m}
                       Offset: 0
                       ByteSize: 8
                     - __kind: DereferenceOp
@@ -3638,8 +3905,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 464 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0xb9edc", Frameless: false}]
+              Type: 472 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0xba34c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -3661,15 +3928,15 @@ Probes:
           dsl: isEmpty(m)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 465 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0xb9e1c", Frameless: false}]
+              Type: 473 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0xba28c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 466 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0xb9edc", Frameless: false}]
+              Type: 474 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0xba34c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: empty={isEmpty(m)}
@@ -3691,15 +3958,15 @@ Probes:
         - name: m_len
           expr: {dsl: len(m), json: {len: {ref: m}}}
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 467 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0xb9e1c", Frameless: false}]
+              Type: 475 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0xba28c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 468 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0xb9edc", Frameless: false}]
+              Type: 476 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0xba34c", Frameless: false}]
               Condition: null
     - id: lenMap_len_eq_cond
       version: 0
@@ -3713,16 +3980,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 469 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0xb9e1c", Frameless: false}]
+              Type: 477 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0xba28c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 39, index: 0, name: m}
+                      Variable: {subprogram: 41, index: 0, name: m}
                       Offset: 0
                       ByteSize: 8
                     - __kind: DereferenceOp
@@ -3736,8 +4003,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 470 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0xb9edc", Frameless: false}]
+              Type: 478 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0xba34c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -3756,15 +4023,15 @@ Probes:
       segments: [len=, {json: {len: {ref: m}}, dsl: len(m)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 471 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0xb9e1c", Frameless: false}]
+              Type: 479 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0xba28c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 472 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0xb9edc", Frameless: false}]
+              Type: 480 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0xba34c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(m)}
@@ -3783,15 +4050,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 473 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0xb9e1c", Frameless: false}]
+              Type: 481 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0xba28c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 474 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0xb9edc", Frameless: false}]
+              Type: 482 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0xba34c", Frameless: false}]
               Condition: null
     - id: lenPtrString_len_template
       version: 0
@@ -3802,15 +4069,15 @@ Probes:
       segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 40}
+        - subprogram: {subprogram: 42}
           events:
             - Kind: Entry
-              Type: 475 EventRootType Probe[main.lenPtrString]
-              InjectionPoints: [{PC: "0xb9f2c", Frameless: false}]
+              Type: 483 EventRootType Probe[main.lenPtrString]
+              InjectionPoints: [{PC: "0xba39c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 476 EventRootType Probe[main.lenPtrString]Return
-              InjectionPoints: [{PC: "0xb9fd4", Frameless: false}]
+              Type: 484 EventRootType Probe[main.lenPtrString]Return
+              InjectionPoints: [{PC: "0xba444", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(s)}
@@ -3829,15 +4096,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 40}
+        - subprogram: {subprogram: 42}
           events:
             - Kind: Entry
-              Type: 477 EventRootType Probe[main.lenPtrString]
-              InjectionPoints: [{PC: "0xb9f2c", Frameless: false}]
+              Type: 485 EventRootType Probe[main.lenPtrString]
+              InjectionPoints: [{PC: "0xba39c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 478 EventRootType Probe[main.lenPtrString]Return
-              InjectionPoints: [{PC: "0xb9fd4", Frameless: false}]
+              Type: 486 EventRootType Probe[main.lenPtrString]Return
+              InjectionPoints: [{PC: "0xba444", Frameless: false}]
               Condition: null
     - id: lenPtrStructFields_nocond
       version: 0
@@ -3848,15 +4115,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 501 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0xba18c", Frameless: false}]
+              Type: 509 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0xba5fc", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 502 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0xba284", Frameless: false}]
+              Type: 510 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0xba6f4", Frameless: false}]
               Condition: null
     - id: lenPtrStruct_field_map
       version: 0
@@ -3870,15 +4137,15 @@ Probes:
           dsl: len(x.Dict)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 503 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0xba18c", Frameless: false}]
+              Type: 511 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0xba5fc", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 504 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0xba284", Frameless: false}]
+              Type: 512 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0xba6f4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.Dict)}
@@ -3900,15 +4167,15 @@ Probes:
           dsl: len(x.Items)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 505 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0xba18c", Frameless: false}]
+              Type: 513 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0xba5fc", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 506 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0xba284", Frameless: false}]
+              Type: 514 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0xba6f4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.Items)}
@@ -3930,15 +4197,15 @@ Probes:
           dsl: len(x.S)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 507 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0xba18c", Frameless: false}]
+              Type: 515 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0xba5fc", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 508 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0xba284", Frameless: false}]
+              Type: 516 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0xba6f4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.S)}
@@ -3958,16 +4225,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 451 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0xb9cfc", Frameless: false}]
+              Type: 459 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0xba16c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 38, index: 0, name: s}
+                      Variable: {subprogram: 40, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -3978,8 +4245,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 452 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0xb9dbc", Frameless: false}]
+              Type: 460 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0xba22c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4001,15 +4268,15 @@ Probes:
           dsl: isEmpty(s)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 453 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0xb9cfc", Frameless: false}]
+              Type: 461 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0xba16c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 454 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0xb9dbc", Frameless: false}]
+              Type: 462 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0xba22c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: empty={isEmpty(s)}
@@ -4031,15 +4298,15 @@ Probes:
         - name: s_len
           expr: {dsl: len(s), json: {len: {ref: s}}}
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 455 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0xb9cfc", Frameless: false}]
+              Type: 463 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0xba16c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 456 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0xb9dbc", Frameless: false}]
+              Type: 464 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0xba22c", Frameless: false}]
               Condition: null
     - id: lenSlice_len_eq_cond
       version: 0
@@ -4053,16 +4320,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 457 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0xb9cfc", Frameless: false}]
+              Type: 465 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0xba16c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 38, index: 0, name: s}
+                      Variable: {subprogram: 40, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4073,8 +4340,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 458 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0xb9dbc", Frameless: false}]
+              Type: 466 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0xba22c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4093,15 +4360,15 @@ Probes:
       segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 459 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0xb9cfc", Frameless: false}]
+              Type: 467 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0xba16c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 460 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0xb9dbc", Frameless: false}]
+              Type: 468 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0xba22c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(s)}
@@ -4120,15 +4387,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 461 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0xb9cfc", Frameless: false}]
+              Type: 469 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0xba16c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 462 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0xb9dbc", Frameless: false}]
+              Type: 470 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0xba22c", Frameless: false}]
               Condition: null
     - id: lenString_eq_capture
       version: 0
@@ -4144,15 +4411,15 @@ Probes:
             dsl: len(s) == 5
             json: {eq: [{len: {ref: s}}, 5]}
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 433 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xb9bec", Frameless: false}]
+              Type: 441 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xba05c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 434 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xb9ca0", Frameless: false}]
+              Type: 442 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xba110", Frameless: false}]
               Condition: null
     - id: lenString_eq_template
       version: 0
@@ -4166,15 +4433,15 @@ Probes:
           dsl: len(s) == 5
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 435 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xb9bec", Frameless: false}]
+              Type: 443 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xba05c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 436 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xb9ca0", Frameless: false}]
+              Type: 444 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xba110", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: eq={len(s) == 5}
@@ -4196,15 +4463,15 @@ Probes:
         - name: s_isEmpty
           expr: {dsl: isEmpty(s), json: {isEmpty: {ref: s}}}
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 437 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xb9bec", Frameless: false}]
+              Type: 445 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xba05c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 438 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xb9ca0", Frameless: false}]
+              Type: 446 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xba110", Frameless: false}]
               Condition: null
     - id: lenString_isEmpty_cond
       version: 0
@@ -4216,16 +4483,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 439 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xb9bec", Frameless: false}]
+              Type: 447 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xba05c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 37, index: 0, name: s}
+                      Variable: {subprogram: 39, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4236,8 +4503,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 440 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xb9ca0", Frameless: false}]
+              Type: 448 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xba110", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4259,15 +4526,15 @@ Probes:
           dsl: isEmpty(s)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 441 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xb9bec", Frameless: false}]
+              Type: 449 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xba05c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 442 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xb9ca0", Frameless: false}]
+              Type: 450 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xba110", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: empty={isEmpty(s)}
@@ -4289,15 +4556,15 @@ Probes:
         - name: s_len
           expr: {dsl: len(s), json: {len: {ref: s}}}
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 443 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xb9bec", Frameless: false}]
+              Type: 451 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xba05c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 444 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xb9ca0", Frameless: false}]
+              Type: 452 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xba110", Frameless: false}]
               Condition: null
     - id: lenString_len_eq_cond
       version: 0
@@ -4311,16 +4578,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 445 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xb9bec", Frameless: false}]
+              Type: 453 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xba05c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 37, index: 0, name: s}
+                      Variable: {subprogram: 39, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4331,8 +4598,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 446 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xb9ca0", Frameless: false}]
+              Type: 454 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xba110", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4351,15 +4618,15 @@ Probes:
       segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 447 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xb9bec", Frameless: false}]
+              Type: 455 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xba05c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 448 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xb9ca0", Frameless: false}]
+              Type: 456 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xba110", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(s)}
@@ -4378,15 +4645,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 449 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xb9bec", Frameless: false}]
+              Type: 457 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xba05c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 450 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xb9ca0", Frameless: false}]
+              Type: 458 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xba110", Frameless: false}]
               Condition: null
     - id: lenStructFields_nocond
       version: 0
@@ -4397,15 +4664,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 481 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xba02c", Frameless: false}]
+              Type: 489 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xba49c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 482 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xba140", Frameless: false}]
+              Type: 490 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xba5b0", Frameless: false}]
               Condition: null
     - id: lenStruct_field_map
       version: 0
@@ -4419,15 +4686,15 @@ Probes:
           dsl: len(x.Dict)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 483 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xba02c", Frameless: false}]
+              Type: 491 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xba49c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 484 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xba140", Frameless: false}]
+              Type: 492 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xba5b0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.Dict)}
@@ -4449,15 +4716,15 @@ Probes:
           dsl: len(x.PtrSlice)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 485 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xba02c", Frameless: false}]
+              Type: 493 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xba49c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 486 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xba140", Frameless: false}]
+              Type: 494 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xba5b0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.PtrSlice)}
@@ -4479,15 +4746,15 @@ Probes:
           dsl: len(x.PtrStr)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 487 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xba02c", Frameless: false}]
+              Type: 495 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xba49c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 488 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xba140", Frameless: false}]
+              Type: 496 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xba5b0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.PtrStr)}
@@ -4509,15 +4776,15 @@ Probes:
           dsl: len(x.Items)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 489 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xba02c", Frameless: false}]
+              Type: 497 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xba49c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 490 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xba140", Frameless: false}]
+              Type: 498 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xba5b0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.Items)}
@@ -4539,15 +4806,15 @@ Probes:
           dsl: len(x.S)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 491 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xba02c", Frameless: false}]
+              Type: 499 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xba49c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 492 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xba140", Frameless: false}]
+              Type: 500 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xba5b0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.S)}
@@ -4569,16 +4836,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 493 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xba02c", Frameless: false}]
+              Type: 501 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xba49c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 41, index: 0, name: x}
+                      Variable: {subprogram: 43, index: 0, name: x}
                       Offset: 40
                       ByteSize: 8
                     - __kind: DereferenceOp
@@ -4592,8 +4859,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 494 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xba140", Frameless: false}]
+              Type: 502 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xba5b0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4615,16 +4882,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 495 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xba02c", Frameless: false}]
+              Type: 503 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xba49c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 41, index: 0, name: x}
+                      Variable: {subprogram: 43, index: 0, name: x}
                       Offset: 24
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4635,8 +4902,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 496 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xba140", Frameless: false}]
+              Type: 504 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xba5b0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4658,16 +4925,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 497 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xba02c", Frameless: false}]
+              Type: 505 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xba49c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 41, index: 0, name: x}
+                      Variable: {subprogram: 43, index: 0, name: x}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4678,8 +4945,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 498 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xba140", Frameless: false}]
+              Type: 506 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xba5b0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4701,11 +4968,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 271 EventRootType Probe[main.stringArg]
-              InjectionPoints: [{PC: "0xb81e8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8428", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 272 EventRootType Probe[main.stringArg]Return
-              InjectionPoints: [{PC: "0xb8224", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8464", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's: {s}'
@@ -4727,11 +4994,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 273 EventRootType Probe[main.stringArg]
-              InjectionPoints: [{PC: "0xb81e8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8428", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 274 EventRootType Probe[main.stringArg]Return
-              InjectionPoints: [{PC: "0xb8224", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8464", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 'x: {x}'
@@ -4751,11 +5018,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 310 EventRootType Probe[main.mapArg]
-              InjectionPoints: [{PC: "0xb8558", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8798", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 311 EventRootType Probe[main.mapArg]Return
-              InjectionPoints: [{PC: "0xb8588", Frameless: false}]
+              InjectionPoints: [{PC: "0xb87c8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 'm: {m}'
@@ -4780,15 +5047,15 @@ Probes:
         - name: false_val
           expr: {dsl: 'm[false]', json: {index: [{ref: m}, false]}}
       instances:
-        - subprogram: {subprogram: 68}
+        - subprogram: {subprogram: 70}
           events:
             - Kind: Entry
-              Type: 593 EventRootType Probe[main.mapIndexBoolKey]
-              InjectionPoints: [{PC: "0xbb538", Frameless: false}]
+              Type: 601 EventRootType Probe[main.mapIndexBoolKey]
+              InjectionPoints: [{PC: "0xbb9a8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 594 EventRootType Probe[main.mapIndexBoolKey]Return
-              InjectionPoints: [{PC: "0xbb568", Frameless: false}]
+              Type: 602 EventRootType Probe[main.mapIndexBoolKey]Return
+              InjectionPoints: [{PC: "0xbb9d8", Frameless: false}]
               Condition: null
     - id: mapIndex_boolKey_true
       version: 0
@@ -4805,15 +5072,15 @@ Probes:
         - name: true_val
           expr: {dsl: 'm[true]', json: {index: [{ref: m}, true]}}
       instances:
-        - subprogram: {subprogram: 68}
+        - subprogram: {subprogram: 70}
           events:
             - Kind: Entry
-              Type: 595 EventRootType Probe[main.mapIndexBoolKey]
-              InjectionPoints: [{PC: "0xbb538", Frameless: false}]
+              Type: 603 EventRootType Probe[main.mapIndexBoolKey]
+              InjectionPoints: [{PC: "0xbb9a8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 596 EventRootType Probe[main.mapIndexBoolKey]Return
-              InjectionPoints: [{PC: "0xbb568", Frameless: false}]
+              Type: 604 EventRootType Probe[main.mapIndexBoolKey]Return
+              InjectionPoints: [{PC: "0xbb9d8", Frameless: false}]
               Condition: null
     - id: mapIndex_emptyKey_capture
       version: 0
@@ -4830,15 +5097,15 @@ Probes:
         - name: empty_val
           expr: {dsl: 'm[""]', json: {index: [{ref: m}, ""]}}
       instances:
-        - subprogram: {subprogram: 65}
+        - subprogram: {subprogram: 67}
           events:
             - Kind: Entry
-              Type: 587 EventRootType Probe[main.mapIndexEmptyKey]
-              InjectionPoints: [{PC: "0xbb388", Frameless: false}]
+              Type: 595 EventRootType Probe[main.mapIndexEmptyKey]
+              InjectionPoints: [{PC: "0xbb7f8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 588 EventRootType Probe[main.mapIndexEmptyKey]Return
-              InjectionPoints: [{PC: "0xbb3dc", Frameless: false}]
+              Type: 596 EventRootType Probe[main.mapIndexEmptyKey]Return
+              InjectionPoints: [{PC: "0xbb84c", Frameless: false}]
               Condition: null
     - id: mapIndex_intKey_capture
       version: 0
@@ -4855,15 +5122,15 @@ Probes:
         - name: m_2
           expr: {dsl: 'm[2]', json: {index: [{ref: m}, 2]}}
       instances:
-        - subprogram: {subprogram: 54}
+        - subprogram: {subprogram: 56}
           events:
             - Kind: Entry
-              Type: 559 EventRootType Probe[main.mapIndexIntKey]
-              InjectionPoints: [{PC: "0xbac98", Frameless: false}]
+              Type: 567 EventRootType Probe[main.mapIndexIntKey]
+              InjectionPoints: [{PC: "0xbb108", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 560 EventRootType Probe[main.mapIndexIntKey]Return
-              InjectionPoints: [{PC: "0xbacc8", Frameless: false}]
+              Type: 568 EventRootType Probe[main.mapIndexIntKey]Return
+              InjectionPoints: [{PC: "0xbb138", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen16
       version: 0
@@ -4882,15 +5149,15 @@ Probes:
             dsl: m["000000000000002a"]
             json: {index: [{ref: m}, 000000000000002a]}
       instances:
-        - subprogram: {subprogram: 66}
+        - subprogram: {subprogram: 68}
           events:
             - Kind: Entry
-              Type: 589 EventRootType Probe[main.mapIndexKeyLen16]
-              InjectionPoints: [{PC: "0xbb418", Frameless: false}]
+              Type: 597 EventRootType Probe[main.mapIndexKeyLen16]
+              InjectionPoints: [{PC: "0xbb888", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 590 EventRootType Probe[main.mapIndexKeyLen16]Return
-              InjectionPoints: [{PC: "0xbb464", Frameless: false}]
+              Type: 598 EventRootType Probe[main.mapIndexKeyLen16]Return
+              InjectionPoints: [{PC: "0xbb8d4", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen17
       version: 0
@@ -4909,15 +5176,15 @@ Probes:
             dsl: m["0000000000000002a"]
             json: {index: [{ref: m}, 0000000000000002a]}
       instances:
-        - subprogram: {subprogram: 67}
+        - subprogram: {subprogram: 69}
           events:
             - Kind: Entry
-              Type: 591 EventRootType Probe[main.mapIndexKeyLen17]
-              InjectionPoints: [{PC: "0xbb4a8", Frameless: false}]
+              Type: 599 EventRootType Probe[main.mapIndexKeyLen17]
+              InjectionPoints: [{PC: "0xbb918", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 592 EventRootType Probe[main.mapIndexKeyLen17]Return
-              InjectionPoints: [{PC: "0xbb4f4", Frameless: false}]
+              Type: 600 EventRootType Probe[main.mapIndexKeyLen17]Return
+              InjectionPoints: [{PC: "0xbb964", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen200
       version: 0
@@ -4939,15 +5206,15 @@ Probes:
                     - ref: m
                     - 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002a
       instances:
-        - subprogram: {subprogram: 62}
+        - subprogram: {subprogram: 64}
           events:
             - Kind: Entry
-              Type: 577 EventRootType Probe[main.mapIndexKeyLen200]
-              InjectionPoints: [{PC: "0xbb1c8", Frameless: false}]
+              Type: 585 EventRootType Probe[main.mapIndexKeyLen200]
+              InjectionPoints: [{PC: "0xbb638", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 578 EventRootType Probe[main.mapIndexKeyLen200]Return
-              InjectionPoints: [{PC: "0xbb214", Frameless: false}]
+              Type: 586 EventRootType Probe[main.mapIndexKeyLen200]Return
+              InjectionPoints: [{PC: "0xbb684", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen24
       version: 0
@@ -4966,15 +5233,15 @@ Probes:
             dsl: m["00000000000000000000002a"]
             json: {index: [{ref: m}, 00000000000000000000002a]}
       instances:
-        - subprogram: {subprogram: 59}
+        - subprogram: {subprogram: 61}
           events:
             - Kind: Entry
-              Type: 571 EventRootType Probe[main.mapIndexKeyLen24]
-              InjectionPoints: [{PC: "0xbb018", Frameless: false}]
+              Type: 579 EventRootType Probe[main.mapIndexKeyLen24]
+              InjectionPoints: [{PC: "0xbb488", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 572 EventRootType Probe[main.mapIndexKeyLen24]Return
-              InjectionPoints: [{PC: "0xbb064", Frameless: false}]
+              Type: 580 EventRootType Probe[main.mapIndexKeyLen24]Return
+              InjectionPoints: [{PC: "0xbb4d4", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen48
       version: 0
@@ -4996,15 +5263,15 @@ Probes:
                     - ref: m
                     - 00000000000000000000000000000000000000000000002a
       instances:
-        - subprogram: {subprogram: 60}
+        - subprogram: {subprogram: 62}
           events:
             - Kind: Entry
-              Type: 573 EventRootType Probe[main.mapIndexKeyLen48]
-              InjectionPoints: [{PC: "0xbb0a8", Frameless: false}]
+              Type: 581 EventRootType Probe[main.mapIndexKeyLen48]
+              InjectionPoints: [{PC: "0xbb518", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 574 EventRootType Probe[main.mapIndexKeyLen48]Return
-              InjectionPoints: [{PC: "0xbb0f4", Frameless: false}]
+              Type: 582 EventRootType Probe[main.mapIndexKeyLen48]Return
+              InjectionPoints: [{PC: "0xbb564", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen8
       version: 0
@@ -5023,15 +5290,15 @@ Probes:
             dsl: m["0000002a"]
             json: {index: [{ref: m}, 0000002a]}
       instances:
-        - subprogram: {subprogram: 58}
+        - subprogram: {subprogram: 60}
           events:
             - Kind: Entry
-              Type: 569 EventRootType Probe[main.mapIndexKeyLen8]
-              InjectionPoints: [{PC: "0xbaf88", Frameless: false}]
+              Type: 577 EventRootType Probe[main.mapIndexKeyLen8]
+              InjectionPoints: [{PC: "0xbb3f8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 570 EventRootType Probe[main.mapIndexKeyLen8]Return
-              InjectionPoints: [{PC: "0xbafd4", Frameless: false}]
+              Type: 578 EventRootType Probe[main.mapIndexKeyLen8]Return
+              InjectionPoints: [{PC: "0xbb444", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen96
       version: 0
@@ -5053,15 +5320,15 @@ Probes:
                     - ref: m
                     - 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002a
       instances:
-        - subprogram: {subprogram: 61}
+        - subprogram: {subprogram: 63}
           events:
             - Kind: Entry
-              Type: 575 EventRootType Probe[main.mapIndexKeyLen96]
-              InjectionPoints: [{PC: "0xbb138", Frameless: false}]
+              Type: 583 EventRootType Probe[main.mapIndexKeyLen96]
+              InjectionPoints: [{PC: "0xbb5a8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 576 EventRootType Probe[main.mapIndexKeyLen96]Return
-              InjectionPoints: [{PC: "0xbb184", Frameless: false}]
+              Type: 584 EventRootType Probe[main.mapIndexKeyLen96]Return
+              InjectionPoints: [{PC: "0xbb5f4", Frameless: false}]
               Condition: null
     - id: mapIndex_largeMap_capture
       version: 0
@@ -5080,15 +5347,15 @@ Probes:
             dsl: m["key42"]
             json: {index: [{ref: m}, key42]}
       instances:
-        - subprogram: {subprogram: 56}
+        - subprogram: {subprogram: 58}
           events:
             - Kind: Entry
-              Type: 565 EventRootType Probe[main.mapIndexLargeMap]
-              InjectionPoints: [{PC: "0xbad78", Frameless: false}]
+              Type: 573 EventRootType Probe[main.mapIndexLargeMap]
+              InjectionPoints: [{PC: "0xbb1e8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 566 EventRootType Probe[main.mapIndexLargeMap]Return
-              InjectionPoints: [{PC: "0xbadc4", Frameless: false}]
+              Type: 574 EventRootType Probe[main.mapIndexLargeMap]Return
+              InjectionPoints: [{PC: "0xbb234", Frameless: false}]
               Condition: null
     - id: mapIndex_largeValue_capture
       version: 0
@@ -5107,15 +5374,15 @@ Probes:
             dsl: m["k"].Val
             json: {getmember: [{index: [{ref: m}, k]}, Val]}
       instances:
-        - subprogram: {subprogram: 71}
+        - subprogram: {subprogram: 73}
           events:
             - Kind: Entry
-              Type: 601 EventRootType Probe[main.mapIndexLargeValue]
-              InjectionPoints: [{PC: "0xbb688", Frameless: false}]
+              Type: 609 EventRootType Probe[main.mapIndexLargeValue]
+              InjectionPoints: [{PC: "0xbbaf8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 602 EventRootType Probe[main.mapIndexLargeValue]Return
-              InjectionPoints: [{PC: "0xbb6dc", Frameless: false}]
+              Type: 610 EventRootType Probe[main.mapIndexLargeValue]Return
+              InjectionPoints: [{PC: "0xbbb4c", Frameless: false}]
               Condition: null
     - id: mapIndex_missing_capture
       version: 0
@@ -5134,15 +5401,15 @@ Probes:
             dsl: m["missing"]
             json: {index: [{ref: m}, missing]}
       instances:
-        - subprogram: {subprogram: 57}
+        - subprogram: {subprogram: 59}
           events:
             - Kind: Entry
-              Type: 567 EventRootType Probe[main.mapIndexMissing]
-              InjectionPoints: [{PC: "0xbae08", Frameless: false}]
+              Type: 575 EventRootType Probe[main.mapIndexMissing]
+              InjectionPoints: [{PC: "0xbb278", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 568 EventRootType Probe[main.mapIndexMissing]Return
-              InjectionPoints: [{PC: "0xbae38", Frameless: false}]
+              Type: 576 EventRootType Probe[main.mapIndexMissing]Return
+              InjectionPoints: [{PC: "0xbb2a8", Frameless: false}]
               Condition: null
     - id: mapIndex_nilPtrVal_capture
       version: 0
@@ -5161,15 +5428,15 @@ Probes:
             dsl: m["nil_key"].Val
             json: {getmember: [{index: [{ref: m}, nil_key]}, Val]}
       instances:
-        - subprogram: {subprogram: 70}
+        - subprogram: {subprogram: 72}
           events:
             - Kind: Entry
-              Type: 599 EventRootType Probe[main.mapIndexNilPtrVal]
-              InjectionPoints: [{PC: "0xbb618", Frameless: false}]
+              Type: 607 EventRootType Probe[main.mapIndexNilPtrVal]
+              InjectionPoints: [{PC: "0xbba88", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 600 EventRootType Probe[main.mapIndexNilPtrVal]Return
-              InjectionPoints: [{PC: "0xbb648", Frameless: false}]
+              Type: 608 EventRootType Probe[main.mapIndexNilPtrVal]Return
+              InjectionPoints: [{PC: "0xbbab8", Frameless: false}]
               Condition: null
     - id: mapIndex_ptrStructVal_capture_int
       version: 0
@@ -5188,15 +5455,15 @@ Probes:
             dsl: m["x"].Val
             json: {getmember: [{index: [{ref: m}, x]}, Val]}
       instances:
-        - subprogram: {subprogram: 64}
+        - subprogram: {subprogram: 66}
           events:
             - Kind: Entry
-              Type: 583 EventRootType Probe[main.mapIndexPtrStructVal]
-              InjectionPoints: [{PC: "0xbb2e8", Frameless: false}]
+              Type: 591 EventRootType Probe[main.mapIndexPtrStructVal]
+              InjectionPoints: [{PC: "0xbb758", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 584 EventRootType Probe[main.mapIndexPtrStructVal]Return
-              InjectionPoints: [{PC: "0xbb344", Frameless: false}]
+              Type: 592 EventRootType Probe[main.mapIndexPtrStructVal]Return
+              InjectionPoints: [{PC: "0xbb7b4", Frameless: false}]
               Condition: null
     - id: mapIndex_ptrStructVal_capture_string
       version: 0
@@ -5215,15 +5482,15 @@ Probes:
             dsl: m["y"].Txt
             json: {getmember: [{index: [{ref: m}, "y"]}, Txt]}
       instances:
-        - subprogram: {subprogram: 64}
+        - subprogram: {subprogram: 66}
           events:
             - Kind: Entry
-              Type: 585 EventRootType Probe[main.mapIndexPtrStructVal]
-              InjectionPoints: [{PC: "0xbb2e8", Frameless: false}]
+              Type: 593 EventRootType Probe[main.mapIndexPtrStructVal]
+              InjectionPoints: [{PC: "0xbb758", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 586 EventRootType Probe[main.mapIndexPtrStructVal]Return
-              InjectionPoints: [{PC: "0xbb344", Frameless: false}]
+              Type: 594 EventRootType Probe[main.mapIndexPtrStructVal]Return
+              InjectionPoints: [{PC: "0xbb7b4", Frameless: false}]
               Condition: null
     - id: mapIndex_stringKey_capture
       version: 0
@@ -5242,15 +5509,15 @@ Probes:
             dsl: m["beta"]
             json: {index: [{ref: m}, beta]}
       instances:
-        - subprogram: {subprogram: 55}
+        - subprogram: {subprogram: 57}
           events:
             - Kind: Entry
-              Type: 561 EventRootType Probe[main.mapIndexStringKey]
-              InjectionPoints: [{PC: "0xbad08", Frameless: false}]
+              Type: 569 EventRootType Probe[main.mapIndexStringKey]
+              InjectionPoints: [{PC: "0xbb178", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 562 EventRootType Probe[main.mapIndexStringKey]Return
-              InjectionPoints: [{PC: "0xbad38", Frameless: false}]
+              Type: 570 EventRootType Probe[main.mapIndexStringKey]Return
+              InjectionPoints: [{PC: "0xbb1a8", Frameless: false}]
               Condition: null
     - id: mapIndex_stringKey_template
       version: 0
@@ -5267,15 +5534,15 @@ Probes:
           dsl: m["beta"]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 55}
+        - subprogram: {subprogram: 57}
           events:
             - Kind: Entry
-              Type: 563 EventRootType Probe[main.mapIndexStringKey]
-              InjectionPoints: [{PC: "0xbad08", Frameless: false}]
+              Type: 571 EventRootType Probe[main.mapIndexStringKey]
+              InjectionPoints: [{PC: "0xbb178", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 564 EventRootType Probe[main.mapIndexStringKey]Return
-              InjectionPoints: [{PC: "0xbad38", Frameless: false}]
+              Type: 572 EventRootType Probe[main.mapIndexStringKey]Return
+              InjectionPoints: [{PC: "0xbb1a8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: beta={m["beta"]}
@@ -5300,15 +5567,15 @@ Probes:
             dsl: m["a"].Val
             json: {getmember: [{index: [{ref: m}, a]}, Val]}
       instances:
-        - subprogram: {subprogram: 63}
+        - subprogram: {subprogram: 65}
           events:
             - Kind: Entry
-              Type: 579 EventRootType Probe[main.mapIndexStructVal]
-              InjectionPoints: [{PC: "0xbb258", Frameless: false}]
+              Type: 587 EventRootType Probe[main.mapIndexStructVal]
+              InjectionPoints: [{PC: "0xbb6c8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 580 EventRootType Probe[main.mapIndexStructVal]Return
-              InjectionPoints: [{PC: "0xbb2b0", Frameless: false}]
+              Type: 588 EventRootType Probe[main.mapIndexStructVal]Return
+              InjectionPoints: [{PC: "0xbb720", Frameless: false}]
               Condition: null
     - id: mapIndex_structVal_capture_string
       version: 0
@@ -5327,15 +5594,15 @@ Probes:
             dsl: m["b"].Txt
             json: {getmember: [{index: [{ref: m}, b]}, Txt]}
       instances:
-        - subprogram: {subprogram: 63}
+        - subprogram: {subprogram: 65}
           events:
             - Kind: Entry
-              Type: 581 EventRootType Probe[main.mapIndexStructVal]
-              InjectionPoints: [{PC: "0xbb258", Frameless: false}]
+              Type: 589 EventRootType Probe[main.mapIndexStructVal]
+              InjectionPoints: [{PC: "0xbb6c8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 582 EventRootType Probe[main.mapIndexStructVal]Return
-              InjectionPoints: [{PC: "0xbb2b0", Frameless: false}]
+              Type: 590 EventRootType Probe[main.mapIndexStructVal]Return
+              InjectionPoints: [{PC: "0xbb720", Frameless: false}]
               Condition: null
     - id: mapIndex_zeroValue_capture
       version: 0
@@ -5354,15 +5621,15 @@ Probes:
             dsl: m["zero"]
             json: {index: [{ref: m}, zero]}
       instances:
-        - subprogram: {subprogram: 69}
+        - subprogram: {subprogram: 71}
           events:
             - Kind: Entry
-              Type: 597 EventRootType Probe[main.mapIndexZeroValue]
-              InjectionPoints: [{PC: "0xbb5a8", Frameless: false}]
+              Type: 605 EventRootType Probe[main.mapIndexZeroValue]
+              InjectionPoints: [{PC: "0xbba18", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 598 EventRootType Probe[main.mapIndexZeroValue]Return
-              InjectionPoints: [{PC: "0xbb5d8", Frameless: false}]
+              Type: 606 EventRootType Probe[main.mapIndexZeroValue]Return
+              InjectionPoints: [{PC: "0xbba48", Frameless: false}]
               Condition: null
     - id: noArgs
       version: 0
@@ -5376,11 +5643,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 314 EventRootType Probe[main.noArgs]
-              InjectionPoints: [{PC: "0xb8688", Frameless: false}]
+              InjectionPoints: [{PC: "0xb88c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 315 EventRootType Probe[main.noArgs]Return
-              InjectionPoints: [{PC: "0xb86c0", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8900", Frameless: false}]
               Condition: null
     - id: stringArg
       version: 0
@@ -5394,11 +5661,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 275 EventRootType Probe[main.stringArg]
-              InjectionPoints: [{PC: "0xb81e8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8428", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 276 EventRootType Probe[main.stringArg]Return
-              InjectionPoints: [{PC: "0xb8224", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8464", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's: {s}'
@@ -5420,11 +5687,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 307 EventRootType Probe[main.stringArrayArg]
-              InjectionPoints: [{PC: "0xb8408", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8648", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 308 EventRootType Probe[main.stringArrayArg]Return
-              InjectionPoints: [{PC: "0xb844c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb868c", Frameless: false}]
               Condition: null
     - id: stringSliceArg
       version: 0
@@ -5438,11 +5705,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 303 EventRootType Probe[main.stringSliceArg]
-              InjectionPoints: [{PC: "0xb8378", Frameless: false}]
+              InjectionPoints: [{PC: "0xb85b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 304 EventRootType Probe[main.stringSliceArg]Return
-              InjectionPoints: [{PC: "0xb83b4", Frameless: false}]
+              InjectionPoints: [{PC: "0xb85f4", Frameless: false}]
               Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
       version: 0
@@ -5453,39 +5720,39 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 46}
+        - subprogram: {subprogram: 48}
           events:
             - Kind: Entry
-              Type: 523 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
-              InjectionPoints: [{PC: "0xba5c0", Frameless: false}]
+              Type: 531 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+              InjectionPoints: [{PC: "0xbaa30", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 524 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
-              InjectionPoints: [{PC: "0xba734", Frameless: false}]
+              Type: 532 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+              InjectionPoints: [{PC: "0xbaba4", Frameless: false}]
               Condition: null
 Subprograms:
     - ID: 1
       Name: main.intArg
-      OutOfLinePCRanges: [0xb8160..0xb81d0]
+      OutOfLinePCRanges: [0xb83a0..0xb8410]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xb8160..0xb8180
+            - Range: 0xb83a0..0xb83c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 2
       Name: main.stringArg
-      OutOfLinePCRanges: [0xb81d0..0xb8250]
+      OutOfLinePCRanges: [0xb8410..0xb8490]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb81d0..0xb81f4
+            - Range: 0xb8410..0xb8434
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -5496,13 +5763,13 @@ Subprograms:
       DictRegister: null
     - ID: 3
       Name: main.intSliceArg
-      OutOfLinePCRanges: [0xb8250..0xb82e0]
+      OutOfLinePCRanges: [0xb8490..0xb8520]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 100 GoSliceHeaderType []int
           Locations:
-            - Range: 0xb8250..0xb8274
+            - Range: 0xb8490..0xb84b4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -5515,26 +5782,26 @@ Subprograms:
       DictRegister: null
     - ID: 4
       Name: main.intArrayArg
-      OutOfLinePCRanges: [0xb82e0..0xb8360]
+      OutOfLinePCRanges: [0xb8520..0xb85a0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 101 ArrayType [3]int
           Locations:
-            - Range: 0xb82e0..0xb8360
+            - Range: 0xb8520..0xb85a0
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 5
       Name: main.stringSliceArg
-      OutOfLinePCRanges: [0xb8360..0xb83f0]
+      OutOfLinePCRanges: [0xb85a0..0xb8630]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 102 GoSliceHeaderType []string
           Locations:
-            - Range: 0xb8360..0xb8384
+            - Range: 0xb85a0..0xb85c4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -5547,86 +5814,86 @@ Subprograms:
       DictRegister: null
     - ID: 6
       Name: main.stringArrayArg
-      OutOfLinePCRanges: [0xb83f0..0xb8470]
+      OutOfLinePCRanges: [0xb8630..0xb86b0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 103 ArrayType [3]string
           Locations:
-            - Range: 0xb83f0..0xb8470
+            - Range: 0xb8630..0xb86b0
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 7
       Name: main.stringArrayArgFrameless
-      OutOfLinePCRanges: [0xb8470..0xb8480]
+      OutOfLinePCRanges: [0xb86b0..0xb86c0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 103 ArrayType [3]string
           Locations:
-            - Range: 0xb8470..0xb8480
+            - Range: 0xb86b0..0xb86c0
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 8
       Name: main.mapArg
-      OutOfLinePCRanges: [0xb8540..0xb85b0]
+      OutOfLinePCRanges: [0xb8780..0xb87f0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 104 GoMapType map[string]int
           Locations:
-            - Range: 0xb8540..0xb8578
+            - Range: 0xb8780..0xb87b8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 9
       Name: main.bigMapArg
-      OutOfLinePCRanges: [0xb85b0..0xb8670]
+      OutOfLinePCRanges: [0xb87f0..0xb88b0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 111 GoMapType map[string]main.bigStruct
           Locations:
-            - Range: 0xb85b0..0xb85e8
+            - Range: 0xb87f0..0xb8828
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb85e8..0xb8670
+            - Range: 0xb8828..0xb88b0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 10
       Name: main.noArgs
-      OutOfLinePCRanges: [0xb8670..0xb86e0]
+      OutOfLinePCRanges: [0xb88b0..0xb8920]
       InlinePCRanges: []
       Variables: []
       DictRegister: null
     - ID: 11
       Name: main.condInt8
-      OutOfLinePCRanges: [0xb86e0..0xb8790]
+      OutOfLinePCRanges: [0xb8920..0xb89d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 BaseType int8
           Locations:
-            - Range: 0xb86e0..0xb8728
+            - Range: 0xb8920..0xb8968
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb86e0..0xb872c
+            - Range: 0xb8920..0xb896c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb872c..0xb8730
+            - Range: 0xb896c..0xb8970
               Pieces:
                 - Size: 8
                   Op: null
@@ -5637,26 +5904,26 @@ Subprograms:
       DictRegister: null
     - ID: 12
       Name: main.condInt16
-      OutOfLinePCRanges: [0xb8790..0xb8840]
+      OutOfLinePCRanges: [0xb89d0..0xb8a80]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 89 BaseType int16
           Locations:
-            - Range: 0xb8790..0xb87bc
+            - Range: 0xb89d0..0xb89fc
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb8790..0xb87bc
+            - Range: 0xb89d0..0xb89fc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb87bc..0xb8840
+            - Range: 0xb89fc..0xb8a80
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -5667,26 +5934,26 @@ Subprograms:
       DictRegister: null
     - ID: 13
       Name: main.condInt32
-      OutOfLinePCRanges: [0xb8840..0xb88f0]
+      OutOfLinePCRanges: [0xb8a80..0xb8b30]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType int32
           Locations:
-            - Range: 0xb8840..0xb886c
+            - Range: 0xb8a80..0xb8aac
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb8840..0xb886c
+            - Range: 0xb8a80..0xb8aac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb886c..0xb88f0
+            - Range: 0xb8aac..0xb8b30
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -5697,26 +5964,26 @@ Subprograms:
       DictRegister: null
     - ID: 14
       Name: main.condInt64
-      OutOfLinePCRanges: [0xb88f0..0xb89a0]
+      OutOfLinePCRanges: [0xb8b30..0xb8be0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 BaseType int64
           Locations:
-            - Range: 0xb88f0..0xb891c
+            - Range: 0xb8b30..0xb8b5c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb88f0..0xb891c
+            - Range: 0xb8b30..0xb8b5c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb891c..0xb89a0
+            - Range: 0xb8b5c..0xb8be0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -5727,26 +5994,26 @@ Subprograms:
       DictRegister: null
     - ID: 15
       Name: main.condUint8
-      OutOfLinePCRanges: [0xb89a0..0xb8a50]
+      OutOfLinePCRanges: [0xb8be0..0xb8c90]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xb89a0..0xb89e8
+            - Range: 0xb8be0..0xb8c28
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb89a0..0xb89ec
+            - Range: 0xb8be0..0xb8c2c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb89ec..0xb89f0
+            - Range: 0xb8c2c..0xb8c30
               Pieces:
                 - Size: 8
                   Op: null
@@ -5757,26 +6024,26 @@ Subprograms:
       DictRegister: null
     - ID: 16
       Name: main.condUint16
-      OutOfLinePCRanges: [0xb8a50..0xb8b00]
+      OutOfLinePCRanges: [0xb8c90..0xb8d40]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType uint16
           Locations:
-            - Range: 0xb8a50..0xb8a7c
+            - Range: 0xb8c90..0xb8cbc
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb8a50..0xb8a7c
+            - Range: 0xb8c90..0xb8cbc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb8a7c..0xb8b00
+            - Range: 0xb8cbc..0xb8d40
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -5787,26 +6054,26 @@ Subprograms:
       DictRegister: null
     - ID: 17
       Name: main.condUint32
-      OutOfLinePCRanges: [0xb8b00..0xb8bb0]
+      OutOfLinePCRanges: [0xb8d40..0xb8df0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0xb8b00..0xb8b2c
+            - Range: 0xb8d40..0xb8d6c
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb8b00..0xb8b2c
+            - Range: 0xb8d40..0xb8d6c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb8b2c..0xb8bb0
+            - Range: 0xb8d6c..0xb8df0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -5817,26 +6084,26 @@ Subprograms:
       DictRegister: null
     - ID: 18
       Name: main.condUint64
-      OutOfLinePCRanges: [0xb8bb0..0xb8c60]
+      OutOfLinePCRanges: [0xb8df0..0xb8ea0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 BaseType uint64
           Locations:
-            - Range: 0xb8bb0..0xb8bdc
+            - Range: 0xb8df0..0xb8e1c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb8bb0..0xb8bdc
+            - Range: 0xb8df0..0xb8e1c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb8bdc..0xb8c60
+            - Range: 0xb8e1c..0xb8ea0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -5847,32 +6114,32 @@ Subprograms:
       DictRegister: null
     - ID: 19
       Name: main.condFloat32
-      OutOfLinePCRanges: [0xb8c60..0xb8d10]
+      OutOfLinePCRanges: [0xb8ea0..0xb8f50]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 BaseType float32
           Locations:
-            - Range: 0xb8c60..0xb8c94
+            - Range: 0xb8ea0..0xb8ed4
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb8c60..0xb8c90
+            - Range: 0xb8ea0..0xb8ed0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xb8c90..0xb8c94
+            - Range: 0xb8ed0..0xb8ed4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xb8c94..0xb8d10
+            - Range: 0xb8ed4..0xb8f50
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -5883,32 +6150,32 @@ Subprograms:
       DictRegister: null
     - ID: 20
       Name: main.condFloat64
-      OutOfLinePCRanges: [0xb8d10..0xb8dc0]
+      OutOfLinePCRanges: [0xb8f50..0xb9000]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType float64
           Locations:
-            - Range: 0xb8d10..0xb8d44
+            - Range: 0xb8f50..0xb8f84
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb8d10..0xb8d40
+            - Range: 0xb8f50..0xb8f80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xb8d40..0xb8d44
+            - Range: 0xb8f80..0xb8f84
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xb8d44..0xb8dc0
+            - Range: 0xb8f84..0xb9000
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -5919,26 +6186,26 @@ Subprograms:
       DictRegister: null
     - ID: 21
       Name: main.condBool
-      OutOfLinePCRanges: [0xb8dc0..0xb8e70]
+      OutOfLinePCRanges: [0xb9000..0xb90b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xb8dc0..0xb8e08
+            - Range: 0xb9000..0xb9048
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb8dc0..0xb8e0c
+            - Range: 0xb9000..0xb904c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb8e0c..0xb8e10
+            - Range: 0xb904c..0xb9050
               Pieces:
                 - Size: 8
                   Op: null
@@ -5949,13 +6216,13 @@ Subprograms:
       DictRegister: null
     - ID: 22
       Name: main.condString
-      OutOfLinePCRanges: [0xb8e70..0xb8f30]
+      OutOfLinePCRanges: [0xb90b0..0xb9170]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb8e70..0xb8ea0
+            - Range: 0xb90b0..0xb90e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -5966,13 +6233,13 @@ Subprograms:
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb8e70..0xb8ea0
+            - Range: 0xb90b0..0xb90e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xb8ea0..0xb8f30
+            - Range: 0xb90e0..0xb9170
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
@@ -5983,32 +6250,32 @@ Subprograms:
       DictRegister: null
     - ID: 23
       Name: main.condStructArg
-      OutOfLinePCRanges: [0xb8f30..0xb9050]
+      OutOfLinePCRanges: [0xb9170..0xb9290]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 116 StructureType main.condFields
           Locations:
-            - Range: 0xb8f30..0xb9050
+            - Range: 0xb9170..0xb9290
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb8f30..0xb8f74
+            - Range: 0xb9170..0xb91b4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xb8f74..0xb8f78
+            - Range: 0xb91b4..0xb91b8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 88}
                 - Size: 8
                   Op: {CfaOffset: 96}
-            - Range: 0xb8f78..0xb9050
+            - Range: 0xb91b8..0xb9290
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 88}
@@ -6019,28 +6286,28 @@ Subprograms:
       DictRegister: null
     - ID: 24
       Name: main.condPtrStructArg
-      OutOfLinePCRanges: [0xb9050..0xb9180]
+      OutOfLinePCRanges: [0xb9290..0xb93c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 118 PointerType *main.condFields
           Locations:
-            - Range: 0xb9050..0xb9098
+            - Range: 0xb9290..0xb92d8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb9098..0xb9180
+            - Range: 0xb92d8..0xb93c0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb9050..0xb909c
+            - Range: 0xb9290..0xb92dc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb909c..0xb9180
+            - Range: 0xb92dc..0xb93c0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -6051,26 +6318,26 @@ Subprograms:
       DictRegister: null
     - ID: 25
       Name: main.condNilPtrStruct
-      OutOfLinePCRanges: [0xb9180..0xb9240]
+      OutOfLinePCRanges: [0xb93c0..0xb9480]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 118 PointerType *main.condFields
           Locations:
-            - Range: 0xb9180..0xb91d4
+            - Range: 0xb93c0..0xb9414
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb9180..0xb91d8
+            - Range: 0xb93c0..0xb9418
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb91d8..0xb91dc
+            - Range: 0xb9418..0xb941c
               Pieces:
                 - Size: 8
                   Op: null
@@ -6081,66 +6348,66 @@ Subprograms:
       DictRegister: null
     - ID: 26
       Name: main.condReturnAndLocal
-      OutOfLinePCRanges: [0xb9240..0xb92e0]
+      OutOfLinePCRanges: [0xb9480..0xb9520]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0xb9240..0xb925c
+            - Range: 0xb9480..0xb949c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0xb9240..0xb9270
+            - Range: 0xb9480..0xb94b0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xb9240..0xb92b8
+            - Range: 0xb9480..0xb94f8
               Pieces: []
-            - Range: 0xb92b8..0xb92b9
+            - Range: 0xb94f8..0xb94f9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb92b9..0xb92e0
+            - Range: 0xb94f9..0xb9520
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: sum
           Type: 9 BaseType int
           Locations:
-            - Range: 0xb925c..0xb9284
+            - Range: 0xb949c..0xb94c4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb9284..0xb92e0
+            - Range: 0xb94c4..0xb9520
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 27
       Name: main.condOnly
-      OutOfLinePCRanges: [0xb92e0..0xb9390]
+      OutOfLinePCRanges: [0xb9520..0xb95d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xb92e0..0xb930c
+            - Range: 0xb9520..0xb954c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb92e0..0xb930c
+            - Range: 0xb9520..0xb954c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb930c..0xb9390
+            - Range: 0xb954c..0xb95d0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -6151,28 +6418,28 @@ Subprograms:
       DictRegister: null
     - ID: 28
       Name: main.condLine
-      OutOfLinePCRanges: [0xb9390..0xb9460]
+      OutOfLinePCRanges: [0xb95d0..0xb96a0]
       InlinePCRanges: []
       Variables:
         - Name: "n"
           Type: 9 BaseType int
           Locations:
-            - Range: 0xb9390..0xb93c8
+            - Range: 0xb95d0..0xb9608
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb93c8..0xb9460
+            - Range: 0xb9608..0xb96a0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb9390..0xb93cc
+            - Range: 0xb95d0..0xb960c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb93cc..0xb9460
+            - Range: 0xb960c..0xb96a0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -6182,14 +6449,107 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 29
+      Name: main.condLineMixed
+      OutOfLinePCRanges: [0xb96a0..0xb9850]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0xb96a0..0xb96f4
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0xb96f4..0xb96f8
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 88}
+                - Size: 8
+                  Op: {CfaOffset: 96}
+            - Range: 0xb96f8..0xb9850
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 88}
+                - Size: 8
+                  Op: {CfaOffset: 96}
+          Role: Parameter
+          DictIndex: -1
+        - Name: b
+          Type: 4 BaseType bool
+          Locations:
+            - Range: 0xb96a0..0xb96f8
+              Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xb96f8..0xb9850
+              Pieces: [{Size: 1, Op: {CfaOffset: 104}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: x
+          Type: 116 StructureType main.condFields
+          Locations:
+            - Range: 0xb96a0..0xb9850
+              Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: p
+          Type: 118 PointerType *main.condFields
+          Locations:
+            - Range: 0xb96a0..0xb96f8
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xb96f8..0xb9850
+              Pieces: [{Size: 8, Op: {CfaOffset: 112}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: ss
+          Type: 100 GoSliceHeaderType []int
+          Locations:
+            - Range: 0xb96a0..0xb96f8
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+            - Range: 0xb96f8..0xb9850
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 120}
+                - Size: 8
+                  Op: {CfaOffset: 128}
+                - Size: 8
+                  Op: {CfaOffset: 136}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 30
+      Name: main.condLineReturn
+      OutOfLinePCRanges: [0xb9850..0xb98d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: "n"
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xb9850..0xb986c
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: ~r0
+          Type: 9 BaseType int
+          Locations: [{Range: 0xb9850..0xb98d0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 31
       Name: main.condSliceArg
-      OutOfLinePCRanges: [0xb9460..0xb9520]
+      OutOfLinePCRanges: [0xb98d0..0xb9990]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 100 GoSliceHeaderType []int
           Locations:
-            - Range: 0xb9460..0xb9490
+            - Range: 0xb98d0..0xb9900
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6202,13 +6562,13 @@ Subprograms:
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb9460..0xb9490
+            - Range: 0xb98d0..0xb9900
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
-            - Range: 0xb9490..0xb9520
+            - Range: 0xb9900..0xb9990
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
@@ -6217,28 +6577,28 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 30
+    - ID: 32
       Name: main.condMapArg
-      OutOfLinePCRanges: [0xb9520..0xb95c0]
+      OutOfLinePCRanges: [0xb9990..0xb9a30]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 104 GoMapType map[string]int
           Locations:
-            - Range: 0xb9520..0xb9558
+            - Range: 0xb9990..0xb99c8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb9520..0xb955c
+            - Range: 0xb9990..0xb99cc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb955c..0xb9560
+            - Range: 0xb99cc..0xb99d0
               Pieces:
                 - Size: 8
                   Op: null
@@ -6247,34 +6607,34 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 31
+    - ID: 33
       Name: main.condStructDirect
-      OutOfLinePCRanges: [0xb95c0..0xb9670]
+      OutOfLinePCRanges: [0xb9a30..0xb9ae0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 116 StructureType main.condFields
           Locations:
-            - Range: 0xb95c0..0xb9670
+            - Range: 0xb9a30..0xb9ae0
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb95c0..0xb95f0
+            - Range: 0xb9a30..0xb9a60
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xb95f0..0xb95f4
+            - Range: 0xb9a60..0xb9a64
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 88}
                 - Size: 8
                   Op: {CfaOffset: 96}
-            - Range: 0xb95f4..0xb9670
+            - Range: 0xb9a64..0xb9ae0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 88}
@@ -6283,134 +6643,36 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 32
+    - ID: 34
       Name: main.condNullPtr
-      OutOfLinePCRanges: [0xb9670..0xb9770]
+      OutOfLinePCRanges: [0xb9ae0..0xb9be0]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 94 PointerType *int
           Locations:
-            - Range: 0xb9670..0xb96d0
+            - Range: 0xb9ae0..0xb9b40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb96d0..0xb9770
+            - Range: 0xb9b40..0xb9be0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb9670..0xb96d4
+            - Range: 0xb9ae0..0xb9b44
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb96d4..0xb96d8
+            - Range: 0xb9b44..0xb9b48
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xb96d8..0xb9770
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 16}
-                - Size: 8
-                  Op: {CfaOffset: 24}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 33
-      Name: main.condNullSlice
-      OutOfLinePCRanges: [0xb9770..0xb98a0]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 100 GoSliceHeaderType []int
-          Locations:
-            - Range: 0xb9770..0xb97e8
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb97e8..0xb97ec
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-                - Size: 8
-                  Op: {CfaOffset: 24}
-            - Range: 0xb97ec..0xb97f0
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-                - Size: 8
-                  Op: {CfaOffset: 24}
-            - Range: 0xb97f0..0xb98a0
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-                - Size: 8
-                  Op: {CfaOffset: 24}
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 10 GoStringHeaderType string
-          Locations:
-            - Range: 0xb9770..0xb97f4
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-            - Range: 0xb97f4..0xb98a0
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 32}
-                - Size: 8
-                  Op: {CfaOffset: 40}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 34
-      Name: main.condNullMap
-      OutOfLinePCRanges: [0xb98a0..0xb99a0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 104 GoMapType map[string]int
-          Locations:
-            - Range: 0xb98a0..0xb9900
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb9900..0xb99a0
-              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 10 GoStringHeaderType string
-          Locations:
-            - Range: 0xb98a0..0xb9904
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb9904..0xb9908
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 16}
-                - Size: 8
-                  Op: {CfaOffset: 24}
-            - Range: 0xb9908..0xb99a0
+            - Range: 0xb9b48..0xb9be0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -6420,87 +6682,95 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 35
-      Name: main.condNullIface
-      OutOfLinePCRanges: [0xb99a0..0xb9ac0]
+      Name: main.condNullSlice
+      OutOfLinePCRanges: [0xb9be0..0xb9d10]
       InlinePCRanges: []
       Variables:
-        - Name: i
-          Type: 18 GoInterfaceType error
+        - Name: s
+          Type: 100 GoSliceHeaderType []int
           Locations:
-            - Range: 0xb99a0..0xb9a14
+            - Range: 0xb9be0..0xb9c58
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xb9a14..0xb9a18
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xb9c58..0xb9c5c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0xb9a18..0xb9ac0
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0xb9c5c..0xb9c60
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0xb9c60..0xb9d10
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb99a0..0xb9a1c
+            - Range: 0xb9be0..0xb9c64
               Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xb9a1c..0xb9a20
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+            - Range: 0xb9c64..0xb9d10
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 24}
-                - Size: 8
                   Op: {CfaOffset: 32}
-            - Range: 0xb9a20..0xb9ac0
-              Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 24}
-                - Size: 8
-                  Op: {CfaOffset: 32}
+                  Op: {CfaOffset: 40}
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 36
-      Name: main.condNullUnsafePtr
-      OutOfLinePCRanges: [0xb9ac0..0xb9bc0]
+      Name: main.condNullMap
+      OutOfLinePCRanges: [0xb9d10..0xb9e10]
       InlinePCRanges: []
       Variables:
-        - Name: p
-          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: m
+          Type: 104 GoMapType map[string]int
           Locations:
-            - Range: 0xb9ac0..0xb9b20
+            - Range: 0xb9d10..0xb9d70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb9b20..0xb9bc0
+            - Range: 0xb9d70..0xb9e10
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb9ac0..0xb9b24
+            - Range: 0xb9d10..0xb9d74
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb9b24..0xb9b28
+            - Range: 0xb9d74..0xb9d78
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xb9b28..0xb9bc0
+            - Range: 0xb9d78..0xb9e10
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -6510,41 +6780,49 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 37
-      Name: main.lenString
-      OutOfLinePCRanges: [0xb9bd0..0xb9ce0]
+      Name: main.condNullIface
+      OutOfLinePCRanges: [0xb9e10..0xb9f30]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 10 GoStringHeaderType string
+        - Name: i
+          Type: 18 GoInterfaceType error
           Locations:
-            - Range: 0xb9bd0..0xb9c38
+            - Range: 0xb9e10..0xb9e84
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xb9c38..0xb9c3c
-              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0xb9c3c..0xb9ce0
-              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
+            - Range: 0xb9e84..0xb9e88
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0xb9e88..0xb9f30
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb9bd0..0xb9c40
+            - Range: 0xb9e10..0xb9e8c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xb9c40..0xb9c44
+            - Range: 0xb9e8c..0xb9e90
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: {CfaOffset: 32}
-            - Range: 0xb9c44..0xb9ce0
+            - Range: 0xb9e90..0xb9f30
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
@@ -6554,14 +6832,96 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 38
+      Name: main.condNullUnsafePtr
+      OutOfLinePCRanges: [0xb9f30..0xba030]
+      InlinePCRanges: []
+      Variables:
+        - Name: p
+          Type: 19 VoidPointerType unsafe.Pointer
+          Locations:
+            - Range: 0xb9f30..0xb9f90
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xb9f90..0xba030
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0xb9f30..0xb9f94
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xb9f94..0xb9f98
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0xb9f98..0xba030
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 39
+      Name: main.lenString
+      OutOfLinePCRanges: [0xba040..0xba150]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0xba040..0xba0a8
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0xba0a8..0xba0ac
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
+            - Range: 0xba0ac..0xba150
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0xba040..0xba0b0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xba0b0..0xba0b4
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 24}
+                - Size: 8
+                  Op: {CfaOffset: 32}
+            - Range: 0xba0b4..0xba150
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 24}
+                - Size: 8
+                  Op: {CfaOffset: 32}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 40
       Name: main.lenSlice
-      OutOfLinePCRanges: [0xb9ce0..0xb9e00]
+      OutOfLinePCRanges: [0xba150..0xba270]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 100 GoSliceHeaderType []int
           Locations:
-            - Range: 0xb9ce0..0xb9d54
+            - Range: 0xba150..0xba1c4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6569,7 +6929,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb9d54..0xb9d58
+            - Range: 0xba1c4..0xba1c8
               Pieces:
                 - Size: 8
                   Op: null
@@ -6577,7 +6937,7 @@ Subprograms:
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb9d58..0xb9d5c
+            - Range: 0xba1c8..0xba1cc
               Pieces:
                 - Size: 8
                   Op: null
@@ -6585,7 +6945,7 @@ Subprograms:
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: null
-            - Range: 0xb9d5c..0xb9e00
+            - Range: 0xba1cc..0xba270
               Pieces:
                 - Size: 8
                   Op: null
@@ -6598,13 +6958,13 @@ Subprograms:
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb9ce0..0xb9d60
+            - Range: 0xba150..0xba1d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
-            - Range: 0xb9d60..0xb9e00
+            - Range: 0xba1d0..0xba270
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
@@ -6613,36 +6973,36 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 39
+    - ID: 41
       Name: main.lenMap
-      OutOfLinePCRanges: [0xb9e00..0xb9f10]
+      OutOfLinePCRanges: [0xba270..0xba380]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 104 GoMapType map[string]int
           Locations:
-            - Range: 0xb9e00..0xb9e60
+            - Range: 0xba270..0xba2d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb9e60..0xb9f10
+            - Range: 0xba2d0..0xba380
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb9e00..0xb9e64
+            - Range: 0xba270..0xba2d4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb9e64..0xb9e68
+            - Range: 0xba2d4..0xba2d8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xb9e68..0xb9f10
+            - Range: 0xba2d8..0xba380
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -6651,110 +7011,36 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 40
+    - ID: 42
       Name: main.lenPtrString
-      OutOfLinePCRanges: [0xb9f10..0xba010]
+      OutOfLinePCRanges: [0xba380..0xba480]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 88 PointerType *string
           Locations:
-            - Range: 0xb9f10..0xb9f70
+            - Range: 0xba380..0xba3e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb9f70..0xba010
+            - Range: 0xba3e0..0xba480
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb9f10..0xb9f74
+            - Range: 0xba380..0xba3e4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb9f74..0xb9f78
+            - Range: 0xba3e4..0xba3e8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xb9f78..0xba010
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 16}
-                - Size: 8
-                  Op: {CfaOffset: 24}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 41
-      Name: main.lenStructFields
-      OutOfLinePCRanges: [0xba010..0xba170]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 119 StructureType main.lenFields
-          Locations:
-            - Range: 0xba010..0xba170
-              Pieces: [{Size: 72, Op: {CfaOffset: 8}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 10 GoStringHeaderType string
-          Locations:
-            - Range: 0xba010..0xba09c
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0xba09c..0xba0a0
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 80}
-                - Size: 8
-                  Op: {CfaOffset: 88}
-            - Range: 0xba0a0..0xba170
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 80}
-                - Size: 8
-                  Op: {CfaOffset: 88}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 42
-      Name: main.lenPtrStructFields
-      OutOfLinePCRanges: [0xba170..0xba2c0]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 121 PointerType *main.lenFields
-          Locations:
-            - Range: 0xba170..0xba1d0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xba1d0..0xba2c0
-              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 10 GoStringHeaderType string
-          Locations:
-            - Range: 0xba170..0xba1d4
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0xba1d4..0xba1d8
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 16}
-                - Size: 8
-                  Op: {CfaOffset: 24}
-            - Range: 0xba1d8..0xba2c0
+            - Range: 0xba3e8..0xba480
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -6764,35 +7050,71 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 43
-      Name: main.lenErrInt
-      OutOfLinePCRanges: [0xba2c0..0xba3c0]
+      Name: main.lenStructFields
+      OutOfLinePCRanges: [0xba480..0xba5e0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 9 BaseType int
+          Type: 119 StructureType main.lenFields
           Locations:
-            - Range: 0xba2c0..0xba328
+            - Range: 0xba480..0xba5e0
+              Pieces: [{Size: 72, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0xba480..0xba50c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0xba50c..0xba510
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 80}
+                - Size: 8
+                  Op: {CfaOffset: 88}
+            - Range: 0xba510..0xba5e0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 80}
+                - Size: 8
+                  Op: {CfaOffset: 88}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 44
+      Name: main.lenPtrStructFields
+      OutOfLinePCRanges: [0xba5e0..0xba730]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 121 PointerType *main.lenFields
+          Locations:
+            - Range: 0xba5e0..0xba640
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xba328..0xba3c0
+            - Range: 0xba640..0xba730
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xba2c0..0xba32c
+            - Range: 0xba5e0..0xba644
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xba32c..0xba330
+            - Range: 0xba644..0xba648
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xba330..0xba3c0
+            - Range: 0xba648..0xba730
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -6801,34 +7123,72 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 44
+    - ID: 45
+      Name: main.lenErrInt
+      OutOfLinePCRanges: [0xba730..0xba830]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xba730..0xba798
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xba798..0xba830
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0xba730..0xba79c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xba79c..0xba7a0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0xba7a0..0xba830
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 46
       Name: main.lenErrStruct
-      OutOfLinePCRanges: [0xba3c0..0xba4e0]
+      OutOfLinePCRanges: [0xba830..0xba950]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 116 StructureType main.condFields
           Locations:
-            - Range: 0xba3c0..0xba4e0
+            - Range: 0xba830..0xba950
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xba3c0..0xba440
+            - Range: 0xba830..0xba8b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xba440..0xba444
+            - Range: 0xba8b0..0xba8b4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 88}
                 - Size: 8
                   Op: {CfaOffset: 96}
-            - Range: 0xba444..0xba4e0
+            - Range: 0xba8b4..0xba950
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 88}
@@ -6837,28 +7197,28 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 45
+    - ID: 47
       Name: main.indexNilPtrSlice
-      OutOfLinePCRanges: [0xba4e0..0xba5a0]
+      OutOfLinePCRanges: [0xba950..0xbaa10]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 121 PointerType *main.lenFields
           Locations:
-            - Range: 0xba4e0..0xba534
+            - Range: 0xba950..0xba9a4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xba4e0..0xba538
+            - Range: 0xba950..0xba9a8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xba538..0xba53c
+            - Range: 0xba9a8..0xba9ac
               Pieces:
                 - Size: 8
                   Op: null
@@ -6867,65 +7227,65 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 46
+    - ID: 48
       Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
-      OutOfLinePCRanges: [0xba5a0..0xba750]
+      OutOfLinePCRanges: [0xbaa10..0xbabc0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 122 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
           Locations:
-            - Range: 0xba5a0..0xba734
+            - Range: 0xbaa10..0xbaba4
               Pieces: []
-            - Range: 0xba734..0xba735
+            - Range: 0xbaba4..0xbaba5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xba735..0xba750
+            - Range: 0xbaba5..0xbabc0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: m
           Type: 127 GoMapType map[string]map[int]main.aStructNotUsedAsAnArgument
-          Locations: [{Range: 0xba5a0..0xba750, Pieces: []}]
+          Locations: [{Range: 0xbaa10..0xbabc0, Pieces: []}]
           Role: Local
           DictIndex: -1
       DictRegister: null
-    - ID: 47
+    - ID: 49
       Name: main.bigArrayArg
-      OutOfLinePCRanges: [0xba750..0xba7e0]
+      OutOfLinePCRanges: [0xbabc0..0xbac50]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 132 ArrayType [131072]int64
           Locations:
-            - Range: 0xba750..0xba7e0
+            - Range: 0xbabc0..0xbac50
               Pieces: [{Size: 1048576, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 48
+    - ID: 50
       Name: main.bigArrayStructArg
-      OutOfLinePCRanges: [0xba7e0..0xba880]
+      OutOfLinePCRanges: [0xbac50..0xbacf0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 133 PointerType *main.bigArrayStruct
           Locations:
-            - Range: 0xba7e0..0xba80c
+            - Range: 0xbac50..0xbac7c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xba80c..0xba880
+            - Range: 0xbac7c..0xbacf0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 49
+    - ID: 51
       Name: main.structSliceArg
-      OutOfLinePCRanges: [0xba880..0xba960]
+      OutOfLinePCRanges: [0xbacf0..0xbadd0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 135 GoSliceHeaderType []main.indexMemberStruct
           Locations:
-            - Range: 0xba880..0xba8bc
+            - Range: 0xbacf0..0xbad2c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6933,7 +7293,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xba8bc..0xba8c0
+            - Range: 0xbad2c..0xbad30
               Pieces:
                 - Size: 8
                   Op: null
@@ -6941,7 +7301,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xba91c..0xba920
+            - Range: 0xbad8c..0xbad90
               Pieces:
                 - Size: 8
                   Op: null
@@ -6949,7 +7309,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xba920..0xba960
+            - Range: 0xbad90..0xbadd0
               Pieces:
                 - Size: 8
                   Op: null
@@ -6962,129 +7322,19 @@ Subprograms:
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xba880..0xba8c0
+            - Range: 0xbacf0..0xbad30
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
-            - Range: 0xba8c0..0xba918
+            - Range: 0xbad30..0xbad88
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
                 - Size: 8
                   Op: {CfaOffset: 40}
-            - Range: 0xba918..0xba960
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 50
-      Name: main.structArrayArg
-      OutOfLinePCRanges: [0xba960..0xbaa10]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 138 ArrayType [2]main.indexMemberStruct
-          Locations:
-            - Range: 0xba960..0xbaa10
-              Pieces: [{Size: 64, Op: {CfaOffset: 8}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 10 GoStringHeaderType string
-          Locations:
-            - Range: 0xba960..0xba990
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0xba990..0xba994
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 72}
-                - Size: 8
-                  Op: {CfaOffset: 80}
-            - Range: 0xba994..0xbaa10
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 72}
-                - Size: 8
-                  Op: {CfaOffset: 80}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 51
-      Name: main.ptrStructSliceArg
-      OutOfLinePCRanges: [0xbaa10..0xbaaf0]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 139 GoSliceHeaderType []*main.indexMemberStruct
-          Locations:
-            - Range: 0xbaa10..0xbaa4c
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbaa4c..0xbaa50
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbaa50..0xbaa54
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbaab0..0xbaab4
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbaab4..0xbaaf0
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 10 GoStringHeaderType string
-          Locations:
-            - Range: 0xbaa10..0xbaa54
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-            - Range: 0xbaa54..0xbaaac
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 32}
-                - Size: 8
-                  Op: {CfaOffset: 40}
-            - Range: 0xbaaac..0xbaaf0
+            - Range: 0xbad88..0xbadd0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -7094,33 +7344,143 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 52
+      Name: main.structArrayArg
+      OutOfLinePCRanges: [0xbadd0..0xbae80]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 138 ArrayType [2]main.indexMemberStruct
+          Locations:
+            - Range: 0xbadd0..0xbae80
+              Pieces: [{Size: 64, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0xbadd0..0xbae00
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0xbae00..0xbae04
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 72}
+                - Size: 8
+                  Op: {CfaOffset: 80}
+            - Range: 0xbae04..0xbae80
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 72}
+                - Size: 8
+                  Op: {CfaOffset: 80}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 53
+      Name: main.ptrStructSliceArg
+      OutOfLinePCRanges: [0xbae80..0xbaf60]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 139 GoSliceHeaderType []*main.indexMemberStruct
+          Locations:
+            - Range: 0xbae80..0xbaebc
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xbaebc..0xbaec0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xbaec0..0xbaec4
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xbaf20..0xbaf24
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xbaf24..0xbaf60
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0xbae80..0xbaec4
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+            - Range: 0xbaec4..0xbaf1c
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 32}
+                - Size: 8
+                  Op: {CfaOffset: 40}
+            - Range: 0xbaf1c..0xbaf60
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 54
       Name: main.ptrStructArrayArg
-      OutOfLinePCRanges: [0xbaaf0..0xbaba0]
+      OutOfLinePCRanges: [0xbaf60..0xbb010]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 141 ArrayType [2]*main.indexMemberStruct
           Locations:
-            - Range: 0xbaaf0..0xbaba0
+            - Range: 0xbaf60..0xbb010
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xbaaf0..0xbab24
+            - Range: 0xbaf60..0xbaf94
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xbab24..0xbab28
+            - Range: 0xbaf94..0xbaf98
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: {CfaOffset: 32}
-            - Range: 0xbab28..0xbaba0
+            - Range: 0xbaf98..0xbb010
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
@@ -7129,30 +7489,30 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 53
+    - ID: 55
       Name: main.indexMemberWrapperArg
-      OutOfLinePCRanges: [0xbaba0..0xbac80]
+      OutOfLinePCRanges: [0xbb010..0xbb0f0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 142 PointerType *main.indexMemberWrapper
           Locations:
-            - Range: 0xbaba0..0xbabdc
+            - Range: 0xbb010..0xbb04c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xbabdc..0xbac80
+            - Range: 0xbb04c..0xbb0f0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xbaba0..0xbabe0
+            - Range: 0xbb010..0xbb050
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbabe0..0xbac80
+            - Range: 0xbb050..0xbb0f0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -7161,261 +7521,261 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 54
+    - ID: 56
       Name: main.mapIndexIntKey
-      OutOfLinePCRanges: [0xbac80..0xbacf0]
+      OutOfLinePCRanges: [0xbb0f0..0xbb160]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 144 GoMapType map[int]string
           Locations:
-            - Range: 0xbac80..0xbacb8
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 55
-      Name: main.mapIndexStringKey
-      OutOfLinePCRanges: [0xbacf0..0xbad60]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 104 GoMapType map[string]int
-          Locations:
-            - Range: 0xbacf0..0xbad28
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 56
-      Name: main.mapIndexLargeMap
-      OutOfLinePCRanges: [0xbad60..0xbadf0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 104 GoMapType map[string]int
-          Locations:
-            - Range: 0xbad60..0xbad90
+            - Range: 0xbb0f0..0xbb128
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 57
-      Name: main.mapIndexMissing
-      OutOfLinePCRanges: [0xbadf0..0xbae60]
+      Name: main.mapIndexStringKey
+      OutOfLinePCRanges: [0xbb160..0xbb1d0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 104 GoMapType map[string]int
           Locations:
-            - Range: 0xbadf0..0xbae28
+            - Range: 0xbb160..0xbb198
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 58
-      Name: main.mapIndexKeyLen8
-      OutOfLinePCRanges: [0xbaf70..0xbb000]
+      Name: main.mapIndexLargeMap
+      OutOfLinePCRanges: [0xbb1d0..0xbb260]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 104 GoMapType map[string]int
           Locations:
-            - Range: 0xbaf70..0xbafa0
+            - Range: 0xbb1d0..0xbb200
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 59
-      Name: main.mapIndexKeyLen24
-      OutOfLinePCRanges: [0xbb000..0xbb090]
+      Name: main.mapIndexMissing
+      OutOfLinePCRanges: [0xbb260..0xbb2d0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 104 GoMapType map[string]int
           Locations:
-            - Range: 0xbb000..0xbb030
+            - Range: 0xbb260..0xbb298
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 60
-      Name: main.mapIndexKeyLen48
-      OutOfLinePCRanges: [0xbb090..0xbb120]
+      Name: main.mapIndexKeyLen8
+      OutOfLinePCRanges: [0xbb3e0..0xbb470]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 104 GoMapType map[string]int
           Locations:
-            - Range: 0xbb090..0xbb0c0
+            - Range: 0xbb3e0..0xbb410
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 61
-      Name: main.mapIndexKeyLen96
-      OutOfLinePCRanges: [0xbb120..0xbb1b0]
+      Name: main.mapIndexKeyLen24
+      OutOfLinePCRanges: [0xbb470..0xbb500]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 104 GoMapType map[string]int
           Locations:
-            - Range: 0xbb120..0xbb150
+            - Range: 0xbb470..0xbb4a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 62
-      Name: main.mapIndexKeyLen200
-      OutOfLinePCRanges: [0xbb1b0..0xbb240]
+      Name: main.mapIndexKeyLen48
+      OutOfLinePCRanges: [0xbb500..0xbb590]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 104 GoMapType map[string]int
           Locations:
-            - Range: 0xbb1b0..0xbb1e0
+            - Range: 0xbb500..0xbb530
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 63
-      Name: main.mapIndexStructVal
-      OutOfLinePCRanges: [0xbb240..0xbb2d0]
+      Name: main.mapIndexKeyLen96
+      OutOfLinePCRanges: [0xbb590..0xbb620]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 149 GoMapType map[string]main.indexMemberStruct
+          Type: 104 GoMapType map[string]int
           Locations:
-            - Range: 0xbb240..0xbb274
+            - Range: 0xbb590..0xbb5c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 64
-      Name: main.mapIndexPtrStructVal
-      OutOfLinePCRanges: [0xbb2d0..0xbb370]
+      Name: main.mapIndexKeyLen200
+      OutOfLinePCRanges: [0xbb620..0xbb6b0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 154 GoMapType map[string]*main.indexMemberStruct
+          Type: 104 GoMapType map[string]int
           Locations:
-            - Range: 0xbb2d0..0xbb304
+            - Range: 0xbb620..0xbb650
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 65
-      Name: main.mapIndexEmptyKey
-      OutOfLinePCRanges: [0xbb370..0xbb400]
+      Name: main.mapIndexStructVal
+      OutOfLinePCRanges: [0xbb6b0..0xbb740]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 104 GoMapType map[string]int
+          Type: 149 GoMapType map[string]main.indexMemberStruct
           Locations:
-            - Range: 0xbb370..0xbb3a0
+            - Range: 0xbb6b0..0xbb6e4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 66
-      Name: main.mapIndexKeyLen16
-      OutOfLinePCRanges: [0xbb400..0xbb490]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 104 GoMapType map[string]int
-          Locations:
-            - Range: 0xbb400..0xbb430
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 67
-      Name: main.mapIndexKeyLen17
-      OutOfLinePCRanges: [0xbb490..0xbb520]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 104 GoMapType map[string]int
-          Locations:
-            - Range: 0xbb490..0xbb4c0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 68
-      Name: main.mapIndexBoolKey
-      OutOfLinePCRanges: [0xbb520..0xbb590]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 159 GoMapType map[bool]int
-          Locations:
-            - Range: 0xbb520..0xbb558
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 69
-      Name: main.mapIndexZeroValue
-      OutOfLinePCRanges: [0xbb590..0xbb600]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 104 GoMapType map[string]int
-          Locations:
-            - Range: 0xbb590..0xbb5c8
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 70
-      Name: main.mapIndexNilPtrVal
-      OutOfLinePCRanges: [0xbb600..0xbb670]
+      Name: main.mapIndexPtrStructVal
+      OutOfLinePCRanges: [0xbb740..0xbb7e0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 154 GoMapType map[string]*main.indexMemberStruct
           Locations:
-            - Range: 0xbb600..0xbb638
+            - Range: 0xbb740..0xbb774
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 67
+      Name: main.mapIndexEmptyKey
+      OutOfLinePCRanges: [0xbb7e0..0xbb870]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 104 GoMapType map[string]int
+          Locations:
+            - Range: 0xbb7e0..0xbb810
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 68
+      Name: main.mapIndexKeyLen16
+      OutOfLinePCRanges: [0xbb870..0xbb900]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 104 GoMapType map[string]int
+          Locations:
+            - Range: 0xbb870..0xbb8a0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 69
+      Name: main.mapIndexKeyLen17
+      OutOfLinePCRanges: [0xbb900..0xbb990]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 104 GoMapType map[string]int
+          Locations:
+            - Range: 0xbb900..0xbb930
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 70
+      Name: main.mapIndexBoolKey
+      OutOfLinePCRanges: [0xbb990..0xbba00]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 159 GoMapType map[bool]int
+          Locations:
+            - Range: 0xbb990..0xbb9c8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 71
-      Name: main.mapIndexLargeValue
-      OutOfLinePCRanges: [0xbb670..0xbb700]
+      Name: main.mapIndexZeroValue
+      OutOfLinePCRanges: [0xbba00..0xbba70]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 164 GoMapType map[string]main.largeValueStruct
+          Type: 104 GoMapType map[string]int
           Locations:
-            - Range: 0xbb670..0xbb6a0
+            - Range: 0xbba00..0xbba38
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 72
+      Name: main.mapIndexNilPtrVal
+      OutOfLinePCRanges: [0xbba70..0xbbae0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 154 GoMapType map[string]*main.indexMemberStruct
+          Locations:
+            - Range: 0xbba70..0xbbaa8
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 73
+      Name: main.mapIndexLargeValue
+      OutOfLinePCRanges: [0xbbae0..0xbbb70]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 164 GoMapType map[string]main.largeValueStruct
+          Locations:
+            - Range: 0xbbae0..0xbbb10
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 74
       Name: main.condMultiReturn
-      OutOfLinePCRanges: [0xbb780..0xbb850]
+      OutOfLinePCRanges: [0xbbbf0..0xbbcc0]
       InlinePCRanges: []
       Variables:
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xbb780..0xbb7c8
+            - Range: 0xbbbf0..0xbbc38
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xbb7c8..0xbb7cc
+            - Range: 0xbbc38..0xbbc3c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0xbb7cc..0xbb850
+            - Range: 0xbbc3c..0xbbcc0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -7426,51 +7786,51 @@ Subprograms:
         - Name: r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xbb780..0xbb824
+            - Range: 0xbbbf0..0xbbc94
               Pieces: []
-            - Range: 0xbb824..0xbb825
+            - Range: 0xbbc94..0xbbc95
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xbb825..0xbb850
+            - Range: 0xbbc95..0xbbcc0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: r1
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xbb780..0xbb824
+            - Range: 0xbbbf0..0xbbc94
               Pieces: []
-            - Range: 0xbb824..0xbb825
+            - Range: 0xbbc94..0xbbc95
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbb825..0xbb850
+            - Range: 0xbbc95..0xbbcc0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 73
+    - ID: 75
       Name: main.genericIdentity[go.shape.string]
-      OutOfLinePCRanges: [0xbb850..0xbb8f0]
+      OutOfLinePCRanges: [0xbbcc0..0xbbd60]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 169 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xbb850..0xbb880
+            - Range: 0xbbcc0..0xbbcf0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbb880..0xbb884
+            - Range: 0xbbcf0..0xbbcf4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xbb884..0xbb8f0
+            - Range: 0xbbcf4..0xbbd60
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -7481,68 +7841,68 @@ Subprograms:
         - Name: ~r0
           Type: 169 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xbb850..0xbb8bc
+            - Range: 0xbbcc0..0xbbd2c
               Pieces: []
-            - Range: 0xbb8bc..0xbb8bd
+            - Range: 0xbbd2c..0xbbd2d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xbb8bd..0xbb8f0
+            - Range: 0xbbd2d..0xbbd60
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 74
+    - ID: 76
       Name: main.genericIdentity[go.shape.int]
-      OutOfLinePCRanges: [0xbb8f0..0xbb980]
+      OutOfLinePCRanges: [0xbbd60..0xbbdf0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 170 BaseType go.shape.int
           Locations:
-            - Range: 0xbb8f0..0xbb91c
+            - Range: 0xbbd60..0xbbd8c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0xbb91c..0xbb980
+            - Range: 0xbbd8c..0xbbdf0
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 170 BaseType go.shape.int
           Locations:
-            - Range: 0xbb8f0..0xbb950
+            - Range: 0xbbd60..0xbbdc0
               Pieces: []
-            - Range: 0xbb950..0xbb951
+            - Range: 0xbbdc0..0xbbdc1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xbb951..0xbb980
+            - Range: 0xbbdc1..0xbbdf0
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 75
+    - ID: 77
       Name: main.inlined
-      OutOfLinePCRanges: [0xb8480..0xb84f0]
+      OutOfLinePCRanges: [0xb86c0..0xb8730]
       InlinePCRanges:
         - Ranges: [0xb5dd4..0xb5e28]
-          RootRanges: [0xb5c10..0xb8160]
+          RootRanges: [0xb5c10..0xb83a0]
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
             - Range: 0xb5dd4..0xb5e28
               Pieces: []
-            - Range: 0xb8480..0xb84a0
+            - Range: 0xb86c0..0xb86e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 76
+    - ID: 78
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xb6034..0xb6070]
-          RootRanges: [0xb5c10..0xb8160]
+          RootRanges: [0xb5c10..0xb83a0]
       Variables:
         - Name: ptr
           Type: 171 PointerType *****int
@@ -7552,12 +7912,12 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 77
+    - ID: 79
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xb607c..0xb60b8]
-          RootRanges: [0xb5c10..0xb8160]
+          RootRanges: [0xb5c10..0xb83a0]
       Variables:
         - Name: ptr
           Type: 173 PointerType **int
@@ -7567,17 +7927,17 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 78
+    - ID: 80
       Name: main.(*methodValueReceiver).inlinedMethod
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xbb984..0xbb988]
-          RootRanges: [0xbb980..0xbb990]
+        - Ranges: [0xbbdf4..0xbbdf8]
+          RootRanges: [0xbbdf0..0xbbe00]
       Variables:
         - Name: m
           Type: 174 PointerType *main.methodValueReceiver
           Locations:
-            - Range: 0xbb984..0xbb990
+            - Range: 0xbbdf4..0xbbe00
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7740,7 +8100,7 @@ Types:
       ID: 228
       Name: '*errors.errorString'
       ByteSize: 8
-      GoRuntimeType: 54592
+      GoRuntimeType: 54688
       GoKind: 22
       Pointee: 229 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
@@ -7837,28 +8197,28 @@ Types:
       ID: 233
       Name: '*internal/bisect.parseError'
       ByteSize: 8
-      GoRuntimeType: 57472
+      GoRuntimeType: 57568
       GoKind: 22
       Pointee: 234 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
       ID: 259
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 71104
+      GoRuntimeType: 71200
       GoKind: 22
       Pointee: 260 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 257
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
-      GoRuntimeType: 70976
+      GoRuntimeType: 71072
       GoKind: 22
       Pointee: 258 StructureType internal/poll.errNetClosing
     - __kind: PointerType
       ID: 255
       Name: '*io/fs.PathError'
       ByteSize: 8
-      GoRuntimeType: 70848
+      GoRuntimeType: 70944
       GoKind: 22
       Pointee: 256 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
@@ -7919,28 +8279,28 @@ Types:
       ID: 251
       Name: '*os.SyscallError'
       ByteSize: 8
-      GoRuntimeType: 67648
+      GoRuntimeType: 67744
       GoKind: 22
       Pointee: 252 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 230
       Name: '*reflect.ValueError'
       ByteSize: 8
-      GoRuntimeType: 55456
+      GoRuntimeType: 55552
       GoKind: 22
       Pointee: 231 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
       ID: 244
       Name: '*runtime.PanicNilError'
       ByteSize: 8
-      GoRuntimeType: 63072
+      GoRuntimeType: 63168
       GoKind: 22
       Pointee: 245 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
       ID: 249
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
-      GoRuntimeType: 64992
+      GoRuntimeType: 65088
       GoKind: 22
       Pointee: 250 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
@@ -7954,14 +8314,14 @@ Types:
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 73760
+      GoRuntimeType: 73856
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 246
       Name: '*runtime.boundsError'
       ByteSize: 8
-      GoRuntimeType: 63200
+      GoRuntimeType: 63296
       GoKind: 22
       Pointee: 247 StructureType runtime.boundsError
     - __kind: PointerType
@@ -7982,14 +8342,14 @@ Types:
       ID: 253
       Name: '*runtime.errorAddressString'
       ByteSize: 8
-      GoRuntimeType: 70080
+      GoRuntimeType: 70176
       GoKind: 22
       Pointee: 254 StructureType runtime.errorAddressString
     - __kind: PointerType
       ID: 243
       Name: '*runtime.errorString'
       ByteSize: 8
-      GoRuntimeType: 62816
+      GoRuntimeType: 62912
       GoKind: 22
       Pointee: 235 GoStringHeaderType runtime.errorString
     - __kind: PointerType
@@ -8001,14 +8361,14 @@ Types:
       ID: 53
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 56224
+      GoRuntimeType: 56320
       GoKind: 22
       Pointee: 22 StructureType runtime.g
     - __kind: PointerType
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 64352
+      GoRuntimeType: 64448
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
@@ -8022,7 +8382,7 @@ Types:
       ID: 248
       Name: '*runtime.plainError'
       ByteSize: 8
-      GoRuntimeType: 64736
+      GoRuntimeType: 64832
       GoKind: 22
       Pointee: 238 GoStringHeaderType runtime.plainError
     - __kind: PointerType
@@ -8041,21 +8401,21 @@ Types:
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 118432
+      GoRuntimeType: 118528
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 72
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 90592
+      GoRuntimeType: 90688
       GoKind: 22
       Pointee: 73 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 241
       Name: '*strconv.NumError'
       ByteSize: 8
-      GoRuntimeType: 61920
+      GoRuntimeType: 62016
       GoKind: 22
       Pointee: 242 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
@@ -8074,14 +8434,14 @@ Types:
       ID: 262
       Name: '*syscall.Errno'
       ByteSize: 8
-      GoRuntimeType: 74880
+      GoRuntimeType: 74976
       GoKind: 22
       Pointee: 261 BaseType syscall.Errno
     - __kind: PointerType
       ID: 232
       Name: '*time.fileSizeError'
       ByteSize: 8
-      GoRuntimeType: 56992
+      GoRuntimeType: 57088
       GoKind: 22
       Pointee: 225 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
@@ -8132,7 +8492,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 613
+      ID: 621
       Name: Probe[main.(*methodValueReceiver).inlinedMethod]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8144,12 +8504,12 @@ Types:
             Type: 174 PointerType *main.methodValueReceiver
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: m}
+                  Variable: {subprogram: 80, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 611
+      ID: 619
       Name: Probe[main.PointerChainArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -8161,7 +8521,7 @@ Types:
             Type: 171 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: ptr}
+                  Variable: {subprogram: 78, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -8172,12 +8532,12 @@ Types:
             Type: 171 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: ptr}
+                  Variable: {subprogram: 78, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 612
+      ID: 620
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8189,12 +8549,12 @@ Types:
             Type: 173 PointerType **int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: ptr}
+                  Variable: {subprogram: 79, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 525
+      ID: 533
       Name: Probe[main.bigArrayArg]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8206,12 +8566,12 @@ Types:
             Type: 14 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: s}
+                  Variable: {subprogram: 49, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 527
+      ID: 535
       Name: Probe[main.bigArrayArg]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8223,18 +8583,18 @@ Types:
             Type: 14 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: s}
+                  Variable: {subprogram: 49, index: 0, name: s}
                   Offset: 1048568
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 526
+      ID: 534
       Name: Probe[main.bigArrayArg]Return
     - __kind: EventRootType
-      ID: 528
+      ID: 536
       Name: Probe[main.bigArrayArg]Return
     - __kind: EventRootType
-      ID: 529
+      ID: 537
       Name: Probe[main.bigArrayStructArg]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8246,7 +8606,7 @@ Types:
             Type: 14 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: s}
+                  Variable: {subprogram: 50, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -8254,7 +8614,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 530
+      ID: 538
       Name: Probe[main.bigArrayStructArg]Return
     - __kind: EventRootType
       ID: 312
@@ -8685,6 +9045,85 @@ Types:
       ID: 319
       Name: Probe[main.condInt8]Return
     - __kind: EventRootType
+      ID: 422
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 423
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 424
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 425
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 426
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 427
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 428
+      Name: Probe[main.condLineMixed]Line
+      ByteSize: 131
+      ExprStatusArraySize: 2
+      Expressions:
+        - Name: s
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: b
+          Offset: 18
+          Kind: local
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 1
+          DictIndex: -1
+        - Name: x
+          Offset: 19
+          Kind: local
+          Expression:
+            Type: 116 StructureType main.condFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 80
+          DictIndex: -1
+        - Name: p
+          Offset: 99
+          Kind: local
+          Expression:
+            Type: 118 PointerType *main.condFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 3, name: p}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: ss
+          Offset: 107
+          Kind: local
+          Expression:
+            Type: 100 GoSliceHeaderType []int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 4, name: ss}
+                  Offset: 0
+                  ByteSize: 24
+          DictIndex: -1
+    - __kind: EventRootType
       ID: 418
       Name: Probe[main.condLine]Line
       ByteSize: 25
@@ -8758,10 +9197,38 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 603
+      ID: 421
+      Name: Probe[main.condLine]Line
+      ByteSize: 25
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: "n"
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 0, name: "n"}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: tag
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 611
       Name: Probe[main.condMultiReturn]
     - __kind: EventRootType
-      ID: 604
+      ID: 612
       Name: Probe[main.condMultiReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -8773,7 +9240,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 1, name: r0}
+                  Variable: {subprogram: 74, index: 1, name: r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -8784,7 +9251,7 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 2, name: r1}
+                  Variable: {subprogram: 74, index: 2, name: r1}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -8880,7 +9347,7 @@ Types:
       ID: 407
       Name: Probe[main.condNilPtrStruct]Return
     - __kind: EventRootType
-      ID: 427
+      ID: 435
       Name: Probe[main.condNullIface]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -8892,76 +9359,16 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 35, index: 1, name: tag}
+                  Variable: {subprogram: 37, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 428
+      ID: 436
       Name: Probe[main.condNullIface]Return
     - __kind: EventRootType
-      ID: 425
+      ID: 433
       Name: Probe[main.condNullMap]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 10 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 34, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 426
-      Name: Probe[main.condNullMap]Return
-    - __kind: EventRootType
-      ID: 421
-      Name: Probe[main.condNullPtr]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 10 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 32, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 422
-      Name: Probe[main.condNullPtr]Return
-    - __kind: EventRootType
-      ID: 423
-      Name: Probe[main.condNullSlice]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 10 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 33, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 424
-      Name: Probe[main.condNullSlice]Return
-    - __kind: EventRootType
-      ID: 429
-      Name: Probe[main.condNullUnsafePtr]
       ByteSize: 17
       ExprStatusArraySize: 1
       Expressions:
@@ -8977,7 +9384,67 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
+      ID: 434
+      Name: Probe[main.condNullMap]Return
+    - __kind: EventRootType
+      ID: 429
+      Name: Probe[main.condNullPtr]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
       ID: 430
+      Name: Probe[main.condNullPtr]Return
+    - __kind: EventRootType
+      ID: 431
+      Name: Probe[main.condNullSlice]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 432
+      Name: Probe[main.condNullSlice]Return
+    - __kind: EventRootType
+      ID: 437
+      Name: Probe[main.condNullUnsafePtr]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 438
       Name: Probe[main.condNullUnsafePtr]Return
     - __kind: EventRootType
       ID: 414
@@ -9789,7 +10256,7 @@ Types:
       ID: 341
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 607
+      ID: 615
       Name: Probe[main.genericIdentity[go.shape.int]]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -9802,12 +10269,12 @@ Types:
             Type: 170 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: x}
+                  Variable: {subprogram: 76, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 608
+      ID: 616
       Name: Probe[main.genericIdentity[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -9820,12 +10287,12 @@ Types:
             Type: 170 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 1, name: ~r0}
+                  Variable: {subprogram: 76, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 605
+      ID: 613
       Name: Probe[main.genericIdentity[go.shape.string]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -9838,12 +10305,12 @@ Types:
             Type: 169 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: x}
+                  Variable: {subprogram: 75, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 606
+      ID: 614
       Name: Probe[main.genericIdentity[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -9856,12 +10323,12 @@ Types:
             Type: 169 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 1, name: ~r0}
+                  Variable: {subprogram: 75, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 551
+      ID: 559
       Name: Probe[main.indexMemberWrapperArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -9873,7 +10340,7 @@ Types:
             Type: 13 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
+                  Variable: {subprogram: 55, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -9884,7 +10351,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 553
+      ID: 561
       Name: Probe[main.indexMemberWrapperArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -9896,7 +10363,7 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
+                  Variable: {subprogram: 55, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -9907,7 +10374,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 555
+      ID: 563
       Name: Probe[main.indexMemberWrapperArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -9919,7 +10386,7 @@ Types:
             Type: 13 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
+                  Variable: {subprogram: 55, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -9933,7 +10400,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 557
+      ID: 565
       Name: Probe[main.indexMemberWrapperArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -9945,7 +10412,7 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
+                  Variable: {subprogram: 55, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -9959,19 +10426,19 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 552
+      ID: 560
       Name: Probe[main.indexMemberWrapperArg]Return
     - __kind: EventRootType
-      ID: 554
+      ID: 562
       Name: Probe[main.indexMemberWrapperArg]Return
     - __kind: EventRootType
-      ID: 556
+      ID: 564
       Name: Probe[main.indexMemberWrapperArg]Return
     - __kind: EventRootType
-      ID: 558
+      ID: 566
       Name: Probe[main.indexMemberWrapperArg]Return
     - __kind: EventRootType
-      ID: 517
+      ID: 525
       Name: Probe[main.indexNilPtrSlice]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -9983,7 +10450,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: x}
+                  Variable: {subprogram: 47, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -9996,7 +10463,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 519
+      ID: 527
       Name: Probe[main.indexNilPtrSlice]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10008,12 +10475,12 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 1, name: tag}
+                  Variable: {subprogram: 47, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 521
+      ID: 529
       Name: Probe[main.indexNilPtrSlice]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10025,7 +10492,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: x}
+                  Variable: {subprogram: 47, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10038,16 +10505,16 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 518
+      ID: 526
       Name: Probe[main.indexNilPtrSlice]Return
     - __kind: EventRootType
-      ID: 520
+      ID: 528
       Name: Probe[main.indexNilPtrSlice]Return
     - __kind: EventRootType
-      ID: 522
+      ID: 530
       Name: Probe[main.indexNilPtrSlice]Return
     - __kind: EventRootType
-      ID: 609
+      ID: 617
       Name: Probe[main.inlined]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10059,12 +10526,12 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: x}
+                  Variable: {subprogram: 77, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 610
+      ID: 618
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
       ID: 269
@@ -10277,7 +10744,7 @@ Types:
       ID: 290
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 509
+      ID: 517
       Name: Probe[main.lenErrInt]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -10289,7 +10756,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: x}
+                  Variable: {subprogram: 45, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -10300,21 +10767,21 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 1, name: tag}
+                  Variable: {subprogram: 45, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 511
+      ID: 519
       Name: Probe[main.lenErrInt]
     - __kind: EventRootType
-      ID: 510
+      ID: 518
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 512
+      ID: 520
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 513
+      ID: 521
       Name: Probe[main.lenErrStruct]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -10326,7 +10793,7 @@ Types:
             Type: 116 StructureType main.condFields
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: x}
+                  Variable: {subprogram: 46, index: 0, name: x}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -10337,21 +10804,21 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 1, name: tag}
+                  Variable: {subprogram: 46, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 515
+      ID: 523
       Name: Probe[main.lenErrStruct]
     - __kind: EventRootType
-      ID: 514
+      ID: 522
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 516
+      ID: 524
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 463
+      ID: 471
       Name: Probe[main.lenMap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10363,12 +10830,12 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Variable: {subprogram: 41, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 465
+      ID: 473
       Name: Probe[main.lenMap]
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -10380,7 +10847,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: m}
+                  Variable: {subprogram: 41, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10394,7 +10861,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 467
+      ID: 475
       Name: Probe[main.lenMap]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10406,7 +10873,7 @@ Types:
             Type: 11 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: m}
+                  Variable: {subprogram: 41, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10414,7 +10881,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 469
+      ID: 477
       Name: Probe[main.lenMap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10426,12 +10893,12 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Variable: {subprogram: 41, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 471
+      ID: 479
       Name: Probe[main.lenMap]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10443,7 +10910,7 @@ Types:
             Type: 11 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: m}
+                  Variable: {subprogram: 41, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10451,7 +10918,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 473
+      ID: 481
       Name: Probe[main.lenMap]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -10463,7 +10930,7 @@ Types:
             Type: 104 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: m}
+                  Variable: {subprogram: 41, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -10474,22 +10941,10 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Variable: {subprogram: 41, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
-    - __kind: EventRootType
-      ID: 464
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 466
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 468
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 470
-      Name: Probe[main.lenMap]Return
     - __kind: EventRootType
       ID: 472
       Name: Probe[main.lenMap]Return
@@ -10497,7 +10952,19 @@ Types:
       ID: 474
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 475
+      ID: 476
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 478
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 480
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 482
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 483
       Name: Probe[main.lenPtrString]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10509,7 +10976,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: s}
+                  Variable: {subprogram: 42, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10517,7 +10984,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 477
+      ID: 485
       Name: Probe[main.lenPtrString]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -10529,66 +10996,7 @@ Types:
             Type: 88 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 8
-          DictIndex: -1
-        - Name: tag
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 10 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 476
-      Name: Probe[main.lenPtrString]Return
-    - __kind: EventRootType
-      ID: 478
-      Name: Probe[main.lenPtrString]Return
-    - __kind: EventRootType
-      ID: 499
-      Name: Probe[main.lenPtrStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: items_0
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 16
-                  ByteSize: 16
-                - __kind: SliceBoundsCheckOp
-                  Index: 0
-                - __kind: DereferenceOp
-                  Bias: 0
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 501
-      Name: Probe[main.lenPtrStructFields]
-      ByteSize: 25
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 121 PointerType *main.lenFields
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
+                  Variable: {subprogram: 42, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -10604,7 +11012,66 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 503
+      ID: 484
+      Name: Probe[main.lenPtrString]Return
+    - __kind: EventRootType
+      ID: 486
+      Name: Probe[main.lenPtrString]Return
+    - __kind: EventRootType
+      ID: 507
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: items_0
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 16
+                  ByteSize: 16
+                - __kind: SliceBoundsCheckOp
+                  Index: 0
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 509
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 25
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 121 PointerType *main.lenFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 511
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10616,7 +11083,7 @@ Types:
             Type: 11 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
+                  Variable: {subprogram: 44, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10627,7 +11094,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 505
+      ID: 513
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10639,7 +11106,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
+                  Variable: {subprogram: 44, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10647,7 +11114,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 507
+      ID: 515
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10659,7 +11126,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
+                  Variable: {subprogram: 44, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10667,22 +11134,22 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 500
-      Name: Probe[main.lenPtrStructFields]Return
-    - __kind: EventRootType
-      ID: 502
-      Name: Probe[main.lenPtrStructFields]Return
-    - __kind: EventRootType
-      ID: 504
-      Name: Probe[main.lenPtrStructFields]Return
-    - __kind: EventRootType
-      ID: 506
-      Name: Probe[main.lenPtrStructFields]Return
-    - __kind: EventRootType
       ID: 508
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 451
+      ID: 510
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 512
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 514
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 516
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 459
       Name: Probe[main.lenSlice]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10694,12 +11161,12 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 1, name: tag}
+                  Variable: {subprogram: 40, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 453
+      ID: 461
       Name: Probe[main.lenSlice]
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -10711,7 +11178,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: s}
+                  Variable: {subprogram: 40, index: 0, name: s}
                   Offset: 8
                   ByteSize: 8
                 - __kind: ExprPushOffsetOp
@@ -10722,7 +11189,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 455
+      ID: 463
       Name: Probe[main.lenSlice]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10734,12 +11201,12 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: s}
+                  Variable: {subprogram: 40, index: 0, name: s}
                   Offset: 8
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 457
+      ID: 465
       Name: Probe[main.lenSlice]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10751,12 +11218,12 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 1, name: tag}
+                  Variable: {subprogram: 40, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 459
+      ID: 467
       Name: Probe[main.lenSlice]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10768,12 +11235,12 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: s}
+                  Variable: {subprogram: 40, index: 0, name: s}
                   Offset: 8
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 461
+      ID: 469
       Name: Probe[main.lenSlice]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -10785,7 +11252,7 @@ Types:
             Type: 100 GoSliceHeaderType []int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: s}
+                  Variable: {subprogram: 40, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -10796,22 +11263,10 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 1, name: tag}
+                  Variable: {subprogram: 40, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
-    - __kind: EventRootType
-      ID: 452
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 454
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 456
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 458
-      Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
       ID: 460
       Name: Probe[main.lenSlice]Return
@@ -10819,7 +11274,19 @@ Types:
       ID: 462
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 431
+      ID: 464
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 466
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 468
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 470
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 439
       Name: Probe[main.lenString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -10831,7 +11298,7 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
+                  Variable: {subprogram: 39, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -10842,12 +11309,12 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 1, name: tag}
+                  Variable: {subprogram: 39, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 433
+      ID: 441
       Name: Probe[main.lenString]
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -10859,7 +11326,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
+                  Variable: {subprogram: 39, index: 0, name: s}
                   Offset: 8
                   ByteSize: 8
                 - __kind: ExprPushOffsetOp
@@ -10870,7 +11337,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 435
+      ID: 443
       Name: Probe[main.lenString]
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -10882,7 +11349,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
+                  Variable: {subprogram: 39, index: 0, name: s}
                   Offset: 8
                   ByteSize: 8
                 - __kind: ExprPushOffsetOp
@@ -10893,7 +11360,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 437
+      ID: 445
       Name: Probe[main.lenString]
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -10905,7 +11372,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
+                  Variable: {subprogram: 39, index: 0, name: s}
                   Offset: 8
                   ByteSize: 8
                 - __kind: ExprPushOffsetOp
@@ -10916,7 +11383,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 439
+      ID: 447
       Name: Probe[main.lenString]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10928,12 +11395,12 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 1, name: tag}
+                  Variable: {subprogram: 39, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 441
+      ID: 449
       Name: Probe[main.lenString]
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -10945,7 +11412,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
+                  Variable: {subprogram: 39, index: 0, name: s}
                   Offset: 8
                   ByteSize: 8
                 - __kind: ExprPushOffsetOp
@@ -10956,7 +11423,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 443
+      ID: 451
       Name: Probe[main.lenString]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10968,12 +11435,12 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
+                  Variable: {subprogram: 39, index: 0, name: s}
                   Offset: 8
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 445
+      ID: 453
       Name: Probe[main.lenString]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10985,12 +11452,12 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 1, name: tag}
+                  Variable: {subprogram: 39, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 447
+      ID: 455
       Name: Probe[main.lenString]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11002,12 +11469,12 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
+                  Variable: {subprogram: 39, index: 0, name: s}
                   Offset: 8
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 449
+      ID: 457
       Name: Probe[main.lenString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -11019,7 +11486,7 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
+                  Variable: {subprogram: 39, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -11030,22 +11497,10 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 1, name: tag}
+                  Variable: {subprogram: 39, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
-    - __kind: EventRootType
-      ID: 432
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 434
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 436
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 438
-      Name: Probe[main.lenString]Return
     - __kind: EventRootType
       ID: 440
       Name: Probe[main.lenString]Return
@@ -11065,7 +11520,19 @@ Types:
       ID: 450
       Name: Probe[main.lenString]Return
     - __kind: EventRootType
-      ID: 479
+      ID: 452
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 454
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 456
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 458
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 487
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11077,7 +11544,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
+                  Variable: {subprogram: 43, index: 0, name: x}
                   Offset: 16
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -11087,7 +11554,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 481
+      ID: 489
       Name: Probe[main.lenStructFields]
       ByteSize: 89
       ExprStatusArraySize: 1
@@ -11099,7 +11566,7 @@ Types:
             Type: 119 StructureType main.lenFields
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
+                  Variable: {subprogram: 43, index: 0, name: x}
                   Offset: 0
                   ByteSize: 72
           DictIndex: -1
@@ -11110,12 +11577,12 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 1, name: tag}
+                  Variable: {subprogram: 43, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 483
+      ID: 491
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11127,7 +11594,7 @@ Types:
             Type: 11 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
+                  Variable: {subprogram: 43, index: 0, name: x}
                   Offset: 40
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11135,7 +11602,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 485
+      ID: 493
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11147,7 +11614,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
+                  Variable: {subprogram: 43, index: 0, name: x}
                   Offset: 56
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11155,7 +11622,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 487
+      ID: 495
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11167,7 +11634,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
+                  Variable: {subprogram: 43, index: 0, name: x}
                   Offset: 48
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11175,7 +11642,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 489
+      ID: 497
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11187,12 +11654,12 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
+                  Variable: {subprogram: 43, index: 0, name: x}
                   Offset: 24
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 491
+      ID: 499
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11204,12 +11671,12 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
+                  Variable: {subprogram: 43, index: 0, name: x}
                   Offset: 8
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 493
+      ID: 501
       Name: Probe[main.lenStructFields]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -11221,12 +11688,12 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 1, name: tag}
+                  Variable: {subprogram: 43, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 495
+      ID: 503
       Name: Probe[main.lenStructFields]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -11238,12 +11705,12 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 1, name: tag}
+                  Variable: {subprogram: 43, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 497
+      ID: 505
       Name: Probe[main.lenStructFields]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -11255,22 +11722,10 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 1, name: tag}
+                  Variable: {subprogram: 43, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
-    - __kind: EventRootType
-      ID: 480
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 482
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 484
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 486
-      Name: Probe[main.lenStructFields]Return
     - __kind: EventRootType
       ID: 488
       Name: Probe[main.lenStructFields]Return
@@ -11288,6 +11743,18 @@ Types:
       Name: Probe[main.lenStructFields]Return
     - __kind: EventRootType
       ID: 498
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 500
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 502
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 504
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 506
       Name: Probe[main.lenStructFields]Return
     - __kind: EventRootType
       ID: 310
@@ -11321,136 +11788,136 @@ Types:
       ID: 311
       Name: Probe[main.mapArg]Return
     - __kind: EventRootType
-      ID: 593
-      Name: Probe[main.mapIndexBoolKey]
-    - __kind: EventRootType
-      ID: 595
-      Name: Probe[main.mapIndexBoolKey]
-    - __kind: EventRootType
-      ID: 594
-      Name: Probe[main.mapIndexBoolKey]Return
-    - __kind: EventRootType
-      ID: 596
-      Name: Probe[main.mapIndexBoolKey]Return
-    - __kind: EventRootType
-      ID: 587
-      Name: Probe[main.mapIndexEmptyKey]
-    - __kind: EventRootType
-      ID: 588
-      Name: Probe[main.mapIndexEmptyKey]Return
-    - __kind: EventRootType
-      ID: 559
-      Name: Probe[main.mapIndexIntKey]
-    - __kind: EventRootType
-      ID: 560
-      Name: Probe[main.mapIndexIntKey]Return
-    - __kind: EventRootType
-      ID: 589
-      Name: Probe[main.mapIndexKeyLen16]
-    - __kind: EventRootType
-      ID: 590
-      Name: Probe[main.mapIndexKeyLen16]Return
-    - __kind: EventRootType
-      ID: 591
-      Name: Probe[main.mapIndexKeyLen17]
-    - __kind: EventRootType
-      ID: 592
-      Name: Probe[main.mapIndexKeyLen17]Return
-    - __kind: EventRootType
-      ID: 577
-      Name: Probe[main.mapIndexKeyLen200]
-    - __kind: EventRootType
-      ID: 578
-      Name: Probe[main.mapIndexKeyLen200]Return
-    - __kind: EventRootType
-      ID: 571
-      Name: Probe[main.mapIndexKeyLen24]
-    - __kind: EventRootType
-      ID: 572
-      Name: Probe[main.mapIndexKeyLen24]Return
-    - __kind: EventRootType
-      ID: 573
-      Name: Probe[main.mapIndexKeyLen48]
-    - __kind: EventRootType
-      ID: 574
-      Name: Probe[main.mapIndexKeyLen48]Return
-    - __kind: EventRootType
-      ID: 569
-      Name: Probe[main.mapIndexKeyLen8]
-    - __kind: EventRootType
-      ID: 570
-      Name: Probe[main.mapIndexKeyLen8]Return
-    - __kind: EventRootType
-      ID: 575
-      Name: Probe[main.mapIndexKeyLen96]
-    - __kind: EventRootType
-      ID: 576
-      Name: Probe[main.mapIndexKeyLen96]Return
-    - __kind: EventRootType
-      ID: 565
-      Name: Probe[main.mapIndexLargeMap]
-    - __kind: EventRootType
-      ID: 566
-      Name: Probe[main.mapIndexLargeMap]Return
-    - __kind: EventRootType
       ID: 601
-      Name: Probe[main.mapIndexLargeValue]
+      Name: Probe[main.mapIndexBoolKey]
+    - __kind: EventRootType
+      ID: 603
+      Name: Probe[main.mapIndexBoolKey]
     - __kind: EventRootType
       ID: 602
-      Name: Probe[main.mapIndexLargeValue]Return
+      Name: Probe[main.mapIndexBoolKey]Return
+    - __kind: EventRootType
+      ID: 604
+      Name: Probe[main.mapIndexBoolKey]Return
+    - __kind: EventRootType
+      ID: 595
+      Name: Probe[main.mapIndexEmptyKey]
+    - __kind: EventRootType
+      ID: 596
+      Name: Probe[main.mapIndexEmptyKey]Return
     - __kind: EventRootType
       ID: 567
-      Name: Probe[main.mapIndexMissing]
+      Name: Probe[main.mapIndexIntKey]
     - __kind: EventRootType
       ID: 568
-      Name: Probe[main.mapIndexMissing]Return
-    - __kind: EventRootType
-      ID: 599
-      Name: Probe[main.mapIndexNilPtrVal]
-    - __kind: EventRootType
-      ID: 600
-      Name: Probe[main.mapIndexNilPtrVal]Return
-    - __kind: EventRootType
-      ID: 583
-      Name: Probe[main.mapIndexPtrStructVal]
-    - __kind: EventRootType
-      ID: 585
-      Name: Probe[main.mapIndexPtrStructVal]
-    - __kind: EventRootType
-      ID: 584
-      Name: Probe[main.mapIndexPtrStructVal]Return
-    - __kind: EventRootType
-      ID: 586
-      Name: Probe[main.mapIndexPtrStructVal]Return
-    - __kind: EventRootType
-      ID: 561
-      Name: Probe[main.mapIndexStringKey]
-    - __kind: EventRootType
-      ID: 563
-      Name: Probe[main.mapIndexStringKey]
-    - __kind: EventRootType
-      ID: 562
-      Name: Probe[main.mapIndexStringKey]Return
-    - __kind: EventRootType
-      ID: 564
-      Name: Probe[main.mapIndexStringKey]Return
-    - __kind: EventRootType
-      ID: 579
-      Name: Probe[main.mapIndexStructVal]
-    - __kind: EventRootType
-      ID: 581
-      Name: Probe[main.mapIndexStructVal]
-    - __kind: EventRootType
-      ID: 580
-      Name: Probe[main.mapIndexStructVal]Return
-    - __kind: EventRootType
-      ID: 582
-      Name: Probe[main.mapIndexStructVal]Return
+      Name: Probe[main.mapIndexIntKey]Return
     - __kind: EventRootType
       ID: 597
-      Name: Probe[main.mapIndexZeroValue]
+      Name: Probe[main.mapIndexKeyLen16]
     - __kind: EventRootType
       ID: 598
+      Name: Probe[main.mapIndexKeyLen16]Return
+    - __kind: EventRootType
+      ID: 599
+      Name: Probe[main.mapIndexKeyLen17]
+    - __kind: EventRootType
+      ID: 600
+      Name: Probe[main.mapIndexKeyLen17]Return
+    - __kind: EventRootType
+      ID: 585
+      Name: Probe[main.mapIndexKeyLen200]
+    - __kind: EventRootType
+      ID: 586
+      Name: Probe[main.mapIndexKeyLen200]Return
+    - __kind: EventRootType
+      ID: 579
+      Name: Probe[main.mapIndexKeyLen24]
+    - __kind: EventRootType
+      ID: 580
+      Name: Probe[main.mapIndexKeyLen24]Return
+    - __kind: EventRootType
+      ID: 581
+      Name: Probe[main.mapIndexKeyLen48]
+    - __kind: EventRootType
+      ID: 582
+      Name: Probe[main.mapIndexKeyLen48]Return
+    - __kind: EventRootType
+      ID: 577
+      Name: Probe[main.mapIndexKeyLen8]
+    - __kind: EventRootType
+      ID: 578
+      Name: Probe[main.mapIndexKeyLen8]Return
+    - __kind: EventRootType
+      ID: 583
+      Name: Probe[main.mapIndexKeyLen96]
+    - __kind: EventRootType
+      ID: 584
+      Name: Probe[main.mapIndexKeyLen96]Return
+    - __kind: EventRootType
+      ID: 573
+      Name: Probe[main.mapIndexLargeMap]
+    - __kind: EventRootType
+      ID: 574
+      Name: Probe[main.mapIndexLargeMap]Return
+    - __kind: EventRootType
+      ID: 609
+      Name: Probe[main.mapIndexLargeValue]
+    - __kind: EventRootType
+      ID: 610
+      Name: Probe[main.mapIndexLargeValue]Return
+    - __kind: EventRootType
+      ID: 575
+      Name: Probe[main.mapIndexMissing]
+    - __kind: EventRootType
+      ID: 576
+      Name: Probe[main.mapIndexMissing]Return
+    - __kind: EventRootType
+      ID: 607
+      Name: Probe[main.mapIndexNilPtrVal]
+    - __kind: EventRootType
+      ID: 608
+      Name: Probe[main.mapIndexNilPtrVal]Return
+    - __kind: EventRootType
+      ID: 591
+      Name: Probe[main.mapIndexPtrStructVal]
+    - __kind: EventRootType
+      ID: 593
+      Name: Probe[main.mapIndexPtrStructVal]
+    - __kind: EventRootType
+      ID: 592
+      Name: Probe[main.mapIndexPtrStructVal]Return
+    - __kind: EventRootType
+      ID: 594
+      Name: Probe[main.mapIndexPtrStructVal]Return
+    - __kind: EventRootType
+      ID: 569
+      Name: Probe[main.mapIndexStringKey]
+    - __kind: EventRootType
+      ID: 571
+      Name: Probe[main.mapIndexStringKey]
+    - __kind: EventRootType
+      ID: 570
+      Name: Probe[main.mapIndexStringKey]Return
+    - __kind: EventRootType
+      ID: 572
+      Name: Probe[main.mapIndexStringKey]Return
+    - __kind: EventRootType
+      ID: 587
+      Name: Probe[main.mapIndexStructVal]
+    - __kind: EventRootType
+      ID: 589
+      Name: Probe[main.mapIndexStructVal]
+    - __kind: EventRootType
+      ID: 588
+      Name: Probe[main.mapIndexStructVal]Return
+    - __kind: EventRootType
+      ID: 590
+      Name: Probe[main.mapIndexStructVal]Return
+    - __kind: EventRootType
+      ID: 605
+      Name: Probe[main.mapIndexZeroValue]
+    - __kind: EventRootType
+      ID: 606
       Name: Probe[main.mapIndexZeroValue]Return
     - __kind: EventRootType
       ID: 314
@@ -11459,7 +11926,7 @@ Types:
       ID: 315
       Name: Probe[main.noArgs]Return
     - __kind: EventRootType
-      ID: 547
+      ID: 555
       Name: Probe[main.ptrStructArrayArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -11471,7 +11938,7 @@ Types:
             Type: 13 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: s}
+                  Variable: {subprogram: 54, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11479,7 +11946,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 549
+      ID: 557
       Name: Probe[main.ptrStructArrayArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -11491,7 +11958,7 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: s}
+                  Variable: {subprogram: 54, index: 0, name: s}
                   Offset: 8
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11499,13 +11966,13 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 548
+      ID: 556
       Name: Probe[main.ptrStructArrayArg]Return
     - __kind: EventRootType
-      ID: 550
+      ID: 558
       Name: Probe[main.ptrStructArrayArg]Return
     - __kind: EventRootType
-      ID: 543
+      ID: 551
       Name: Probe[main.ptrStructSliceArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -11517,7 +11984,7 @@ Types:
             Type: 13 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: s}
+                  Variable: {subprogram: 53, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -11530,7 +11997,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 545
+      ID: 553
       Name: Probe[main.ptrStructSliceArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -11542,7 +12009,7 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: s}
+                  Variable: {subprogram: 53, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -11555,10 +12022,10 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 544
+      ID: 552
       Name: Probe[main.ptrStructSliceArg]Return
     - __kind: EventRootType
-      ID: 546
+      ID: 554
       Name: Probe[main.ptrStructSliceArg]Return
     - __kind: EventRootType
       ID: 271
@@ -11720,7 +12187,7 @@ Types:
       ID: 304
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 539
+      ID: 547
       Name: Probe[main.structArrayArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -11732,12 +12199,12 @@ Types:
             Type: 13 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: s}
+                  Variable: {subprogram: 52, index: 0, name: s}
                   Offset: 0
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 541
+      ID: 549
       Name: Probe[main.structArrayArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -11749,18 +12216,18 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: s}
+                  Variable: {subprogram: 52, index: 0, name: s}
                   Offset: 40
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 540
+      ID: 548
       Name: Probe[main.structArrayArg]Return
     - __kind: EventRootType
-      ID: 542
+      ID: 550
       Name: Probe[main.structArrayArg]Return
     - __kind: EventRootType
-      ID: 531
+      ID: 539
       Name: Probe[main.structSliceArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -11772,7 +12239,7 @@ Types:
             Type: 13 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: s}
+                  Variable: {subprogram: 51, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -11782,7 +12249,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 533
+      ID: 541
       Name: Probe[main.structSliceArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -11794,7 +12261,7 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: s}
+                  Variable: {subprogram: 51, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -11804,7 +12271,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 535
+      ID: 543
       Name: Probe[main.structSliceArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -11816,12 +12283,12 @@ Types:
             Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 1, name: tag}
+                  Variable: {subprogram: 51, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 537
+      ID: 545
       Name: Probe[main.structSliceArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -11833,7 +12300,7 @@ Types:
             Type: 13 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: s}
+                  Variable: {subprogram: 51, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -11843,22 +12310,22 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 532
+      ID: 540
       Name: Probe[main.structSliceArg]Return
     - __kind: EventRootType
-      ID: 534
+      ID: 542
       Name: Probe[main.structSliceArg]Return
     - __kind: EventRootType
-      ID: 536
+      ID: 544
       Name: Probe[main.structSliceArg]Return
     - __kind: EventRootType
-      ID: 538
+      ID: 546
       Name: Probe[main.structSliceArg]Return
     - __kind: EventRootType
-      ID: 523
+      ID: 531
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 524
+      ID: 532
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11870,7 +12337,7 @@ Types:
             Type: 122 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: ~r0}
+                  Variable: {subprogram: 48, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -11878,7 +12345,7 @@ Types:
       ID: 85
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 50560
+      GoRuntimeType: 50656
       GoKind: 17
       Count: 10
       HasCount: true
@@ -11922,7 +12389,7 @@ Types:
       ID: 71
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 50272
+      GoRuntimeType: 50368
       GoKind: 17
       Count: 2
       HasCount: true
@@ -11931,7 +12398,7 @@ Types:
       ID: 77
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 50464
+      GoRuntimeType: 50560
       GoKind: 17
       Count: 2
       HasCount: true
@@ -11948,7 +12415,7 @@ Types:
       ID: 52
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 46720
+      GoRuntimeType: 46816
       GoKind: 17
       Count: 2
       HasCount: true
@@ -11957,7 +12424,7 @@ Types:
       ID: 83
       Name: '[32]uint64'
       ByteSize: 256
-      GoRuntimeType: 52288
+      GoRuntimeType: 52384
       GoKind: 17
       Count: 32
       HasCount: true
@@ -11966,7 +12433,7 @@ Types:
       ID: 63
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 50080
+      GoRuntimeType: 50176
       GoKind: 17
       Count: 32
       HasCount: true
@@ -11993,7 +12460,7 @@ Types:
       ID: 51
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 49792
+      GoRuntimeType: 49888
       GoKind: 17
       Count: 3
       HasCount: true
@@ -12011,7 +12478,7 @@ Types:
       ID: 84
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 51520
+      GoRuntimeType: 51616
       GoKind: 17
       Count: 4
       HasCount: true
@@ -12020,7 +12487,7 @@ Types:
       ID: 56
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 49024
+      GoRuntimeType: 49120
       GoKind: 17
       Count: 6
       HasCount: true
@@ -12029,7 +12496,7 @@ Types:
       ID: 78
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 50368
+      GoRuntimeType: 50464
       GoKind: 17
       Count: 8
       HasCount: true
@@ -12541,7 +13008,7 @@ Types:
       ID: 18
       Name: error
       ByteSize: 16
-      GoRuntimeType: 62688
+      GoRuntimeType: 62784
       GoKind: 20
       RawFields:
         - Name: tab
@@ -12576,7 +13043,7 @@ Types:
       ID: 67
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 54400
+      GoRuntimeType: 54496
       GoKind: 19
     - __kind: BaseType
       ID: 170
@@ -12979,7 +13446,7 @@ Types:
       ID: 82
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 109376
+      GoRuntimeType: 109472
       GoKind: 25
       RawFields:
         - Name: buf
@@ -13004,14 +13471,14 @@ Types:
     - __kind: StructureType
       ID: 258
       Name: internal/poll.errNetClosing
-      GoRuntimeType: 83648
+      GoRuntimeType: 83744
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 71488
+      GoRuntimeType: 71584
       GoKind: 25
       RawFields:
         - Name: u
@@ -13021,7 +13488,7 @@ Types:
       ID: 65
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 94240
+      GoRuntimeType: 94336
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -13037,7 +13504,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 84128
+      GoRuntimeType: 84224
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -13050,7 +13517,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 83968
+      GoRuntimeType: 84064
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -13063,7 +13530,7 @@ Types:
       ID: 70
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 84288
+      GoRuntimeType: 84384
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -13075,13 +13542,13 @@ Types:
     - __kind: StructureType
       ID: 66
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 61120
+      GoRuntimeType: 61216
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 33
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 61024
+      GoRuntimeType: 61120
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -13092,14 +13559,14 @@ Types:
       ID: 223
       Name: main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 67008
+      GoRuntimeType: 67104
       GoKind: 25
       RawFields: [{Name: a, Offset: 0, Type: 9 BaseType int}]
     - __kind: StructureType
       ID: 134
       Name: main.bigArrayStruct
       ByteSize: 1048584
-      GoRuntimeType: 76608
+      GoRuntimeType: 76704
       GoKind: 25
       RawFields:
         - Name: tag
@@ -13112,7 +13579,7 @@ Types:
       ID: 192
       Name: main.bigStruct
       ByteSize: 184
-      GoRuntimeType: 116640
+      GoRuntimeType: 116736
       GoKind: 25
       RawFields:
         - Name: Field1
@@ -13143,7 +13610,7 @@ Types:
       ID: 116
       Name: main.condFields
       ByteSize: 80
-      GoRuntimeType: 122784
+      GoRuntimeType: 122880
       GoKind: 25
       RawFields:
         - Name: I8
@@ -13189,7 +13656,7 @@ Types:
       ID: 137
       Name: main.indexMemberStruct
       ByteSize: 32
-      GoRuntimeType: 87328
+      GoRuntimeType: 87424
       GoKind: 25
       RawFields:
         - Name: Val
@@ -13220,7 +13687,7 @@ Types:
       ID: 218
       Name: main.largeValueStruct
       ByteSize: 264
-      GoRuntimeType: 76448
+      GoRuntimeType: 76544
       GoKind: 25
       RawFields:
         - Name: Pad
@@ -13233,7 +13700,7 @@ Types:
       ID: 119
       Name: main.lenFields
       ByteSize: 72
-      GoRuntimeType: 111264
+      GoRuntimeType: 111360
       GoKind: 25
       RawFields:
         - Name: S
@@ -13264,70 +13731,70 @@ Types:
       ID: 159
       Name: map[bool]int
       ByteSize: 8
-      GoRuntimeType: 57664
+      GoRuntimeType: 57760
       GoKind: 21
       HeaderType: 161 GoHMapHeaderType hash<bool,int>
     - __kind: GoMapType
       ID: 196
       Name: map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 57760
+      GoRuntimeType: 57856
       GoKind: 21
       HeaderType: 198 GoHMapHeaderType hash<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 144
       Name: map[int]string
       ByteSize: 8
-      GoRuntimeType: 57856
+      GoRuntimeType: 57952
       GoKind: 21
       HeaderType: 146 GoHMapHeaderType hash<int,string>
     - __kind: GoMapType
       ID: 154
       Name: map[string]*main.indexMemberStruct
       ByteSize: 8
-      GoRuntimeType: 57952
+      GoRuntimeType: 58048
       GoKind: 21
       HeaderType: 156 GoHMapHeaderType hash<string,*main.indexMemberStruct>
     - __kind: GoMapType
       ID: 104
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 57568
+      GoRuntimeType: 57664
       GoKind: 21
       HeaderType: 106 GoHMapHeaderType hash<string,int>
     - __kind: GoMapType
       ID: 111
       Name: map[string]main.bigStruct
       ByteSize: 8
-      GoRuntimeType: 58048
+      GoRuntimeType: 58144
       GoKind: 21
       HeaderType: 113 GoHMapHeaderType hash<string,main.bigStruct>
     - __kind: GoMapType
       ID: 149
       Name: map[string]main.indexMemberStruct
       ByteSize: 8
-      GoRuntimeType: 58144
+      GoRuntimeType: 58240
       GoKind: 21
       HeaderType: 151 GoHMapHeaderType hash<string,main.indexMemberStruct>
     - __kind: GoMapType
       ID: 164
       Name: map[string]main.largeValueStruct
       ByteSize: 8
-      GoRuntimeType: 58240
+      GoRuntimeType: 58336
       GoKind: 21
       HeaderType: 166 GoHMapHeaderType hash<string,main.largeValueStruct>
     - __kind: GoMapType
       ID: 127
       Name: map[string]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 58336
+      GoRuntimeType: 58432
       GoKind: 21
       HeaderType: 129 GoHMapHeaderType hash<string,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 122
       Name: map[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 58432
+      GoRuntimeType: 58528
       GoKind: 21
       HeaderType: 124 GoHMapHeaderType hash<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: UnresolvedPointeeType
@@ -13358,7 +13825,7 @@ Types:
       ID: 247
       Name: runtime.boundsError
       ByteSize: 24
-      GoRuntimeType: 109824
+      GoRuntimeType: 109920
       GoKind: 25
       RawFields:
         - Name: x
@@ -13390,14 +13857,14 @@ Types:
     - __kind: StructureType
       ID: 80
       Name: runtime.dlogPerM
-      GoRuntimeType: 60448
+      GoRuntimeType: 60544
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 254
       Name: runtime.errorAddressString
       ByteSize: 24
-      GoRuntimeType: 103648
+      GoRuntimeType: 103744
       GoKind: 25
       RawFields:
         - Name: msg
@@ -13410,7 +13877,7 @@ Types:
       ID: 235
       Name: runtime.errorString
       ByteSize: 16
-      GoRuntimeType: 60064
+      GoRuntimeType: 60160
       GoKind: 24
       RawFields:
         - Name: str
@@ -13429,7 +13896,7 @@ Types:
       ID: 22
       Name: runtime.g
       ByteSize: 432
-      GoRuntimeType: 137056
+      GoRuntimeType: 137152
       GoKind: 25
       RawFields:
         - Name: stack
@@ -13604,7 +14071,7 @@ Types:
       ID: 49
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 69824
+      GoRuntimeType: 69920
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -13614,7 +14081,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 56
-      GoRuntimeType: 114624
+      GoRuntimeType: 114720
       GoKind: 25
       RawFields:
         - Name: sp
@@ -13642,7 +14109,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 81888
+      GoRuntimeType: 81984
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -13655,7 +14122,7 @@ Types:
       ID: 54
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 102688
+      GoRuntimeType: 102784
       GoKind: 25
       RawFields:
         - Name: stack
@@ -13674,13 +14141,13 @@ Types:
       ID: 31
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 53056
+      GoRuntimeType: 53152
       GoKind: 12
     - __kind: StructureType
       ID: 86
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 81728
+      GoRuntimeType: 81824
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -13693,7 +14160,7 @@ Types:
       ID: 74
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 113312
+      GoRuntimeType: 113408
       GoKind: 25
       RawFields:
         - Name: fn
@@ -13718,13 +14185,13 @@ Types:
       ID: 87
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 52960
+      GoRuntimeType: 53056
       GoKind: 2
     - __kind: StructureType
       ID: 29
       Name: runtime.m
       ByteSize: 1760
-      GoRuntimeType: 140224
+      GoRuntimeType: 140320
       GoKind: 25
       RawFields:
         - Name: g0
@@ -13944,7 +14411,7 @@ Types:
       ID: 64
       Name: runtime.mLockProfile
       ByteSize: 64
-      GoRuntimeType: 113056
+      GoRuntimeType: 113152
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -13969,7 +14436,7 @@ Types:
       ID: 81
       Name: runtime.mOS
       ByteSize: 8
-      GoRuntimeType: 90976
+      GoRuntimeType: 91072
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -13985,7 +14452,7 @@ Types:
       ID: 69
       Name: runtime.mTraceState
       ByteSize: 32
-      GoRuntimeType: 90784
+      GoRuntimeType: 90880
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -14005,20 +14472,20 @@ Types:
       ID: 37
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 52672
+      GoRuntimeType: 52768
       GoKind: 12
     - __kind: StructureType
       ID: 62
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 69440
+      GoRuntimeType: 69536
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: StructureType
       ID: 76
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 81568
+      GoRuntimeType: 81664
       GoKind: 25
       RawFields:
         - Name: entries
@@ -14031,7 +14498,7 @@ Types:
       ID: 79
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 103456
+      GoRuntimeType: 103552
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -14050,7 +14517,7 @@ Types:
       ID: 238
       Name: runtime.plainError
       ByteSize: 16
-      GoRuntimeType: 60640
+      GoRuntimeType: 60736
       GoKind: 24
       RawFields:
         - Name: str
@@ -14069,13 +14536,13 @@ Types:
       ID: 58
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 52864
+      GoRuntimeType: 52960
       GoKind: 12
     - __kind: ArrayType
       ID: 55
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 55840
+      GoRuntimeType: 55936
       GoKind: 17
       Count: 2
       HasCount: true
@@ -14084,7 +14551,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 79968
+      GoRuntimeType: 80064
       GoKind: 25
       RawFields:
         - Name: lo
@@ -14121,7 +14588,7 @@ Types:
       ID: 50
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 80928
+      GoRuntimeType: 81024
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -14134,12 +14601,12 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 66656
+      GoRuntimeType: 66752
       GoKind: 8
     - __kind: StructureType
       ID: 75
       Name: runtime.winlibcall
-      GoRuntimeType: 60352
+      GoRuntimeType: 60448
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -14169,13 +14636,13 @@ Types:
       ID: 261
       Name: syscall.Errno
       ByteSize: 8
-      GoRuntimeType: 72128
+      GoRuntimeType: 72224
       GoKind: 12
     - __kind: GoStringHeaderType
       ID: 225
       Name: time.fileSizeError
       ByteSize: 16
-      GoRuntimeType: 53152
+      GoRuntimeType: 53248
       GoKind: 24
       RawFields:
         - Name: str
@@ -14232,7 +14699,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 40672
       GoKind: 26
-MaxTypeID: 613
+MaxTypeID: 621
 Issues:
     - probe_definition:
         id: condCompound_eq_of_eq
@@ -14540,6 +15007,48 @@ Issues:
       issue:
         Kind: 7
         Message: condition variable "x" not available at any event
+    - probe_definition:
+        id: condLineReturn_cond_return
+        version: 0
+        type: LOG_PROBE
+        where:
+            methodName: main.condLineReturn
+            sourceFile: main.go
+            lines: ["571"]
+        tags: ['issue:ConditionVariableUnavailable']
+        when:
+            dsl: '@return == 14'
+            json: {eq: [{ref: '@return'}, 14]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: matched
+        segments: [matched]
+        captureSnapshot: false
+      issue:
+        Kind: 7
+        Message: condition variable "@return" not found
+    - probe_definition:
+        id: condLine_local_cond
+        version: 0
+        type: LOG_PROBE
+        where:
+            methodName: main.condLine
+            sourceFile: main.go
+            lines: ["548"]
+        tags:
+            - skip_integration:arch=arm64,toolchain=go1.23.11
+            - skip_integration:arch=amd64,toolchain=go1.23.11
+            - issue:ConditionVariableUnavailable@arch=arm64,toolchain=go1.23.11
+            - issue:ConditionVariableUnavailable@arch=amd64,toolchain=go1.23.11
+        when: {dsl: result == 14, json: {eq: [{ref: result}, 14]}}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: tag={tag}
+        segments: [tag=, {json: {ref: tag}, dsl: tag}]
+        captureSnapshot: false
+      issue:
+        Kind: 7
+        Message: condition variable "result" not found
     - probe_definition:
         id: condNull_int_vs_null
         version: 0

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -9,10 +9,10 @@ Probes:
       segments: ['ptr: ', {json: {ref: ptr}, dsl: ptr}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 76}
+        - subprogram: {subprogram: 78}
           events:
             - Kind: Entry
-              Type: 660 EventRootType Probe[main.PointerChainArg]
+              Type: 669 EventRootType Probe[main.PointerChainArg]
               InjectionPoints: [{PC: "0xb5f04", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -32,10 +32,10 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 77}
+        - subprogram: {subprogram: 79}
           events:
             - Kind: Entry
-              Type: 661 EventRootType Probe[main.PointerSmallChainArg]
+              Type: 670 EventRootType Probe[main.PointerSmallChainArg]
               InjectionPoints: [{PC: "0xb5f4c", Frameless: false}]
               Condition: null
     - id: bigMapArg
@@ -50,11 +50,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 359 EventRootType Probe[main.bigMapArg]
-              InjectionPoints: [{PC: "0xb84e0", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8730", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 360 EventRootType Probe[main.bigMapArg]Return
-              InjectionPoints: [{PC: "0xb8554", Frameless: false}]
+              InjectionPoints: [{PC: "0xb87a4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 'm: {m}'
@@ -78,7 +78,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 405 EventRootType Probe[main.condBool]
-              InjectionPoints: [{PC: "0xb8c88", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8ed8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -95,7 +95,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 406 EventRootType Probe[main.condBool]Return
-              InjectionPoints: [{PC: "0xb8cf0", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8f40", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -119,7 +119,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 407 EventRootType Probe[main.condBool]
-              InjectionPoints: [{PC: "0xb8c88", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8ed8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -136,7 +136,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 408 EventRootType Probe[main.condBool]Return
-              InjectionPoints: [{PC: "0xb8cf0", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8f40", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -159,11 +159,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 409 EventRootType Probe[main.condBool]
-              InjectionPoints: [{PC: "0xb8c88", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8ed8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 410 EventRootType Probe[main.condBool]Return
-              InjectionPoints: [{PC: "0xb8cf0", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8f40", Frameless: false}]
               Condition: null
     - id: condCompound_and
       version: 0
@@ -188,7 +188,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 455 EventRootType Probe[main.condReturnAndLocal]
-              InjectionPoints: [{PC: "0xb90d8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9328", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -220,7 +220,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 456 EventRootType Probe[main.condReturnAndLocal]Return
-              InjectionPoints: [{PC: "0xb9138", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9388", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: a == 1 && b == 1 [a={a}, b={b}]
@@ -262,7 +262,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 425 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0xb8dec", Frameless: false}]
+              InjectionPoints: [{PC: "0xb903c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -292,7 +292,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 426 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0xb8eb8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9108", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x.S == "world" && tag == "match" [x.S={x.S}, tag={tag}]
@@ -314,7 +314,7 @@ Probes:
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["519"]
+        lines: ["547"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -338,7 +338,7 @@ Probes:
           events:
             - Kind: Line
               Type: 465 EventRootType Probe[main.condLine]Line
-              InjectionPoints: [{PC: "0xb9224", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9474", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -412,7 +412,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 427 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0xb8dec", Frameless: false}]
+              InjectionPoints: [{PC: "0xb903c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -460,7 +460,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 428 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0xb8eb8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9108", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: (x.I32 == 300 || x.I32 == 999) && !isEmpty(x.S) [x.I32={x.I32}, x.S={x.S}, tag={tag}]
@@ -502,7 +502,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 411 EventRootType Probe[main.condBool]
-              InjectionPoints: [{PC: "0xb8c88", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8ed8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -520,7 +520,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 412 EventRootType Probe[main.condBool]Return
-              InjectionPoints: [{PC: "0xb8cf0", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8f40", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '!x [x={x}, tag={tag}]'
@@ -559,7 +559,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 371 EventRootType Probe[main.condInt32]
-              InjectionPoints: [{PC: "0xb8758", Frameless: false}]
+              InjectionPoints: [{PC: "0xb89a8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -591,7 +591,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 372 EventRootType Probe[main.condInt32]Return
-              InjectionPoints: [{PC: "0xb87b8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8a08", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x == 42 || x == 100 [x={x}, tag={tag}]
@@ -629,16 +629,16 @@ Probes:
         - ']'
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 478 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xb99fc", Frameless: false}]
+              Type: 487 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xb9e5c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 37, index: 1, name: tag}
+                      Variable: {subprogram: 39, index: 1, name: tag}
                       Offset: 0
                       ByteSize: 16
                     - __kind: ExprReadStringOp
@@ -650,7 +650,7 @@ Probes:
                       Cond: true
                       Target: 1
                     - __kind: LocationOp
-                      Variable: {subprogram: 37, index: 0, name: s}
+                      Variable: {subprogram: 39, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -664,8 +664,8 @@ Probes:
                       ID: 1
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 479 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xb9ab0", Frameless: false}]
+              Type: 488 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xb9f10", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag == "match" || !isEmpty(s) [s={s}, tag={tag}]
@@ -703,20 +703,20 @@ Probes:
         - ']'
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 72}
+        - subprogram: {subprogram: 74}
           events:
             - Kind: Entry
-              Type: 652 EventRootType Probe[main.condMultiReturn]
-              InjectionPoints: [{PC: "0xbb508", Frameless: false}]
+              Type: 661 EventRootType Probe[main.condMultiReturn]
+              InjectionPoints: [{PC: "0xbb968", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 653 EventRootType Probe[main.condMultiReturn]Return
-              InjectionPoints: [{PC: "0xbb594", Frameless: false}]
+              Type: 662 EventRootType Probe[main.condMultiReturn]Return
+              InjectionPoints: [{PC: "0xbb9f4", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 72, index: 1, name: r0}
+                      Variable: {subprogram: 74, index: 1, name: r0}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -729,7 +729,7 @@ Probes:
                       Cond: false
                       Target: 1
                     - __kind: LocationOp
-                      Variable: {subprogram: 72, index: 2, name: r1}
+                      Variable: {subprogram: 74, index: 2, name: r1}
                       Offset: 0
                       ByteSize: 16
                     - __kind: ExprReadStringOp
@@ -777,7 +777,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 447 EventRootType Probe[main.condNilPtrStruct]
-              InjectionPoints: [{PC: "0xb9018", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9268", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -811,7 +811,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 448 EventRootType Probe[main.condNilPtrStruct]Return
-              InjectionPoints: [{PC: "0xb908c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb92dc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag == "nilptr" && x.I32 == 300 [tag={tag}]
@@ -845,7 +845,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 449 EventRootType Probe[main.condNilPtrStruct]
-              InjectionPoints: [{PC: "0xb9018", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9268", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -879,7 +879,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 450 EventRootType Probe[main.condNilPtrStruct]Return
-              InjectionPoints: [{PC: "0xb908c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb92dc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag == "nilptr" || x.I32 == 300 [tag={tag}]
@@ -903,11 +903,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 401 EventRootType Probe[main.condFloat32]
-              InjectionPoints: [{PC: "0xb8b28", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8d78", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 402 EventRootType Probe[main.condFloat32]Return
-              InjectionPoints: [{PC: "0xb8b8c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8ddc", Frameless: false}]
               Condition: null
     - id: condFloat64_nocond
       version: 0
@@ -922,11 +922,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 403 EventRootType Probe[main.condFloat64]
-              InjectionPoints: [{PC: "0xb8bd8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8e28", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 404 EventRootType Probe[main.condFloat64]Return
-              InjectionPoints: [{PC: "0xb8c3c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8e8c", Frameless: false}]
               Condition: null
     - id: condInt16_cond
       version: 0
@@ -942,7 +942,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 367 EventRootType Probe[main.condInt16]
-              InjectionPoints: [{PC: "0xb86b8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8908", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -959,7 +959,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 368 EventRootType Probe[main.condInt16]Return
-              InjectionPoints: [{PC: "0xb8718", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8968", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -982,11 +982,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 369 EventRootType Probe[main.condInt16]
-              InjectionPoints: [{PC: "0xb86b8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8908", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 370 EventRootType Probe[main.condInt16]Return
-              InjectionPoints: [{PC: "0xb8718", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8968", Frameless: false}]
               Condition: null
     - id: condInt32_cond
       version: 0
@@ -1002,7 +1002,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 373 EventRootType Probe[main.condInt32]
-              InjectionPoints: [{PC: "0xb8758", Frameless: false}]
+              InjectionPoints: [{PC: "0xb89a8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1019,7 +1019,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 374 EventRootType Probe[main.condInt32]Return
-              InjectionPoints: [{PC: "0xb87b8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8a08", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1046,7 +1046,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 375 EventRootType Probe[main.condInt32]
-              InjectionPoints: [{PC: "0xb8758", Frameless: false}]
+              InjectionPoints: [{PC: "0xb89a8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1063,7 +1063,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 376 EventRootType Probe[main.condInt32]Return
-              InjectionPoints: [{PC: "0xb87b8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8a08", Frameless: false}]
               Condition: null
     - id: condInt32_nocond
       version: 0
@@ -1078,11 +1078,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 377 EventRootType Probe[main.condInt32]
-              InjectionPoints: [{PC: "0xb8758", Frameless: false}]
+              InjectionPoints: [{PC: "0xb89a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 378 EventRootType Probe[main.condInt32]Return
-              InjectionPoints: [{PC: "0xb87b8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8a08", Frameless: false}]
               Condition: null
     - id: condInt64_cond
       version: 0
@@ -1098,7 +1098,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 379 EventRootType Probe[main.condInt64]
-              InjectionPoints: [{PC: "0xb87f8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8a48", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1115,7 +1115,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 380 EventRootType Probe[main.condInt64]Return
-              InjectionPoints: [{PC: "0xb8858", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8aa8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1138,11 +1138,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 381 EventRootType Probe[main.condInt64]
-              InjectionPoints: [{PC: "0xb87f8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8a48", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 382 EventRootType Probe[main.condInt64]Return
-              InjectionPoints: [{PC: "0xb8858", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8aa8", Frameless: false}]
               Condition: null
     - id: condInt8_cond
       version: 0
@@ -1158,7 +1158,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 363 EventRootType Probe[main.condInt8]
-              InjectionPoints: [{PC: "0xb8608", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8858", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1175,7 +1175,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 364 EventRootType Probe[main.condInt8]Return
-              InjectionPoints: [{PC: "0xb8670", Frameless: false}]
+              InjectionPoints: [{PC: "0xb88c0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1198,11 +1198,257 @@ Probes:
           events:
             - Kind: Entry
               Type: 365 EventRootType Probe[main.condInt8]
-              InjectionPoints: [{PC: "0xb8608", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8858", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 366 EventRootType Probe[main.condInt8]Return
-              InjectionPoints: [{PC: "0xb8670", Frameless: false}]
+              InjectionPoints: [{PC: "0xb88c0", Frameless: false}]
+              Condition: null
+    - id: condLineMixed_cond_bool
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when: {dsl: b == true, json: {eq: [{ref: b}, true]}}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 470 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0xb9558", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 1, name: b}
+                      Offset: 0
+                      ByteSize: 1
+                    - __kind: ExprPushOffsetOp
+                      ByteSize: 1
+                    - __kind: ExprLoadLiteralOp
+                      Data: AQ==
+                    - __kind: ExprCmpEqBaseOp
+                      ByteSize: 1
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_isEmpty_slice
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when: {dsl: isEmpty(ss), json: {isEmpty: {ref: ss}}}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 471 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0xb9558", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 4, name: ss}
+                      Offset: 8
+                      ByteSize: 8
+                    - __kind: ExprPushOffsetOp
+                      ByteSize: 8
+                    - __kind: ExprLoadLiteralOp
+                      Data: AAAAAAAAAAA=
+                    - __kind: ExprCmpEqBaseOp
+                      ByteSize: 8
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_len_string
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when:
+        dsl: len(s) == 5
+        json: {eq: [{len: {ref: s}}, 5]}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 472 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0xb9558", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 0, name: s}
+                      Offset: 8
+                      ByteSize: 8
+                    - __kind: ExprPushOffsetOp
+                      ByteSize: 8
+                    - __kind: ExprLoadLiteralOp
+                      Data: BQAAAAAAAAA=
+                    - __kind: ExprCmpEqBaseOp
+                      ByteSize: 8
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_ptrstruct_field
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when:
+        dsl: p.S == "world"
+        json: {eq: [{getmember: [{ref: p}, S]}, world]}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 473 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0xb9558", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 3, name: p}
+                      Offset: 0
+                      ByteSize: 8
+                    - __kind: DereferenceOp
+                      Bias: 56
+                      ByteSize: 16
+                    - __kind: ExprReadStringOp
+                      MaxLen: 255
+                    - __kind: ExprLoadLiteralOp
+                      Data: BQAAAHdvcmxk
+                    - __kind: ExprCmpEqStringOp
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_string
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when:
+        dsl: s == "hello"
+        json: {eq: [{ref: s}, hello]}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 474 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0xb9558", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 0, name: s}
+                      Offset: 0
+                      ByteSize: 16
+                    - __kind: ExprReadStringOp
+                      MaxLen: 255
+                    - __kind: ExprLoadLiteralOp
+                      Data: BQAAAGhlbGxv
+                    - __kind: ExprCmpEqStringOp
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_struct_field
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when:
+        dsl: x.I32 == 300
+        json: {eq: [{getmember: [{ref: x}, I32]}, 300]}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 475 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0xb9558", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 2, name: x}
+                      Offset: 4
+                      ByteSize: 4
+                    - __kind: ExprPushOffsetOp
+                      ByteSize: 4
+                    - __kind: ExprLoadLiteralOp
+                      Data: LAEAAA==
+                    - __kind: ExprCmpEqBaseOp
+                      ByteSize: 4
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_nocond
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 476 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0xb9558", Frameless: false}]
               Condition: null
     - id: condLine_cond
       version: 0
@@ -1210,7 +1456,7 @@ Probes:
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["519"]
+        lines: ["547"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -1227,7 +1473,7 @@ Probes:
           events:
             - Kind: Line
               Type: 466 EventRootType Probe[main.condLine]Line
-              InjectionPoints: [{PC: "0xb9224", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9474", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1242,13 +1488,58 @@ Probes:
                     - __kind: ExprCmpEqBaseOp
                       ByteSize: 8
                     - __kind: ConditionCheckOp
-    - id: condLine_nocond
+    - id: condLine_local_cond
       version: 0
       type: LOG_PROBE
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["519"]
+        lines: ["548"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+        - issue:ConditionVariableUnavailable@arch=arm64,toolchain=go1.23.11
+        - issue:ConditionVariableUnavailable@arch=amd64,toolchain=go1.23.11
+      when: {dsl: result == 14, json: {eq: [{ref: result}, 14]}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 28}
+          events:
+            - Kind: Line
+              Type: 467 EventRootType Probe[main.condLine]Line
+              InjectionPoints: [{PC: "0xb9478", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 28, index: 2, name: result}
+                      Offset: 0
+                      ByteSize: 8
+                    - __kind: ExprPushOffsetOp
+                      ByteSize: 8
+                    - __kind: ExprLoadLiteralOp
+                      Data: DgAAAAAAAAA=
+                    - __kind: ExprCmpEqBaseOp
+                      ByteSize: 8
+                    - __kind: ConditionCheckOp
+          probeTemplate:
+            TemplateString: tag={tag}
+            Segments:
+                - tag=
+                - JSON: {Ref: tag}
+                  DSL: tag
+                  EventKind: Line
+                  EventExpressionIndex: 0
+    - id: condLine_local_nocond
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLine
+        sourceFile: main.go
+        lines: ["548"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -1260,8 +1551,29 @@ Probes:
         - subprogram: {subprogram: 28}
           events:
             - Kind: Line
-              Type: 467 EventRootType Probe[main.condLine]Line
-              InjectionPoints: [{PC: "0xb9224", Frameless: false}]
+              Type: 468 EventRootType Probe[main.condLine]Line
+              InjectionPoints: [{PC: "0xb9478", Frameless: false}]
+              Condition: null
+    - id: condLine_nocond
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLine
+        sourceFile: main.go
+        lines: ["547"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 28}
+          events:
+            - Kind: Line
+              Type: 469 EventRootType Probe[main.condLine]Line
+              InjectionPoints: [{PC: "0xb9474", Frameless: false}]
               Condition: null
     - id: condNilPtr_cond
       version: 0
@@ -1279,7 +1591,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 451 EventRootType Probe[main.condNilPtrStruct]
-              InjectionPoints: [{PC: "0xb9018", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9268", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1299,7 +1611,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 452 EventRootType Probe[main.condNilPtrStruct]Return
-              InjectionPoints: [{PC: "0xb908c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb92dc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: condNilPtr {tag}
@@ -1322,11 +1634,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 453 EventRootType Probe[main.condNilPtrStruct]
-              InjectionPoints: [{PC: "0xb9018", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9268", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 454 EventRootType Probe[main.condNilPtrStruct]Return
-              InjectionPoints: [{PC: "0xb908c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb92dc", Frameless: false}]
               Condition: null
     - id: condNull_iface
       version: 0
@@ -1338,16 +1650,16 @@ Probes:
       segments: ['i == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 35}
+        - subprogram: {subprogram: 37}
           events:
             - Kind: Entry
-              Type: 474 EventRootType Probe[main.condNullIface]
-              InjectionPoints: [{PC: "0xb97ec", Frameless: false}]
+              Type: 483 EventRootType Probe[main.condNullIface]
+              InjectionPoints: [{PC: "0xb9c4c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 35, index: 0, name: i}
+                      Variable: {subprogram: 37, index: 0, name: i}
                       Offset: 0
                       ByteSize: 16
                     - __kind: ExprPushOffsetOp
@@ -1358,8 +1670,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 475 EventRootType Probe[main.condNullIface]Return
-              InjectionPoints: [{PC: "0xb98ac", Frameless: false}]
+              Type: 484 EventRootType Probe[main.condNullIface]Return
+              InjectionPoints: [{PC: "0xb9d0c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: i == nil [tag={tag}]
@@ -1380,16 +1692,16 @@ Probes:
       segments: ['m == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 34}
+        - subprogram: {subprogram: 36}
           events:
             - Kind: Entry
-              Type: 472 EventRootType Probe[main.condNullMap]
-              InjectionPoints: [{PC: "0xb96fc", Frameless: false}]
+              Type: 481 EventRootType Probe[main.condNullMap]
+              InjectionPoints: [{PC: "0xb9b5c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 34, index: 0, name: m}
+                      Variable: {subprogram: 36, index: 0, name: m}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -1400,8 +1712,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 473 EventRootType Probe[main.condNullMap]Return
-              InjectionPoints: [{PC: "0xb97a4", Frameless: false}]
+              Type: 482 EventRootType Probe[main.condNullMap]Return
+              InjectionPoints: [{PC: "0xb9c04", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: m == nil [tag={tag}]
@@ -1422,16 +1734,16 @@ Probes:
       segments: ['p == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 32}
+        - subprogram: {subprogram: 34}
           events:
             - Kind: Entry
-              Type: 468 EventRootType Probe[main.condNullPtr]
-              InjectionPoints: [{PC: "0xb94ec", Frameless: false}]
+              Type: 477 EventRootType Probe[main.condNullPtr]
+              InjectionPoints: [{PC: "0xb994c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 32, index: 0, name: p}
+                      Variable: {subprogram: 34, index: 0, name: p}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -1442,8 +1754,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 469 EventRootType Probe[main.condNullPtr]Return
-              InjectionPoints: [{PC: "0xb9594", Frameless: false}]
+              Type: 478 EventRootType Probe[main.condNullPtr]Return
+              InjectionPoints: [{PC: "0xb99f4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p == nil [tag={tag}]
@@ -1464,16 +1776,16 @@ Probes:
       segments: ['s == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 33}
+        - subprogram: {subprogram: 35}
           events:
             - Kind: Entry
-              Type: 470 EventRootType Probe[main.condNullSlice]
-              InjectionPoints: [{PC: "0xb95dc", Frameless: false}]
+              Type: 479 EventRootType Probe[main.condNullSlice]
+              InjectionPoints: [{PC: "0xb9a3c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 33, index: 0, name: s}
+                      Variable: {subprogram: 35, index: 0, name: s}
                       Offset: 0
                       ByteSize: 24
                     - __kind: ExprPushOffsetOp
@@ -1484,8 +1796,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 471 EventRootType Probe[main.condNullSlice]Return
-              InjectionPoints: [{PC: "0xb96a8", Frameless: false}]
+              Type: 480 EventRootType Probe[main.condNullSlice]Return
+              InjectionPoints: [{PC: "0xb9b08", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: s == nil [tag={tag}]
@@ -1506,16 +1818,16 @@ Probes:
       segments: ['p == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 36}
+        - subprogram: {subprogram: 38}
           events:
             - Kind: Entry
-              Type: 476 EventRootType Probe[main.condNullUnsafePtr]
-              InjectionPoints: [{PC: "0xb98fc", Frameless: false}]
+              Type: 485 EventRootType Probe[main.condNullUnsafePtr]
+              InjectionPoints: [{PC: "0xb9d5c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 36, index: 0, name: p}
+                      Variable: {subprogram: 38, index: 0, name: p}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -1526,8 +1838,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 477 EventRootType Probe[main.condNullUnsafePtr]Return
-              InjectionPoints: [{PC: "0xb99a4", Frameless: false}]
+              Type: 486 EventRootType Probe[main.condNullUnsafePtr]Return
+              InjectionPoints: [{PC: "0xb9e04", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p == nil [tag={tag}]
@@ -1552,7 +1864,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 461 EventRootType Probe[main.condOnly]
-              InjectionPoints: [{PC: "0xb9178", Frameless: false}]
+              InjectionPoints: [{PC: "0xb93c8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1569,7 +1881,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 462 EventRootType Probe[main.condOnly]Return
-              InjectionPoints: [{PC: "0xb91d8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9428", Frameless: false}]
               Condition: null
     - id: condOnly_nocond
       version: 0
@@ -1584,11 +1896,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 463 EventRootType Probe[main.condOnly]
-              InjectionPoints: [{PC: "0xb9178", Frameless: false}]
+              InjectionPoints: [{PC: "0xb93c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 464 EventRootType Probe[main.condOnly]Return
-              InjectionPoints: [{PC: "0xb91d8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9428", Frameless: false}]
               Condition: null
     - id: condPtrStruct_field_i32
       version: 0
@@ -1606,7 +1918,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 441 EventRootType Probe[main.condPtrStructArg]
-              InjectionPoints: [{PC: "0xb8efc", Frameless: false}]
+              InjectionPoints: [{PC: "0xb914c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1626,7 +1938,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 442 EventRootType Probe[main.condPtrStructArg]Return
-              InjectionPoints: [{PC: "0xb8fd4", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9224", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1652,7 +1964,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 443 EventRootType Probe[main.condPtrStructArg]
-              InjectionPoints: [{PC: "0xb8efc", Frameless: false}]
+              InjectionPoints: [{PC: "0xb914c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1671,7 +1983,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 444 EventRootType Probe[main.condPtrStructArg]Return
-              InjectionPoints: [{PC: "0xb8fd4", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9224", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1694,11 +2006,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 445 EventRootType Probe[main.condPtrStructArg]
-              InjectionPoints: [{PC: "0xb8efc", Frameless: false}]
+              InjectionPoints: [{PC: "0xb914c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 446 EventRootType Probe[main.condPtrStructArg]Return
-              InjectionPoints: [{PC: "0xb8fd4", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9224", Frameless: false}]
               Condition: null
     - id: condReturnAndLocal_cond_param
       version: 0
@@ -1714,7 +2026,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 457 EventRootType Probe[main.condReturnAndLocal]
-              InjectionPoints: [{PC: "0xb90d8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9328", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1731,7 +2043,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 458 EventRootType Probe[main.condReturnAndLocal]Return
-              InjectionPoints: [{PC: "0xb9138", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9388", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: b={b}
@@ -1754,11 +2066,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 459 EventRootType Probe[main.condReturnAndLocal]
-              InjectionPoints: [{PC: "0xb90d8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9328", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 460 EventRootType Probe[main.condReturnAndLocal]Return
-              InjectionPoints: [{PC: "0xb9138", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9388", Frameless: false}]
               Condition: null
     - id: condString_cond
       version: 0
@@ -1776,7 +2088,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 413 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0xb8d38", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8f88", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1792,7 +2104,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 414 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0xb8d9c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8fec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1816,7 +2128,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 415 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0xb8d38", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8f88", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1832,7 +2144,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 416 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0xb8d9c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8fec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1860,11 +2172,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 417 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0xb8d38", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8f88", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 418 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0xb8d9c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8fec", Frameless: false}]
               Condition: null
     - id: condString_eq_template
       version: 0
@@ -1882,11 +2194,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 419 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0xb8d38", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8f88", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 420 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0xb8d9c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8fec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: eq={x == "hello"}
@@ -1909,11 +2221,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 421 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0xb8d38", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8f88", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 422 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0xb8d9c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8fec", Frameless: false}]
               Condition: null
     - id: condString_snapshot_with_cond
       version: 0
@@ -1931,7 +2243,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 423 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0xb8d38", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8f88", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1947,7 +2259,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 424 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0xb8d9c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8fec", Frameless: false}]
               Condition: null
     - id: condStruct_cond_i32_capture_tag
       version: 0
@@ -1968,7 +2280,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 429 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0xb8dec", Frameless: false}]
+              InjectionPoints: [{PC: "0xb903c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1985,7 +2297,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 430 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0xb8eb8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9108", Frameless: false}]
               Condition: null
     - id: condStruct_field_bool
       version: 0
@@ -2003,7 +2315,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 431 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0xb8dec", Frameless: false}]
+              InjectionPoints: [{PC: "0xb903c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2020,7 +2332,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 432 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0xb8eb8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9108", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2046,7 +2358,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 433 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0xb8dec", Frameless: false}]
+              InjectionPoints: [{PC: "0xb903c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2063,7 +2375,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 434 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0xb8eb8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9108", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2089,7 +2401,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 435 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0xb8dec", Frameless: false}]
+              InjectionPoints: [{PC: "0xb903c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2106,7 +2418,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 436 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0xb8eb8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9108", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2132,7 +2444,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 437 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0xb8dec", Frameless: false}]
+              InjectionPoints: [{PC: "0xb903c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2148,7 +2460,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 438 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0xb8eb8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9108", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2171,11 +2483,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 439 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0xb8dec", Frameless: false}]
+              InjectionPoints: [{PC: "0xb903c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 440 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0xb8eb8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb9108", Frameless: false}]
               Condition: null
     - id: condUint16_cond
       version: 0
@@ -2191,7 +2503,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 389 EventRootType Probe[main.condUint16]
-              InjectionPoints: [{PC: "0xb8948", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8b98", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2208,7 +2520,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 390 EventRootType Probe[main.condUint16]Return
-              InjectionPoints: [{PC: "0xb89a8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8bf8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2231,11 +2543,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 391 EventRootType Probe[main.condUint16]
-              InjectionPoints: [{PC: "0xb8948", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8b98", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 392 EventRootType Probe[main.condUint16]Return
-              InjectionPoints: [{PC: "0xb89a8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8bf8", Frameless: false}]
               Condition: null
     - id: condUint32_cond
       version: 0
@@ -2251,7 +2563,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 393 EventRootType Probe[main.condUint32]
-              InjectionPoints: [{PC: "0xb89e8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8c38", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2268,7 +2580,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 394 EventRootType Probe[main.condUint32]Return
-              InjectionPoints: [{PC: "0xb8a48", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8c98", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2291,11 +2603,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 395 EventRootType Probe[main.condUint32]
-              InjectionPoints: [{PC: "0xb89e8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8c38", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 396 EventRootType Probe[main.condUint32]Return
-              InjectionPoints: [{PC: "0xb8a48", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8c98", Frameless: false}]
               Condition: null
     - id: condUint64_cond
       version: 0
@@ -2311,7 +2623,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 397 EventRootType Probe[main.condUint64]
-              InjectionPoints: [{PC: "0xb8a88", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8cd8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2328,7 +2640,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 398 EventRootType Probe[main.condUint64]Return
-              InjectionPoints: [{PC: "0xb8ae8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8d38", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2351,11 +2663,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 399 EventRootType Probe[main.condUint64]
-              InjectionPoints: [{PC: "0xb8a88", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8cd8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 400 EventRootType Probe[main.condUint64]Return
-              InjectionPoints: [{PC: "0xb8ae8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8d38", Frameless: false}]
               Condition: null
     - id: condUint8_cond
       version: 0
@@ -2371,7 +2683,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 383 EventRootType Probe[main.condUint8]
-              InjectionPoints: [{PC: "0xb8898", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8ae8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2388,7 +2700,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 384 EventRootType Probe[main.condUint8]Return
-              InjectionPoints: [{PC: "0xb8900", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8b50", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2412,7 +2724,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 385 EventRootType Probe[main.condUint8]
-              InjectionPoints: [{PC: "0xb8898", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8ae8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2429,7 +2741,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 386 EventRootType Probe[main.condUint8]Return
-              InjectionPoints: [{PC: "0xb8900", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8b50", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2452,11 +2764,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 387 EventRootType Probe[main.condUint8]
-              InjectionPoints: [{PC: "0xb8898", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8ae8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 388 EventRootType Probe[main.condUint8]Return
-              InjectionPoints: [{PC: "0xb8900", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8b50", Frameless: false}]
               Condition: null
     - id: genericIdentity
       version: 0
@@ -2466,25 +2778,25 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 73}
+        - subprogram: {subprogram: 75}
           events:
             - Kind: Entry
-              Type: 654 EventRootType Probe[main.genericIdentity[go.shape.string]]
-              InjectionPoints: [{PC: "0xbb5d8", Frameless: false}]
+              Type: 663 EventRootType Probe[main.genericIdentity[go.shape.string]]
+              InjectionPoints: [{PC: "0xbba38", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 655 EventRootType Probe[main.genericIdentity[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xbb62c", Frameless: false}]
+              Type: 664 EventRootType Probe[main.genericIdentity[go.shape.string]]Return
+              InjectionPoints: [{PC: "0xbba8c", Frameless: false}]
               Condition: null
-        - subprogram: {subprogram: 74}
+        - subprogram: {subprogram: 76}
           events:
             - Kind: Entry
-              Type: 656 EventRootType Probe[main.genericIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0xbb678", Frameless: false}]
+              Type: 665 EventRootType Probe[main.genericIdentity[go.shape.int]]
+              InjectionPoints: [{PC: "0xbbad8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 657 EventRootType Probe[main.genericIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xbb6c0", Frameless: false}]
+              Type: 666 EventRootType Probe[main.genericIdentity[go.shape.int]]Return
+              InjectionPoints: [{PC: "0xbbb20", Frameless: false}]
               Condition: null
     - id: indexBigArrayStruct_last
       version: 0
@@ -2500,15 +2812,15 @@ Probes:
             dsl: s.data[131071]
             json: {index: [{getmember: [{ref: s}, data]}, 131071]}
       instances:
-        - subprogram: {subprogram: 48}
+        - subprogram: {subprogram: 50}
           events:
             - Kind: Entry
-              Type: 576 EventRootType Probe[main.bigArrayStructArg]
-              InjectionPoints: [{PC: "0xba5b8", Frameless: false}]
+              Type: 585 EventRootType Probe[main.bigArrayStructArg]
+              InjectionPoints: [{PC: "0xbaa18", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 577 EventRootType Probe[main.bigArrayStructArg]Return
-              InjectionPoints: [{PC: "0xba618", Frameless: false}]
+              Type: 586 EventRootType Probe[main.bigArrayStructArg]Return
+              InjectionPoints: [{PC: "0xbaa78", Frameless: false}]
               Condition: null
     - id: indexBigArray_first
       version: 0
@@ -2522,15 +2834,15 @@ Probes:
         - name: s_0
           expr: {dsl: 's[0]', json: {index: [{ref: s}, 0]}}
       instances:
-        - subprogram: {subprogram: 47}
+        - subprogram: {subprogram: 49}
           events:
             - Kind: Entry
-              Type: 572 EventRootType Probe[main.bigArrayArg]
-              InjectionPoints: [{PC: "0xba528", Frameless: false}]
+              Type: 581 EventRootType Probe[main.bigArrayArg]
+              InjectionPoints: [{PC: "0xba988", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 573 EventRootType Probe[main.bigArrayArg]Return
-              InjectionPoints: [{PC: "0xba584", Frameless: false}]
+              Type: 582 EventRootType Probe[main.bigArrayArg]Return
+              InjectionPoints: [{PC: "0xba9e4", Frameless: false}]
               Condition: null
     - id: indexBigArray_last
       version: 0
@@ -2544,15 +2856,15 @@ Probes:
         - name: s_131071
           expr: {dsl: 's[131071]', json: {index: [{ref: s}, 131071]}}
       instances:
-        - subprogram: {subprogram: 47}
+        - subprogram: {subprogram: 49}
           events:
             - Kind: Entry
-              Type: 574 EventRootType Probe[main.bigArrayArg]
-              InjectionPoints: [{PC: "0xba528", Frameless: false}]
+              Type: 583 EventRootType Probe[main.bigArrayArg]
+              InjectionPoints: [{PC: "0xba988", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 575 EventRootType Probe[main.bigArrayArg]Return
-              InjectionPoints: [{PC: "0xba584", Frameless: false}]
+              Type: 584 EventRootType Probe[main.bigArrayArg]Return
+              InjectionPoints: [{PC: "0xba9e4", Frameless: false}]
               Condition: null
     - id: indexErr_array_oob_capture
       version: 0
@@ -2570,11 +2882,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 338 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0xb8218", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8468", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 339 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0xb825c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb84ac", Frameless: false}]
               Condition: null
     - id: indexErr_array_oob_template
       version: 0
@@ -2589,11 +2901,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 340 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0xb8218", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8468", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 341 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0xb825c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb84ac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's[3]: {s[3]}'
@@ -2617,11 +2929,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 324 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0xb8198", Frameless: false}]
+              InjectionPoints: [{PC: "0xb83e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 325 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0xb81d4", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8424", Frameless: false}]
               Condition: null
     - id: indexErr_slice_oob_cond
       version: 0
@@ -2639,7 +2951,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 326 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0xb8198", Frameless: false}]
+              InjectionPoints: [{PC: "0xb83e8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2661,7 +2973,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 327 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0xb81d4", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8424", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: matched, Segments: [matched]}
     - id: indexErr_slice_oob_template
@@ -2677,11 +2989,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 328 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0xb8198", Frameless: false}]
+              InjectionPoints: [{PC: "0xb83e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 329 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0xb81d4", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8424", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's[5]: {s[5]}'
@@ -2707,11 +3019,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 342 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0xb8218", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8468", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 343 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0xb825c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb84ac", Frameless: false}]
               Condition: null
     - id: indexIntArray_cond
       version: 0
@@ -2729,7 +3041,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 344 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0xb8218", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8468", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2746,7 +3058,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 345 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0xb825c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb84ac", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: matched, Segments: [matched]}
     - id: indexIntSlice_capture
@@ -2765,11 +3077,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 330 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0xb8198", Frameless: false}]
+              InjectionPoints: [{PC: "0xb83e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 331 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0xb81d4", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8424", Frameless: false}]
               Condition: null
     - id: indexIntSlice_cond
       version: 0
@@ -2787,7 +3099,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 332 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0xb8198", Frameless: false}]
+              InjectionPoints: [{PC: "0xb83e8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2809,7 +3121,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 333 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0xb81d4", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8424", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: matched, Segments: [matched]}
     - id: indexIntSlice_template
@@ -2825,11 +3137,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 334 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0xb8198", Frameless: false}]
+              InjectionPoints: [{PC: "0xb83e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 335 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0xb81d4", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8424", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's[1]: {s[1]}'
@@ -2853,15 +3165,15 @@ Probes:
             dsl: s[0].Val
             json: {getmember: [{index: [{ref: s}, 0]}, Val]}
       instances:
-        - subprogram: {subprogram: 50}
+        - subprogram: {subprogram: 52}
           events:
             - Kind: Entry
-              Type: 586 EventRootType Probe[main.structArrayArg]
-              InjectionPoints: [{PC: "0xba728", Frameless: false}]
+              Type: 595 EventRootType Probe[main.structArrayArg]
+              InjectionPoints: [{PC: "0xbab88", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 587 EventRootType Probe[main.structArrayArg]Return
-              InjectionPoints: [{PC: "0xba78c", Frameless: false}]
+              Type: 596 EventRootType Probe[main.structArrayArg]Return
+              InjectionPoints: [{PC: "0xbabec", Frameless: false}]
               Condition: null
     - id: indexMember_arrayStruct_capture_string
       version: 0
@@ -2877,15 +3189,15 @@ Probes:
             dsl: s[1].Txt
             json: {getmember: [{index: [{ref: s}, 1]}, Txt]}
       instances:
-        - subprogram: {subprogram: 50}
+        - subprogram: {subprogram: 52}
           events:
             - Kind: Entry
-              Type: 588 EventRootType Probe[main.structArrayArg]
-              InjectionPoints: [{PC: "0xba728", Frameless: false}]
+              Type: 597 EventRootType Probe[main.structArrayArg]
+              InjectionPoints: [{PC: "0xbab88", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 589 EventRootType Probe[main.structArrayArg]Return
-              InjectionPoints: [{PC: "0xba78c", Frameless: false}]
+              Type: 598 EventRootType Probe[main.structArrayArg]Return
+              InjectionPoints: [{PC: "0xbabec", Frameless: false}]
               Condition: null
     - id: indexMember_ptrArrayStruct_capture_int
       version: 0
@@ -2901,15 +3213,15 @@ Probes:
             dsl: s[0].Val
             json: {getmember: [{index: [{ref: s}, 0]}, Val]}
       instances:
-        - subprogram: {subprogram: 52}
+        - subprogram: {subprogram: 54}
           events:
             - Kind: Entry
-              Type: 594 EventRootType Probe[main.ptrStructArrayArg]
-              InjectionPoints: [{PC: "0xba898", Frameless: false}]
+              Type: 603 EventRootType Probe[main.ptrStructArrayArg]
+              InjectionPoints: [{PC: "0xbacf8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 595 EventRootType Probe[main.ptrStructArrayArg]Return
-              InjectionPoints: [{PC: "0xba900", Frameless: false}]
+              Type: 604 EventRootType Probe[main.ptrStructArrayArg]Return
+              InjectionPoints: [{PC: "0xbad60", Frameless: false}]
               Condition: null
     - id: indexMember_ptrArrayStruct_capture_string
       version: 0
@@ -2925,15 +3237,15 @@ Probes:
             dsl: s[1].Txt
             json: {getmember: [{index: [{ref: s}, 1]}, Txt]}
       instances:
-        - subprogram: {subprogram: 52}
+        - subprogram: {subprogram: 54}
           events:
             - Kind: Entry
-              Type: 596 EventRootType Probe[main.ptrStructArrayArg]
-              InjectionPoints: [{PC: "0xba898", Frameless: false}]
+              Type: 605 EventRootType Probe[main.ptrStructArrayArg]
+              InjectionPoints: [{PC: "0xbacf8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 597 EventRootType Probe[main.ptrStructArrayArg]Return
-              InjectionPoints: [{PC: "0xba900", Frameless: false}]
+              Type: 606 EventRootType Probe[main.ptrStructArrayArg]Return
+              InjectionPoints: [{PC: "0xbad60", Frameless: false}]
               Condition: null
     - id: indexMember_ptrSliceStruct_capture_int
       version: 0
@@ -2949,15 +3261,15 @@ Probes:
             dsl: s[0].Val
             json: {getmember: [{index: [{ref: s}, 0]}, Val]}
       instances:
-        - subprogram: {subprogram: 51}
+        - subprogram: {subprogram: 53}
           events:
             - Kind: Entry
-              Type: 590 EventRootType Probe[main.ptrStructSliceArg]
-              InjectionPoints: [{PC: "0xba7c8", Frameless: false}]
+              Type: 599 EventRootType Probe[main.ptrStructSliceArg]
+              InjectionPoints: [{PC: "0xbac28", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 591 EventRootType Probe[main.ptrStructSliceArg]Return
-              InjectionPoints: [{PC: "0xba840", Frameless: false}]
+              Type: 600 EventRootType Probe[main.ptrStructSliceArg]Return
+              InjectionPoints: [{PC: "0xbaca0", Frameless: false}]
               Condition: null
     - id: indexMember_ptrSliceStruct_capture_string
       version: 0
@@ -2973,15 +3285,15 @@ Probes:
             dsl: s[1].Txt
             json: {getmember: [{index: [{ref: s}, 1]}, Txt]}
       instances:
-        - subprogram: {subprogram: 51}
+        - subprogram: {subprogram: 53}
           events:
             - Kind: Entry
-              Type: 592 EventRootType Probe[main.ptrStructSliceArg]
-              InjectionPoints: [{PC: "0xba7c8", Frameless: false}]
+              Type: 601 EventRootType Probe[main.ptrStructSliceArg]
+              InjectionPoints: [{PC: "0xbac28", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 593 EventRootType Probe[main.ptrStructSliceArg]Return
-              InjectionPoints: [{PC: "0xba840", Frameless: false}]
+              Type: 602 EventRootType Probe[main.ptrStructSliceArg]Return
+              InjectionPoints: [{PC: "0xbaca0", Frameless: false}]
               Condition: null
     - id: indexMember_sliceStruct_capture_int
       version: 0
@@ -2997,15 +3309,15 @@ Probes:
             dsl: s[0].Val
             json: {getmember: [{index: [{ref: s}, 0]}, Val]}
       instances:
-        - subprogram: {subprogram: 49}
+        - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 578 EventRootType Probe[main.structSliceArg]
-              InjectionPoints: [{PC: "0xba658", Frameless: false}]
+              Type: 587 EventRootType Probe[main.structSliceArg]
+              InjectionPoints: [{PC: "0xbaab8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 579 EventRootType Probe[main.structSliceArg]Return
-              InjectionPoints: [{PC: "0xba6cc", Frameless: false}]
+              Type: 588 EventRootType Probe[main.structSliceArg]Return
+              InjectionPoints: [{PC: "0xbab2c", Frameless: false}]
               Condition: null
     - id: indexMember_sliceStruct_capture_string
       version: 0
@@ -3021,15 +3333,15 @@ Probes:
             dsl: s[1].Txt
             json: {getmember: [{index: [{ref: s}, 1]}, Txt]}
       instances:
-        - subprogram: {subprogram: 49}
+        - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 580 EventRootType Probe[main.structSliceArg]
-              InjectionPoints: [{PC: "0xba658", Frameless: false}]
+              Type: 589 EventRootType Probe[main.structSliceArg]
+              InjectionPoints: [{PC: "0xbaab8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 581 EventRootType Probe[main.structSliceArg]Return
-              InjectionPoints: [{PC: "0xba6cc", Frameless: false}]
+              Type: 590 EventRootType Probe[main.structSliceArg]Return
+              InjectionPoints: [{PC: "0xbab2c", Frameless: false}]
               Condition: null
     - id: indexMember_sliceStruct_cond
       version: 0
@@ -3044,16 +3356,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 49}
+        - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 582 EventRootType Probe[main.structSliceArg]
-              InjectionPoints: [{PC: "0xba658", Frameless: false}]
+              Type: 591 EventRootType Probe[main.structSliceArg]
+              InjectionPoints: [{PC: "0xbaab8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 49, index: 0, name: s}
+                      Variable: {subprogram: 51, index: 0, name: s}
                       Offset: 0
                       ByteSize: 16
                     - __kind: SliceBoundsCheckOp
@@ -3069,8 +3381,8 @@ Probes:
                       ByteSize: 4
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 583 EventRootType Probe[main.structSliceArg]Return
-              InjectionPoints: [{PC: "0xba6cc", Frameless: false}]
+              Type: 592 EventRootType Probe[main.structSliceArg]Return
+              InjectionPoints: [{PC: "0xbab2c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -3092,15 +3404,15 @@ Probes:
           dsl: s[0].Val
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 49}
+        - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 584 EventRootType Probe[main.structSliceArg]
-              InjectionPoints: [{PC: "0xba658", Frameless: false}]
+              Type: 593 EventRootType Probe[main.structSliceArg]
+              InjectionPoints: [{PC: "0xbaab8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 585 EventRootType Probe[main.structSliceArg]Return
-              InjectionPoints: [{PC: "0xba6cc", Frameless: false}]
+              Type: 594 EventRootType Probe[main.structSliceArg]Return
+              InjectionPoints: [{PC: "0xbab2c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: s[0].Val={s[0].Val}
@@ -3127,15 +3439,15 @@ Probes:
             json:
                 getmember: [{index: [{getmember: [{ref: s}, Arr]}, 0]}, Val]
       instances:
-        - subprogram: {subprogram: 53}
+        - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 598 EventRootType Probe[main.indexMemberWrapperArg]
-              InjectionPoints: [{PC: "0xba938", Frameless: false}]
+              Type: 607 EventRootType Probe[main.indexMemberWrapperArg]
+              InjectionPoints: [{PC: "0xbad98", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 599 EventRootType Probe[main.indexMemberWrapperArg]Return
-              InjectionPoints: [{PC: "0xba9cc", Frameless: false}]
+              Type: 608 EventRootType Probe[main.indexMemberWrapperArg]Return
+              InjectionPoints: [{PC: "0xbae2c", Frameless: false}]
               Condition: null
     - id: indexMember_wrapper_arr_capture_1
       version: 0
@@ -3152,15 +3464,15 @@ Probes:
             json:
                 getmember: [{index: [{getmember: [{ref: s}, Arr]}, 1]}, Txt]
       instances:
-        - subprogram: {subprogram: 53}
+        - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 600 EventRootType Probe[main.indexMemberWrapperArg]
-              InjectionPoints: [{PC: "0xba938", Frameless: false}]
+              Type: 609 EventRootType Probe[main.indexMemberWrapperArg]
+              InjectionPoints: [{PC: "0xbad98", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 601 EventRootType Probe[main.indexMemberWrapperArg]Return
-              InjectionPoints: [{PC: "0xba9cc", Frameless: false}]
+              Type: 610 EventRootType Probe[main.indexMemberWrapperArg]Return
+              InjectionPoints: [{PC: "0xbae2c", Frameless: false}]
               Condition: null
     - id: indexMember_wrapper_ptrArr_capture
       version: 0
@@ -3177,15 +3489,15 @@ Probes:
             json:
                 getmember: [{index: [{getmember: [{ref: s}, PtrArr]}, 0]}, Val]
       instances:
-        - subprogram: {subprogram: 53}
+        - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 602 EventRootType Probe[main.indexMemberWrapperArg]
-              InjectionPoints: [{PC: "0xba938", Frameless: false}]
+              Type: 611 EventRootType Probe[main.indexMemberWrapperArg]
+              InjectionPoints: [{PC: "0xbad98", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 603 EventRootType Probe[main.indexMemberWrapperArg]Return
-              InjectionPoints: [{PC: "0xba9cc", Frameless: false}]
+              Type: 612 EventRootType Probe[main.indexMemberWrapperArg]Return
+              InjectionPoints: [{PC: "0xbae2c", Frameless: false}]
               Condition: null
     - id: indexMember_wrapper_ptrArr_capture_1
       version: 0
@@ -3202,15 +3514,15 @@ Probes:
             json:
                 getmember: [{index: [{getmember: [{ref: s}, PtrArr]}, 1]}, Txt]
       instances:
-        - subprogram: {subprogram: 53}
+        - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 604 EventRootType Probe[main.indexMemberWrapperArg]
-              InjectionPoints: [{PC: "0xba938", Frameless: false}]
+              Type: 613 EventRootType Probe[main.indexMemberWrapperArg]
+              InjectionPoints: [{PC: "0xbad98", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 605 EventRootType Probe[main.indexMemberWrapperArg]Return
-              InjectionPoints: [{PC: "0xba9cc", Frameless: false}]
+              Type: 614 EventRootType Probe[main.indexMemberWrapperArg]Return
+              InjectionPoints: [{PC: "0xbae2c", Frameless: false}]
               Condition: null
     - id: indexNilPtr_capture
       version: 0
@@ -3226,15 +3538,15 @@ Probes:
             dsl: x.Items[0]
             json: {index: [{getmember: [{ref: x}, Items]}, 0]}
       instances:
-        - subprogram: {subprogram: 45}
+        - subprogram: {subprogram: 47}
           events:
             - Kind: Entry
-              Type: 564 EventRootType Probe[main.indexNilPtrSlice]
-              InjectionPoints: [{PC: "0xba2a8", Frameless: false}]
+              Type: 573 EventRootType Probe[main.indexNilPtrSlice]
+              InjectionPoints: [{PC: "0xba708", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 565 EventRootType Probe[main.indexNilPtrSlice]Return
-              InjectionPoints: [{PC: "0xba31c", Frameless: false}]
+              Type: 574 EventRootType Probe[main.indexNilPtrSlice]Return
+              InjectionPoints: [{PC: "0xba77c", Frameless: false}]
               Condition: null
     - id: indexNilPtr_cond
       version: 0
@@ -3249,16 +3561,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 45}
+        - subprogram: {subprogram: 47}
           events:
             - Kind: Entry
-              Type: 566 EventRootType Probe[main.indexNilPtrSlice]
-              InjectionPoints: [{PC: "0xba2a8", Frameless: false}]
+              Type: 575 EventRootType Probe[main.indexNilPtrSlice]
+              InjectionPoints: [{PC: "0xba708", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 45, index: 0, name: x}
+                      Variable: {subprogram: 47, index: 0, name: x}
                       Offset: 0
                       ByteSize: 8
                     - __kind: DereferenceOp
@@ -3277,8 +3589,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 567 EventRootType Probe[main.indexNilPtrSlice]Return
-              InjectionPoints: [{PC: "0xba31c", Frameless: false}]
+              Type: 576 EventRootType Probe[main.indexNilPtrSlice]Return
+              InjectionPoints: [{PC: "0xba77c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -3300,15 +3612,15 @@ Probes:
           dsl: x.Items[0]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 45}
+        - subprogram: {subprogram: 47}
           events:
             - Kind: Entry
-              Type: 568 EventRootType Probe[main.indexNilPtrSlice]
-              InjectionPoints: [{PC: "0xba2a8", Frameless: false}]
+              Type: 577 EventRootType Probe[main.indexNilPtrSlice]
+              InjectionPoints: [{PC: "0xba708", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 569 EventRootType Probe[main.indexNilPtrSlice]Return
-              InjectionPoints: [{PC: "0xba31c", Frameless: false}]
+              Type: 578 EventRootType Probe[main.indexNilPtrSlice]Return
+              InjectionPoints: [{PC: "0xba77c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 'items[0]: {x.Items[0]}'
@@ -3334,15 +3646,15 @@ Probes:
             dsl: x.Items[0]
             json: {index: [{getmember: [{ref: x}, Items]}, 0]}
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 546 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0xb9f5c", Frameless: false}]
+              Type: 555 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0xba3bc", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 547 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0xba054", Frameless: false}]
+              Type: 556 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0xba4b4", Frameless: false}]
               Condition: null
     - id: indexStringArray_capture
       version: 0
@@ -3360,11 +3672,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 352 EventRootType Probe[main.stringArrayArg]
-              InjectionPoints: [{PC: "0xb8318", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8568", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 353 EventRootType Probe[main.stringArrayArg]Return
-              InjectionPoints: [{PC: "0xb835c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb85ac", Frameless: false}]
               Condition: null
     - id: indexStringSlice_capture
       version: 0
@@ -3382,11 +3694,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 348 EventRootType Probe[main.stringSliceArg]
-              InjectionPoints: [{PC: "0xb8298", Frameless: false}]
+              InjectionPoints: [{PC: "0xb84e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 349 EventRootType Probe[main.stringSliceArg]Return
-              InjectionPoints: [{PC: "0xb82d4", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8524", Frameless: false}]
               Condition: null
     - id: indexStructSliceField_capture
       version: 0
@@ -3402,15 +3714,15 @@ Probes:
             dsl: x.Items[2]
             json: {index: [{getmember: [{ref: x}, Items]}, 2]}
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 526 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xb9e0c", Frameless: false}]
+              Type: 535 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xba26c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 527 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xb9f20", Frameless: false}]
+              Type: 536 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xba380", Frameless: false}]
               Condition: null
     - id: inlined
       version: 0
@@ -3421,19 +3733,19 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 75}
+        - subprogram: {subprogram: 77}
           events:
             - Kind: Entry
-              Type: 658 EventRootType Probe[main.inlined]
+              Type: 667 EventRootType Probe[main.inlined]
               InjectionPoints:
                 - PC: "0xb5cb0"
                   Frameless: false
-                - PC: "0xb83a8"
+                - PC: "0xb85f8"
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 659 EventRootType Probe[main.inlined]Return
-              InjectionPoints: [{PC: "0xb83e0", Frameless: false}]
+              Type: 668 EventRootType Probe[main.inlined]Return
+              InjectionPoints: [{PC: "0xb8630", Frameless: false}]
               Condition: null
     - id: inlinedMethod
       version: 0
@@ -3443,11 +3755,11 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 78}
+        - subprogram: {subprogram: 80}
           events:
             - Kind: Entry
-              Type: 662 EventRootType Probe[main.(*methodValueReceiver).inlinedMethod]
-              InjectionPoints: [{PC: "0xbb6e4", Frameless: true}]
+              Type: 671 EventRootType Probe[main.(*methodValueReceiver).inlinedMethod]
+              InjectionPoints: [{PC: "0xbbb44", Frameless: true}]
               Condition: null
     - id: intArg
       version: 0
@@ -3461,11 +3773,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 316 EventRootType Probe[main.intArg]
-              InjectionPoints: [{PC: "0xb80a8", Frameless: false}]
+              InjectionPoints: [{PC: "0xb82f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 317 EventRootType Probe[main.intArg]Return
-              InjectionPoints: [{PC: "0xb80e0", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8330", Frameless: false}]
               Condition: null
     - id: intArrayArg
       version: 0
@@ -3479,11 +3791,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 346 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0xb8218", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8468", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 347 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0xb825c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb84ac", Frameless: false}]
               Condition: null
     - id: intArrayArgFrameless
       version: 0
@@ -3497,7 +3809,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 356 EventRootType Probe[main.stringArrayArgFrameless]
-              InjectionPoints: [{PC: "0xb8380", Frameless: true}]
+              InjectionPoints: [{PC: "0xb85d0", Frameless: true}]
               Condition: null
     - id: intSliceArg
       version: 0
@@ -3511,11 +3823,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 336 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0xb8198", Frameless: false}]
+              InjectionPoints: [{PC: "0xb83e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 337 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0xb81d4", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8424", Frameless: false}]
               Condition: null
     - id: lenErrInt_nocond
       version: 0
@@ -3526,15 +3838,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 43}
+        - subprogram: {subprogram: 45}
           events:
             - Kind: Entry
-              Type: 556 EventRootType Probe[main.lenErrInt]
-              InjectionPoints: [{PC: "0xba09c", Frameless: false}]
+              Type: 565 EventRootType Probe[main.lenErrInt]
+              InjectionPoints: [{PC: "0xba4fc", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 557 EventRootType Probe[main.lenErrInt]Return
-              InjectionPoints: [{PC: "0xba150", Frameless: false}]
+              Type: 566 EventRootType Probe[main.lenErrInt]Return
+              InjectionPoints: [{PC: "0xba5b0", Frameless: false}]
               Condition: null
     - id: lenErrStruct_nocond
       version: 0
@@ -3545,15 +3857,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 44}
+        - subprogram: {subprogram: 46}
           events:
             - Kind: Entry
-              Type: 560 EventRootType Probe[main.lenErrStruct]
-              InjectionPoints: [{PC: "0xba19c", Frameless: false}]
+              Type: 569 EventRootType Probe[main.lenErrStruct]
+              InjectionPoints: [{PC: "0xba5fc", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 561 EventRootType Probe[main.lenErrStruct]Return
-              InjectionPoints: [{PC: "0xba26c", Frameless: false}]
+              Type: 570 EventRootType Probe[main.lenErrStruct]Return
+              InjectionPoints: [{PC: "0xba6cc", Frameless: false}]
               Condition: null
     - id: lenErr_int
       version: 0
@@ -3564,15 +3876,15 @@ Probes:
       segments: [len=, {json: {len: {ref: x}}, dsl: len(x)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 43}
+        - subprogram: {subprogram: 45}
           events:
             - Kind: Entry
-              Type: 558 EventRootType Probe[main.lenErrInt]
-              InjectionPoints: [{PC: "0xba09c", Frameless: false}]
+              Type: 567 EventRootType Probe[main.lenErrInt]
+              InjectionPoints: [{PC: "0xba4fc", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 559 EventRootType Probe[main.lenErrInt]Return
-              InjectionPoints: [{PC: "0xba150", Frameless: false}]
+              Type: 568 EventRootType Probe[main.lenErrInt]Return
+              InjectionPoints: [{PC: "0xba5b0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x)}
@@ -3589,15 +3901,15 @@ Probes:
       segments: [len=, {json: {len: {ref: x}}, dsl: len(x)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 44}
+        - subprogram: {subprogram: 46}
           events:
             - Kind: Entry
-              Type: 562 EventRootType Probe[main.lenErrStruct]
-              InjectionPoints: [{PC: "0xba19c", Frameless: false}]
+              Type: 571 EventRootType Probe[main.lenErrStruct]
+              InjectionPoints: [{PC: "0xba5fc", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 563 EventRootType Probe[main.lenErrStruct]Return
-              InjectionPoints: [{PC: "0xba26c", Frameless: false}]
+              Type: 572 EventRootType Probe[main.lenErrStruct]Return
+              InjectionPoints: [{PC: "0xba6cc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x)}
@@ -3615,16 +3927,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 510 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0xb9c0c", Frameless: false}]
+              Type: 519 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0xba06c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 39, index: 0, name: m}
+                      Variable: {subprogram: 41, index: 0, name: m}
                       Offset: 0
                       ByteSize: 8
                     - __kind: DereferenceOp
@@ -3638,8 +3950,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 511 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0xb9ccc", Frameless: false}]
+              Type: 520 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0xba12c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -3661,15 +3973,15 @@ Probes:
           dsl: isEmpty(m)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 512 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0xb9c0c", Frameless: false}]
+              Type: 521 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0xba06c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 513 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0xb9ccc", Frameless: false}]
+              Type: 522 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0xba12c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: empty={isEmpty(m)}
@@ -3691,15 +4003,15 @@ Probes:
         - name: m_len
           expr: {dsl: len(m), json: {len: {ref: m}}}
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 514 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0xb9c0c", Frameless: false}]
+              Type: 523 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0xba06c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 515 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0xb9ccc", Frameless: false}]
+              Type: 524 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0xba12c", Frameless: false}]
               Condition: null
     - id: lenMap_len_eq_cond
       version: 0
@@ -3713,16 +4025,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 516 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0xb9c0c", Frameless: false}]
+              Type: 525 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0xba06c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 39, index: 0, name: m}
+                      Variable: {subprogram: 41, index: 0, name: m}
                       Offset: 0
                       ByteSize: 8
                     - __kind: DereferenceOp
@@ -3736,8 +4048,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 517 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0xb9ccc", Frameless: false}]
+              Type: 526 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0xba12c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -3756,15 +4068,15 @@ Probes:
       segments: [len=, {json: {len: {ref: m}}, dsl: len(m)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 518 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0xb9c0c", Frameless: false}]
+              Type: 527 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0xba06c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 519 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0xb9ccc", Frameless: false}]
+              Type: 528 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0xba12c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(m)}
@@ -3783,15 +4095,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 520 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0xb9c0c", Frameless: false}]
+              Type: 529 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0xba06c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 521 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0xb9ccc", Frameless: false}]
+              Type: 530 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0xba12c", Frameless: false}]
               Condition: null
     - id: lenPtrString_len_template
       version: 0
@@ -3802,15 +4114,15 @@ Probes:
       segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 40}
+        - subprogram: {subprogram: 42}
           events:
             - Kind: Entry
-              Type: 522 EventRootType Probe[main.lenPtrString]
-              InjectionPoints: [{PC: "0xb9d1c", Frameless: false}]
+              Type: 531 EventRootType Probe[main.lenPtrString]
+              InjectionPoints: [{PC: "0xba17c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 523 EventRootType Probe[main.lenPtrString]Return
-              InjectionPoints: [{PC: "0xb9dc4", Frameless: false}]
+              Type: 532 EventRootType Probe[main.lenPtrString]Return
+              InjectionPoints: [{PC: "0xba224", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(s)}
@@ -3829,15 +4141,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 40}
+        - subprogram: {subprogram: 42}
           events:
             - Kind: Entry
-              Type: 524 EventRootType Probe[main.lenPtrString]
-              InjectionPoints: [{PC: "0xb9d1c", Frameless: false}]
+              Type: 533 EventRootType Probe[main.lenPtrString]
+              InjectionPoints: [{PC: "0xba17c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 525 EventRootType Probe[main.lenPtrString]Return
-              InjectionPoints: [{PC: "0xb9dc4", Frameless: false}]
+              Type: 534 EventRootType Probe[main.lenPtrString]Return
+              InjectionPoints: [{PC: "0xba224", Frameless: false}]
               Condition: null
     - id: lenPtrStructFields_nocond
       version: 0
@@ -3848,15 +4160,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 548 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0xb9f5c", Frameless: false}]
+              Type: 557 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0xba3bc", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 549 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0xba054", Frameless: false}]
+              Type: 558 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0xba4b4", Frameless: false}]
               Condition: null
     - id: lenPtrStruct_field_map
       version: 0
@@ -3870,15 +4182,15 @@ Probes:
           dsl: len(x.Dict)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 550 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0xb9f5c", Frameless: false}]
+              Type: 559 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0xba3bc", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 551 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0xba054", Frameless: false}]
+              Type: 560 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0xba4b4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.Dict)}
@@ -3900,15 +4212,15 @@ Probes:
           dsl: len(x.Items)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 552 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0xb9f5c", Frameless: false}]
+              Type: 561 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0xba3bc", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 553 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0xba054", Frameless: false}]
+              Type: 562 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0xba4b4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.Items)}
@@ -3930,15 +4242,15 @@ Probes:
           dsl: len(x.S)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 554 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0xb9f5c", Frameless: false}]
+              Type: 563 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0xba3bc", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 555 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0xba054", Frameless: false}]
+              Type: 564 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0xba4b4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.S)}
@@ -3958,16 +4270,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 498 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0xb9afc", Frameless: false}]
+              Type: 507 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0xb9f5c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 38, index: 0, name: s}
+                      Variable: {subprogram: 40, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -3978,8 +4290,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 499 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0xb9bbc", Frameless: false}]
+              Type: 508 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0xba01c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4001,15 +4313,15 @@ Probes:
           dsl: isEmpty(s)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 500 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0xb9afc", Frameless: false}]
+              Type: 509 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0xb9f5c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 501 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0xb9bbc", Frameless: false}]
+              Type: 510 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0xba01c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: empty={isEmpty(s)}
@@ -4031,15 +4343,15 @@ Probes:
         - name: s_len
           expr: {dsl: len(s), json: {len: {ref: s}}}
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 502 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0xb9afc", Frameless: false}]
+              Type: 511 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0xb9f5c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 503 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0xb9bbc", Frameless: false}]
+              Type: 512 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0xba01c", Frameless: false}]
               Condition: null
     - id: lenSlice_len_eq_cond
       version: 0
@@ -4053,16 +4365,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 504 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0xb9afc", Frameless: false}]
+              Type: 513 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0xb9f5c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 38, index: 0, name: s}
+                      Variable: {subprogram: 40, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4073,8 +4385,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 505 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0xb9bbc", Frameless: false}]
+              Type: 514 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0xba01c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4093,15 +4405,15 @@ Probes:
       segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 506 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0xb9afc", Frameless: false}]
+              Type: 515 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0xb9f5c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 507 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0xb9bbc", Frameless: false}]
+              Type: 516 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0xba01c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(s)}
@@ -4120,15 +4432,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 508 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0xb9afc", Frameless: false}]
+              Type: 517 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0xb9f5c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 509 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0xb9bbc", Frameless: false}]
+              Type: 518 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0xba01c", Frameless: false}]
               Condition: null
     - id: lenString_eq_capture
       version: 0
@@ -4144,15 +4456,15 @@ Probes:
             dsl: len(s) == 5
             json: {eq: [{len: {ref: s}}, 5]}
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 480 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xb99fc", Frameless: false}]
+              Type: 489 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xb9e5c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 481 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xb9ab0", Frameless: false}]
+              Type: 490 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xb9f10", Frameless: false}]
               Condition: null
     - id: lenString_eq_template
       version: 0
@@ -4166,15 +4478,15 @@ Probes:
           dsl: len(s) == 5
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 482 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xb99fc", Frameless: false}]
+              Type: 491 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xb9e5c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 483 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xb9ab0", Frameless: false}]
+              Type: 492 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xb9f10", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: eq={len(s) == 5}
@@ -4196,15 +4508,15 @@ Probes:
         - name: s_isEmpty
           expr: {dsl: isEmpty(s), json: {isEmpty: {ref: s}}}
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 484 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xb99fc", Frameless: false}]
+              Type: 493 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xb9e5c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 485 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xb9ab0", Frameless: false}]
+              Type: 494 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xb9f10", Frameless: false}]
               Condition: null
     - id: lenString_isEmpty_cond
       version: 0
@@ -4216,16 +4528,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 486 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xb99fc", Frameless: false}]
+              Type: 495 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xb9e5c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 37, index: 0, name: s}
+                      Variable: {subprogram: 39, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4236,8 +4548,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 487 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xb9ab0", Frameless: false}]
+              Type: 496 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xb9f10", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4259,15 +4571,15 @@ Probes:
           dsl: isEmpty(s)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 488 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xb99fc", Frameless: false}]
+              Type: 497 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xb9e5c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 489 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xb9ab0", Frameless: false}]
+              Type: 498 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xb9f10", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: empty={isEmpty(s)}
@@ -4289,15 +4601,15 @@ Probes:
         - name: s_len
           expr: {dsl: len(s), json: {len: {ref: s}}}
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 490 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xb99fc", Frameless: false}]
+              Type: 499 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xb9e5c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 491 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xb9ab0", Frameless: false}]
+              Type: 500 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xb9f10", Frameless: false}]
               Condition: null
     - id: lenString_len_eq_cond
       version: 0
@@ -4311,16 +4623,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 492 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xb99fc", Frameless: false}]
+              Type: 501 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xb9e5c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 37, index: 0, name: s}
+                      Variable: {subprogram: 39, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4331,8 +4643,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 493 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xb9ab0", Frameless: false}]
+              Type: 502 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xb9f10", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4351,15 +4663,15 @@ Probes:
       segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 494 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xb99fc", Frameless: false}]
+              Type: 503 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xb9e5c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 495 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xb9ab0", Frameless: false}]
+              Type: 504 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xb9f10", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(s)}
@@ -4378,15 +4690,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 496 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xb99fc", Frameless: false}]
+              Type: 505 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xb9e5c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 497 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xb9ab0", Frameless: false}]
+              Type: 506 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xb9f10", Frameless: false}]
               Condition: null
     - id: lenStructFields_nocond
       version: 0
@@ -4397,15 +4709,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 528 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xb9e0c", Frameless: false}]
+              Type: 537 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xba26c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 529 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xb9f20", Frameless: false}]
+              Type: 538 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xba380", Frameless: false}]
               Condition: null
     - id: lenStruct_field_map
       version: 0
@@ -4419,15 +4731,15 @@ Probes:
           dsl: len(x.Dict)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 530 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xb9e0c", Frameless: false}]
+              Type: 539 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xba26c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 531 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xb9f20", Frameless: false}]
+              Type: 540 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xba380", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.Dict)}
@@ -4449,15 +4761,15 @@ Probes:
           dsl: len(x.PtrSlice)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 532 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xb9e0c", Frameless: false}]
+              Type: 541 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xba26c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 533 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xb9f20", Frameless: false}]
+              Type: 542 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xba380", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.PtrSlice)}
@@ -4479,15 +4791,15 @@ Probes:
           dsl: len(x.PtrStr)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 534 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xb9e0c", Frameless: false}]
+              Type: 543 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xba26c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 535 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xb9f20", Frameless: false}]
+              Type: 544 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xba380", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.PtrStr)}
@@ -4509,15 +4821,15 @@ Probes:
           dsl: len(x.Items)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 536 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xb9e0c", Frameless: false}]
+              Type: 545 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xba26c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 537 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xb9f20", Frameless: false}]
+              Type: 546 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xba380", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.Items)}
@@ -4539,15 +4851,15 @@ Probes:
           dsl: len(x.S)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 538 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xb9e0c", Frameless: false}]
+              Type: 547 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xba26c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 539 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xb9f20", Frameless: false}]
+              Type: 548 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xba380", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.S)}
@@ -4569,16 +4881,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 540 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xb9e0c", Frameless: false}]
+              Type: 549 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xba26c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 41, index: 0, name: x}
+                      Variable: {subprogram: 43, index: 0, name: x}
                       Offset: 40
                       ByteSize: 8
                     - __kind: DereferenceOp
@@ -4592,8 +4904,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 541 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xb9f20", Frameless: false}]
+              Type: 550 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xba380", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4615,16 +4927,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 542 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xb9e0c", Frameless: false}]
+              Type: 551 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xba26c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 41, index: 0, name: x}
+                      Variable: {subprogram: 43, index: 0, name: x}
                       Offset: 24
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4635,8 +4947,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 543 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xb9f20", Frameless: false}]
+              Type: 552 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xba380", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4658,16 +4970,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 544 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xb9e0c", Frameless: false}]
+              Type: 553 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xba26c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 41, index: 0, name: x}
+                      Variable: {subprogram: 43, index: 0, name: x}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4678,8 +4990,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 545 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xb9f20", Frameless: false}]
+              Type: 554 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xba380", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4701,11 +5013,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 318 EventRootType Probe[main.stringArg]
-              InjectionPoints: [{PC: "0xb8118", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8368", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 319 EventRootType Probe[main.stringArg]Return
-              InjectionPoints: [{PC: "0xb8154", Frameless: false}]
+              InjectionPoints: [{PC: "0xb83a4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's: {s}'
@@ -4727,11 +5039,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 320 EventRootType Probe[main.stringArg]
-              InjectionPoints: [{PC: "0xb8118", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8368", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 321 EventRootType Probe[main.stringArg]Return
-              InjectionPoints: [{PC: "0xb8154", Frameless: false}]
+              InjectionPoints: [{PC: "0xb83a4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 'x: {x}'
@@ -4751,11 +5063,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 357 EventRootType Probe[main.mapArg]
-              InjectionPoints: [{PC: "0xb8468", Frameless: false}]
+              InjectionPoints: [{PC: "0xb86b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 358 EventRootType Probe[main.mapArg]Return
-              InjectionPoints: [{PC: "0xb8498", Frameless: false}]
+              InjectionPoints: [{PC: "0xb86e8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 'm: {m}'
@@ -4780,15 +5092,15 @@ Probes:
         - name: false_val
           expr: {dsl: 'm[false]', json: {index: [{ref: m}, false]}}
       instances:
-        - subprogram: {subprogram: 68}
+        - subprogram: {subprogram: 70}
           events:
             - Kind: Entry
-              Type: 642 EventRootType Probe[main.mapIndexBoolKey]
-              InjectionPoints: [{PC: "0xbb2a8", Frameless: false}]
+              Type: 651 EventRootType Probe[main.mapIndexBoolKey]
+              InjectionPoints: [{PC: "0xbb708", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 643 EventRootType Probe[main.mapIndexBoolKey]Return
-              InjectionPoints: [{PC: "0xbb2d8", Frameless: false}]
+              Type: 652 EventRootType Probe[main.mapIndexBoolKey]Return
+              InjectionPoints: [{PC: "0xbb738", Frameless: false}]
               Condition: null
     - id: mapIndex_boolKey_true
       version: 0
@@ -4805,15 +5117,15 @@ Probes:
         - name: true_val
           expr: {dsl: 'm[true]', json: {index: [{ref: m}, true]}}
       instances:
-        - subprogram: {subprogram: 68}
+        - subprogram: {subprogram: 70}
           events:
             - Kind: Entry
-              Type: 644 EventRootType Probe[main.mapIndexBoolKey]
-              InjectionPoints: [{PC: "0xbb2a8", Frameless: false}]
+              Type: 653 EventRootType Probe[main.mapIndexBoolKey]
+              InjectionPoints: [{PC: "0xbb708", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 645 EventRootType Probe[main.mapIndexBoolKey]Return
-              InjectionPoints: [{PC: "0xbb2d8", Frameless: false}]
+              Type: 654 EventRootType Probe[main.mapIndexBoolKey]Return
+              InjectionPoints: [{PC: "0xbb738", Frameless: false}]
               Condition: null
     - id: mapIndex_emptyKey_capture
       version: 0
@@ -4830,15 +5142,15 @@ Probes:
         - name: empty_val
           expr: {dsl: 'm[""]', json: {index: [{ref: m}, ""]}}
       instances:
-        - subprogram: {subprogram: 65}
+        - subprogram: {subprogram: 67}
           events:
             - Kind: Entry
-              Type: 636 EventRootType Probe[main.mapIndexEmptyKey]
-              InjectionPoints: [{PC: "0xbb0f8", Frameless: false}]
+              Type: 645 EventRootType Probe[main.mapIndexEmptyKey]
+              InjectionPoints: [{PC: "0xbb558", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 637 EventRootType Probe[main.mapIndexEmptyKey]Return
-              InjectionPoints: [{PC: "0xbb14c", Frameless: false}]
+              Type: 646 EventRootType Probe[main.mapIndexEmptyKey]Return
+              InjectionPoints: [{PC: "0xbb5ac", Frameless: false}]
               Condition: null
     - id: mapIndex_intKey_capture
       version: 0
@@ -4855,15 +5167,15 @@ Probes:
         - name: m_2
           expr: {dsl: 'm[2]', json: {index: [{ref: m}, 2]}}
       instances:
-        - subprogram: {subprogram: 54}
+        - subprogram: {subprogram: 56}
           events:
             - Kind: Entry
-              Type: 606 EventRootType Probe[main.mapIndexIntKey]
-              InjectionPoints: [{PC: "0xbaa18", Frameless: false}]
+              Type: 615 EventRootType Probe[main.mapIndexIntKey]
+              InjectionPoints: [{PC: "0xbae78", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 607 EventRootType Probe[main.mapIndexIntKey]Return
-              InjectionPoints: [{PC: "0xbaa48", Frameless: false}]
+              Type: 616 EventRootType Probe[main.mapIndexIntKey]Return
+              InjectionPoints: [{PC: "0xbaea8", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen16
       version: 0
@@ -4882,15 +5194,15 @@ Probes:
             dsl: m["000000000000002a"]
             json: {index: [{ref: m}, 000000000000002a]}
       instances:
-        - subprogram: {subprogram: 66}
+        - subprogram: {subprogram: 68}
           events:
             - Kind: Entry
-              Type: 638 EventRootType Probe[main.mapIndexKeyLen16]
-              InjectionPoints: [{PC: "0xbb188", Frameless: false}]
+              Type: 647 EventRootType Probe[main.mapIndexKeyLen16]
+              InjectionPoints: [{PC: "0xbb5e8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 639 EventRootType Probe[main.mapIndexKeyLen16]Return
-              InjectionPoints: [{PC: "0xbb1d4", Frameless: false}]
+              Type: 648 EventRootType Probe[main.mapIndexKeyLen16]Return
+              InjectionPoints: [{PC: "0xbb634", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen17
       version: 0
@@ -4909,15 +5221,15 @@ Probes:
             dsl: m["0000000000000002a"]
             json: {index: [{ref: m}, 0000000000000002a]}
       instances:
-        - subprogram: {subprogram: 67}
+        - subprogram: {subprogram: 69}
           events:
             - Kind: Entry
-              Type: 640 EventRootType Probe[main.mapIndexKeyLen17]
-              InjectionPoints: [{PC: "0xbb218", Frameless: false}]
+              Type: 649 EventRootType Probe[main.mapIndexKeyLen17]
+              InjectionPoints: [{PC: "0xbb678", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 641 EventRootType Probe[main.mapIndexKeyLen17]Return
-              InjectionPoints: [{PC: "0xbb264", Frameless: false}]
+              Type: 650 EventRootType Probe[main.mapIndexKeyLen17]Return
+              InjectionPoints: [{PC: "0xbb6c4", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen200
       version: 0
@@ -4939,15 +5251,15 @@ Probes:
                     - ref: m
                     - 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002a
       instances:
-        - subprogram: {subprogram: 62}
+        - subprogram: {subprogram: 64}
           events:
             - Kind: Entry
-              Type: 626 EventRootType Probe[main.mapIndexKeyLen200]
-              InjectionPoints: [{PC: "0xbaf38", Frameless: false}]
+              Type: 635 EventRootType Probe[main.mapIndexKeyLen200]
+              InjectionPoints: [{PC: "0xbb398", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 627 EventRootType Probe[main.mapIndexKeyLen200]Return
-              InjectionPoints: [{PC: "0xbaf84", Frameless: false}]
+              Type: 636 EventRootType Probe[main.mapIndexKeyLen200]Return
+              InjectionPoints: [{PC: "0xbb3e4", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen24
       version: 0
@@ -4966,15 +5278,15 @@ Probes:
             dsl: m["00000000000000000000002a"]
             json: {index: [{ref: m}, 00000000000000000000002a]}
       instances:
-        - subprogram: {subprogram: 59}
+        - subprogram: {subprogram: 61}
           events:
             - Kind: Entry
-              Type: 620 EventRootType Probe[main.mapIndexKeyLen24]
-              InjectionPoints: [{PC: "0xbad88", Frameless: false}]
+              Type: 629 EventRootType Probe[main.mapIndexKeyLen24]
+              InjectionPoints: [{PC: "0xbb1e8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 621 EventRootType Probe[main.mapIndexKeyLen24]Return
-              InjectionPoints: [{PC: "0xbadd4", Frameless: false}]
+              Type: 630 EventRootType Probe[main.mapIndexKeyLen24]Return
+              InjectionPoints: [{PC: "0xbb234", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen48
       version: 0
@@ -4996,15 +5308,15 @@ Probes:
                     - ref: m
                     - 00000000000000000000000000000000000000000000002a
       instances:
-        - subprogram: {subprogram: 60}
+        - subprogram: {subprogram: 62}
           events:
             - Kind: Entry
-              Type: 622 EventRootType Probe[main.mapIndexKeyLen48]
-              InjectionPoints: [{PC: "0xbae18", Frameless: false}]
+              Type: 631 EventRootType Probe[main.mapIndexKeyLen48]
+              InjectionPoints: [{PC: "0xbb278", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 623 EventRootType Probe[main.mapIndexKeyLen48]Return
-              InjectionPoints: [{PC: "0xbae64", Frameless: false}]
+              Type: 632 EventRootType Probe[main.mapIndexKeyLen48]Return
+              InjectionPoints: [{PC: "0xbb2c4", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen8
       version: 0
@@ -5023,15 +5335,15 @@ Probes:
             dsl: m["0000002a"]
             json: {index: [{ref: m}, 0000002a]}
       instances:
-        - subprogram: {subprogram: 58}
+        - subprogram: {subprogram: 60}
           events:
             - Kind: Entry
-              Type: 618 EventRootType Probe[main.mapIndexKeyLen8]
-              InjectionPoints: [{PC: "0xbacf8", Frameless: false}]
+              Type: 627 EventRootType Probe[main.mapIndexKeyLen8]
+              InjectionPoints: [{PC: "0xbb158", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 619 EventRootType Probe[main.mapIndexKeyLen8]Return
-              InjectionPoints: [{PC: "0xbad44", Frameless: false}]
+              Type: 628 EventRootType Probe[main.mapIndexKeyLen8]Return
+              InjectionPoints: [{PC: "0xbb1a4", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen96
       version: 0
@@ -5053,15 +5365,15 @@ Probes:
                     - ref: m
                     - 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002a
       instances:
-        - subprogram: {subprogram: 61}
+        - subprogram: {subprogram: 63}
           events:
             - Kind: Entry
-              Type: 624 EventRootType Probe[main.mapIndexKeyLen96]
-              InjectionPoints: [{PC: "0xbaea8", Frameless: false}]
+              Type: 633 EventRootType Probe[main.mapIndexKeyLen96]
+              InjectionPoints: [{PC: "0xbb308", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 625 EventRootType Probe[main.mapIndexKeyLen96]Return
-              InjectionPoints: [{PC: "0xbaef4", Frameless: false}]
+              Type: 634 EventRootType Probe[main.mapIndexKeyLen96]Return
+              InjectionPoints: [{PC: "0xbb354", Frameless: false}]
               Condition: null
     - id: mapIndex_largeMap_capture
       version: 0
@@ -5080,15 +5392,15 @@ Probes:
             dsl: m["key42"]
             json: {index: [{ref: m}, key42]}
       instances:
-        - subprogram: {subprogram: 56}
+        - subprogram: {subprogram: 58}
           events:
             - Kind: Entry
-              Type: 614 EventRootType Probe[main.mapIndexLargeMap]
-              InjectionPoints: [{PC: "0xbaaf8", Frameless: false}]
+              Type: 623 EventRootType Probe[main.mapIndexLargeMap]
+              InjectionPoints: [{PC: "0xbaf58", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 615 EventRootType Probe[main.mapIndexLargeMap]Return
-              InjectionPoints: [{PC: "0xbab44", Frameless: false}]
+              Type: 624 EventRootType Probe[main.mapIndexLargeMap]Return
+              InjectionPoints: [{PC: "0xbafa4", Frameless: false}]
               Condition: null
     - id: mapIndex_largeValue_capture
       version: 0
@@ -5107,15 +5419,15 @@ Probes:
             dsl: m["k"].Val
             json: {getmember: [{index: [{ref: m}, k]}, Val]}
       instances:
-        - subprogram: {subprogram: 71}
+        - subprogram: {subprogram: 73}
           events:
             - Kind: Entry
-              Type: 650 EventRootType Probe[main.mapIndexLargeValue]
-              InjectionPoints: [{PC: "0xbb3f8", Frameless: false}]
+              Type: 659 EventRootType Probe[main.mapIndexLargeValue]
+              InjectionPoints: [{PC: "0xbb858", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 651 EventRootType Probe[main.mapIndexLargeValue]Return
-              InjectionPoints: [{PC: "0xbb44c", Frameless: false}]
+              Type: 660 EventRootType Probe[main.mapIndexLargeValue]Return
+              InjectionPoints: [{PC: "0xbb8ac", Frameless: false}]
               Condition: null
     - id: mapIndex_missing_capture
       version: 0
@@ -5134,15 +5446,15 @@ Probes:
             dsl: m["missing"]
             json: {index: [{ref: m}, missing]}
       instances:
-        - subprogram: {subprogram: 57}
+        - subprogram: {subprogram: 59}
           events:
             - Kind: Entry
-              Type: 616 EventRootType Probe[main.mapIndexMissing]
-              InjectionPoints: [{PC: "0xbab88", Frameless: false}]
+              Type: 625 EventRootType Probe[main.mapIndexMissing]
+              InjectionPoints: [{PC: "0xbafe8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 617 EventRootType Probe[main.mapIndexMissing]Return
-              InjectionPoints: [{PC: "0xbabb8", Frameless: false}]
+              Type: 626 EventRootType Probe[main.mapIndexMissing]Return
+              InjectionPoints: [{PC: "0xbb018", Frameless: false}]
               Condition: null
     - id: mapIndex_nilPtrVal_capture
       version: 0
@@ -5161,15 +5473,15 @@ Probes:
             dsl: m["nil_key"].Val
             json: {getmember: [{index: [{ref: m}, nil_key]}, Val]}
       instances:
-        - subprogram: {subprogram: 70}
+        - subprogram: {subprogram: 72}
           events:
             - Kind: Entry
-              Type: 648 EventRootType Probe[main.mapIndexNilPtrVal]
-              InjectionPoints: [{PC: "0xbb388", Frameless: false}]
+              Type: 657 EventRootType Probe[main.mapIndexNilPtrVal]
+              InjectionPoints: [{PC: "0xbb7e8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 649 EventRootType Probe[main.mapIndexNilPtrVal]Return
-              InjectionPoints: [{PC: "0xbb3b8", Frameless: false}]
+              Type: 658 EventRootType Probe[main.mapIndexNilPtrVal]Return
+              InjectionPoints: [{PC: "0xbb818", Frameless: false}]
               Condition: null
     - id: mapIndex_ptrStructVal_capture_int
       version: 0
@@ -5188,15 +5500,15 @@ Probes:
             dsl: m["x"].Val
             json: {getmember: [{index: [{ref: m}, x]}, Val]}
       instances:
-        - subprogram: {subprogram: 64}
+        - subprogram: {subprogram: 66}
           events:
             - Kind: Entry
-              Type: 632 EventRootType Probe[main.mapIndexPtrStructVal]
-              InjectionPoints: [{PC: "0xbb058", Frameless: false}]
+              Type: 641 EventRootType Probe[main.mapIndexPtrStructVal]
+              InjectionPoints: [{PC: "0xbb4b8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 633 EventRootType Probe[main.mapIndexPtrStructVal]Return
-              InjectionPoints: [{PC: "0xbb0b4", Frameless: false}]
+              Type: 642 EventRootType Probe[main.mapIndexPtrStructVal]Return
+              InjectionPoints: [{PC: "0xbb514", Frameless: false}]
               Condition: null
     - id: mapIndex_ptrStructVal_capture_string
       version: 0
@@ -5215,15 +5527,15 @@ Probes:
             dsl: m["y"].Txt
             json: {getmember: [{index: [{ref: m}, "y"]}, Txt]}
       instances:
-        - subprogram: {subprogram: 64}
+        - subprogram: {subprogram: 66}
           events:
             - Kind: Entry
-              Type: 634 EventRootType Probe[main.mapIndexPtrStructVal]
-              InjectionPoints: [{PC: "0xbb058", Frameless: false}]
+              Type: 643 EventRootType Probe[main.mapIndexPtrStructVal]
+              InjectionPoints: [{PC: "0xbb4b8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 635 EventRootType Probe[main.mapIndexPtrStructVal]Return
-              InjectionPoints: [{PC: "0xbb0b4", Frameless: false}]
+              Type: 644 EventRootType Probe[main.mapIndexPtrStructVal]Return
+              InjectionPoints: [{PC: "0xbb514", Frameless: false}]
               Condition: null
     - id: mapIndex_stringKey_capture
       version: 0
@@ -5242,15 +5554,15 @@ Probes:
             dsl: m["beta"]
             json: {index: [{ref: m}, beta]}
       instances:
-        - subprogram: {subprogram: 55}
+        - subprogram: {subprogram: 57}
           events:
             - Kind: Entry
-              Type: 608 EventRootType Probe[main.mapIndexStringKey]
-              InjectionPoints: [{PC: "0xbaa88", Frameless: false}]
+              Type: 617 EventRootType Probe[main.mapIndexStringKey]
+              InjectionPoints: [{PC: "0xbaee8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 609 EventRootType Probe[main.mapIndexStringKey]Return
-              InjectionPoints: [{PC: "0xbaab8", Frameless: false}]
+              Type: 618 EventRootType Probe[main.mapIndexStringKey]Return
+              InjectionPoints: [{PC: "0xbaf18", Frameless: false}]
               Condition: null
     - id: mapIndex_stringKey_cond
       version: 0
@@ -5267,16 +5579,16 @@ Probes:
       segments: [matched]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 55}
+        - subprogram: {subprogram: 57}
           events:
             - Kind: Entry
-              Type: 610 EventRootType Probe[main.mapIndexStringKey]
-              InjectionPoints: [{PC: "0xbaa88", Frameless: false}]
+              Type: 619 EventRootType Probe[main.mapIndexStringKey]
+              InjectionPoints: [{PC: "0xbaee8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 55, index: 0, name: m}
+                      Variable: {subprogram: 57, index: 0, name: m}
                       Offset: 0
                       ByteSize: 8
                     - __kind: DereferenceOp
@@ -5309,8 +5621,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 611 EventRootType Probe[main.mapIndexStringKey]Return
-              InjectionPoints: [{PC: "0xbaab8", Frameless: false}]
+              Type: 620 EventRootType Probe[main.mapIndexStringKey]Return
+              InjectionPoints: [{PC: "0xbaf18", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: matched, Segments: [matched]}
     - id: mapIndex_stringKey_template
@@ -5328,15 +5640,15 @@ Probes:
           dsl: m["beta"]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 55}
+        - subprogram: {subprogram: 57}
           events:
             - Kind: Entry
-              Type: 612 EventRootType Probe[main.mapIndexStringKey]
-              InjectionPoints: [{PC: "0xbaa88", Frameless: false}]
+              Type: 621 EventRootType Probe[main.mapIndexStringKey]
+              InjectionPoints: [{PC: "0xbaee8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 613 EventRootType Probe[main.mapIndexStringKey]Return
-              InjectionPoints: [{PC: "0xbaab8", Frameless: false}]
+              Type: 622 EventRootType Probe[main.mapIndexStringKey]Return
+              InjectionPoints: [{PC: "0xbaf18", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: beta={m["beta"]}
@@ -5363,15 +5675,15 @@ Probes:
             dsl: m["a"].Val
             json: {getmember: [{index: [{ref: m}, a]}, Val]}
       instances:
-        - subprogram: {subprogram: 63}
+        - subprogram: {subprogram: 65}
           events:
             - Kind: Entry
-              Type: 628 EventRootType Probe[main.mapIndexStructVal]
-              InjectionPoints: [{PC: "0xbafc8", Frameless: false}]
+              Type: 637 EventRootType Probe[main.mapIndexStructVal]
+              InjectionPoints: [{PC: "0xbb428", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 629 EventRootType Probe[main.mapIndexStructVal]Return
-              InjectionPoints: [{PC: "0xbb020", Frameless: false}]
+              Type: 638 EventRootType Probe[main.mapIndexStructVal]Return
+              InjectionPoints: [{PC: "0xbb480", Frameless: false}]
               Condition: null
     - id: mapIndex_structVal_capture_string
       version: 0
@@ -5390,15 +5702,15 @@ Probes:
             dsl: m["b"].Txt
             json: {getmember: [{index: [{ref: m}, b]}, Txt]}
       instances:
-        - subprogram: {subprogram: 63}
+        - subprogram: {subprogram: 65}
           events:
             - Kind: Entry
-              Type: 630 EventRootType Probe[main.mapIndexStructVal]
-              InjectionPoints: [{PC: "0xbafc8", Frameless: false}]
+              Type: 639 EventRootType Probe[main.mapIndexStructVal]
+              InjectionPoints: [{PC: "0xbb428", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 631 EventRootType Probe[main.mapIndexStructVal]Return
-              InjectionPoints: [{PC: "0xbb020", Frameless: false}]
+              Type: 640 EventRootType Probe[main.mapIndexStructVal]Return
+              InjectionPoints: [{PC: "0xbb480", Frameless: false}]
               Condition: null
     - id: mapIndex_zeroValue_capture
       version: 0
@@ -5417,15 +5729,15 @@ Probes:
             dsl: m["zero"]
             json: {index: [{ref: m}, zero]}
       instances:
-        - subprogram: {subprogram: 69}
+        - subprogram: {subprogram: 71}
           events:
             - Kind: Entry
-              Type: 646 EventRootType Probe[main.mapIndexZeroValue]
-              InjectionPoints: [{PC: "0xbb318", Frameless: false}]
+              Type: 655 EventRootType Probe[main.mapIndexZeroValue]
+              InjectionPoints: [{PC: "0xbb778", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 647 EventRootType Probe[main.mapIndexZeroValue]Return
-              InjectionPoints: [{PC: "0xbb348", Frameless: false}]
+              Type: 656 EventRootType Probe[main.mapIndexZeroValue]Return
+              InjectionPoints: [{PC: "0xbb7a8", Frameless: false}]
               Condition: null
     - id: noArgs
       version: 0
@@ -5439,11 +5751,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 361 EventRootType Probe[main.noArgs]
-              InjectionPoints: [{PC: "0xb8598", Frameless: false}]
+              InjectionPoints: [{PC: "0xb87e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 362 EventRootType Probe[main.noArgs]Return
-              InjectionPoints: [{PC: "0xb85d0", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8820", Frameless: false}]
               Condition: null
     - id: stringArg
       version: 0
@@ -5457,11 +5769,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 322 EventRootType Probe[main.stringArg]
-              InjectionPoints: [{PC: "0xb8118", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8368", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 323 EventRootType Probe[main.stringArg]Return
-              InjectionPoints: [{PC: "0xb8154", Frameless: false}]
+              InjectionPoints: [{PC: "0xb83a4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's: {s}'
@@ -5483,11 +5795,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 354 EventRootType Probe[main.stringArrayArg]
-              InjectionPoints: [{PC: "0xb8318", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8568", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 355 EventRootType Probe[main.stringArrayArg]Return
-              InjectionPoints: [{PC: "0xb835c", Frameless: false}]
+              InjectionPoints: [{PC: "0xb85ac", Frameless: false}]
               Condition: null
     - id: stringSliceArg
       version: 0
@@ -5501,11 +5813,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 350 EventRootType Probe[main.stringSliceArg]
-              InjectionPoints: [{PC: "0xb8298", Frameless: false}]
+              InjectionPoints: [{PC: "0xb84e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 351 EventRootType Probe[main.stringSliceArg]Return
-              InjectionPoints: [{PC: "0xb82d4", Frameless: false}]
+              InjectionPoints: [{PC: "0xb8524", Frameless: false}]
               Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
       version: 0
@@ -5516,39 +5828,39 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 46}
+        - subprogram: {subprogram: 48}
           events:
             - Kind: Entry
-              Type: 570 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
-              InjectionPoints: [{PC: "0xba370", Frameless: false}]
+              Type: 579 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+              InjectionPoints: [{PC: "0xba7d0", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 571 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
-              InjectionPoints: [{PC: "0xba4f0", Frameless: false}]
+              Type: 580 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+              InjectionPoints: [{PC: "0xba950", Frameless: false}]
               Condition: null
 Subprograms:
     - ID: 1
       Name: main.intArg
-      OutOfLinePCRanges: [0xb8090..0xb8100]
+      OutOfLinePCRanges: [0xb82e0..0xb8350]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xb8090..0xb80b0
+            - Range: 0xb82e0..0xb8300
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 2
       Name: main.stringArg
-      OutOfLinePCRanges: [0xb8100..0xb8180]
+      OutOfLinePCRanges: [0xb8350..0xb83d0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb8100..0xb8124
+            - Range: 0xb8350..0xb8374
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -5559,13 +5871,13 @@ Subprograms:
       DictRegister: null
     - ID: 3
       Name: main.intSliceArg
-      OutOfLinePCRanges: [0xb8180..0xb8200]
+      OutOfLinePCRanges: [0xb83d0..0xb8450]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 105 GoSliceHeaderType []int
           Locations:
-            - Range: 0xb8180..0xb81a4
+            - Range: 0xb83d0..0xb83f4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -5578,26 +5890,26 @@ Subprograms:
       DictRegister: null
     - ID: 4
       Name: main.intArrayArg
-      OutOfLinePCRanges: [0xb8200..0xb8280]
+      OutOfLinePCRanges: [0xb8450..0xb84d0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 106 ArrayType [3]int
           Locations:
-            - Range: 0xb8200..0xb8280
+            - Range: 0xb8450..0xb84d0
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 5
       Name: main.stringSliceArg
-      OutOfLinePCRanges: [0xb8280..0xb8300]
+      OutOfLinePCRanges: [0xb84d0..0xb8550]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 107 GoSliceHeaderType []string
           Locations:
-            - Range: 0xb8280..0xb82a4
+            - Range: 0xb84d0..0xb84f4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -5610,86 +5922,86 @@ Subprograms:
       DictRegister: null
     - ID: 6
       Name: main.stringArrayArg
-      OutOfLinePCRanges: [0xb8300..0xb8380]
+      OutOfLinePCRanges: [0xb8550..0xb85d0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 108 ArrayType [3]string
           Locations:
-            - Range: 0xb8300..0xb8380
+            - Range: 0xb8550..0xb85d0
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 7
       Name: main.stringArrayArgFrameless
-      OutOfLinePCRanges: [0xb8380..0xb8390]
+      OutOfLinePCRanges: [0xb85d0..0xb85e0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 108 ArrayType [3]string
           Locations:
-            - Range: 0xb8380..0xb8390
+            - Range: 0xb85d0..0xb85e0
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 8
       Name: main.mapArg
-      OutOfLinePCRanges: [0xb8450..0xb84c0]
+      OutOfLinePCRanges: [0xb86a0..0xb8710]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 109 GoMapType map[string]int
           Locations:
-            - Range: 0xb8450..0xb8488
+            - Range: 0xb86a0..0xb86d8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 9
       Name: main.bigMapArg
-      OutOfLinePCRanges: [0xb84c0..0xb8580]
+      OutOfLinePCRanges: [0xb8710..0xb87d0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 114 GoMapType map[string]main.bigStruct
           Locations:
-            - Range: 0xb84c0..0xb84f8
+            - Range: 0xb8710..0xb8748
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb84f8..0xb8580
+            - Range: 0xb8748..0xb87d0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 10
       Name: main.noArgs
-      OutOfLinePCRanges: [0xb8580..0xb85f0]
+      OutOfLinePCRanges: [0xb87d0..0xb8840]
       InlinePCRanges: []
       Variables: []
       DictRegister: null
     - ID: 11
       Name: main.condInt8
-      OutOfLinePCRanges: [0xb85f0..0xb86a0]
+      OutOfLinePCRanges: [0xb8840..0xb88f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 BaseType int8
           Locations:
-            - Range: 0xb85f0..0xb8638
+            - Range: 0xb8840..0xb8888
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb85f0..0xb863c
+            - Range: 0xb8840..0xb888c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb863c..0xb8640
+            - Range: 0xb888c..0xb8890
               Pieces:
                 - Size: 8
                   Op: null
@@ -5700,26 +6012,26 @@ Subprograms:
       DictRegister: null
     - ID: 12
       Name: main.condInt16
-      OutOfLinePCRanges: [0xb86a0..0xb8740]
+      OutOfLinePCRanges: [0xb88f0..0xb8990]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 94 BaseType int16
           Locations:
-            - Range: 0xb86a0..0xb86cc
+            - Range: 0xb88f0..0xb891c
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb86a0..0xb86cc
+            - Range: 0xb88f0..0xb891c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb86cc..0xb8740
+            - Range: 0xb891c..0xb8990
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -5730,26 +6042,26 @@ Subprograms:
       DictRegister: null
     - ID: 13
       Name: main.condInt32
-      OutOfLinePCRanges: [0xb8740..0xb87e0]
+      OutOfLinePCRanges: [0xb8990..0xb8a30]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType int32
           Locations:
-            - Range: 0xb8740..0xb876c
+            - Range: 0xb8990..0xb89bc
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb8740..0xb876c
+            - Range: 0xb8990..0xb89bc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb876c..0xb87e0
+            - Range: 0xb89bc..0xb8a30
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -5760,26 +6072,26 @@ Subprograms:
       DictRegister: null
     - ID: 14
       Name: main.condInt64
-      OutOfLinePCRanges: [0xb87e0..0xb8880]
+      OutOfLinePCRanges: [0xb8a30..0xb8ad0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType int64
           Locations:
-            - Range: 0xb87e0..0xb880c
+            - Range: 0xb8a30..0xb8a5c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb87e0..0xb880c
+            - Range: 0xb8a30..0xb8a5c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb880c..0xb8880
+            - Range: 0xb8a5c..0xb8ad0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -5790,26 +6102,26 @@ Subprograms:
       DictRegister: null
     - ID: 15
       Name: main.condUint8
-      OutOfLinePCRanges: [0xb8880..0xb8930]
+      OutOfLinePCRanges: [0xb8ad0..0xb8b80]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xb8880..0xb88c8
+            - Range: 0xb8ad0..0xb8b18
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb8880..0xb88cc
+            - Range: 0xb8ad0..0xb8b1c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb88cc..0xb88d0
+            - Range: 0xb8b1c..0xb8b20
               Pieces:
                 - Size: 8
                   Op: null
@@ -5820,26 +6132,26 @@ Subprograms:
       DictRegister: null
     - ID: 16
       Name: main.condUint16
-      OutOfLinePCRanges: [0xb8930..0xb89d0]
+      OutOfLinePCRanges: [0xb8b80..0xb8c20]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0xb8930..0xb895c
+            - Range: 0xb8b80..0xb8bac
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb8930..0xb895c
+            - Range: 0xb8b80..0xb8bac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb895c..0xb89d0
+            - Range: 0xb8bac..0xb8c20
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -5850,26 +6162,26 @@ Subprograms:
       DictRegister: null
     - ID: 17
       Name: main.condUint32
-      OutOfLinePCRanges: [0xb89d0..0xb8a70]
+      OutOfLinePCRanges: [0xb8c20..0xb8cc0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0xb89d0..0xb89fc
+            - Range: 0xb8c20..0xb8c4c
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb89d0..0xb89fc
+            - Range: 0xb8c20..0xb8c4c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb89fc..0xb8a70
+            - Range: 0xb8c4c..0xb8cc0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -5880,26 +6192,26 @@ Subprograms:
       DictRegister: null
     - ID: 18
       Name: main.condUint64
-      OutOfLinePCRanges: [0xb8a70..0xb8b10]
+      OutOfLinePCRanges: [0xb8cc0..0xb8d60]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0xb8a70..0xb8a9c
+            - Range: 0xb8cc0..0xb8cec
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb8a70..0xb8a9c
+            - Range: 0xb8cc0..0xb8cec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb8a9c..0xb8b10
+            - Range: 0xb8cec..0xb8d60
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -5910,32 +6222,32 @@ Subprograms:
       DictRegister: null
     - ID: 19
       Name: main.condFloat32
-      OutOfLinePCRanges: [0xb8b10..0xb8bc0]
+      OutOfLinePCRanges: [0xb8d60..0xb8e10]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType float32
           Locations:
-            - Range: 0xb8b10..0xb8b40
+            - Range: 0xb8d60..0xb8d90
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb8b10..0xb8b3c
+            - Range: 0xb8d60..0xb8d8c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xb8b3c..0xb8b40
+            - Range: 0xb8d8c..0xb8d90
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xb8b40..0xb8bc0
+            - Range: 0xb8d90..0xb8e10
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -5946,32 +6258,32 @@ Subprograms:
       DictRegister: null
     - ID: 20
       Name: main.condFloat64
-      OutOfLinePCRanges: [0xb8bc0..0xb8c70]
+      OutOfLinePCRanges: [0xb8e10..0xb8ec0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 18 BaseType float64
           Locations:
-            - Range: 0xb8bc0..0xb8bf0
+            - Range: 0xb8e10..0xb8e40
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb8bc0..0xb8bec
+            - Range: 0xb8e10..0xb8e3c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xb8bec..0xb8bf0
+            - Range: 0xb8e3c..0xb8e40
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xb8bf0..0xb8c70
+            - Range: 0xb8e40..0xb8ec0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -5982,26 +6294,26 @@ Subprograms:
       DictRegister: null
     - ID: 21
       Name: main.condBool
-      OutOfLinePCRanges: [0xb8c70..0xb8d20]
+      OutOfLinePCRanges: [0xb8ec0..0xb8f70]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xb8c70..0xb8cb8
+            - Range: 0xb8ec0..0xb8f08
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb8c70..0xb8cbc
+            - Range: 0xb8ec0..0xb8f0c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb8cbc..0xb8cc0
+            - Range: 0xb8f0c..0xb8f10
               Pieces:
                 - Size: 8
                   Op: null
@@ -6012,13 +6324,13 @@ Subprograms:
       DictRegister: null
     - ID: 22
       Name: main.condString
-      OutOfLinePCRanges: [0xb8d20..0xb8dd0]
+      OutOfLinePCRanges: [0xb8f70..0xb9020]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb8d20..0xb8d50
+            - Range: 0xb8f70..0xb8fa0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6029,13 +6341,13 @@ Subprograms:
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb8d20..0xb8d50
+            - Range: 0xb8f70..0xb8fa0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xb8d50..0xb8dd0
+            - Range: 0xb8fa0..0xb9020
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
@@ -6046,32 +6358,32 @@ Subprograms:
       DictRegister: null
     - ID: 23
       Name: main.condStructArg
-      OutOfLinePCRanges: [0xb8dd0..0xb8ee0]
+      OutOfLinePCRanges: [0xb9020..0xb9130]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 119 StructureType main.condFields
           Locations:
-            - Range: 0xb8dd0..0xb8ee0
+            - Range: 0xb9020..0xb9130
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb8dd0..0xb8e10
+            - Range: 0xb9020..0xb9060
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xb8e10..0xb8e14
+            - Range: 0xb9060..0xb9064
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 88}
                 - Size: 8
                   Op: {CfaOffset: 96}
-            - Range: 0xb8e14..0xb8ee0
+            - Range: 0xb9064..0xb9130
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 88}
@@ -6082,28 +6394,28 @@ Subprograms:
       DictRegister: null
     - ID: 24
       Name: main.condPtrStructArg
-      OutOfLinePCRanges: [0xb8ee0..0xb9000]
+      OutOfLinePCRanges: [0xb9130..0xb9250]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 121 PointerType *main.condFields
           Locations:
-            - Range: 0xb8ee0..0xb8f24
+            - Range: 0xb9130..0xb9174
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb8f24..0xb9000
+            - Range: 0xb9174..0xb9250
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb8ee0..0xb8f28
+            - Range: 0xb9130..0xb9178
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb8f28..0xb9000
+            - Range: 0xb9178..0xb9250
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -6114,26 +6426,26 @@ Subprograms:
       DictRegister: null
     - ID: 25
       Name: main.condNilPtrStruct
-      OutOfLinePCRanges: [0xb9000..0xb90c0]
+      OutOfLinePCRanges: [0xb9250..0xb9310]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 121 PointerType *main.condFields
           Locations:
-            - Range: 0xb9000..0xb9054
+            - Range: 0xb9250..0xb92a4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb9000..0xb9058
+            - Range: 0xb9250..0xb92a8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb9058..0xb905c
+            - Range: 0xb92a8..0xb92ac
               Pieces:
                 - Size: 8
                   Op: null
@@ -6144,66 +6456,66 @@ Subprograms:
       DictRegister: null
     - ID: 26
       Name: main.condReturnAndLocal
-      OutOfLinePCRanges: [0xb90c0..0xb9160]
+      OutOfLinePCRanges: [0xb9310..0xb93b0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xb90c0..0xb90dc
+            - Range: 0xb9310..0xb932c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xb90c0..0xb90f0
+            - Range: 0xb9310..0xb9340
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xb90c0..0xb9138
+            - Range: 0xb9310..0xb9388
               Pieces: []
-            - Range: 0xb9138..0xb9139
+            - Range: 0xb9388..0xb9389
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb9139..0xb9160
+            - Range: 0xb9389..0xb93b0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: sum
           Type: 7 BaseType int
           Locations:
-            - Range: 0xb90dc..0xb9104
+            - Range: 0xb932c..0xb9354
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb9104..0xb9160
+            - Range: 0xb9354..0xb93b0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 27
       Name: main.condOnly
-      OutOfLinePCRanges: [0xb9160..0xb9200]
+      OutOfLinePCRanges: [0xb93b0..0xb9450]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xb9160..0xb918c
+            - Range: 0xb93b0..0xb93dc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb9160..0xb918c
+            - Range: 0xb93b0..0xb93dc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb918c..0xb9200
+            - Range: 0xb93dc..0xb9450
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -6214,28 +6526,28 @@ Subprograms:
       DictRegister: null
     - ID: 28
       Name: main.condLine
-      OutOfLinePCRanges: [0xb9200..0xb92d0]
+      OutOfLinePCRanges: [0xb9450..0xb9520]
       InlinePCRanges: []
       Variables:
         - Name: "n"
           Type: 7 BaseType int
           Locations:
-            - Range: 0xb9200..0xb9228
+            - Range: 0xb9450..0xb9478
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb9228..0xb92d0
+            - Range: 0xb9478..0xb9520
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb9200..0xb9238
+            - Range: 0xb9450..0xb9488
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb9238..0xb92d0
+            - Range: 0xb9488..0xb9520
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -6246,20 +6558,122 @@ Subprograms:
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0xb9228..0xb9238
+            - Range: 0xb9478..0xb9488
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 29
+      Name: main.condLineMixed
+      OutOfLinePCRanges: [0xb9520..0xb96b0]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xb9520..0xb9574
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0xb9574..0xb9578
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 88}
+                - Size: 8
+                  Op: {CfaOffset: 96}
+            - Range: 0xb9578..0xb96b0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 88}
+                - Size: 8
+                  Op: {CfaOffset: 96}
+          Role: Parameter
+          DictIndex: -1
+        - Name: b
+          Type: 4 BaseType bool
+          Locations:
+            - Range: 0xb9520..0xb9578
+              Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xb9578..0xb96b0
+              Pieces: [{Size: 1, Op: {CfaOffset: 104}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: x
+          Type: 119 StructureType main.condFields
+          Locations:
+            - Range: 0xb9520..0xb96b0
+              Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: p
+          Type: 121 PointerType *main.condFields
+          Locations:
+            - Range: 0xb9520..0xb9578
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xb9578..0xb96b0
+              Pieces: [{Size: 8, Op: {CfaOffset: 112}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: ss
+          Type: 105 GoSliceHeaderType []int
+          Locations:
+            - Range: 0xb9520..0xb9578
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+            - Range: 0xb9578..0xb96b0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 120}
+                - Size: 8
+                  Op: {CfaOffset: 128}
+                - Size: 8
+                  Op: {CfaOffset: 136}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 30
+      Name: main.condLineReturn
+      OutOfLinePCRanges: [0xb96b0..0xb9730]
+      InlinePCRanges: []
+      Variables:
+        - Name: "n"
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xb96b0..0xb96cc
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations: [{Range: 0xb96b0..0xb9730, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: doubled
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xb96cc..0xb96d8
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xb96d8..0xb9730
+              Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
+          Role: Local
+          DictIndex: -1
+      DictRegister: null
+    - ID: 31
       Name: main.condSliceArg
-      OutOfLinePCRanges: [0xb92d0..0xb9380]
+      OutOfLinePCRanges: [0xb9730..0xb97e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 105 GoSliceHeaderType []int
           Locations:
-            - Range: 0xb92d0..0xb9300
+            - Range: 0xb9730..0xb9760
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6272,13 +6686,13 @@ Subprograms:
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb92d0..0xb9300
+            - Range: 0xb9730..0xb9760
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
-            - Range: 0xb9300..0xb9380
+            - Range: 0xb9760..0xb97e0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
@@ -6287,28 +6701,28 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 30
+    - ID: 32
       Name: main.condMapArg
-      OutOfLinePCRanges: [0xb9380..0xb9420]
+      OutOfLinePCRanges: [0xb97e0..0xb9880]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 109 GoMapType map[string]int
           Locations:
-            - Range: 0xb9380..0xb93b8
+            - Range: 0xb97e0..0xb9818
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb9380..0xb93bc
+            - Range: 0xb97e0..0xb981c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb93bc..0xb93c0
+            - Range: 0xb981c..0xb9820
               Pieces:
                 - Size: 8
                   Op: null
@@ -6317,34 +6731,34 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 31
+    - ID: 33
       Name: main.condStructDirect
-      OutOfLinePCRanges: [0xb9420..0xb94d0]
+      OutOfLinePCRanges: [0xb9880..0xb9930]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 119 StructureType main.condFields
           Locations:
-            - Range: 0xb9420..0xb94d0
+            - Range: 0xb9880..0xb9930
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb9420..0xb9450
+            - Range: 0xb9880..0xb98b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xb9450..0xb9454
+            - Range: 0xb98b0..0xb98b4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 88}
                 - Size: 8
                   Op: {CfaOffset: 96}
-            - Range: 0xb9454..0xb94d0
+            - Range: 0xb98b4..0xb9930
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 88}
@@ -6353,140 +6767,36 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 32
+    - ID: 34
       Name: main.condNullPtr
-      OutOfLinePCRanges: [0xb94d0..0xb95c0]
+      OutOfLinePCRanges: [0xb9930..0xb9a20]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 99 PointerType *int
           Locations:
-            - Range: 0xb94d0..0xb9530
+            - Range: 0xb9930..0xb9990
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb9530..0xb95c0
+            - Range: 0xb9990..0xb9a20
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb94d0..0xb9534
+            - Range: 0xb9930..0xb9994
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb9534..0xb9538
+            - Range: 0xb9994..0xb9998
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xb9538..0xb95c0
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 16}
-                - Size: 8
-                  Op: {CfaOffset: 24}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 33
-      Name: main.condNullSlice
-      OutOfLinePCRanges: [0xb95c0..0xb96e0]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 105 GoSliceHeaderType []int
-          Locations:
-            - Range: 0xb95c0..0xb9638
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb9638..0xb963c
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-                - Size: 8
-                  Op: {CfaOffset: 24}
-            - Range: 0xb963c..0xb9640
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-                - Size: 8
-                  Op: {CfaOffset: 24}
-            - Range: 0xb9640..0xb96e0
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-                - Size: 8
-                  Op: {CfaOffset: 24}
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xb95c0..0xb9628
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-            - Range: 0xb9628..0xb9644
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 32}
-                - Size: 8
-                  Op: {CfaOffset: 40}
-            - Range: 0xb9644..0xb96e0
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 32}
-                - Size: 8
-                  Op: {CfaOffset: 40}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 34
-      Name: main.condNullMap
-      OutOfLinePCRanges: [0xb96e0..0xb97d0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 109 GoMapType map[string]int
-          Locations:
-            - Range: 0xb96e0..0xb9740
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb9740..0xb97d0
-              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xb96e0..0xb9744
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb9744..0xb9748
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 16}
-                - Size: 8
-                  Op: {CfaOffset: 24}
-            - Range: 0xb9748..0xb97d0
+            - Range: 0xb9998..0xb9a20
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -6496,87 +6806,101 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 35
-      Name: main.condNullIface
-      OutOfLinePCRanges: [0xb97d0..0xb98e0]
+      Name: main.condNullSlice
+      OutOfLinePCRanges: [0xb9a20..0xb9b40]
       InlinePCRanges: []
       Variables:
-        - Name: i
-          Type: 14 GoInterfaceType error
+        - Name: s
+          Type: 105 GoSliceHeaderType []int
           Locations:
-            - Range: 0xb97d0..0xb9844
+            - Range: 0xb9a20..0xb9a98
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xb9844..0xb9848
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xb9a98..0xb9a9c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0xb9848..0xb98e0
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0xb9a9c..0xb9aa0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0xb9aa0..0xb9b40
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb97d0..0xb9834
+            - Range: 0xb9a20..0xb9a88
               Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xb9834..0xb984c
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+            - Range: 0xb9a88..0xb9aa4
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 24}
-                - Size: 8
                   Op: {CfaOffset: 32}
-            - Range: 0xb984c..0xb98e0
+                - Size: 8
+                  Op: {CfaOffset: 40}
+            - Range: 0xb9aa4..0xb9b40
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 24}
-                - Size: 8
                   Op: {CfaOffset: 32}
+                - Size: 8
+                  Op: {CfaOffset: 40}
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 36
-      Name: main.condNullUnsafePtr
-      OutOfLinePCRanges: [0xb98e0..0xb99d0]
+      Name: main.condNullMap
+      OutOfLinePCRanges: [0xb9b40..0xb9c30]
       InlinePCRanges: []
       Variables:
-        - Name: p
-          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: m
+          Type: 109 GoMapType map[string]int
           Locations:
-            - Range: 0xb98e0..0xb9940
+            - Range: 0xb9b40..0xb9ba0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb9940..0xb99d0
+            - Range: 0xb9ba0..0xb9c30
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb98e0..0xb9944
+            - Range: 0xb9b40..0xb9ba4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb9944..0xb9948
+            - Range: 0xb9ba4..0xb9ba8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xb9948..0xb99d0
+            - Range: 0xb9ba8..0xb9c30
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -6586,41 +6910,49 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 37
-      Name: main.lenString
-      OutOfLinePCRanges: [0xb99e0..0xb9ae0]
+      Name: main.condNullIface
+      OutOfLinePCRanges: [0xb9c30..0xb9d40]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 9 GoStringHeaderType string
+        - Name: i
+          Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0xb99e0..0xb9a48
+            - Range: 0xb9c30..0xb9ca4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xb9a48..0xb9a4c
-              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0xb9a4c..0xb9ae0
-              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
+            - Range: 0xb9ca4..0xb9ca8
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0xb9ca8..0xb9d40
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb99e0..0xb9a40
+            - Range: 0xb9c30..0xb9c94
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xb9a40..0xb9a50
+            - Range: 0xb9c94..0xb9cac
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: {CfaOffset: 32}
-            - Range: 0xb9a50..0xb9ae0
+            - Range: 0xb9cac..0xb9d40
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
@@ -6630,14 +6962,96 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 38
+      Name: main.condNullUnsafePtr
+      OutOfLinePCRanges: [0xb9d40..0xb9e30]
+      InlinePCRanges: []
+      Variables:
+        - Name: p
+          Type: 15 VoidPointerType unsafe.Pointer
+          Locations:
+            - Range: 0xb9d40..0xb9da0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xb9da0..0xb9e30
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xb9d40..0xb9da4
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xb9da4..0xb9da8
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0xb9da8..0xb9e30
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 39
+      Name: main.lenString
+      OutOfLinePCRanges: [0xb9e40..0xb9f40]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xb9e40..0xb9ea8
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0xb9ea8..0xb9eac
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
+            - Range: 0xb9eac..0xb9f40
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xb9e40..0xb9ea0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xb9ea0..0xb9eb0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 24}
+                - Size: 8
+                  Op: {CfaOffset: 32}
+            - Range: 0xb9eb0..0xb9f40
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 24}
+                - Size: 8
+                  Op: {CfaOffset: 32}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 40
       Name: main.lenSlice
-      OutOfLinePCRanges: [0xb9ae0..0xb9bf0]
+      OutOfLinePCRanges: [0xb9f40..0xba050]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 105 GoSliceHeaderType []int
           Locations:
-            - Range: 0xb9ae0..0xb9b54
+            - Range: 0xb9f40..0xb9fb4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6645,7 +7059,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb9b54..0xb9b58
+            - Range: 0xb9fb4..0xb9fb8
               Pieces:
                 - Size: 8
                   Op: null
@@ -6653,7 +7067,7 @@ Subprograms:
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb9b58..0xb9b5c
+            - Range: 0xb9fb8..0xb9fbc
               Pieces:
                 - Size: 8
                   Op: null
@@ -6661,7 +7075,7 @@ Subprograms:
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb9b5c..0xb9bf0
+            - Range: 0xb9fbc..0xba050
               Pieces:
                 - Size: 8
                   Op: null
@@ -6669,156 +7083,6 @@ Subprograms:
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: null
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xb9ae0..0xb9b44
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-            - Range: 0xb9b44..0xb9b60
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 32}
-                - Size: 8
-                  Op: {CfaOffset: 40}
-            - Range: 0xb9b60..0xb9bf0
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 32}
-                - Size: 8
-                  Op: {CfaOffset: 40}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 39
-      Name: main.lenMap
-      OutOfLinePCRanges: [0xb9bf0..0xb9d00]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 109 GoMapType map[string]int
-          Locations:
-            - Range: 0xb9bf0..0xb9c50
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb9c50..0xb9d00
-              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xb9bf0..0xb9c54
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb9c54..0xb9c58
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 16}
-                - Size: 8
-                  Op: {CfaOffset: 24}
-            - Range: 0xb9c58..0xb9d00
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 16}
-                - Size: 8
-                  Op: {CfaOffset: 24}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 40
-      Name: main.lenPtrString
-      OutOfLinePCRanges: [0xb9d00..0xb9df0]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 93 PointerType *string
-          Locations:
-            - Range: 0xb9d00..0xb9d60
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb9d60..0xb9df0
-              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xb9d00..0xb9d64
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb9d64..0xb9d68
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 16}
-                - Size: 8
-                  Op: {CfaOffset: 24}
-            - Range: 0xb9d68..0xb9df0
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 16}
-                - Size: 8
-                  Op: {CfaOffset: 24}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 41
-      Name: main.lenStructFields
-      OutOfLinePCRanges: [0xb9df0..0xb9f40]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 122 StructureType main.lenFields
-          Locations:
-            - Range: 0xb9df0..0xb9f40
-              Pieces: [{Size: 72, Op: {CfaOffset: 8}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xb9df0..0xb9e78
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0xb9e78..0xb9e7c
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 80}
-                - Size: 8
-                  Op: {CfaOffset: 88}
-            - Range: 0xb9e7c..0xb9f40
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 80}
-                - Size: 8
-                  Op: {CfaOffset: 88}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 42
-      Name: main.lenPtrStructFields
-      OutOfLinePCRanges: [0xb9f40..0xba080]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 124 PointerType *main.lenFields
-          Locations:
-            - Range: 0xb9f40..0xb9fa0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb9fa0..0xba080
-              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
@@ -6827,16 +7091,92 @@ Subprograms:
             - Range: 0xb9f40..0xb9fa4
               Pieces:
                 - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+            - Range: 0xb9fa4..0xb9fc0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 32}
+                - Size: 8
+                  Op: {CfaOffset: 40}
+            - Range: 0xb9fc0..0xba050
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 32}
+                - Size: 8
+                  Op: {CfaOffset: 40}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 41
+      Name: main.lenMap
+      OutOfLinePCRanges: [0xba050..0xba160]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 109 GoMapType map[string]int
+          Locations:
+            - Range: 0xba050..0xba0b0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xba0b0..0xba160
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xba050..0xba0b4
+              Pieces:
+                - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb9fa4..0xb9fa8
+            - Range: 0xba0b4..0xba0b8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xb9fa8..0xba080
+            - Range: 0xba0b8..0xba160
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 42
+      Name: main.lenPtrString
+      OutOfLinePCRanges: [0xba160..0xba250]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 93 PointerType *string
+          Locations:
+            - Range: 0xba160..0xba1c0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xba1c0..0xba250
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xba160..0xba1c4
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xba1c4..0xba1c8
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0xba1c8..0xba250
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -6846,35 +7186,71 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 43
-      Name: main.lenErrInt
-      OutOfLinePCRanges: [0xba080..0xba180]
+      Name: main.lenStructFields
+      OutOfLinePCRanges: [0xba250..0xba3a0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 7 BaseType int
+          Type: 122 StructureType main.lenFields
           Locations:
-            - Range: 0xba080..0xba0e8
+            - Range: 0xba250..0xba3a0
+              Pieces: [{Size: 72, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xba250..0xba2d8
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0xba2d8..0xba2dc
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 80}
+                - Size: 8
+                  Op: {CfaOffset: 88}
+            - Range: 0xba2dc..0xba3a0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 80}
+                - Size: 8
+                  Op: {CfaOffset: 88}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 44
+      Name: main.lenPtrStructFields
+      OutOfLinePCRanges: [0xba3a0..0xba4e0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 124 PointerType *main.lenFields
+          Locations:
+            - Range: 0xba3a0..0xba400
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xba0e8..0xba180
+            - Range: 0xba400..0xba4e0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xba080..0xba0ec
+            - Range: 0xba3a0..0xba404
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xba0ec..0xba0f0
+            - Range: 0xba404..0xba408
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xba0f0..0xba180
+            - Range: 0xba408..0xba4e0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -6883,34 +7259,72 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 44
+    - ID: 45
+      Name: main.lenErrInt
+      OutOfLinePCRanges: [0xba4e0..0xba5e0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xba4e0..0xba548
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xba548..0xba5e0
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xba4e0..0xba54c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xba54c..0xba550
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0xba550..0xba5e0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 46
       Name: main.lenErrStruct
-      OutOfLinePCRanges: [0xba180..0xba290]
+      OutOfLinePCRanges: [0xba5e0..0xba6f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 119 StructureType main.condFields
           Locations:
-            - Range: 0xba180..0xba290
+            - Range: 0xba5e0..0xba6f0
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xba180..0xba1fc
+            - Range: 0xba5e0..0xba65c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xba1fc..0xba200
+            - Range: 0xba65c..0xba660
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 88}
                 - Size: 8
                   Op: {CfaOffset: 96}
-            - Range: 0xba200..0xba290
+            - Range: 0xba660..0xba6f0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 88}
@@ -6919,28 +7333,28 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 45
+    - ID: 47
       Name: main.indexNilPtrSlice
-      OutOfLinePCRanges: [0xba290..0xba350]
+      OutOfLinePCRanges: [0xba6f0..0xba7b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 124 PointerType *main.lenFields
           Locations:
-            - Range: 0xba290..0xba2e4
+            - Range: 0xba6f0..0xba744
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xba290..0xba2e8
+            - Range: 0xba6f0..0xba748
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xba2e8..0xba2ec
+            - Range: 0xba748..0xba74c
               Pieces:
                 - Size: 8
                   Op: null
@@ -6949,60 +7363,60 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 46
+    - ID: 48
       Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
-      OutOfLinePCRanges: [0xba350..0xba510]
+      OutOfLinePCRanges: [0xba7b0..0xba970]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 125 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
           Locations:
-            - Range: 0xba350..0xba4f0
+            - Range: 0xba7b0..0xba950
               Pieces: []
-            - Range: 0xba4f0..0xba4f1
+            - Range: 0xba950..0xba951
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xba4f1..0xba510
+            - Range: 0xba951..0xba970
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 47
+    - ID: 49
       Name: main.bigArrayArg
-      OutOfLinePCRanges: [0xba510..0xba5a0]
+      OutOfLinePCRanges: [0xba970..0xbaa00]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 130 ArrayType [131072]int64
           Locations:
-            - Range: 0xba510..0xba5a0
+            - Range: 0xba970..0xbaa00
               Pieces: [{Size: 1048576, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 48
+    - ID: 50
       Name: main.bigArrayStructArg
-      OutOfLinePCRanges: [0xba5a0..0xba640]
+      OutOfLinePCRanges: [0xbaa00..0xbaaa0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 131 PointerType *main.bigArrayStruct
           Locations:
-            - Range: 0xba5a0..0xba5c8
+            - Range: 0xbaa00..0xbaa28
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xba5c8..0xba640
+            - Range: 0xbaa28..0xbaaa0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 49
+    - ID: 51
       Name: main.structSliceArg
-      OutOfLinePCRanges: [0xba640..0xba710]
+      OutOfLinePCRanges: [0xbaaa0..0xbab70]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 133 GoSliceHeaderType []main.indexMemberStruct
           Locations:
-            - Range: 0xba640..0xba67c
+            - Range: 0xbaaa0..0xbaadc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7010,7 +7424,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xba67c..0xba680
+            - Range: 0xbaadc..0xbaae0
               Pieces:
                 - Size: 8
                   Op: null
@@ -7018,7 +7432,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xba6dc..0xba6e0
+            - Range: 0xbab3c..0xbab40
               Pieces:
                 - Size: 8
                   Op: null
@@ -7026,7 +7440,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xba6e0..0xba710
+            - Range: 0xbab40..0xbab70
               Pieces:
                 - Size: 8
                   Op: null
@@ -7039,129 +7453,19 @@ Subprograms:
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xba640..0xba680
+            - Range: 0xbaaa0..0xbaae0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
-            - Range: 0xba680..0xba6d8
+            - Range: 0xbaae0..0xbab38
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
                 - Size: 8
                   Op: {CfaOffset: 40}
-            - Range: 0xba6d8..0xba710
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 50
-      Name: main.structArrayArg
-      OutOfLinePCRanges: [0xba710..0xba7b0]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 136 ArrayType [2]main.indexMemberStruct
-          Locations:
-            - Range: 0xba710..0xba7b0
-              Pieces: [{Size: 64, Op: {CfaOffset: 8}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xba710..0xba73c
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0xba73c..0xba740
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 72}
-                - Size: 8
-                  Op: {CfaOffset: 80}
-            - Range: 0xba740..0xba7b0
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 72}
-                - Size: 8
-                  Op: {CfaOffset: 80}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 51
-      Name: main.ptrStructSliceArg
-      OutOfLinePCRanges: [0xba7b0..0xba880]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 137 GoSliceHeaderType []*main.indexMemberStruct
-          Locations:
-            - Range: 0xba7b0..0xba7ec
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0xba7ec..0xba7f0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0xba7f0..0xba7f4
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0xba850..0xba854
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0xba854..0xba880
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xba7b0..0xba7f4
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-            - Range: 0xba7f4..0xba84c
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 32}
-                - Size: 8
-                  Op: {CfaOffset: 40}
-            - Range: 0xba84c..0xba880
+            - Range: 0xbab38..0xbab70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -7171,33 +7475,143 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 52
+      Name: main.structArrayArg
+      OutOfLinePCRanges: [0xbab70..0xbac10]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 136 ArrayType [2]main.indexMemberStruct
+          Locations:
+            - Range: 0xbab70..0xbac10
+              Pieces: [{Size: 64, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xbab70..0xbab9c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0xbab9c..0xbaba0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 72}
+                - Size: 8
+                  Op: {CfaOffset: 80}
+            - Range: 0xbaba0..0xbac10
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 72}
+                - Size: 8
+                  Op: {CfaOffset: 80}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 53
+      Name: main.ptrStructSliceArg
+      OutOfLinePCRanges: [0xbac10..0xbace0]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 137 GoSliceHeaderType []*main.indexMemberStruct
+          Locations:
+            - Range: 0xbac10..0xbac4c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xbac4c..0xbac50
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xbac50..0xbac54
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xbacb0..0xbacb4
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xbacb4..0xbace0
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xbac10..0xbac54
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+            - Range: 0xbac54..0xbacac
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 32}
+                - Size: 8
+                  Op: {CfaOffset: 40}
+            - Range: 0xbacac..0xbace0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 54
       Name: main.ptrStructArrayArg
-      OutOfLinePCRanges: [0xba880..0xba920]
+      OutOfLinePCRanges: [0xbace0..0xbad80]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 139 ArrayType [2]*main.indexMemberStruct
           Locations:
-            - Range: 0xba880..0xba920
+            - Range: 0xbace0..0xbad80
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xba880..0xba8ac
+            - Range: 0xbace0..0xbad0c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xba8ac..0xba8b0
+            - Range: 0xbad0c..0xbad10
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: {CfaOffset: 32}
-            - Range: 0xba8b0..0xba920
+            - Range: 0xbad10..0xbad80
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
@@ -7206,36 +7620,36 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 53
+    - ID: 55
       Name: main.indexMemberWrapperArg
-      OutOfLinePCRanges: [0xba920..0xbaa00]
+      OutOfLinePCRanges: [0xbad80..0xbae60]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 140 PointerType *main.indexMemberWrapper
           Locations:
-            - Range: 0xba920..0xba958
+            - Range: 0xbad80..0xbadb8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xba958..0xbaa00
+            - Range: 0xbadb8..0xbae60
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xba920..0xba954
+            - Range: 0xbad80..0xbadb4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xba954..0xba95c
+            - Range: 0xbadb4..0xbadbc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xba95c..0xbaa00
+            - Range: 0xbadbc..0xbae60
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -7244,261 +7658,261 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 54
+    - ID: 56
       Name: main.mapIndexIntKey
-      OutOfLinePCRanges: [0xbaa00..0xbaa70]
+      OutOfLinePCRanges: [0xbae60..0xbaed0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 142 GoMapType map[int]string
           Locations:
-            - Range: 0xbaa00..0xbaa38
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 55
-      Name: main.mapIndexStringKey
-      OutOfLinePCRanges: [0xbaa70..0xbaae0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 109 GoMapType map[string]int
-          Locations:
-            - Range: 0xbaa70..0xbaaa8
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 56
-      Name: main.mapIndexLargeMap
-      OutOfLinePCRanges: [0xbaae0..0xbab70]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 109 GoMapType map[string]int
-          Locations:
-            - Range: 0xbaae0..0xbab10
+            - Range: 0xbae60..0xbae98
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 57
-      Name: main.mapIndexMissing
-      OutOfLinePCRanges: [0xbab70..0xbabe0]
+      Name: main.mapIndexStringKey
+      OutOfLinePCRanges: [0xbaed0..0xbaf40]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 109 GoMapType map[string]int
           Locations:
-            - Range: 0xbab70..0xbaba8
+            - Range: 0xbaed0..0xbaf08
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 58
-      Name: main.mapIndexKeyLen8
-      OutOfLinePCRanges: [0xbace0..0xbad70]
+      Name: main.mapIndexLargeMap
+      OutOfLinePCRanges: [0xbaf40..0xbafd0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 109 GoMapType map[string]int
           Locations:
-            - Range: 0xbace0..0xbad10
+            - Range: 0xbaf40..0xbaf70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 59
-      Name: main.mapIndexKeyLen24
-      OutOfLinePCRanges: [0xbad70..0xbae00]
+      Name: main.mapIndexMissing
+      OutOfLinePCRanges: [0xbafd0..0xbb040]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 109 GoMapType map[string]int
           Locations:
-            - Range: 0xbad70..0xbada0
+            - Range: 0xbafd0..0xbb008
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 60
-      Name: main.mapIndexKeyLen48
-      OutOfLinePCRanges: [0xbae00..0xbae90]
+      Name: main.mapIndexKeyLen8
+      OutOfLinePCRanges: [0xbb140..0xbb1d0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 109 GoMapType map[string]int
           Locations:
-            - Range: 0xbae00..0xbae30
+            - Range: 0xbb140..0xbb170
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 61
-      Name: main.mapIndexKeyLen96
-      OutOfLinePCRanges: [0xbae90..0xbaf20]
+      Name: main.mapIndexKeyLen24
+      OutOfLinePCRanges: [0xbb1d0..0xbb260]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 109 GoMapType map[string]int
           Locations:
-            - Range: 0xbae90..0xbaec0
+            - Range: 0xbb1d0..0xbb200
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 62
-      Name: main.mapIndexKeyLen200
-      OutOfLinePCRanges: [0xbaf20..0xbafb0]
+      Name: main.mapIndexKeyLen48
+      OutOfLinePCRanges: [0xbb260..0xbb2f0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 109 GoMapType map[string]int
           Locations:
-            - Range: 0xbaf20..0xbaf50
+            - Range: 0xbb260..0xbb290
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 63
-      Name: main.mapIndexStructVal
-      OutOfLinePCRanges: [0xbafb0..0xbb040]
+      Name: main.mapIndexKeyLen96
+      OutOfLinePCRanges: [0xbb2f0..0xbb380]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 147 GoMapType map[string]main.indexMemberStruct
+          Type: 109 GoMapType map[string]int
           Locations:
-            - Range: 0xbafb0..0xbafe4
+            - Range: 0xbb2f0..0xbb320
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 64
-      Name: main.mapIndexPtrStructVal
-      OutOfLinePCRanges: [0xbb040..0xbb0e0]
+      Name: main.mapIndexKeyLen200
+      OutOfLinePCRanges: [0xbb380..0xbb410]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 152 GoMapType map[string]*main.indexMemberStruct
+          Type: 109 GoMapType map[string]int
           Locations:
-            - Range: 0xbb040..0xbb074
+            - Range: 0xbb380..0xbb3b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 65
-      Name: main.mapIndexEmptyKey
-      OutOfLinePCRanges: [0xbb0e0..0xbb170]
+      Name: main.mapIndexStructVal
+      OutOfLinePCRanges: [0xbb410..0xbb4a0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 109 GoMapType map[string]int
+          Type: 147 GoMapType map[string]main.indexMemberStruct
           Locations:
-            - Range: 0xbb0e0..0xbb110
+            - Range: 0xbb410..0xbb444
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 66
-      Name: main.mapIndexKeyLen16
-      OutOfLinePCRanges: [0xbb170..0xbb200]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 109 GoMapType map[string]int
-          Locations:
-            - Range: 0xbb170..0xbb1a0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 67
-      Name: main.mapIndexKeyLen17
-      OutOfLinePCRanges: [0xbb200..0xbb290]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 109 GoMapType map[string]int
-          Locations:
-            - Range: 0xbb200..0xbb230
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 68
-      Name: main.mapIndexBoolKey
-      OutOfLinePCRanges: [0xbb290..0xbb300]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 157 GoMapType map[bool]int
-          Locations:
-            - Range: 0xbb290..0xbb2c8
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 69
-      Name: main.mapIndexZeroValue
-      OutOfLinePCRanges: [0xbb300..0xbb370]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 109 GoMapType map[string]int
-          Locations:
-            - Range: 0xbb300..0xbb338
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 70
-      Name: main.mapIndexNilPtrVal
-      OutOfLinePCRanges: [0xbb370..0xbb3e0]
+      Name: main.mapIndexPtrStructVal
+      OutOfLinePCRanges: [0xbb4a0..0xbb540]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 152 GoMapType map[string]*main.indexMemberStruct
           Locations:
-            - Range: 0xbb370..0xbb3a8
+            - Range: 0xbb4a0..0xbb4d4
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 67
+      Name: main.mapIndexEmptyKey
+      OutOfLinePCRanges: [0xbb540..0xbb5d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 109 GoMapType map[string]int
+          Locations:
+            - Range: 0xbb540..0xbb570
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 68
+      Name: main.mapIndexKeyLen16
+      OutOfLinePCRanges: [0xbb5d0..0xbb660]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 109 GoMapType map[string]int
+          Locations:
+            - Range: 0xbb5d0..0xbb600
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 69
+      Name: main.mapIndexKeyLen17
+      OutOfLinePCRanges: [0xbb660..0xbb6f0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 109 GoMapType map[string]int
+          Locations:
+            - Range: 0xbb660..0xbb690
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 70
+      Name: main.mapIndexBoolKey
+      OutOfLinePCRanges: [0xbb6f0..0xbb760]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 157 GoMapType map[bool]int
+          Locations:
+            - Range: 0xbb6f0..0xbb728
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 71
-      Name: main.mapIndexLargeValue
-      OutOfLinePCRanges: [0xbb3e0..0xbb470]
+      Name: main.mapIndexZeroValue
+      OutOfLinePCRanges: [0xbb760..0xbb7d0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 162 GoMapType map[string]main.largeValueStruct
+          Type: 109 GoMapType map[string]int
           Locations:
-            - Range: 0xbb3e0..0xbb410
+            - Range: 0xbb760..0xbb798
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 72
+      Name: main.mapIndexNilPtrVal
+      OutOfLinePCRanges: [0xbb7d0..0xbb840]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 152 GoMapType map[string]*main.indexMemberStruct
+          Locations:
+            - Range: 0xbb7d0..0xbb808
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 73
+      Name: main.mapIndexLargeValue
+      OutOfLinePCRanges: [0xbb840..0xbb8d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 162 GoMapType map[string]main.largeValueStruct
+          Locations:
+            - Range: 0xbb840..0xbb870
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 74
       Name: main.condMultiReturn
-      OutOfLinePCRanges: [0xbb4f0..0xbb5c0]
+      OutOfLinePCRanges: [0xbb950..0xbba20]
       InlinePCRanges: []
       Variables:
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xbb4f0..0xbb538
+            - Range: 0xbb950..0xbb998
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xbb538..0xbb53c
+            - Range: 0xbb998..0xbb99c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0xbb53c..0xbb5c0
+            - Range: 0xbb99c..0xbba20
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -7509,51 +7923,51 @@ Subprograms:
         - Name: r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xbb4f0..0xbb594
+            - Range: 0xbb950..0xbb9f4
               Pieces: []
-            - Range: 0xbb594..0xbb595
+            - Range: 0xbb9f4..0xbb9f5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xbb595..0xbb5c0
+            - Range: 0xbb9f5..0xbba20
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: r1
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xbb4f0..0xbb594
+            - Range: 0xbb950..0xbb9f4
               Pieces: []
-            - Range: 0xbb594..0xbb595
+            - Range: 0xbb9f4..0xbb9f5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbb595..0xbb5c0
+            - Range: 0xbb9f5..0xbba20
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 73
+    - ID: 75
       Name: main.genericIdentity[go.shape.string]
-      OutOfLinePCRanges: [0xbb5c0..0xbb660]
+      OutOfLinePCRanges: [0xbba20..0xbbac0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 167 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xbb5c0..0xbb5f0
+            - Range: 0xbba20..0xbba50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbb5f0..0xbb5f4
+            - Range: 0xbba50..0xbba54
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xbb5f4..0xbb660
+            - Range: 0xbba54..0xbbac0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -7564,68 +7978,68 @@ Subprograms:
         - Name: ~r0
           Type: 167 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xbb5c0..0xbb62c
+            - Range: 0xbba20..0xbba8c
               Pieces: []
-            - Range: 0xbb62c..0xbb62d
+            - Range: 0xbba8c..0xbba8d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xbb62d..0xbb660
+            - Range: 0xbba8d..0xbbac0
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 74
+    - ID: 76
       Name: main.genericIdentity[go.shape.int]
-      OutOfLinePCRanges: [0xbb660..0xbb6e0]
+      OutOfLinePCRanges: [0xbbac0..0xbbb40]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 168 BaseType go.shape.int
           Locations:
-            - Range: 0xbb660..0xbb68c
+            - Range: 0xbbac0..0xbbaec
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0xbb68c..0xbb6e0
+            - Range: 0xbbaec..0xbbb40
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 168 BaseType go.shape.int
           Locations:
-            - Range: 0xbb660..0xbb6c0
+            - Range: 0xbbac0..0xbbb20
               Pieces: []
-            - Range: 0xbb6c0..0xbb6c1
+            - Range: 0xbbb20..0xbbb21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xbb6c1..0xbb6e0
+            - Range: 0xbbb21..0xbbb40
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 75
+    - ID: 77
       Name: main.inlined
-      OutOfLinePCRanges: [0xb8390..0xb8400]
+      OutOfLinePCRanges: [0xb85e0..0xb8650]
       InlinePCRanges:
         - Ranges: [0xb5cb0..0xb5d00]
-          RootRanges: [0xb5af0..0xb8090]
+          RootRanges: [0xb5af0..0xb82e0]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
             - Range: 0xb5cb0..0xb5d00
               Pieces: []
-            - Range: 0xb8390..0xb83b0
+            - Range: 0xb85e0..0xb8600
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 76
+    - ID: 78
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xb5f04..0xb5f40]
-          RootRanges: [0xb5af0..0xb8090]
+          RootRanges: [0xb5af0..0xb82e0]
       Variables:
         - Name: ptr
           Type: 169 PointerType *****int
@@ -7635,12 +8049,12 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 77
+    - ID: 79
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xb5f4c..0xb5f88]
-          RootRanges: [0xb5af0..0xb8090]
+          RootRanges: [0xb5af0..0xb82e0]
       Variables:
         - Name: ptr
           Type: 171 PointerType **int
@@ -7650,17 +8064,17 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 78
+    - ID: 80
       Name: main.(*methodValueReceiver).inlinedMethod
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xbb6e4..0xbb6e8]
-          RootRanges: [0xbb6e0..0xbb6f0]
+        - Ranges: [0xbbb44..0xbbb48]
+          RootRanges: [0xbbb40..0xbbb50]
       Variables:
         - Name: m
           Type: 172 PointerType *main.methodValueReceiver
           Locations:
-            - Range: 0xbb6e4..0xbb6f0
+            - Range: 0xbbb44..0xbbb50
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7818,7 +8232,7 @@ Types:
       ID: 275
       Name: '*errors.errorString'
       ByteSize: 8
-      GoRuntimeType: 60864
+      GoRuntimeType: 60960
       GoKind: 22
       Pointee: 276 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
@@ -7865,28 +8279,28 @@ Types:
       ID: 280
       Name: '*internal/bisect.parseError'
       ByteSize: 8
-      GoRuntimeType: 63840
+      GoRuntimeType: 63936
       GoKind: 22
       Pointee: 281 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
       ID: 306
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 78144
+      GoRuntimeType: 78240
       GoKind: 22
       Pointee: 307 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 304
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
-      GoRuntimeType: 78016
+      GoRuntimeType: 78112
       GoKind: 22
       Pointee: 305 StructureType internal/poll.errNetClosing
     - __kind: PointerType
       ID: 302
       Name: '*io/fs.PathError'
       ByteSize: 8
-      GoRuntimeType: 77888
+      GoRuntimeType: 77984
       GoKind: 22
       Pointee: 303 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
@@ -8037,28 +8451,28 @@ Types:
       ID: 298
       Name: '*os.SyscallError'
       ByteSize: 8
-      GoRuntimeType: 74944
+      GoRuntimeType: 75040
       GoKind: 22
       Pointee: 299 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 277
       Name: '*reflect.ValueError'
       ByteSize: 8
-      GoRuntimeType: 61728
+      GoRuntimeType: 61824
       GoKind: 22
       Pointee: 278 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
       ID: 292
       Name: '*runtime.PanicNilError'
       ByteSize: 8
-      GoRuntimeType: 67936
+      GoRuntimeType: 68032
       GoKind: 22
       Pointee: 293 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
       ID: 296
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
-      GoRuntimeType: 69728
+      GoRuntimeType: 69824
       GoKind: 22
       Pointee: 297 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
@@ -8072,14 +8486,14 @@ Types:
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 86560
+      GoRuntimeType: 86656
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 294
       Name: '*runtime.boundsError'
       ByteSize: 8
-      GoRuntimeType: 68064
+      GoRuntimeType: 68160
       GoKind: 22
       Pointee: 295 StructureType runtime.boundsError
     - __kind: PointerType
@@ -8100,14 +8514,14 @@ Types:
       ID: 300
       Name: '*runtime.errorAddressString'
       ByteSize: 8
-      GoRuntimeType: 77376
+      GoRuntimeType: 77472
       GoKind: 22
       Pointee: 301 StructureType runtime.errorAddressString
     - __kind: PointerType
       ID: 290
       Name: '*runtime.errorString'
       ByteSize: 8
-      GoRuntimeType: 67552
+      GoRuntimeType: 67648
       GoKind: 22
       Pointee: 282 GoStringHeaderType runtime.errorString
     - __kind: PointerType
@@ -8119,21 +8533,21 @@ Types:
       ID: 55
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 62496
+      GoRuntimeType: 62592
       GoKind: 22
       Pointee: 22 StructureType runtime.g
     - __kind: PointerType
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 69216
+      GoRuntimeType: 69312
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
       ID: 291
       Name: '*runtime.plainError'
       ByteSize: 8
-      GoRuntimeType: 67680
+      GoRuntimeType: 67776
       GoKind: 22
       Pointee: 285 GoStringHeaderType runtime.plainError
     - __kind: PointerType
@@ -8152,28 +8566,28 @@ Types:
       ID: 49
       Name: '*runtime.synctestGroup'
       ByteSize: 8
-      GoRuntimeType: 98848
+      GoRuntimeType: 98944
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.synctestGroup
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 130336
+      GoRuntimeType: 130432
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 76
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 104224
+      GoRuntimeType: 104320
       GoKind: 22
       Pointee: 77 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 288
       Name: '*strconv.NumError'
       ByteSize: 8
-      GoRuntimeType: 66656
+      GoRuntimeType: 66752
       GoKind: 22
       Pointee: 289 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
@@ -8192,7 +8606,7 @@ Types:
       ID: 309
       Name: '*syscall.Errno'
       ByteSize: 8
-      GoRuntimeType: 87840
+      GoRuntimeType: 87936
       GoKind: 22
       Pointee: 308 BaseType syscall.Errno
     - __kind: PointerType
@@ -8244,7 +8658,7 @@ Types:
       ID: 279
       Name: '*time.fileSizeError'
       ByteSize: 8
-      GoRuntimeType: 63264
+      GoRuntimeType: 63360
       GoKind: 22
       Pointee: 272 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
@@ -8295,7 +8709,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 662
+      ID: 671
       Name: Probe[main.(*methodValueReceiver).inlinedMethod]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8307,12 +8721,12 @@ Types:
             Type: 172 PointerType *main.methodValueReceiver
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: m}
+                  Variable: {subprogram: 80, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 660
+      ID: 669
       Name: Probe[main.PointerChainArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -8324,7 +8738,7 @@ Types:
             Type: 169 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: ptr}
+                  Variable: {subprogram: 78, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -8335,12 +8749,12 @@ Types:
             Type: 169 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: ptr}
+                  Variable: {subprogram: 78, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 661
+      ID: 670
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8352,12 +8766,12 @@ Types:
             Type: 171 PointerType **int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: ptr}
+                  Variable: {subprogram: 79, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 572
+      ID: 581
       Name: Probe[main.bigArrayArg]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8369,12 +8783,12 @@ Types:
             Type: 13 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: s}
+                  Variable: {subprogram: 49, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 574
+      ID: 583
       Name: Probe[main.bigArrayArg]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8386,18 +8800,18 @@ Types:
             Type: 13 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: s}
+                  Variable: {subprogram: 49, index: 0, name: s}
                   Offset: 1048568
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 573
+      ID: 582
       Name: Probe[main.bigArrayArg]Return
     - __kind: EventRootType
-      ID: 575
+      ID: 584
       Name: Probe[main.bigArrayArg]Return
     - __kind: EventRootType
-      ID: 576
+      ID: 585
       Name: Probe[main.bigArrayStructArg]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8409,7 +8823,7 @@ Types:
             Type: 13 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: s}
+                  Variable: {subprogram: 50, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -8417,7 +8831,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 577
+      ID: 586
       Name: Probe[main.bigArrayStructArg]Return
     - __kind: EventRootType
       ID: 359
@@ -8848,6 +9262,85 @@ Types:
       ID: 366
       Name: Probe[main.condInt8]Return
     - __kind: EventRootType
+      ID: 470
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 471
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 472
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 473
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 474
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 475
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 476
+      Name: Probe[main.condLineMixed]Line
+      ByteSize: 131
+      ExprStatusArraySize: 2
+      Expressions:
+        - Name: s
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: b
+          Offset: 18
+          Kind: local
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 1
+          DictIndex: -1
+        - Name: x
+          Offset: 19
+          Kind: local
+          Expression:
+            Type: 119 StructureType main.condFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 80
+          DictIndex: -1
+        - Name: p
+          Offset: 99
+          Kind: local
+          Expression:
+            Type: 121 PointerType *main.condFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 3, name: p}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: ss
+          Offset: 107
+          Kind: local
+          Expression:
+            Type: 105 GoSliceHeaderType []int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 4, name: ss}
+                  Offset: 0
+                  ByteSize: 24
+          DictIndex: -1
+    - __kind: EventRootType
       ID: 465
       Name: Probe[main.condLine]Line
       ByteSize: 25
@@ -8895,6 +9388,62 @@ Types:
     - __kind: EventRootType
       ID: 467
       Name: Probe[main.condLine]Line
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 468
+      Name: Probe[main.condLine]Line
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: "n"
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 0, name: "n"}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: tag
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: result
+          Offset: 25
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 2, name: result}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 469
+      Name: Probe[main.condLine]Line
       ByteSize: 25
       ExprStatusArraySize: 1
       Expressions:
@@ -8921,10 +9470,10 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 652
+      ID: 661
       Name: Probe[main.condMultiReturn]
     - __kind: EventRootType
-      ID: 653
+      ID: 662
       Name: Probe[main.condMultiReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -8936,7 +9485,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 1, name: r0}
+                  Variable: {subprogram: 74, index: 1, name: r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -8947,7 +9496,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 2, name: r1}
+                  Variable: {subprogram: 74, index: 2, name: r1}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -9043,7 +9592,7 @@ Types:
       ID: 454
       Name: Probe[main.condNilPtrStruct]Return
     - __kind: EventRootType
-      ID: 474
+      ID: 483
       Name: Probe[main.condNullIface]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -9055,76 +9604,16 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 35, index: 1, name: tag}
+                  Variable: {subprogram: 37, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 475
+      ID: 484
       Name: Probe[main.condNullIface]Return
     - __kind: EventRootType
-      ID: 472
+      ID: 481
       Name: Probe[main.condNullMap]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 34, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 473
-      Name: Probe[main.condNullMap]Return
-    - __kind: EventRootType
-      ID: 468
-      Name: Probe[main.condNullPtr]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 32, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 469
-      Name: Probe[main.condNullPtr]Return
-    - __kind: EventRootType
-      ID: 470
-      Name: Probe[main.condNullSlice]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 33, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 471
-      Name: Probe[main.condNullSlice]Return
-    - __kind: EventRootType
-      ID: 476
-      Name: Probe[main.condNullUnsafePtr]
       ByteSize: 17
       ExprStatusArraySize: 1
       Expressions:
@@ -9140,7 +9629,67 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
+      ID: 482
+      Name: Probe[main.condNullMap]Return
+    - __kind: EventRootType
       ID: 477
+      Name: Probe[main.condNullPtr]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 478
+      Name: Probe[main.condNullPtr]Return
+    - __kind: EventRootType
+      ID: 479
+      Name: Probe[main.condNullSlice]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 480
+      Name: Probe[main.condNullSlice]Return
+    - __kind: EventRootType
+      ID: 485
+      Name: Probe[main.condNullUnsafePtr]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 486
       Name: Probe[main.condNullUnsafePtr]Return
     - __kind: EventRootType
       ID: 461
@@ -9952,7 +10501,7 @@ Types:
       ID: 388
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 656
+      ID: 665
       Name: Probe[main.genericIdentity[go.shape.int]]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -9965,12 +10514,12 @@ Types:
             Type: 168 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: x}
+                  Variable: {subprogram: 76, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 657
+      ID: 666
       Name: Probe[main.genericIdentity[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -9983,12 +10532,12 @@ Types:
             Type: 168 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 1, name: ~r0}
+                  Variable: {subprogram: 76, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 654
+      ID: 663
       Name: Probe[main.genericIdentity[go.shape.string]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -10001,12 +10550,12 @@ Types:
             Type: 167 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: x}
+                  Variable: {subprogram: 75, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 655
+      ID: 664
       Name: Probe[main.genericIdentity[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -10019,12 +10568,12 @@ Types:
             Type: 167 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 1, name: ~r0}
+                  Variable: {subprogram: 75, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 598
+      ID: 607
       Name: Probe[main.indexMemberWrapperArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -10036,7 +10585,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
+                  Variable: {subprogram: 55, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10047,7 +10596,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 600
+      ID: 609
       Name: Probe[main.indexMemberWrapperArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10059,7 +10608,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
+                  Variable: {subprogram: 55, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10070,7 +10619,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 602
+      ID: 611
       Name: Probe[main.indexMemberWrapperArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -10082,7 +10631,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
+                  Variable: {subprogram: 55, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10096,7 +10645,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 604
+      ID: 613
       Name: Probe[main.indexMemberWrapperArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10108,7 +10657,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
+                  Variable: {subprogram: 55, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10122,19 +10671,19 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 599
+      ID: 608
       Name: Probe[main.indexMemberWrapperArg]Return
     - __kind: EventRootType
-      ID: 601
+      ID: 610
       Name: Probe[main.indexMemberWrapperArg]Return
     - __kind: EventRootType
-      ID: 603
+      ID: 612
       Name: Probe[main.indexMemberWrapperArg]Return
     - __kind: EventRootType
-      ID: 605
+      ID: 614
       Name: Probe[main.indexMemberWrapperArg]Return
     - __kind: EventRootType
-      ID: 564
+      ID: 573
       Name: Probe[main.indexNilPtrSlice]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10146,7 +10695,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: x}
+                  Variable: {subprogram: 47, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10159,7 +10708,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 566
+      ID: 575
       Name: Probe[main.indexNilPtrSlice]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10171,12 +10720,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 1, name: tag}
+                  Variable: {subprogram: 47, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 568
+      ID: 577
       Name: Probe[main.indexNilPtrSlice]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10188,7 +10737,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: x}
+                  Variable: {subprogram: 47, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10201,16 +10750,16 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 565
+      ID: 574
       Name: Probe[main.indexNilPtrSlice]Return
     - __kind: EventRootType
-      ID: 567
+      ID: 576
       Name: Probe[main.indexNilPtrSlice]Return
     - __kind: EventRootType
-      ID: 569
+      ID: 578
       Name: Probe[main.indexNilPtrSlice]Return
     - __kind: EventRootType
-      ID: 658
+      ID: 667
       Name: Probe[main.inlined]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10222,12 +10771,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: x}
+                  Variable: {subprogram: 77, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 659
+      ID: 668
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
       ID: 316
@@ -10440,7 +10989,7 @@ Types:
       ID: 337
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 556
+      ID: 565
       Name: Probe[main.lenErrInt]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -10452,7 +11001,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: x}
+                  Variable: {subprogram: 45, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -10463,21 +11012,21 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 1, name: tag}
+                  Variable: {subprogram: 45, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 558
+      ID: 567
       Name: Probe[main.lenErrInt]
     - __kind: EventRootType
-      ID: 557
+      ID: 566
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 559
+      ID: 568
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 560
+      ID: 569
       Name: Probe[main.lenErrStruct]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -10489,7 +11038,7 @@ Types:
             Type: 119 StructureType main.condFields
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: x}
+                  Variable: {subprogram: 46, index: 0, name: x}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -10500,21 +11049,21 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 1, name: tag}
+                  Variable: {subprogram: 46, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 562
+      ID: 571
       Name: Probe[main.lenErrStruct]
     - __kind: EventRootType
-      ID: 561
+      ID: 570
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 563
+      ID: 572
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 510
+      ID: 519
       Name: Probe[main.lenMap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10526,12 +11075,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Variable: {subprogram: 41, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 512
+      ID: 521
       Name: Probe[main.lenMap]
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -10543,7 +11092,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: m}
+                  Variable: {subprogram: 41, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10557,7 +11106,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 514
+      ID: 523
       Name: Probe[main.lenMap]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10569,845 +11118,16 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: m}
+                  Variable: {subprogram: 41, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
                   Bias: 0
                   ByteSize: 8
           DictIndex: -1
-    - __kind: EventRootType
-      ID: 516
-      Name: Probe[main.lenMap]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 518
-      Name: Probe[main.lenMap]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(m)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 8 BaseType uint64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 0
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 520
-      Name: Probe[main.lenMap]
-      ByteSize: 25
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 109 GoMapType map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-          DictIndex: -1
-        - Name: tag
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 511
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 513
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 515
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 517
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 519
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 521
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 522
-      Name: Probe[main.lenPtrString]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(s)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 524
-      Name: Probe[main.lenPtrString]
-      ByteSize: 25
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 93 PointerType *string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 8
-          DictIndex: -1
-        - Name: tag
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 523
-      Name: Probe[main.lenPtrString]Return
     - __kind: EventRootType
       ID: 525
-      Name: Probe[main.lenPtrString]Return
-    - __kind: EventRootType
-      ID: 546
-      Name: Probe[main.lenPtrStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: items_0
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 16
-                  ByteSize: 16
-                - __kind: SliceBoundsCheckOp
-                  Index: 0
-                - __kind: DereferenceOp
-                  Bias: 0
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 548
-      Name: Probe[main.lenPtrStructFields]
-      ByteSize: 25
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 124 PointerType *main.lenFields
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-          DictIndex: -1
-        - Name: tag
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 550
-      Name: Probe[main.lenPtrStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.Dict)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 8 BaseType uint64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 40
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 0
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 552
-      Name: Probe[main.lenPtrStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.Items)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 24
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 554
-      Name: Probe[main.lenPtrStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.S)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 547
-      Name: Probe[main.lenPtrStructFields]Return
-    - __kind: EventRootType
-      ID: 549
-      Name: Probe[main.lenPtrStructFields]Return
-    - __kind: EventRootType
-      ID: 551
-      Name: Probe[main.lenPtrStructFields]Return
-    - __kind: EventRootType
-      ID: 553
-      Name: Probe[main.lenPtrStructFields]Return
-    - __kind: EventRootType
-      ID: 555
-      Name: Probe[main.lenPtrStructFields]Return
-    - __kind: EventRootType
-      ID: 498
-      Name: Probe[main.lenSlice]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 500
-      Name: Probe[main.lenSlice]
-      ByteSize: 2
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: isEmpty(s)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-                - __kind: ExprPushOffsetOp
-                  ByteSize: 8
-                - __kind: ExprLoadLiteralOp
-                  Data: AAAAAAAAAAA=
-                - __kind: ExprCmpEqBaseOp
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 502
-      Name: Probe[main.lenSlice]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s_len
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 504
-      Name: Probe[main.lenSlice]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 506
-      Name: Probe[main.lenSlice]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(s)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 508
-      Name: Probe[main.lenSlice]
-      ByteSize: 41
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 105 GoSliceHeaderType []int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 24
-          DictIndex: -1
-        - Name: tag
-          Offset: 25
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 499
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 501
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 503
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 505
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 507
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 509
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 478
-      Name: Probe[main.lenString]
-      ByteSize: 33
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-        - Name: tag
-          Offset: 17
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 480
-      Name: Probe[main.lenString]
-      ByteSize: 2
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s_len_eq_5
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-                - __kind: ExprPushOffsetOp
-                  ByteSize: 8
-                - __kind: ExprLoadLiteralOp
-                  Data: BQAAAAAAAAA=
-                - __kind: ExprCmpEqBaseOp
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 482
-      Name: Probe[main.lenString]
-      ByteSize: 2
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(s) == 5
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-                - __kind: ExprPushOffsetOp
-                  ByteSize: 8
-                - __kind: ExprLoadLiteralOp
-                  Data: BQAAAAAAAAA=
-                - __kind: ExprCmpEqBaseOp
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 484
-      Name: Probe[main.lenString]
-      ByteSize: 2
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s_isEmpty
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-                - __kind: ExprPushOffsetOp
-                  ByteSize: 8
-                - __kind: ExprLoadLiteralOp
-                  Data: AAAAAAAAAAA=
-                - __kind: ExprCmpEqBaseOp
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 486
-      Name: Probe[main.lenString]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 488
-      Name: Probe[main.lenString]
-      ByteSize: 2
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: isEmpty(s)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-                - __kind: ExprPushOffsetOp
-                  ByteSize: 8
-                - __kind: ExprLoadLiteralOp
-                  Data: AAAAAAAAAAA=
-                - __kind: ExprCmpEqBaseOp
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 490
-      Name: Probe[main.lenString]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s_len
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 492
-      Name: Probe[main.lenString]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 494
-      Name: Probe[main.lenString]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(s)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 496
-      Name: Probe[main.lenString]
-      ByteSize: 33
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-        - Name: tag
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 479
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 481
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 483
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 485
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 487
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 489
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 491
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 493
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 495
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 497
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 526
-      Name: Probe[main.lenStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: items_2
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 16
-                  ByteSize: 16
-                - __kind: SliceBoundsCheckOp
-                  Index: 2
-                - __kind: DereferenceOp
-                  Bias: 16
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 528
-      Name: Probe[main.lenStructFields]
-      ByteSize: 89
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 122 StructureType main.lenFields
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 72
-          DictIndex: -1
-        - Name: tag
-          Offset: 73
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 530
-      Name: Probe[main.lenStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.Dict)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 8 BaseType uint64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 40
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 0
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 532
-      Name: Probe[main.lenStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.PtrSlice)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 56
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 534
-      Name: Probe[main.lenStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.PtrStr)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 48
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 536
-      Name: Probe[main.lenStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.Items)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 24
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 538
-      Name: Probe[main.lenStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.S)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 540
-      Name: Probe[main.lenStructFields]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 542
-      Name: Probe[main.lenStructFields]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 544
-      Name: Probe[main.lenStructFields]
+      Name: Probe[main.lenMap]
       ByteSize: 17
       ExprStatusArraySize: 1
       Expressions:
@@ -11424,33 +11144,862 @@ Types:
           DictIndex: -1
     - __kind: EventRootType
       ID: 527
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenMap]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(m)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 41, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+          DictIndex: -1
     - __kind: EventRootType
       ID: 529
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenMap]
+      ByteSize: 25
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 109 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 41, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 41, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 520
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 522
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 524
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 526
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 528
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 530
+      Name: Probe[main.lenMap]Return
     - __kind: EventRootType
       ID: 531
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenPtrString]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 42, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+          DictIndex: -1
     - __kind: EventRootType
       ID: 533
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenPtrString]
+      ByteSize: 25
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 93 PointerType *string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 42, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 42, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 532
+      Name: Probe[main.lenPtrString]Return
+    - __kind: EventRootType
+      ID: 534
+      Name: Probe[main.lenPtrString]Return
+    - __kind: EventRootType
+      ID: 555
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: items_0
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 16
+                  ByteSize: 16
+                - __kind: SliceBoundsCheckOp
+                  Index: 0
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 557
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 25
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 124 PointerType *main.lenFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 559
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.Dict)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 40
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 561
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.Items)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 24
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 563
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.S)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 556
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 558
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 560
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 562
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 564
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 507
+      Name: Probe[main.lenSlice]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 509
+      Name: Probe[main.lenSlice]
+      ByteSize: 2
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: isEmpty(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 511
+      Name: Probe[main.lenSlice]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s_len
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 513
+      Name: Probe[main.lenSlice]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 515
+      Name: Probe[main.lenSlice]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 517
+      Name: Probe[main.lenSlice]
+      ByteSize: 41
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 105 GoSliceHeaderType []int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+          DictIndex: -1
+        - Name: tag
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 508
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 510
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 512
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 514
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 516
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 518
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 487
+      Name: Probe[main.lenString]
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: tag
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 489
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s_len_eq_5
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 491
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(s) == 5
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 493
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s_isEmpty
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 495
+      Name: Probe[main.lenString]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 497
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: isEmpty(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 499
+      Name: Probe[main.lenString]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s_len
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 501
+      Name: Probe[main.lenString]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 503
+      Name: Probe[main.lenString]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 505
+      Name: Probe[main.lenString]
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: tag
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 488
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 490
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 492
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 494
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 496
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 498
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 500
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 502
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 504
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 506
+      Name: Probe[main.lenString]Return
     - __kind: EventRootType
       ID: 535
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: items_2
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 16
+                  ByteSize: 16
+                - __kind: SliceBoundsCheckOp
+                  Index: 2
+                - __kind: DereferenceOp
+                  Bias: 16
+                  ByteSize: 8
+          DictIndex: -1
     - __kind: EventRootType
       ID: 537
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenStructFields]
+      ByteSize: 89
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 122 StructureType main.lenFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 72
+          DictIndex: -1
+        - Name: tag
+          Offset: 73
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
     - __kind: EventRootType
       ID: 539
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.Dict)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 40
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+          DictIndex: -1
     - __kind: EventRootType
       ID: 541
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.PtrSlice)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 56
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+          DictIndex: -1
     - __kind: EventRootType
       ID: 543
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.PtrStr)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 48
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+          DictIndex: -1
     - __kind: EventRootType
       ID: 545
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.Items)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 24
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 547
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.S)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 8
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 549
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 551
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 553
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 536
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 538
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 540
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 542
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 544
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 546
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 548
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 550
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 552
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 554
       Name: Probe[main.lenStructFields]Return
     - __kind: EventRootType
       ID: 357
@@ -11484,7 +12033,7 @@ Types:
       ID: 358
       Name: Probe[main.mapArg]Return
     - __kind: EventRootType
-      ID: 642
+      ID: 651
       Name: Probe[main.mapIndexBoolKey]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11496,7 +12045,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11523,7 +12072,7 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 644
+      ID: 653
       Name: Probe[main.mapIndexBoolKey]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11535,7 +12084,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11562,13 +12111,13 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 643
+      ID: 652
+      Name: Probe[main.mapIndexBoolKey]Return
+    - __kind: EventRootType
+      ID: 654
       Name: Probe[main.mapIndexBoolKey]Return
     - __kind: EventRootType
       ID: 645
-      Name: Probe[main.mapIndexBoolKey]Return
-    - __kind: EventRootType
-      ID: 636
       Name: Probe[main.mapIndexEmptyKey]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11580,7 +12129,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11607,10 +12156,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 637
+      ID: 646
       Name: Probe[main.mapIndexEmptyKey]Return
     - __kind: EventRootType
-      ID: 606
+      ID: 615
       Name: Probe[main.mapIndexIntKey]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -11622,7 +12171,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: m}
+                  Variable: {subprogram: 56, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11649,10 +12198,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 607
+      ID: 616
       Name: Probe[main.mapIndexIntKey]Return
     - __kind: EventRootType
-      ID: 638
+      ID: 647
       Name: Probe[main.mapIndexKeyLen16]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11664,7 +12213,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11691,10 +12240,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 639
+      ID: 648
       Name: Probe[main.mapIndexKeyLen16]Return
     - __kind: EventRootType
-      ID: 640
+      ID: 649
       Name: Probe[main.mapIndexKeyLen17]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11706,7 +12255,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11733,10 +12282,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 641
+      ID: 650
       Name: Probe[main.mapIndexKeyLen17]Return
     - __kind: EventRootType
-      ID: 626
+      ID: 635
       Name: Probe[main.mapIndexKeyLen200]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11748,7 +12297,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
+                  Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11775,10 +12324,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 627
+      ID: 636
       Name: Probe[main.mapIndexKeyLen200]Return
     - __kind: EventRootType
-      ID: 620
+      ID: 629
       Name: Probe[main.mapIndexKeyLen24]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11790,7 +12339,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
+                  Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11817,10 +12366,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 621
+      ID: 630
       Name: Probe[main.mapIndexKeyLen24]Return
     - __kind: EventRootType
-      ID: 622
+      ID: 631
       Name: Probe[main.mapIndexKeyLen48]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11832,7 +12381,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
+                  Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11859,10 +12408,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 623
+      ID: 632
       Name: Probe[main.mapIndexKeyLen48]Return
     - __kind: EventRootType
-      ID: 618
+      ID: 627
       Name: Probe[main.mapIndexKeyLen8]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11874,7 +12423,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
+                  Variable: {subprogram: 60, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11901,10 +12450,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 619
+      ID: 628
       Name: Probe[main.mapIndexKeyLen8]Return
     - __kind: EventRootType
-      ID: 624
+      ID: 633
       Name: Probe[main.mapIndexKeyLen96]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11916,7 +12465,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11943,10 +12492,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 625
+      ID: 634
       Name: Probe[main.mapIndexKeyLen96]Return
     - __kind: EventRootType
-      ID: 614
+      ID: 623
       Name: Probe[main.mapIndexLargeMap]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11958,7 +12507,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: m}
+                  Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11985,10 +12534,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 615
+      ID: 624
       Name: Probe[main.mapIndexLargeMap]Return
     - __kind: EventRootType
-      ID: 650
+      ID: 659
       Name: Probe[main.mapIndexLargeValue]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12000,7 +12549,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12030,10 +12579,10 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 651
+      ID: 660
       Name: Probe[main.mapIndexLargeValue]Return
     - __kind: EventRootType
-      ID: 616
+      ID: 625
       Name: Probe[main.mapIndexMissing]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12045,7 +12594,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
+                  Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12072,10 +12621,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 617
+      ID: 626
       Name: Probe[main.mapIndexMissing]Return
     - __kind: EventRootType
-      ID: 648
+      ID: 657
       Name: Probe[main.mapIndexNilPtrVal]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12087,7 +12636,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 72, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12117,10 +12666,10 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 649
+      ID: 658
       Name: Probe[main.mapIndexNilPtrVal]Return
     - __kind: EventRootType
-      ID: 632
+      ID: 641
       Name: Probe[main.mapIndexPtrStructVal]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12132,7 +12681,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12162,7 +12711,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 634
+      ID: 643
       Name: Probe[main.mapIndexPtrStructVal]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12174,7 +12723,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12204,13 +12753,13 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 633
+      ID: 642
       Name: Probe[main.mapIndexPtrStructVal]Return
     - __kind: EventRootType
-      ID: 635
+      ID: 644
       Name: Probe[main.mapIndexPtrStructVal]Return
     - __kind: EventRootType
-      ID: 608
+      ID: 617
       Name: Probe[main.mapIndexStringKey]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12222,7 +12771,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12249,10 +12798,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 610
+      ID: 619
       Name: Probe[main.mapIndexStringKey]
     - __kind: EventRootType
-      ID: 612
+      ID: 621
       Name: Probe[main.mapIndexStringKey]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12264,7 +12813,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12291,16 +12840,16 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 609
+      ID: 618
       Name: Probe[main.mapIndexStringKey]Return
     - __kind: EventRootType
-      ID: 611
+      ID: 620
       Name: Probe[main.mapIndexStringKey]Return
     - __kind: EventRootType
-      ID: 613
+      ID: 622
       Name: Probe[main.mapIndexStringKey]Return
     - __kind: EventRootType
-      ID: 628
+      ID: 637
       Name: Probe[main.mapIndexStructVal]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12312,7 +12861,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12339,7 +12888,7 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 630
+      ID: 639
       Name: Probe[main.mapIndexStructVal]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12351,7 +12900,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12378,13 +12927,13 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 629
+      ID: 638
       Name: Probe[main.mapIndexStructVal]Return
     - __kind: EventRootType
-      ID: 631
+      ID: 640
       Name: Probe[main.mapIndexStructVal]Return
     - __kind: EventRootType
-      ID: 646
+      ID: 655
       Name: Probe[main.mapIndexZeroValue]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12396,7 +12945,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12423,7 +12972,7 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 647
+      ID: 656
       Name: Probe[main.mapIndexZeroValue]Return
     - __kind: EventRootType
       ID: 361
@@ -12432,7 +12981,7 @@ Types:
       ID: 362
       Name: Probe[main.noArgs]Return
     - __kind: EventRootType
-      ID: 594
+      ID: 603
       Name: Probe[main.ptrStructArrayArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12444,7 +12993,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: s}
+                  Variable: {subprogram: 54, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12452,7 +13001,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 596
+      ID: 605
       Name: Probe[main.ptrStructArrayArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12464,7 +13013,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: s}
+                  Variable: {subprogram: 54, index: 0, name: s}
                   Offset: 8
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12472,13 +13021,13 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 595
+      ID: 604
       Name: Probe[main.ptrStructArrayArg]Return
     - __kind: EventRootType
-      ID: 597
+      ID: 606
       Name: Probe[main.ptrStructArrayArg]Return
     - __kind: EventRootType
-      ID: 590
+      ID: 599
       Name: Probe[main.ptrStructSliceArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12490,7 +13039,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: s}
+                  Variable: {subprogram: 53, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -12503,7 +13052,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 592
+      ID: 601
       Name: Probe[main.ptrStructSliceArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12515,7 +13064,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: s}
+                  Variable: {subprogram: 53, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -12528,10 +13077,10 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 591
+      ID: 600
       Name: Probe[main.ptrStructSliceArg]Return
     - __kind: EventRootType
-      ID: 593
+      ID: 602
       Name: Probe[main.ptrStructSliceArg]Return
     - __kind: EventRootType
       ID: 318
@@ -12693,7 +13242,7 @@ Types:
       ID: 351
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 586
+      ID: 595
       Name: Probe[main.structArrayArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12705,12 +13254,12 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: s}
+                  Variable: {subprogram: 52, index: 0, name: s}
                   Offset: 0
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 588
+      ID: 597
       Name: Probe[main.structArrayArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12722,18 +13271,18 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: s}
+                  Variable: {subprogram: 52, index: 0, name: s}
                   Offset: 40
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
+      ID: 596
+      Name: Probe[main.structArrayArg]Return
+    - __kind: EventRootType
+      ID: 598
+      Name: Probe[main.structArrayArg]Return
+    - __kind: EventRootType
       ID: 587
-      Name: Probe[main.structArrayArg]Return
-    - __kind: EventRootType
-      ID: 589
-      Name: Probe[main.structArrayArg]Return
-    - __kind: EventRootType
-      ID: 578
       Name: Probe[main.structSliceArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12745,7 +13294,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: s}
+                  Variable: {subprogram: 51, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -12755,7 +13304,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 580
+      ID: 589
       Name: Probe[main.structSliceArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12767,7 +13316,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: s}
+                  Variable: {subprogram: 51, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -12777,7 +13326,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 582
+      ID: 591
       Name: Probe[main.structSliceArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12789,12 +13338,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 1, name: tag}
+                  Variable: {subprogram: 51, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 584
+      ID: 593
       Name: Probe[main.structSliceArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12806,7 +13355,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: s}
+                  Variable: {subprogram: 51, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -12816,22 +13365,22 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
+      ID: 588
+      Name: Probe[main.structSliceArg]Return
+    - __kind: EventRootType
+      ID: 590
+      Name: Probe[main.structSliceArg]Return
+    - __kind: EventRootType
+      ID: 592
+      Name: Probe[main.structSliceArg]Return
+    - __kind: EventRootType
+      ID: 594
+      Name: Probe[main.structSliceArg]Return
+    - __kind: EventRootType
       ID: 579
-      Name: Probe[main.structSliceArg]Return
-    - __kind: EventRootType
-      ID: 581
-      Name: Probe[main.structSliceArg]Return
-    - __kind: EventRootType
-      ID: 583
-      Name: Probe[main.structSliceArg]Return
-    - __kind: EventRootType
-      ID: 585
-      Name: Probe[main.structSliceArg]Return
-    - __kind: EventRootType
-      ID: 570
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 571
+      ID: 580
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12843,14 +13392,14 @@ Types:
             Type: 125 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: ~r0}
+                  Variable: {subprogram: 48, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: ArrayType
       ID: 92
       Name: '[0]uint8'
-      GoRuntimeType: 56384
+      GoRuntimeType: 56480
       GoKind: 17
       HasCount: true
       Element: 3 BaseType uint8
@@ -12858,7 +13407,7 @@ Types:
       ID: 89
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 56288
+      GoRuntimeType: 56384
       GoKind: 17
       Count: 10
       HasCount: true
@@ -12902,7 +13451,7 @@ Types:
       ID: 75
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 55904
+      GoRuntimeType: 56000
       GoKind: 17
       Count: 2
       HasCount: true
@@ -12911,7 +13460,7 @@ Types:
       ID: 74
       Name: '[2][2]*runtime.traceBuf'
       ByteSize: 32
-      GoRuntimeType: 56000
+      GoRuntimeType: 56096
       GoKind: 17
       Count: 2
       HasCount: true
@@ -12920,7 +13469,7 @@ Types:
       ID: 81
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 56192
+      GoRuntimeType: 56288
       GoKind: 17
       Count: 2
       HasCount: true
@@ -12937,7 +13486,7 @@ Types:
       ID: 54
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 52256
+      GoRuntimeType: 52352
       GoKind: 17
       Count: 2
       HasCount: true
@@ -12946,7 +13495,7 @@ Types:
       ID: 87
       Name: '[32]uint64'
       ByteSize: 256
-      GoRuntimeType: 58304
+      GoRuntimeType: 58400
       GoKind: 17
       Count: 32
       HasCount: true
@@ -12955,7 +13504,7 @@ Types:
       ID: 65
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 55712
+      GoRuntimeType: 55808
       GoKind: 17
       Count: 32
       HasCount: true
@@ -12982,7 +13531,7 @@ Types:
       ID: 53
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 55424
+      GoRuntimeType: 55520
       GoKind: 17
       Count: 3
       HasCount: true
@@ -13000,7 +13549,7 @@ Types:
       ID: 88
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 57536
+      GoRuntimeType: 57632
       GoKind: 17
       Count: 4
       HasCount: true
@@ -13009,7 +13558,7 @@ Types:
       ID: 58
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 54656
+      GoRuntimeType: 54752
       GoKind: 17
       Count: 6
       HasCount: true
@@ -13018,7 +13567,7 @@ Types:
       ID: 82
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 56096
+      GoRuntimeType: 56192
       GoKind: 17
       Count: 8
       HasCount: true
@@ -13293,7 +13842,7 @@ Types:
       ID: 14
       Name: error
       ByteSize: 16
-      GoRuntimeType: 67424
+      GoRuntimeType: 67520
       GoKind: 20
       RawFields:
         - Name: tab
@@ -13328,7 +13877,7 @@ Types:
       ID: 70
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 60576
+      GoRuntimeType: 60672
       GoKind: 19
     - __kind: BaseType
       ID: 168
@@ -13517,7 +14066,7 @@ Types:
       ID: 86
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 120000
+      GoRuntimeType: 120096
       GoKind: 25
       RawFields:
         - Name: buf
@@ -13542,14 +14091,14 @@ Types:
     - __kind: StructureType
       ID: 305
       Name: internal/poll.errNetClosing
-      GoRuntimeType: 96608
+      GoRuntimeType: 96704
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 78656
+      GoRuntimeType: 78752
       GoKind: 25
       RawFields:
         - Name: u
@@ -13559,7 +14108,7 @@ Types:
       ID: 68
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 107296
+      GoRuntimeType: 107392
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -13575,7 +14124,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 97408
+      GoRuntimeType: 97504
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -13588,7 +14137,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 97248
+      GoRuntimeType: 97344
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -13601,7 +14150,7 @@ Types:
       ID: 73
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 97568
+      GoRuntimeType: 97664
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -13613,13 +14162,13 @@ Types:
     - __kind: StructureType
       ID: 69
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 65856
+      GoRuntimeType: 65952
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 33
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 65760
+      GoRuntimeType: 65856
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -13630,14 +14179,14 @@ Types:
       ID: 269
       Name: main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 74304
+      GoRuntimeType: 74400
       GoKind: 25
       RawFields: [{Name: a, Offset: 0, Type: 7 BaseType int}]
     - __kind: StructureType
       ID: 132
       Name: main.bigArrayStruct
       ByteSize: 1048584
-      GoRuntimeType: 89888
+      GoRuntimeType: 89984
       GoKind: 25
       RawFields:
         - Name: tag
@@ -13650,7 +14199,7 @@ Types:
       ID: 199
       Name: main.bigStruct
       ByteSize: 184
-      GoRuntimeType: 127968
+      GoRuntimeType: 128064
       GoKind: 25
       RawFields:
         - Name: Field1
@@ -13681,7 +14230,7 @@ Types:
       ID: 119
       Name: main.condFields
       ByteSize: 80
-      GoRuntimeType: 135040
+      GoRuntimeType: 135136
       GoKind: 25
       RawFields:
         - Name: I8
@@ -13727,7 +14276,7 @@ Types:
       ID: 135
       Name: main.indexMemberStruct
       ByteSize: 32
-      GoRuntimeType: 100768
+      GoRuntimeType: 100864
       GoKind: 25
       RawFields:
         - Name: Val
@@ -13758,7 +14307,7 @@ Types:
       ID: 258
       Name: main.largeValueStruct
       ByteSize: 264
-      GoRuntimeType: 89728
+      GoRuntimeType: 89824
       GoKind: 25
       RawFields:
         - Name: Pad
@@ -13771,7 +14320,7 @@ Types:
       ID: 122
       Name: main.lenFields
       ByteSize: 72
-      GoRuntimeType: 122336
+      GoRuntimeType: 122432
       GoKind: 25
       RawFields:
         - Name: S
@@ -14090,63 +14639,63 @@ Types:
       ID: 157
       Name: map[bool]int
       ByteSize: 8
-      GoRuntimeType: 71648
+      GoRuntimeType: 71744
       GoKind: 21
       HeaderType: 159 GoSwissMapHeaderType map<bool,int>
     - __kind: GoMapType
       ID: 208
       Name: map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 71776
+      GoRuntimeType: 71872
       GoKind: 21
       HeaderType: 210 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 142
       Name: map[int]string
       ByteSize: 8
-      GoRuntimeType: 71904
+      GoRuntimeType: 72000
       GoKind: 21
       HeaderType: 144 GoSwissMapHeaderType map<int,string>
     - __kind: GoMapType
       ID: 152
       Name: map[string]*main.indexMemberStruct
       ByteSize: 8
-      GoRuntimeType: 72032
+      GoRuntimeType: 72128
       GoKind: 21
       HeaderType: 154 GoSwissMapHeaderType map<string,*main.indexMemberStruct>
     - __kind: GoMapType
       ID: 109
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 71520
+      GoRuntimeType: 71616
       GoKind: 21
       HeaderType: 111 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 114
       Name: map[string]main.bigStruct
       ByteSize: 8
-      GoRuntimeType: 72160
+      GoRuntimeType: 72256
       GoKind: 21
       HeaderType: 116 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: GoMapType
       ID: 147
       Name: map[string]main.indexMemberStruct
       ByteSize: 8
-      GoRuntimeType: 72288
+      GoRuntimeType: 72384
       GoKind: 21
       HeaderType: 149 GoSwissMapHeaderType map<string,main.indexMemberStruct>
     - __kind: GoMapType
       ID: 162
       Name: map[string]main.largeValueStruct
       ByteSize: 8
-      GoRuntimeType: 72416
+      GoRuntimeType: 72512
       GoKind: 21
       HeaderType: 164 GoSwissMapHeaderType map<string,main.largeValueStruct>
     - __kind: GoMapType
       ID: 125
       Name: map[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 72672
+      GoRuntimeType: 72768
       GoKind: 21
       HeaderType: 127 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: ArrayType
@@ -14234,7 +14783,7 @@ Types:
       ID: 246
       Name: noalg.map.group[bool]int
       ByteSize: 136
-      GoRuntimeType: 80320
+      GoRuntimeType: 80416
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14247,7 +14796,7 @@ Types:
       ID: 266
       Name: noalg.map.group[int]main.aStructNotUsedAsAnArgument
       ByteSize: 136
-      GoRuntimeType: 80576
+      GoRuntimeType: 80672
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14260,7 +14809,7 @@ Types:
       ID: 222
       Name: noalg.map.group[int]string
       ByteSize: 200
-      GoRuntimeType: 80832
+      GoRuntimeType: 80928
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14273,7 +14822,7 @@ Types:
       ID: 238
       Name: noalg.map.group[string]*main.indexMemberStruct
       ByteSize: 200
-      GoRuntimeType: 81088
+      GoRuntimeType: 81184
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14286,7 +14835,7 @@ Types:
       ID: 187
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 80064
+      GoRuntimeType: 80160
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14299,7 +14848,7 @@ Types:
       ID: 195
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
-      GoRuntimeType: 81344
+      GoRuntimeType: 81440
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14312,7 +14861,7 @@ Types:
       ID: 230
       Name: noalg.map.group[string]main.indexMemberStruct
       ByteSize: 392
-      GoRuntimeType: 81600
+      GoRuntimeType: 81696
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14325,7 +14874,7 @@ Types:
       ID: 254
       Name: noalg.map.group[string]main.largeValueStruct
       ByteSize: 200
-      GoRuntimeType: 81856
+      GoRuntimeType: 81952
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14338,7 +14887,7 @@ Types:
       ID: 205
       Name: noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 136
-      GoRuntimeType: 82368
+      GoRuntimeType: 82464
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14351,7 +14900,7 @@ Types:
       ID: 248
       Name: noalg.struct { key bool; elem int }
       ByteSize: 16
-      GoRuntimeType: 80192
+      GoRuntimeType: 80288
       GoKind: 25
       RawFields:
         - Name: key
@@ -14364,7 +14913,7 @@ Types:
       ID: 268
       Name: noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
       ByteSize: 16
-      GoRuntimeType: 80448
+      GoRuntimeType: 80544
       GoKind: 25
       RawFields:
         - Name: key
@@ -14377,7 +14926,7 @@ Types:
       ID: 224
       Name: noalg.struct { key int; elem string }
       ByteSize: 24
-      GoRuntimeType: 80704
+      GoRuntimeType: 80800
       GoKind: 25
       RawFields:
         - Name: key
@@ -14390,7 +14939,7 @@ Types:
       ID: 197
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
-      GoRuntimeType: 81216
+      GoRuntimeType: 81312
       GoKind: 25
       RawFields:
         - Name: key
@@ -14403,7 +14952,7 @@ Types:
       ID: 240
       Name: noalg.struct { key string; elem *main.indexMemberStruct }
       ByteSize: 24
-      GoRuntimeType: 80960
+      GoRuntimeType: 81056
       GoKind: 25
       RawFields:
         - Name: key
@@ -14416,7 +14965,7 @@ Types:
       ID: 256
       Name: noalg.struct { key string; elem *main.largeValueStruct }
       ByteSize: 24
-      GoRuntimeType: 81728
+      GoRuntimeType: 81824
       GoKind: 25
       RawFields:
         - Name: key
@@ -14429,7 +14978,7 @@ Types:
       ID: 189
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 79936
+      GoRuntimeType: 80032
       GoKind: 25
       RawFields:
         - Name: key
@@ -14442,7 +14991,7 @@ Types:
       ID: 232
       Name: noalg.struct { key string; elem main.indexMemberStruct }
       ByteSize: 48
-      GoRuntimeType: 81472
+      GoRuntimeType: 81568
       GoKind: 25
       RawFields:
         - Name: key
@@ -14455,7 +15004,7 @@ Types:
       ID: 207
       Name: noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
       ByteSize: 16
-      GoRuntimeType: 82240
+      GoRuntimeType: 82336
       GoKind: 25
       RawFields:
         - Name: key
@@ -14492,7 +15041,7 @@ Types:
       ID: 295
       Name: runtime.boundsError
       ByteSize: 24
-      GoRuntimeType: 120896
+      GoRuntimeType: 120992
       GoKind: 25
       RawFields:
         - Name: x
@@ -14524,14 +15073,14 @@ Types:
     - __kind: StructureType
       ID: 84
       Name: runtime.dlogPerM
-      GoRuntimeType: 64992
+      GoRuntimeType: 65088
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 301
       Name: runtime.errorAddressString
       ByteSize: 24
-      GoRuntimeType: 113440
+      GoRuntimeType: 113536
       GoKind: 25
       RawFields:
         - Name: msg
@@ -14544,7 +15093,7 @@ Types:
       ID: 282
       Name: runtime.errorString
       ByteSize: 16
-      GoRuntimeType: 64512
+      GoRuntimeType: 64608
       GoKind: 24
       RawFields:
         - Name: str
@@ -14563,7 +15112,7 @@ Types:
       ID: 22
       Name: runtime.g
       ByteSize: 440
-      GoRuntimeType: 150240
+      GoRuntimeType: 150336
       GoKind: 25
       RawFields:
         - Name: stack
@@ -14744,7 +15293,7 @@ Types:
       ID: 51
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 77120
+      GoRuntimeType: 77216
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -14754,7 +15303,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 56
-      GoRuntimeType: 125952
+      GoRuntimeType: 126048
       GoKind: 25
       RawFields:
         - Name: sp
@@ -14782,7 +15331,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 94848
+      GoRuntimeType: 94944
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -14795,7 +15344,7 @@ Types:
       ID: 56
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 112480
+      GoRuntimeType: 112576
       GoKind: 25
       RawFields:
         - Name: stack
@@ -14814,13 +15363,13 @@ Types:
       ID: 31
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 59136
+      GoRuntimeType: 59232
       GoKind: 12
     - __kind: StructureType
       ID: 90
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 94688
+      GoRuntimeType: 94784
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -14833,7 +15382,7 @@ Types:
       ID: 78
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 124128
+      GoRuntimeType: 124224
       GoKind: 25
       RawFields:
         - Name: fn
@@ -14858,13 +15407,13 @@ Types:
       ID: 91
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 59040
+      GoRuntimeType: 59136
       GoKind: 2
     - __kind: StructureType
       ID: 29
       Name: runtime.m
       ByteSize: 1808
-      GoRuntimeType: 155296
+      GoRuntimeType: 155392
       GoKind: 25
       RawFields:
         - Name: g0
@@ -15087,7 +15636,7 @@ Types:
       ID: 67
       Name: runtime.mLockProfile
       ByteSize: 64
-      GoRuntimeType: 126240
+      GoRuntimeType: 126336
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -15115,7 +15664,7 @@ Types:
       ID: 85
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 118656
+      GoRuntimeType: 118752
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -15137,7 +15686,7 @@ Types:
       ID: 72
       Name: runtime.mTraceState
       ByteSize: 56
-      GoRuntimeType: 118432
+      GoRuntimeType: 118528
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -15159,7 +15708,7 @@ Types:
       ID: 66
       Name: runtime.mWaitList
       ByteSize: 8
-      GoRuntimeType: 76864
+      GoRuntimeType: 76960
       GoKind: 25
       RawFields:
         - Name: next
@@ -15169,20 +15718,20 @@ Types:
       ID: 37
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 58752
+      GoRuntimeType: 58848
       GoKind: 12
     - __kind: StructureType
       ID: 64
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 76736
+      GoRuntimeType: 76832
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: StructureType
       ID: 80
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 94528
+      GoRuntimeType: 94624
       GoKind: 25
       RawFields:
         - Name: entries
@@ -15195,7 +15744,7 @@ Types:
       ID: 83
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 113248
+      GoRuntimeType: 113344
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -15214,7 +15763,7 @@ Types:
       ID: 285
       Name: runtime.plainError
       ByteSize: 16
-      GoRuntimeType: 64608
+      GoRuntimeType: 64704
       GoKind: 24
       RawFields:
         - Name: str
@@ -15233,13 +15782,13 @@ Types:
       ID: 60
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 58944
+      GoRuntimeType: 59040
       GoKind: 12
     - __kind: ArrayType
       ID: 57
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 62112
+      GoRuntimeType: 62208
       GoKind: 17
       Count: 2
       HasCount: true
@@ -15248,7 +15797,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 92928
+      GoRuntimeType: 93024
       GoKind: 25
       RawFields:
         - Name: lo
@@ -15289,7 +15838,7 @@ Types:
       ID: 52
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 93888
+      GoRuntimeType: 93984
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -15302,12 +15851,12 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 79680
+      GoRuntimeType: 79776
       GoKind: 8
     - __kind: StructureType
       ID: 79
       Name: runtime.winlibcall
-      GoRuntimeType: 64896
+      GoRuntimeType: 64992
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -15337,7 +15886,7 @@ Types:
       ID: 308
       Name: syscall.Errno
       ByteSize: 8
-      GoRuntimeType: 79808
+      GoRuntimeType: 79904
       GoKind: 12
     - __kind: StructureType
       ID: 243
@@ -15559,7 +16108,7 @@ Types:
       ID: 272
       Name: time.fileSizeError
       ByteSize: 16
-      GoRuntimeType: 59232
+      GoRuntimeType: 59328
       GoKind: 24
       RawFields:
         - Name: str
@@ -15616,7 +16165,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 45344
       GoKind: 26
-MaxTypeID: 662
+MaxTypeID: 671
 Issues:
     - probe_definition:
         id: condCompound_eq_of_eq
@@ -15924,6 +16473,26 @@ Issues:
       issue:
         Kind: 7
         Message: condition variable "x" not available at any event
+    - probe_definition:
+        id: condLineReturn_cond_return
+        version: 0
+        type: LOG_PROBE
+        where:
+            methodName: main.condLineReturn
+            sourceFile: main.go
+            lines: ["571"]
+        tags: ['issue:ConditionVariableUnavailable']
+        when:
+            dsl: '@return == 14'
+            json: {eq: [{ref: '@return'}, 14]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: matched
+        segments: [matched]
+        captureSnapshot: false
+      issue:
+        Kind: 7
+        Message: condition variable "@return" not found
     - probe_definition:
         id: condNull_int_vs_null
         version: 0

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
@@ -9,10 +9,10 @@ Probes:
       segments: ['ptr: ', {json: {ref: ptr}, dsl: ptr}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 76}
+        - subprogram: {subprogram: 78}
           events:
             - Kind: Entry
-              Type: 675 EventRootType Probe[main.PointerChainArg]
+              Type: 684 EventRootType Probe[main.PointerChainArg]
               InjectionPoints: [{PC: "0xb8b20", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -32,10 +32,10 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 77}
+        - subprogram: {subprogram: 79}
           events:
             - Kind: Entry
-              Type: 676 EventRootType Probe[main.PointerSmallChainArg]
+              Type: 685 EventRootType Probe[main.PointerSmallChainArg]
               InjectionPoints: [{PC: "0xb8b64", Frameless: false}]
               Condition: null
     - id: bigMapArg
@@ -50,11 +50,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 374 EventRootType Probe[main.bigMapArg]
-              InjectionPoints: [{PC: "0xbb010", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb240", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 375 EventRootType Probe[main.bigMapArg]Return
-              InjectionPoints: [{PC: "0xbb080", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb2b0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 'm: {m}'
@@ -78,7 +78,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 420 EventRootType Probe[main.condBool]
-              InjectionPoints: [{PC: "0xbb768", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb998", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -95,7 +95,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 421 EventRootType Probe[main.condBool]Return
-              InjectionPoints: [{PC: "0xbb7c8", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb9f8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -119,7 +119,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 422 EventRootType Probe[main.condBool]
-              InjectionPoints: [{PC: "0xbb768", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb998", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -136,7 +136,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 423 EventRootType Probe[main.condBool]Return
-              InjectionPoints: [{PC: "0xbb7c8", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb9f8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -159,11 +159,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 424 EventRootType Probe[main.condBool]
-              InjectionPoints: [{PC: "0xbb768", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb998", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 425 EventRootType Probe[main.condBool]Return
-              InjectionPoints: [{PC: "0xbb7c8", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb9f8", Frameless: false}]
               Condition: null
     - id: condCompound_and
       version: 0
@@ -188,7 +188,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 470 EventRootType Probe[main.condReturnAndLocal]
-              InjectionPoints: [{PC: "0xbbb58", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbd88", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -220,7 +220,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 471 EventRootType Probe[main.condReturnAndLocal]Return
-              InjectionPoints: [{PC: "0xbbbb0", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbde0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: a == 1 && b == 1 [a={a}, b={b}]
@@ -262,7 +262,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 440 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0xbb8ac", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbadc", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -292,7 +292,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 441 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0xbb960", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbb90", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x.S == "world" && tag == "match" [x.S={x.S}, tag={tag}]
@@ -314,7 +314,7 @@ Probes:
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["519"]
+        lines: ["547"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -338,7 +338,7 @@ Probes:
           events:
             - Kind: Line
               Type: 480 EventRootType Probe[main.condLine]Line
-              InjectionPoints: [{PC: "0xbbc94", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbec4", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -412,7 +412,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 442 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0xbb8ac", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbadc", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -460,7 +460,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 443 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0xbb960", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbb90", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: (x.I32 == 300 || x.I32 == 999) && !isEmpty(x.S) [x.I32={x.I32}, x.S={x.S}, tag={tag}]
@@ -502,7 +502,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 426 EventRootType Probe[main.condBool]
-              InjectionPoints: [{PC: "0xbb768", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb998", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -520,7 +520,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 427 EventRootType Probe[main.condBool]Return
-              InjectionPoints: [{PC: "0xbb7c8", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb9f8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '!x [x={x}, tag={tag}]'
@@ -559,7 +559,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 386 EventRootType Probe[main.condInt32]
-              InjectionPoints: [{PC: "0xbb268", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb498", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -591,7 +591,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 387 EventRootType Probe[main.condInt32]Return
-              InjectionPoints: [{PC: "0xbb2c0", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb4f0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x == 42 || x == 100 [x={x}, tag={tag}]
@@ -629,16 +629,16 @@ Probes:
         - ']'
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 493 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xbc39c", Frameless: false}]
+              Type: 502 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xbc7bc", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 37, index: 1, name: tag}
+                      Variable: {subprogram: 39, index: 1, name: tag}
                       Offset: 0
                       ByteSize: 16
                     - __kind: ExprReadStringOp
@@ -650,7 +650,7 @@ Probes:
                       Cond: true
                       Target: 1
                     - __kind: LocationOp
-                      Variable: {subprogram: 37, index: 0, name: s}
+                      Variable: {subprogram: 39, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -664,8 +664,8 @@ Probes:
                       ID: 1
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 494 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xbc430", Frameless: false}]
+              Type: 503 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xbc850", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag == "match" || !isEmpty(s) [s={s}, tag={tag}]
@@ -703,20 +703,20 @@ Probes:
         - ']'
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 72}
+        - subprogram: {subprogram: 74}
           events:
             - Kind: Entry
-              Type: 667 EventRootType Probe[main.condMultiReturn]
-              InjectionPoints: [{PC: "0xbdcd8", Frameless: false}]
+              Type: 676 EventRootType Probe[main.condMultiReturn]
+              InjectionPoints: [{PC: "0xbe0f8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 668 EventRootType Probe[main.condMultiReturn]Return
-              InjectionPoints: [{PC: "0xbdd58", Frameless: false}]
+              Type: 677 EventRootType Probe[main.condMultiReturn]Return
+              InjectionPoints: [{PC: "0xbe178", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 72, index: 1, name: r0}
+                      Variable: {subprogram: 74, index: 1, name: r0}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -729,7 +729,7 @@ Probes:
                       Cond: false
                       Target: 1
                     - __kind: LocationOp
-                      Variable: {subprogram: 72, index: 2, name: r1}
+                      Variable: {subprogram: 74, index: 2, name: r1}
                       Offset: 0
                       ByteSize: 16
                     - __kind: ExprReadStringOp
@@ -777,7 +777,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 462 EventRootType Probe[main.condNilPtrStruct]
-              InjectionPoints: [{PC: "0xbbaa8", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbcd8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -811,7 +811,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 463 EventRootType Probe[main.condNilPtrStruct]Return
-              InjectionPoints: [{PC: "0xbbb10", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbd40", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag == "nilptr" && x.I32 == 300 [tag={tag}]
@@ -845,7 +845,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 464 EventRootType Probe[main.condNilPtrStruct]
-              InjectionPoints: [{PC: "0xbbaa8", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbcd8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -879,7 +879,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 465 EventRootType Probe[main.condNilPtrStruct]Return
-              InjectionPoints: [{PC: "0xbbb10", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbd40", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag == "nilptr" || x.I32 == 300 [tag={tag}]
@@ -903,11 +903,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 416 EventRootType Probe[main.condFloat32]
-              InjectionPoints: [{PC: "0xbb628", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb858", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 417 EventRootType Probe[main.condFloat32]Return
-              InjectionPoints: [{PC: "0xbb684", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb8b4", Frameless: false}]
               Condition: null
     - id: condFloat64_nocond
       version: 0
@@ -922,11 +922,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 418 EventRootType Probe[main.condFloat64]
-              InjectionPoints: [{PC: "0xbb6c8", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb8f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 419 EventRootType Probe[main.condFloat64]Return
-              InjectionPoints: [{PC: "0xbb724", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb954", Frameless: false}]
               Condition: null
     - id: condInt16_cond
       version: 0
@@ -942,7 +942,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 382 EventRootType Probe[main.condInt16]
-              InjectionPoints: [{PC: "0xbb1c8", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb3f8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -959,7 +959,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 383 EventRootType Probe[main.condInt16]Return
-              InjectionPoints: [{PC: "0xbb220", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb450", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -982,11 +982,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 384 EventRootType Probe[main.condInt16]
-              InjectionPoints: [{PC: "0xbb1c8", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb3f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 385 EventRootType Probe[main.condInt16]Return
-              InjectionPoints: [{PC: "0xbb220", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb450", Frameless: false}]
               Condition: null
     - id: condInt32_cond
       version: 0
@@ -1002,7 +1002,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 388 EventRootType Probe[main.condInt32]
-              InjectionPoints: [{PC: "0xbb268", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb498", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1019,7 +1019,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 389 EventRootType Probe[main.condInt32]Return
-              InjectionPoints: [{PC: "0xbb2c0", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb4f0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1046,7 +1046,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 390 EventRootType Probe[main.condInt32]
-              InjectionPoints: [{PC: "0xbb268", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb498", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1063,7 +1063,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 391 EventRootType Probe[main.condInt32]Return
-              InjectionPoints: [{PC: "0xbb2c0", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb4f0", Frameless: false}]
               Condition: null
     - id: condInt32_nocond
       version: 0
@@ -1078,11 +1078,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 392 EventRootType Probe[main.condInt32]
-              InjectionPoints: [{PC: "0xbb268", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb498", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 393 EventRootType Probe[main.condInt32]Return
-              InjectionPoints: [{PC: "0xbb2c0", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb4f0", Frameless: false}]
               Condition: null
     - id: condInt64_cond
       version: 0
@@ -1098,7 +1098,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 394 EventRootType Probe[main.condInt64]
-              InjectionPoints: [{PC: "0xbb308", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb538", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1115,7 +1115,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 395 EventRootType Probe[main.condInt64]Return
-              InjectionPoints: [{PC: "0xbb360", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb590", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1138,11 +1138,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 396 EventRootType Probe[main.condInt64]
-              InjectionPoints: [{PC: "0xbb308", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb538", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 397 EventRootType Probe[main.condInt64]Return
-              InjectionPoints: [{PC: "0xbb360", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb590", Frameless: false}]
               Condition: null
     - id: condInt8_cond
       version: 0
@@ -1158,7 +1158,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 378 EventRootType Probe[main.condInt8]
-              InjectionPoints: [{PC: "0xbb128", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb358", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1175,7 +1175,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 379 EventRootType Probe[main.condInt8]Return
-              InjectionPoints: [{PC: "0xbb188", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb3b8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1198,11 +1198,257 @@ Probes:
           events:
             - Kind: Entry
               Type: 380 EventRootType Probe[main.condInt8]
-              InjectionPoints: [{PC: "0xbb128", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb358", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 381 EventRootType Probe[main.condInt8]Return
-              InjectionPoints: [{PC: "0xbb188", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb3b8", Frameless: false}]
+              Condition: null
+    - id: condLineMixed_cond_bool
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when: {dsl: b == true, json: {eq: [{ref: b}, true]}}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 485 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0xbbf98", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 1, name: b}
+                      Offset: 0
+                      ByteSize: 1
+                    - __kind: ExprPushOffsetOp
+                      ByteSize: 1
+                    - __kind: ExprLoadLiteralOp
+                      Data: AQ==
+                    - __kind: ExprCmpEqBaseOp
+                      ByteSize: 1
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_isEmpty_slice
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when: {dsl: isEmpty(ss), json: {isEmpty: {ref: ss}}}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 486 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0xbbf98", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 4, name: ss}
+                      Offset: 8
+                      ByteSize: 8
+                    - __kind: ExprPushOffsetOp
+                      ByteSize: 8
+                    - __kind: ExprLoadLiteralOp
+                      Data: AAAAAAAAAAA=
+                    - __kind: ExprCmpEqBaseOp
+                      ByteSize: 8
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_len_string
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when:
+        dsl: len(s) == 5
+        json: {eq: [{len: {ref: s}}, 5]}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 487 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0xbbf98", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 0, name: s}
+                      Offset: 8
+                      ByteSize: 8
+                    - __kind: ExprPushOffsetOp
+                      ByteSize: 8
+                    - __kind: ExprLoadLiteralOp
+                      Data: BQAAAAAAAAA=
+                    - __kind: ExprCmpEqBaseOp
+                      ByteSize: 8
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_ptrstruct_field
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when:
+        dsl: p.S == "world"
+        json: {eq: [{getmember: [{ref: p}, S]}, world]}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 488 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0xbbf98", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 3, name: p}
+                      Offset: 0
+                      ByteSize: 8
+                    - __kind: DereferenceOp
+                      Bias: 56
+                      ByteSize: 16
+                    - __kind: ExprReadStringOp
+                      MaxLen: 255
+                    - __kind: ExprLoadLiteralOp
+                      Data: BQAAAHdvcmxk
+                    - __kind: ExprCmpEqStringOp
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_string
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when:
+        dsl: s == "hello"
+        json: {eq: [{ref: s}, hello]}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 489 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0xbbf98", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 0, name: s}
+                      Offset: 0
+                      ByteSize: 16
+                    - __kind: ExprReadStringOp
+                      MaxLen: 255
+                    - __kind: ExprLoadLiteralOp
+                      Data: BQAAAGhlbGxv
+                    - __kind: ExprCmpEqStringOp
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_struct_field
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when:
+        dsl: x.I32 == 300
+        json: {eq: [{getmember: [{ref: x}, I32]}, 300]}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 490 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0xbbf98", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 2, name: x}
+                      Offset: 4
+                      ByteSize: 4
+                    - __kind: ExprPushOffsetOp
+                      ByteSize: 4
+                    - __kind: ExprLoadLiteralOp
+                      Data: LAEAAA==
+                    - __kind: ExprCmpEqBaseOp
+                      ByteSize: 4
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_nocond
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 491 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0xbbf98", Frameless: false}]
               Condition: null
     - id: condLine_cond
       version: 0
@@ -1210,7 +1456,7 @@ Probes:
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["519"]
+        lines: ["547"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -1227,7 +1473,7 @@ Probes:
           events:
             - Kind: Line
               Type: 481 EventRootType Probe[main.condLine]Line
-              InjectionPoints: [{PC: "0xbbc94", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbec4", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1242,13 +1488,58 @@ Probes:
                     - __kind: ExprCmpEqBaseOp
                       ByteSize: 8
                     - __kind: ConditionCheckOp
-    - id: condLine_nocond
+    - id: condLine_local_cond
       version: 0
       type: LOG_PROBE
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["519"]
+        lines: ["548"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+        - issue:ConditionVariableUnavailable@arch=arm64,toolchain=go1.23.11
+        - issue:ConditionVariableUnavailable@arch=amd64,toolchain=go1.23.11
+      when: {dsl: result == 14, json: {eq: [{ref: result}, 14]}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 28}
+          events:
+            - Kind: Line
+              Type: 482 EventRootType Probe[main.condLine]Line
+              InjectionPoints: [{PC: "0xbbec8", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 28, index: 2, name: result}
+                      Offset: 0
+                      ByteSize: 8
+                    - __kind: ExprPushOffsetOp
+                      ByteSize: 8
+                    - __kind: ExprLoadLiteralOp
+                      Data: DgAAAAAAAAA=
+                    - __kind: ExprCmpEqBaseOp
+                      ByteSize: 8
+                    - __kind: ConditionCheckOp
+          probeTemplate:
+            TemplateString: tag={tag}
+            Segments:
+                - tag=
+                - JSON: {Ref: tag}
+                  DSL: tag
+                  EventKind: Line
+                  EventExpressionIndex: 0
+    - id: condLine_local_nocond
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLine
+        sourceFile: main.go
+        lines: ["548"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -1260,8 +1551,29 @@ Probes:
         - subprogram: {subprogram: 28}
           events:
             - Kind: Line
-              Type: 482 EventRootType Probe[main.condLine]Line
-              InjectionPoints: [{PC: "0xbbc94", Frameless: false}]
+              Type: 483 EventRootType Probe[main.condLine]Line
+              InjectionPoints: [{PC: "0xbbec8", Frameless: false}]
+              Condition: null
+    - id: condLine_nocond
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLine
+        sourceFile: main.go
+        lines: ["547"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 28}
+          events:
+            - Kind: Line
+              Type: 484 EventRootType Probe[main.condLine]Line
+              InjectionPoints: [{PC: "0xbbec4", Frameless: false}]
               Condition: null
     - id: condNilPtr_cond
       version: 0
@@ -1279,7 +1591,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 466 EventRootType Probe[main.condNilPtrStruct]
-              InjectionPoints: [{PC: "0xbbaa8", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbcd8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1299,7 +1611,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 467 EventRootType Probe[main.condNilPtrStruct]Return
-              InjectionPoints: [{PC: "0xbbb10", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbd40", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: condNilPtr {tag}
@@ -1322,11 +1634,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 468 EventRootType Probe[main.condNilPtrStruct]
-              InjectionPoints: [{PC: "0xbbaa8", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbcd8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 469 EventRootType Probe[main.condNilPtrStruct]Return
-              InjectionPoints: [{PC: "0xbbb10", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbd40", Frameless: false}]
               Condition: null
     - id: condNull_iface
       version: 0
@@ -1338,16 +1650,16 @@ Probes:
       segments: ['i == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 35}
+        - subprogram: {subprogram: 37}
           events:
             - Kind: Entry
-              Type: 489 EventRootType Probe[main.condNullIface]
-              InjectionPoints: [{PC: "0xbc1cc", Frameless: false}]
+              Type: 498 EventRootType Probe[main.condNullIface]
+              InjectionPoints: [{PC: "0xbc5ec", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 35, index: 0, name: i}
+                      Variable: {subprogram: 37, index: 0, name: i}
                       Offset: 0
                       ByteSize: 16
                     - __kind: ExprPushOffsetOp
@@ -1358,8 +1670,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 490 EventRootType Probe[main.condNullIface]Return
-              InjectionPoints: [{PC: "0xbc278", Frameless: false}]
+              Type: 499 EventRootType Probe[main.condNullIface]Return
+              InjectionPoints: [{PC: "0xbc698", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: i == nil [tag={tag}]
@@ -1380,16 +1692,16 @@ Probes:
       segments: ['m == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 34}
+        - subprogram: {subprogram: 36}
           events:
             - Kind: Entry
-              Type: 487 EventRootType Probe[main.condNullMap]
-              InjectionPoints: [{PC: "0xbc0fc", Frameless: false}]
+              Type: 496 EventRootType Probe[main.condNullMap]
+              InjectionPoints: [{PC: "0xbc51c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 34, index: 0, name: m}
+                      Variable: {subprogram: 36, index: 0, name: m}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -1400,8 +1712,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 488 EventRootType Probe[main.condNullMap]Return
-              InjectionPoints: [{PC: "0xbc188", Frameless: false}]
+              Type: 497 EventRootType Probe[main.condNullMap]Return
+              InjectionPoints: [{PC: "0xbc5a8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: m == nil [tag={tag}]
@@ -1422,16 +1734,16 @@ Probes:
       segments: ['p == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 32}
+        - subprogram: {subprogram: 34}
           events:
             - Kind: Entry
-              Type: 483 EventRootType Probe[main.condNullPtr]
-              InjectionPoints: [{PC: "0xbbf2c", Frameless: false}]
+              Type: 492 EventRootType Probe[main.condNullPtr]
+              InjectionPoints: [{PC: "0xbc34c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 32, index: 0, name: p}
+                      Variable: {subprogram: 34, index: 0, name: p}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -1442,8 +1754,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 484 EventRootType Probe[main.condNullPtr]Return
-              InjectionPoints: [{PC: "0xbbfb8", Frameless: false}]
+              Type: 493 EventRootType Probe[main.condNullPtr]Return
+              InjectionPoints: [{PC: "0xbc3d8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p == nil [tag={tag}]
@@ -1464,16 +1776,16 @@ Probes:
       segments: ['s == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 33}
+        - subprogram: {subprogram: 35}
           events:
             - Kind: Entry
-              Type: 485 EventRootType Probe[main.condNullSlice]
-              InjectionPoints: [{PC: "0xbbffc", Frameless: false}]
+              Type: 494 EventRootType Probe[main.condNullSlice]
+              InjectionPoints: [{PC: "0xbc41c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 33, index: 0, name: s}
+                      Variable: {subprogram: 35, index: 0, name: s}
                       Offset: 0
                       ByteSize: 24
                     - __kind: ExprPushOffsetOp
@@ -1484,8 +1796,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 486 EventRootType Probe[main.condNullSlice]Return
-              InjectionPoints: [{PC: "0xbc0a8", Frameless: false}]
+              Type: 495 EventRootType Probe[main.condNullSlice]Return
+              InjectionPoints: [{PC: "0xbc4c8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: s == nil [tag={tag}]
@@ -1506,16 +1818,16 @@ Probes:
       segments: ['p == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 36}
+        - subprogram: {subprogram: 38}
           events:
             - Kind: Entry
-              Type: 491 EventRootType Probe[main.condNullUnsafePtr]
-              InjectionPoints: [{PC: "0xbc2bc", Frameless: false}]
+              Type: 500 EventRootType Probe[main.condNullUnsafePtr]
+              InjectionPoints: [{PC: "0xbc6dc", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 36, index: 0, name: p}
+                      Variable: {subprogram: 38, index: 0, name: p}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -1526,8 +1838,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 492 EventRootType Probe[main.condNullUnsafePtr]Return
-              InjectionPoints: [{PC: "0xbc348", Frameless: false}]
+              Type: 501 EventRootType Probe[main.condNullUnsafePtr]Return
+              InjectionPoints: [{PC: "0xbc768", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p == nil [tag={tag}]
@@ -1552,7 +1864,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 476 EventRootType Probe[main.condOnly]
-              InjectionPoints: [{PC: "0xbbbe8", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbe18", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1569,7 +1881,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 477 EventRootType Probe[main.condOnly]Return
-              InjectionPoints: [{PC: "0xbbc40", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbe70", Frameless: false}]
               Condition: null
     - id: condOnly_nocond
       version: 0
@@ -1584,11 +1896,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 478 EventRootType Probe[main.condOnly]
-              InjectionPoints: [{PC: "0xbbbe8", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbe18", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 479 EventRootType Probe[main.condOnly]Return
-              InjectionPoints: [{PC: "0xbbc40", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbe70", Frameless: false}]
               Condition: null
     - id: condPtrStruct_field_i32
       version: 0
@@ -1606,7 +1918,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 456 EventRootType Probe[main.condPtrStructArg]
-              InjectionPoints: [{PC: "0xbb99c", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbbcc", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1626,7 +1938,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 457 EventRootType Probe[main.condPtrStructArg]Return
-              InjectionPoints: [{PC: "0xbba5c", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbc8c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1652,7 +1964,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 458 EventRootType Probe[main.condPtrStructArg]
-              InjectionPoints: [{PC: "0xbb99c", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbbcc", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1671,7 +1983,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 459 EventRootType Probe[main.condPtrStructArg]Return
-              InjectionPoints: [{PC: "0xbba5c", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbc8c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1694,11 +2006,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 460 EventRootType Probe[main.condPtrStructArg]
-              InjectionPoints: [{PC: "0xbb99c", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbbcc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 461 EventRootType Probe[main.condPtrStructArg]Return
-              InjectionPoints: [{PC: "0xbba5c", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbc8c", Frameless: false}]
               Condition: null
     - id: condReturnAndLocal_cond_param
       version: 0
@@ -1714,7 +2026,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 472 EventRootType Probe[main.condReturnAndLocal]
-              InjectionPoints: [{PC: "0xbbb58", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbd88", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1731,7 +2043,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 473 EventRootType Probe[main.condReturnAndLocal]Return
-              InjectionPoints: [{PC: "0xbbbb0", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbde0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: b={b}
@@ -1754,11 +2066,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 474 EventRootType Probe[main.condReturnAndLocal]
-              InjectionPoints: [{PC: "0xbbb58", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbd88", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 475 EventRootType Probe[main.condReturnAndLocal]Return
-              InjectionPoints: [{PC: "0xbbbb0", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbde0", Frameless: false}]
               Condition: null
     - id: condString_cond
       version: 0
@@ -1776,7 +2088,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 428 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0xbb808", Frameless: false}]
+              InjectionPoints: [{PC: "0xbba38", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1792,7 +2104,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 429 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0xbb864", Frameless: false}]
+              InjectionPoints: [{PC: "0xbba94", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1816,7 +2128,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 430 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0xbb808", Frameless: false}]
+              InjectionPoints: [{PC: "0xbba38", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1832,7 +2144,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 431 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0xbb864", Frameless: false}]
+              InjectionPoints: [{PC: "0xbba94", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1860,11 +2172,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 432 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0xbb808", Frameless: false}]
+              InjectionPoints: [{PC: "0xbba38", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 433 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0xbb864", Frameless: false}]
+              InjectionPoints: [{PC: "0xbba94", Frameless: false}]
               Condition: null
     - id: condString_eq_template
       version: 0
@@ -1882,11 +2194,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 434 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0xbb808", Frameless: false}]
+              InjectionPoints: [{PC: "0xbba38", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 435 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0xbb864", Frameless: false}]
+              InjectionPoints: [{PC: "0xbba94", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: eq={x == "hello"}
@@ -1909,11 +2221,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 436 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0xbb808", Frameless: false}]
+              InjectionPoints: [{PC: "0xbba38", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 437 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0xbb864", Frameless: false}]
+              InjectionPoints: [{PC: "0xbba94", Frameless: false}]
               Condition: null
     - id: condString_snapshot_with_cond
       version: 0
@@ -1931,7 +2243,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 438 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0xbb808", Frameless: false}]
+              InjectionPoints: [{PC: "0xbba38", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1947,7 +2259,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 439 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0xbb864", Frameless: false}]
+              InjectionPoints: [{PC: "0xbba94", Frameless: false}]
               Condition: null
     - id: condStruct_cond_i32_capture_tag
       version: 0
@@ -1968,7 +2280,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 444 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0xbb8ac", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbadc", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1985,7 +2297,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 445 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0xbb960", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbb90", Frameless: false}]
               Condition: null
     - id: condStruct_field_bool
       version: 0
@@ -2003,7 +2315,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 446 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0xbb8ac", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbadc", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2020,7 +2332,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 447 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0xbb960", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbb90", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2046,7 +2358,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 448 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0xbb8ac", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbadc", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2063,7 +2375,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 449 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0xbb960", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbb90", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2089,7 +2401,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 450 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0xbb8ac", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbadc", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2106,7 +2418,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 451 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0xbb960", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbb90", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2132,7 +2444,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 452 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0xbb8ac", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbadc", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2148,7 +2460,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 453 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0xbb960", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbb90", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2171,11 +2483,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 454 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0xbb8ac", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbadc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 455 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0xbb960", Frameless: false}]
+              InjectionPoints: [{PC: "0xbbb90", Frameless: false}]
               Condition: null
     - id: condUint16_cond
       version: 0
@@ -2191,7 +2503,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 404 EventRootType Probe[main.condUint16]
-              InjectionPoints: [{PC: "0xbb448", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb678", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2208,7 +2520,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 405 EventRootType Probe[main.condUint16]Return
-              InjectionPoints: [{PC: "0xbb4a0", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb6d0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2231,11 +2543,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 406 EventRootType Probe[main.condUint16]
-              InjectionPoints: [{PC: "0xbb448", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb678", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 407 EventRootType Probe[main.condUint16]Return
-              InjectionPoints: [{PC: "0xbb4a0", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb6d0", Frameless: false}]
               Condition: null
     - id: condUint32_cond
       version: 0
@@ -2251,7 +2563,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 408 EventRootType Probe[main.condUint32]
-              InjectionPoints: [{PC: "0xbb4e8", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb718", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2268,7 +2580,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 409 EventRootType Probe[main.condUint32]Return
-              InjectionPoints: [{PC: "0xbb540", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb770", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2291,11 +2603,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 410 EventRootType Probe[main.condUint32]
-              InjectionPoints: [{PC: "0xbb4e8", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb718", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 411 EventRootType Probe[main.condUint32]Return
-              InjectionPoints: [{PC: "0xbb540", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb770", Frameless: false}]
               Condition: null
     - id: condUint64_cond
       version: 0
@@ -2311,7 +2623,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 412 EventRootType Probe[main.condUint64]
-              InjectionPoints: [{PC: "0xbb588", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb7b8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2328,7 +2640,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 413 EventRootType Probe[main.condUint64]Return
-              InjectionPoints: [{PC: "0xbb5e0", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb810", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2351,11 +2663,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 414 EventRootType Probe[main.condUint64]
-              InjectionPoints: [{PC: "0xbb588", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb7b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 415 EventRootType Probe[main.condUint64]Return
-              InjectionPoints: [{PC: "0xbb5e0", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb810", Frameless: false}]
               Condition: null
     - id: condUint8_cond
       version: 0
@@ -2371,7 +2683,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 398 EventRootType Probe[main.condUint8]
-              InjectionPoints: [{PC: "0xbb3a8", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb5d8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2388,7 +2700,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 399 EventRootType Probe[main.condUint8]Return
-              InjectionPoints: [{PC: "0xbb408", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb638", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2412,7 +2724,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 400 EventRootType Probe[main.condUint8]
-              InjectionPoints: [{PC: "0xbb3a8", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb5d8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2429,7 +2741,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 401 EventRootType Probe[main.condUint8]Return
-              InjectionPoints: [{PC: "0xbb408", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb638", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2452,11 +2764,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 402 EventRootType Probe[main.condUint8]
-              InjectionPoints: [{PC: "0xbb3a8", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb5d8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 403 EventRootType Probe[main.condUint8]Return
-              InjectionPoints: [{PC: "0xbb408", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb638", Frameless: false}]
               Condition: null
     - id: genericIdentity
       version: 0
@@ -2466,25 +2778,25 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 73}
+        - subprogram: {subprogram: 75}
           events:
             - Kind: Entry
-              Type: 669 EventRootType Probe[main.genericIdentity[go.shape.string]]
-              InjectionPoints: [{PC: "0xbdd98", Frameless: false}]
+              Type: 678 EventRootType Probe[main.genericIdentity[go.shape.string]]
+              InjectionPoints: [{PC: "0xbe1b8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 670 EventRootType Probe[main.genericIdentity[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xbdde8", Frameless: false}]
+              Type: 679 EventRootType Probe[main.genericIdentity[go.shape.string]]Return
+              InjectionPoints: [{PC: "0xbe208", Frameless: false}]
               Condition: null
-        - subprogram: {subprogram: 74}
+        - subprogram: {subprogram: 76}
           events:
             - Kind: Entry
-              Type: 671 EventRootType Probe[main.genericIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0xbde28", Frameless: false}]
+              Type: 680 EventRootType Probe[main.genericIdentity[go.shape.int]]
+              InjectionPoints: [{PC: "0xbe248", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 672 EventRootType Probe[main.genericIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xbde6c", Frameless: false}]
+              Type: 681 EventRootType Probe[main.genericIdentity[go.shape.int]]Return
+              InjectionPoints: [{PC: "0xbe28c", Frameless: false}]
               Condition: null
     - id: indexBigArrayStruct_last
       version: 0
@@ -2500,15 +2812,15 @@ Probes:
             dsl: s.data[131071]
             json: {index: [{getmember: [{ref: s}, data]}, 131071]}
       instances:
-        - subprogram: {subprogram: 48}
+        - subprogram: {subprogram: 50}
           events:
             - Kind: Entry
-              Type: 591 EventRootType Probe[main.bigArrayStructArg]
-              InjectionPoints: [{PC: "0xbce38", Frameless: false}]
+              Type: 600 EventRootType Probe[main.bigArrayStructArg]
+              InjectionPoints: [{PC: "0xbd258", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 592 EventRootType Probe[main.bigArrayStructArg]Return
-              InjectionPoints: [{PC: "0xbce90", Frameless: false}]
+              Type: 601 EventRootType Probe[main.bigArrayStructArg]Return
+              InjectionPoints: [{PC: "0xbd2b0", Frameless: false}]
               Condition: null
     - id: indexBigArray_first
       version: 0
@@ -2522,15 +2834,15 @@ Probes:
         - name: s_0
           expr: {dsl: 's[0]', json: {index: [{ref: s}, 0]}}
       instances:
-        - subprogram: {subprogram: 47}
+        - subprogram: {subprogram: 49}
           events:
             - Kind: Entry
-              Type: 587 EventRootType Probe[main.bigArrayArg]
-              InjectionPoints: [{PC: "0xbcda8", Frameless: false}]
+              Type: 596 EventRootType Probe[main.bigArrayArg]
+              InjectionPoints: [{PC: "0xbd1c8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 588 EventRootType Probe[main.bigArrayArg]Return
-              InjectionPoints: [{PC: "0xbcdfc", Frameless: false}]
+              Type: 597 EventRootType Probe[main.bigArrayArg]Return
+              InjectionPoints: [{PC: "0xbd21c", Frameless: false}]
               Condition: null
     - id: indexBigArray_last
       version: 0
@@ -2544,15 +2856,15 @@ Probes:
         - name: s_131071
           expr: {dsl: 's[131071]', json: {index: [{ref: s}, 131071]}}
       instances:
-        - subprogram: {subprogram: 47}
+        - subprogram: {subprogram: 49}
           events:
             - Kind: Entry
-              Type: 589 EventRootType Probe[main.bigArrayArg]
-              InjectionPoints: [{PC: "0xbcda8", Frameless: false}]
+              Type: 598 EventRootType Probe[main.bigArrayArg]
+              InjectionPoints: [{PC: "0xbd1c8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 590 EventRootType Probe[main.bigArrayArg]Return
-              InjectionPoints: [{PC: "0xbcdfc", Frameless: false}]
+              Type: 599 EventRootType Probe[main.bigArrayArg]Return
+              InjectionPoints: [{PC: "0xbd21c", Frameless: false}]
               Condition: null
     - id: indexErr_array_oob_capture
       version: 0
@@ -2570,11 +2882,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 353 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0xbad68", Frameless: false}]
+              InjectionPoints: [{PC: "0xbaf98", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 354 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0xbada8", Frameless: false}]
+              InjectionPoints: [{PC: "0xbafd8", Frameless: false}]
               Condition: null
     - id: indexErr_array_oob_template
       version: 0
@@ -2589,11 +2901,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 355 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0xbad68", Frameless: false}]
+              InjectionPoints: [{PC: "0xbaf98", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 356 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0xbada8", Frameless: false}]
+              InjectionPoints: [{PC: "0xbafd8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's[3]: {s[3]}'
@@ -2617,11 +2929,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 339 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0xbace8", Frameless: false}]
+              InjectionPoints: [{PC: "0xbaf18", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 340 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0xbad20", Frameless: false}]
+              InjectionPoints: [{PC: "0xbaf50", Frameless: false}]
               Condition: null
     - id: indexErr_slice_oob_cond
       version: 0
@@ -2639,7 +2951,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 341 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0xbace8", Frameless: false}]
+              InjectionPoints: [{PC: "0xbaf18", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2661,7 +2973,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 342 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0xbad20", Frameless: false}]
+              InjectionPoints: [{PC: "0xbaf50", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: matched, Segments: [matched]}
     - id: indexErr_slice_oob_template
@@ -2677,11 +2989,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 343 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0xbace8", Frameless: false}]
+              InjectionPoints: [{PC: "0xbaf18", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 344 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0xbad20", Frameless: false}]
+              InjectionPoints: [{PC: "0xbaf50", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's[5]: {s[5]}'
@@ -2707,11 +3019,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 357 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0xbad68", Frameless: false}]
+              InjectionPoints: [{PC: "0xbaf98", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 358 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0xbada8", Frameless: false}]
+              InjectionPoints: [{PC: "0xbafd8", Frameless: false}]
               Condition: null
     - id: indexIntArray_cond
       version: 0
@@ -2729,7 +3041,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 359 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0xbad68", Frameless: false}]
+              InjectionPoints: [{PC: "0xbaf98", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2746,7 +3058,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 360 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0xbada8", Frameless: false}]
+              InjectionPoints: [{PC: "0xbafd8", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: matched, Segments: [matched]}
     - id: indexIntSlice_capture
@@ -2765,11 +3077,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 345 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0xbace8", Frameless: false}]
+              InjectionPoints: [{PC: "0xbaf18", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 346 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0xbad20", Frameless: false}]
+              InjectionPoints: [{PC: "0xbaf50", Frameless: false}]
               Condition: null
     - id: indexIntSlice_cond
       version: 0
@@ -2787,7 +3099,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 347 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0xbace8", Frameless: false}]
+              InjectionPoints: [{PC: "0xbaf18", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2809,7 +3121,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 348 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0xbad20", Frameless: false}]
+              InjectionPoints: [{PC: "0xbaf50", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: matched, Segments: [matched]}
     - id: indexIntSlice_template
@@ -2825,11 +3137,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 349 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0xbace8", Frameless: false}]
+              InjectionPoints: [{PC: "0xbaf18", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 350 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0xbad20", Frameless: false}]
+              InjectionPoints: [{PC: "0xbaf50", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's[1]: {s[1]}'
@@ -2853,15 +3165,15 @@ Probes:
             dsl: s[0].Val
             json: {getmember: [{index: [{ref: s}, 0]}, Val]}
       instances:
-        - subprogram: {subprogram: 50}
+        - subprogram: {subprogram: 52}
           events:
             - Kind: Entry
-              Type: 601 EventRootType Probe[main.structArrayArg]
-              InjectionPoints: [{PC: "0xbcf98", Frameless: false}]
+              Type: 610 EventRootType Probe[main.structArrayArg]
+              InjectionPoints: [{PC: "0xbd3b8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 602 EventRootType Probe[main.structArrayArg]Return
-              InjectionPoints: [{PC: "0xbcff4", Frameless: false}]
+              Type: 611 EventRootType Probe[main.structArrayArg]Return
+              InjectionPoints: [{PC: "0xbd414", Frameless: false}]
               Condition: null
     - id: indexMember_arrayStruct_capture_string
       version: 0
@@ -2877,15 +3189,15 @@ Probes:
             dsl: s[1].Txt
             json: {getmember: [{index: [{ref: s}, 1]}, Txt]}
       instances:
-        - subprogram: {subprogram: 50}
+        - subprogram: {subprogram: 52}
           events:
             - Kind: Entry
-              Type: 603 EventRootType Probe[main.structArrayArg]
-              InjectionPoints: [{PC: "0xbcf98", Frameless: false}]
+              Type: 612 EventRootType Probe[main.structArrayArg]
+              InjectionPoints: [{PC: "0xbd3b8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 604 EventRootType Probe[main.structArrayArg]Return
-              InjectionPoints: [{PC: "0xbcff4", Frameless: false}]
+              Type: 613 EventRootType Probe[main.structArrayArg]Return
+              InjectionPoints: [{PC: "0xbd414", Frameless: false}]
               Condition: null
     - id: indexMember_ptrArrayStruct_capture_int
       version: 0
@@ -2901,15 +3213,15 @@ Probes:
             dsl: s[0].Val
             json: {getmember: [{index: [{ref: s}, 0]}, Val]}
       instances:
-        - subprogram: {subprogram: 52}
+        - subprogram: {subprogram: 54}
           events:
             - Kind: Entry
-              Type: 609 EventRootType Probe[main.ptrStructArrayArg]
-              InjectionPoints: [{PC: "0xbd108", Frameless: false}]
+              Type: 618 EventRootType Probe[main.ptrStructArrayArg]
+              InjectionPoints: [{PC: "0xbd528", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 610 EventRootType Probe[main.ptrStructArrayArg]Return
-              InjectionPoints: [{PC: "0xbd168", Frameless: false}]
+              Type: 619 EventRootType Probe[main.ptrStructArrayArg]Return
+              InjectionPoints: [{PC: "0xbd588", Frameless: false}]
               Condition: null
     - id: indexMember_ptrArrayStruct_capture_string
       version: 0
@@ -2925,15 +3237,15 @@ Probes:
             dsl: s[1].Txt
             json: {getmember: [{index: [{ref: s}, 1]}, Txt]}
       instances:
-        - subprogram: {subprogram: 52}
+        - subprogram: {subprogram: 54}
           events:
             - Kind: Entry
-              Type: 611 EventRootType Probe[main.ptrStructArrayArg]
-              InjectionPoints: [{PC: "0xbd108", Frameless: false}]
+              Type: 620 EventRootType Probe[main.ptrStructArrayArg]
+              InjectionPoints: [{PC: "0xbd528", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 612 EventRootType Probe[main.ptrStructArrayArg]Return
-              InjectionPoints: [{PC: "0xbd168", Frameless: false}]
+              Type: 621 EventRootType Probe[main.ptrStructArrayArg]Return
+              InjectionPoints: [{PC: "0xbd588", Frameless: false}]
               Condition: null
     - id: indexMember_ptrSliceStruct_capture_int
       version: 0
@@ -2949,15 +3261,15 @@ Probes:
             dsl: s[0].Val
             json: {getmember: [{index: [{ref: s}, 0]}, Val]}
       instances:
-        - subprogram: {subprogram: 51}
+        - subprogram: {subprogram: 53}
           events:
             - Kind: Entry
-              Type: 605 EventRootType Probe[main.ptrStructSliceArg]
-              InjectionPoints: [{PC: "0xbd038", Frameless: false}]
+              Type: 614 EventRootType Probe[main.ptrStructSliceArg]
+              InjectionPoints: [{PC: "0xbd458", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 606 EventRootType Probe[main.ptrStructSliceArg]Return
-              InjectionPoints: [{PC: "0xbd0a8", Frameless: false}]
+              Type: 615 EventRootType Probe[main.ptrStructSliceArg]Return
+              InjectionPoints: [{PC: "0xbd4c8", Frameless: false}]
               Condition: null
     - id: indexMember_ptrSliceStruct_capture_string
       version: 0
@@ -2973,15 +3285,15 @@ Probes:
             dsl: s[1].Txt
             json: {getmember: [{index: [{ref: s}, 1]}, Txt]}
       instances:
-        - subprogram: {subprogram: 51}
+        - subprogram: {subprogram: 53}
           events:
             - Kind: Entry
-              Type: 607 EventRootType Probe[main.ptrStructSliceArg]
-              InjectionPoints: [{PC: "0xbd038", Frameless: false}]
+              Type: 616 EventRootType Probe[main.ptrStructSliceArg]
+              InjectionPoints: [{PC: "0xbd458", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 608 EventRootType Probe[main.ptrStructSliceArg]Return
-              InjectionPoints: [{PC: "0xbd0a8", Frameless: false}]
+              Type: 617 EventRootType Probe[main.ptrStructSliceArg]Return
+              InjectionPoints: [{PC: "0xbd4c8", Frameless: false}]
               Condition: null
     - id: indexMember_sliceStruct_capture_int
       version: 0
@@ -2997,15 +3309,15 @@ Probes:
             dsl: s[0].Val
             json: {getmember: [{index: [{ref: s}, 0]}, Val]}
       instances:
-        - subprogram: {subprogram: 49}
+        - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 593 EventRootType Probe[main.structSliceArg]
-              InjectionPoints: [{PC: "0xbcec8", Frameless: false}]
+              Type: 602 EventRootType Probe[main.structSliceArg]
+              InjectionPoints: [{PC: "0xbd2e8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 594 EventRootType Probe[main.structSliceArg]Return
-              InjectionPoints: [{PC: "0xbcf34", Frameless: false}]
+              Type: 603 EventRootType Probe[main.structSliceArg]Return
+              InjectionPoints: [{PC: "0xbd354", Frameless: false}]
               Condition: null
     - id: indexMember_sliceStruct_capture_string
       version: 0
@@ -3021,15 +3333,15 @@ Probes:
             dsl: s[1].Txt
             json: {getmember: [{index: [{ref: s}, 1]}, Txt]}
       instances:
-        - subprogram: {subprogram: 49}
+        - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 595 EventRootType Probe[main.structSliceArg]
-              InjectionPoints: [{PC: "0xbcec8", Frameless: false}]
+              Type: 604 EventRootType Probe[main.structSliceArg]
+              InjectionPoints: [{PC: "0xbd2e8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 596 EventRootType Probe[main.structSliceArg]Return
-              InjectionPoints: [{PC: "0xbcf34", Frameless: false}]
+              Type: 605 EventRootType Probe[main.structSliceArg]Return
+              InjectionPoints: [{PC: "0xbd354", Frameless: false}]
               Condition: null
     - id: indexMember_sliceStruct_cond
       version: 0
@@ -3044,16 +3356,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 49}
+        - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 597 EventRootType Probe[main.structSliceArg]
-              InjectionPoints: [{PC: "0xbcec8", Frameless: false}]
+              Type: 606 EventRootType Probe[main.structSliceArg]
+              InjectionPoints: [{PC: "0xbd2e8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 49, index: 0, name: s}
+                      Variable: {subprogram: 51, index: 0, name: s}
                       Offset: 0
                       ByteSize: 16
                     - __kind: SliceBoundsCheckOp
@@ -3069,8 +3381,8 @@ Probes:
                       ByteSize: 4
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 598 EventRootType Probe[main.structSliceArg]Return
-              InjectionPoints: [{PC: "0xbcf34", Frameless: false}]
+              Type: 607 EventRootType Probe[main.structSliceArg]Return
+              InjectionPoints: [{PC: "0xbd354", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -3092,15 +3404,15 @@ Probes:
           dsl: s[0].Val
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 49}
+        - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 599 EventRootType Probe[main.structSliceArg]
-              InjectionPoints: [{PC: "0xbcec8", Frameless: false}]
+              Type: 608 EventRootType Probe[main.structSliceArg]
+              InjectionPoints: [{PC: "0xbd2e8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 600 EventRootType Probe[main.structSliceArg]Return
-              InjectionPoints: [{PC: "0xbcf34", Frameless: false}]
+              Type: 609 EventRootType Probe[main.structSliceArg]Return
+              InjectionPoints: [{PC: "0xbd354", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: s[0].Val={s[0].Val}
@@ -3127,15 +3439,15 @@ Probes:
             json:
                 getmember: [{index: [{getmember: [{ref: s}, Arr]}, 0]}, Val]
       instances:
-        - subprogram: {subprogram: 53}
+        - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 613 EventRootType Probe[main.indexMemberWrapperArg]
-              InjectionPoints: [{PC: "0xbd1a8", Frameless: false}]
+              Type: 622 EventRootType Probe[main.indexMemberWrapperArg]
+              InjectionPoints: [{PC: "0xbd5c8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 614 EventRootType Probe[main.indexMemberWrapperArg]Return
-              InjectionPoints: [{PC: "0xbd230", Frameless: false}]
+              Type: 623 EventRootType Probe[main.indexMemberWrapperArg]Return
+              InjectionPoints: [{PC: "0xbd650", Frameless: false}]
               Condition: null
     - id: indexMember_wrapper_arr_capture_1
       version: 0
@@ -3152,15 +3464,15 @@ Probes:
             json:
                 getmember: [{index: [{getmember: [{ref: s}, Arr]}, 1]}, Txt]
       instances:
-        - subprogram: {subprogram: 53}
+        - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 615 EventRootType Probe[main.indexMemberWrapperArg]
-              InjectionPoints: [{PC: "0xbd1a8", Frameless: false}]
+              Type: 624 EventRootType Probe[main.indexMemberWrapperArg]
+              InjectionPoints: [{PC: "0xbd5c8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 616 EventRootType Probe[main.indexMemberWrapperArg]Return
-              InjectionPoints: [{PC: "0xbd230", Frameless: false}]
+              Type: 625 EventRootType Probe[main.indexMemberWrapperArg]Return
+              InjectionPoints: [{PC: "0xbd650", Frameless: false}]
               Condition: null
     - id: indexMember_wrapper_ptrArr_capture
       version: 0
@@ -3177,15 +3489,15 @@ Probes:
             json:
                 getmember: [{index: [{getmember: [{ref: s}, PtrArr]}, 0]}, Val]
       instances:
-        - subprogram: {subprogram: 53}
+        - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 617 EventRootType Probe[main.indexMemberWrapperArg]
-              InjectionPoints: [{PC: "0xbd1a8", Frameless: false}]
+              Type: 626 EventRootType Probe[main.indexMemberWrapperArg]
+              InjectionPoints: [{PC: "0xbd5c8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 618 EventRootType Probe[main.indexMemberWrapperArg]Return
-              InjectionPoints: [{PC: "0xbd230", Frameless: false}]
+              Type: 627 EventRootType Probe[main.indexMemberWrapperArg]Return
+              InjectionPoints: [{PC: "0xbd650", Frameless: false}]
               Condition: null
     - id: indexMember_wrapper_ptrArr_capture_1
       version: 0
@@ -3202,15 +3514,15 @@ Probes:
             json:
                 getmember: [{index: [{getmember: [{ref: s}, PtrArr]}, 1]}, Txt]
       instances:
-        - subprogram: {subprogram: 53}
+        - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 619 EventRootType Probe[main.indexMemberWrapperArg]
-              InjectionPoints: [{PC: "0xbd1a8", Frameless: false}]
+              Type: 628 EventRootType Probe[main.indexMemberWrapperArg]
+              InjectionPoints: [{PC: "0xbd5c8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 620 EventRootType Probe[main.indexMemberWrapperArg]Return
-              InjectionPoints: [{PC: "0xbd230", Frameless: false}]
+              Type: 629 EventRootType Probe[main.indexMemberWrapperArg]Return
+              InjectionPoints: [{PC: "0xbd650", Frameless: false}]
               Condition: null
     - id: indexNilPtr_capture
       version: 0
@@ -3226,15 +3538,15 @@ Probes:
             dsl: x.Items[0]
             json: {index: [{getmember: [{ref: x}, Items]}, 0]}
       instances:
-        - subprogram: {subprogram: 45}
+        - subprogram: {subprogram: 47}
           events:
             - Kind: Entry
-              Type: 579 EventRootType Probe[main.indexNilPtrSlice]
-              InjectionPoints: [{PC: "0xbcb48", Frameless: false}]
+              Type: 588 EventRootType Probe[main.indexNilPtrSlice]
+              InjectionPoints: [{PC: "0xbcf68", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 580 EventRootType Probe[main.indexNilPtrSlice]Return
-              InjectionPoints: [{PC: "0xbcbb0", Frameless: false}]
+              Type: 589 EventRootType Probe[main.indexNilPtrSlice]Return
+              InjectionPoints: [{PC: "0xbcfd0", Frameless: false}]
               Condition: null
     - id: indexNilPtr_cond
       version: 0
@@ -3249,16 +3561,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 45}
+        - subprogram: {subprogram: 47}
           events:
             - Kind: Entry
-              Type: 581 EventRootType Probe[main.indexNilPtrSlice]
-              InjectionPoints: [{PC: "0xbcb48", Frameless: false}]
+              Type: 590 EventRootType Probe[main.indexNilPtrSlice]
+              InjectionPoints: [{PC: "0xbcf68", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 45, index: 0, name: x}
+                      Variable: {subprogram: 47, index: 0, name: x}
                       Offset: 0
                       ByteSize: 8
                     - __kind: DereferenceOp
@@ -3277,8 +3589,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 582 EventRootType Probe[main.indexNilPtrSlice]Return
-              InjectionPoints: [{PC: "0xbcbb0", Frameless: false}]
+              Type: 591 EventRootType Probe[main.indexNilPtrSlice]Return
+              InjectionPoints: [{PC: "0xbcfd0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -3300,15 +3612,15 @@ Probes:
           dsl: x.Items[0]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 45}
+        - subprogram: {subprogram: 47}
           events:
             - Kind: Entry
-              Type: 583 EventRootType Probe[main.indexNilPtrSlice]
-              InjectionPoints: [{PC: "0xbcb48", Frameless: false}]
+              Type: 592 EventRootType Probe[main.indexNilPtrSlice]
+              InjectionPoints: [{PC: "0xbcf68", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 584 EventRootType Probe[main.indexNilPtrSlice]Return
-              InjectionPoints: [{PC: "0xbcbb0", Frameless: false}]
+              Type: 593 EventRootType Probe[main.indexNilPtrSlice]Return
+              InjectionPoints: [{PC: "0xbcfd0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 'items[0]: {x.Items[0]}'
@@ -3334,15 +3646,15 @@ Probes:
             dsl: x.Items[0]
             json: {index: [{getmember: [{ref: x}, Items]}, 0]}
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 561 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0xbc85c", Frameless: false}]
+              Type: 570 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0xbcc7c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 562 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0xbc928", Frameless: false}]
+              Type: 571 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0xbcd48", Frameless: false}]
               Condition: null
     - id: indexStringArray_capture
       version: 0
@@ -3360,11 +3672,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 367 EventRootType Probe[main.stringArrayArg]
-              InjectionPoints: [{PC: "0xbae58", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb088", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 368 EventRootType Probe[main.stringArrayArg]Return
-              InjectionPoints: [{PC: "0xbae98", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb0c8", Frameless: false}]
               Condition: null
     - id: indexStringSlice_capture
       version: 0
@@ -3382,11 +3694,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 363 EventRootType Probe[main.stringSliceArg]
-              InjectionPoints: [{PC: "0xbadd8", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb008", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 364 EventRootType Probe[main.stringSliceArg]Return
-              InjectionPoints: [{PC: "0xbae10", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb040", Frameless: false}]
               Condition: null
     - id: indexStructSliceField_capture
       version: 0
@@ -3402,15 +3714,15 @@ Probes:
             dsl: x.Items[2]
             json: {index: [{getmember: [{ref: x}, Items]}, 2]}
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 541 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xbc72c", Frameless: false}]
+              Type: 550 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xbcb4c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 542 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xbc81c", Frameless: false}]
+              Type: 551 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xbcc3c", Frameless: false}]
               Condition: null
     - id: inlined
       version: 0
@@ -3421,19 +3733,19 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 75}
+        - subprogram: {subprogram: 77}
           events:
             - Kind: Entry
-              Type: 673 EventRootType Probe[main.inlined]
+              Type: 682 EventRootType Probe[main.inlined]
               InjectionPoints:
                 - PC: "0xb88dc"
                   Frameless: false
-                - PC: "0xbaed8"
+                - PC: "0xbb108"
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 674 EventRootType Probe[main.inlined]Return
-              InjectionPoints: [{PC: "0xbaf0c", Frameless: false}]
+              Type: 683 EventRootType Probe[main.inlined]Return
+              InjectionPoints: [{PC: "0xbb13c", Frameless: false}]
               Condition: null
     - id: inlinedMethod
       version: 0
@@ -3443,11 +3755,11 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 78}
+        - subprogram: {subprogram: 80}
           events:
             - Kind: Entry
-              Type: 677 EventRootType Probe[main.(*methodValueReceiver).inlinedMethod]
-              InjectionPoints: [{PC: "0xbde94", Frameless: true}]
+              Type: 686 EventRootType Probe[main.(*methodValueReceiver).inlinedMethod]
+              InjectionPoints: [{PC: "0xbe2b4", Frameless: true}]
               Condition: null
     - id: intArg
       version: 0
@@ -3461,11 +3773,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 331 EventRootType Probe[main.intArg]
-              InjectionPoints: [{PC: "0xbac08", Frameless: false}]
+              InjectionPoints: [{PC: "0xbae38", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 332 EventRootType Probe[main.intArg]Return
-              InjectionPoints: [{PC: "0xbac3c", Frameless: false}]
+              InjectionPoints: [{PC: "0xbae6c", Frameless: false}]
               Condition: null
     - id: intArrayArg
       version: 0
@@ -3479,11 +3791,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 361 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0xbad68", Frameless: false}]
+              InjectionPoints: [{PC: "0xbaf98", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 362 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0xbada8", Frameless: false}]
+              InjectionPoints: [{PC: "0xbafd8", Frameless: false}]
               Condition: null
     - id: intArrayArgFrameless
       version: 0
@@ -3497,7 +3809,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 371 EventRootType Probe[main.stringArrayArgFrameless]
-              InjectionPoints: [{PC: "0xbaeb0", Frameless: true}]
+              InjectionPoints: [{PC: "0xbb0e0", Frameless: true}]
               Condition: null
     - id: intSliceArg
       version: 0
@@ -3511,11 +3823,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 351 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0xbace8", Frameless: false}]
+              InjectionPoints: [{PC: "0xbaf18", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 352 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0xbad20", Frameless: false}]
+              InjectionPoints: [{PC: "0xbaf50", Frameless: false}]
               Condition: null
     - id: lenErrInt_nocond
       version: 0
@@ -3526,15 +3838,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 43}
+        - subprogram: {subprogram: 45}
           events:
             - Kind: Entry
-              Type: 571 EventRootType Probe[main.lenErrInt]
-              InjectionPoints: [{PC: "0xbc96c", Frameless: false}]
+              Type: 580 EventRootType Probe[main.lenErrInt]
+              InjectionPoints: [{PC: "0xbcd8c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 572 EventRootType Probe[main.lenErrInt]Return
-              InjectionPoints: [{PC: "0xbca04", Frameless: false}]
+              Type: 581 EventRootType Probe[main.lenErrInt]Return
+              InjectionPoints: [{PC: "0xbce24", Frameless: false}]
               Condition: null
     - id: lenErrStruct_nocond
       version: 0
@@ -3545,15 +3857,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 44}
+        - subprogram: {subprogram: 46}
           events:
             - Kind: Entry
-              Type: 575 EventRootType Probe[main.lenErrStruct]
-              InjectionPoints: [{PC: "0xbca4c", Frameless: false}]
+              Type: 584 EventRootType Probe[main.lenErrStruct]
+              InjectionPoints: [{PC: "0xbce6c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 576 EventRootType Probe[main.lenErrStruct]Return
-              InjectionPoints: [{PC: "0xbcb08", Frameless: false}]
+              Type: 585 EventRootType Probe[main.lenErrStruct]Return
+              InjectionPoints: [{PC: "0xbcf28", Frameless: false}]
               Condition: null
     - id: lenErr_int
       version: 0
@@ -3564,15 +3876,15 @@ Probes:
       segments: [len=, {json: {len: {ref: x}}, dsl: len(x)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 43}
+        - subprogram: {subprogram: 45}
           events:
             - Kind: Entry
-              Type: 573 EventRootType Probe[main.lenErrInt]
-              InjectionPoints: [{PC: "0xbc96c", Frameless: false}]
+              Type: 582 EventRootType Probe[main.lenErrInt]
+              InjectionPoints: [{PC: "0xbcd8c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 574 EventRootType Probe[main.lenErrInt]Return
-              InjectionPoints: [{PC: "0xbca04", Frameless: false}]
+              Type: 583 EventRootType Probe[main.lenErrInt]Return
+              InjectionPoints: [{PC: "0xbce24", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x)}
@@ -3589,15 +3901,15 @@ Probes:
       segments: [len=, {json: {len: {ref: x}}, dsl: len(x)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 44}
+        - subprogram: {subprogram: 46}
           events:
             - Kind: Entry
-              Type: 577 EventRootType Probe[main.lenErrStruct]
-              InjectionPoints: [{PC: "0xbca4c", Frameless: false}]
+              Type: 586 EventRootType Probe[main.lenErrStruct]
+              InjectionPoints: [{PC: "0xbce6c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 578 EventRootType Probe[main.lenErrStruct]Return
-              InjectionPoints: [{PC: "0xbcb08", Frameless: false}]
+              Type: 587 EventRootType Probe[main.lenErrStruct]Return
+              InjectionPoints: [{PC: "0xbcf28", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x)}
@@ -3615,16 +3927,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 525 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0xbc56c", Frameless: false}]
+              Type: 534 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0xbc98c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 39, index: 0, name: m}
+                      Variable: {subprogram: 41, index: 0, name: m}
                       Offset: 0
                       ByteSize: 8
                     - __kind: DereferenceOp
@@ -3638,8 +3950,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 526 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0xbc610", Frameless: false}]
+              Type: 535 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0xbca30", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -3661,15 +3973,15 @@ Probes:
           dsl: isEmpty(m)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 527 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0xbc56c", Frameless: false}]
+              Type: 536 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0xbc98c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 528 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0xbc610", Frameless: false}]
+              Type: 537 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0xbca30", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: empty={isEmpty(m)}
@@ -3691,15 +4003,15 @@ Probes:
         - name: m_len
           expr: {dsl: len(m), json: {len: {ref: m}}}
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 529 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0xbc56c", Frameless: false}]
+              Type: 538 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0xbc98c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 530 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0xbc610", Frameless: false}]
+              Type: 539 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0xbca30", Frameless: false}]
               Condition: null
     - id: lenMap_len_eq_cond
       version: 0
@@ -3713,16 +4025,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 531 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0xbc56c", Frameless: false}]
+              Type: 540 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0xbc98c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 39, index: 0, name: m}
+                      Variable: {subprogram: 41, index: 0, name: m}
                       Offset: 0
                       ByteSize: 8
                     - __kind: DereferenceOp
@@ -3736,8 +4048,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 532 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0xbc610", Frameless: false}]
+              Type: 541 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0xbca30", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -3756,15 +4068,15 @@ Probes:
       segments: [len=, {json: {len: {ref: m}}, dsl: len(m)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 533 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0xbc56c", Frameless: false}]
+              Type: 542 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0xbc98c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 534 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0xbc610", Frameless: false}]
+              Type: 543 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0xbca30", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(m)}
@@ -3783,15 +4095,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 535 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0xbc56c", Frameless: false}]
+              Type: 544 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0xbc98c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 536 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0xbc610", Frameless: false}]
+              Type: 545 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0xbca30", Frameless: false}]
               Condition: null
     - id: lenPtrString_len_template
       version: 0
@@ -3802,15 +4114,15 @@ Probes:
       segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 40}
+        - subprogram: {subprogram: 42}
           events:
             - Kind: Entry
-              Type: 537 EventRootType Probe[main.lenPtrString]
-              InjectionPoints: [{PC: "0xbc65c", Frameless: false}]
+              Type: 546 EventRootType Probe[main.lenPtrString]
+              InjectionPoints: [{PC: "0xbca7c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 538 EventRootType Probe[main.lenPtrString]Return
-              InjectionPoints: [{PC: "0xbc6e8", Frameless: false}]
+              Type: 547 EventRootType Probe[main.lenPtrString]Return
+              InjectionPoints: [{PC: "0xbcb08", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(s)}
@@ -3829,15 +4141,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 40}
+        - subprogram: {subprogram: 42}
           events:
             - Kind: Entry
-              Type: 539 EventRootType Probe[main.lenPtrString]
-              InjectionPoints: [{PC: "0xbc65c", Frameless: false}]
+              Type: 548 EventRootType Probe[main.lenPtrString]
+              InjectionPoints: [{PC: "0xbca7c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 540 EventRootType Probe[main.lenPtrString]Return
-              InjectionPoints: [{PC: "0xbc6e8", Frameless: false}]
+              Type: 549 EventRootType Probe[main.lenPtrString]Return
+              InjectionPoints: [{PC: "0xbcb08", Frameless: false}]
               Condition: null
     - id: lenPtrStructFields_nocond
       version: 0
@@ -3848,15 +4160,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 563 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0xbc85c", Frameless: false}]
+              Type: 572 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0xbcc7c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 564 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0xbc928", Frameless: false}]
+              Type: 573 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0xbcd48", Frameless: false}]
               Condition: null
     - id: lenPtrStruct_field_map
       version: 0
@@ -3870,15 +4182,15 @@ Probes:
           dsl: len(x.Dict)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 565 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0xbc85c", Frameless: false}]
+              Type: 574 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0xbcc7c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 566 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0xbc928", Frameless: false}]
+              Type: 575 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0xbcd48", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.Dict)}
@@ -3900,15 +4212,15 @@ Probes:
           dsl: len(x.Items)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 567 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0xbc85c", Frameless: false}]
+              Type: 576 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0xbcc7c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 568 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0xbc928", Frameless: false}]
+              Type: 577 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0xbcd48", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.Items)}
@@ -3930,15 +4242,15 @@ Probes:
           dsl: len(x.S)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 569 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0xbc85c", Frameless: false}]
+              Type: 578 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0xbcc7c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 570 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0xbc928", Frameless: false}]
+              Type: 579 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0xbcd48", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.S)}
@@ -3958,16 +4270,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 513 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0xbc47c", Frameless: false}]
+              Type: 522 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0xbc89c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 38, index: 0, name: s}
+                      Variable: {subprogram: 40, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -3978,8 +4290,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 514 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0xbc51c", Frameless: false}]
+              Type: 523 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0xbc93c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4001,15 +4313,15 @@ Probes:
           dsl: isEmpty(s)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 515 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0xbc47c", Frameless: false}]
+              Type: 524 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0xbc89c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 516 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0xbc51c", Frameless: false}]
+              Type: 525 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0xbc93c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: empty={isEmpty(s)}
@@ -4031,15 +4343,15 @@ Probes:
         - name: s_len
           expr: {dsl: len(s), json: {len: {ref: s}}}
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 517 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0xbc47c", Frameless: false}]
+              Type: 526 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0xbc89c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 518 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0xbc51c", Frameless: false}]
+              Type: 527 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0xbc93c", Frameless: false}]
               Condition: null
     - id: lenSlice_len_eq_cond
       version: 0
@@ -4053,16 +4365,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 519 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0xbc47c", Frameless: false}]
+              Type: 528 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0xbc89c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 38, index: 0, name: s}
+                      Variable: {subprogram: 40, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4073,8 +4385,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 520 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0xbc51c", Frameless: false}]
+              Type: 529 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0xbc93c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4093,15 +4405,15 @@ Probes:
       segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 521 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0xbc47c", Frameless: false}]
+              Type: 530 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0xbc89c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 522 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0xbc51c", Frameless: false}]
+              Type: 531 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0xbc93c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(s)}
@@ -4120,15 +4432,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 523 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0xbc47c", Frameless: false}]
+              Type: 532 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0xbc89c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 524 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0xbc51c", Frameless: false}]
+              Type: 533 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0xbc93c", Frameless: false}]
               Condition: null
     - id: lenString_eq_capture
       version: 0
@@ -4144,15 +4456,15 @@ Probes:
             dsl: len(s) == 5
             json: {eq: [{len: {ref: s}}, 5]}
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 495 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xbc39c", Frameless: false}]
+              Type: 504 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xbc7bc", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 496 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xbc430", Frameless: false}]
+              Type: 505 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xbc850", Frameless: false}]
               Condition: null
     - id: lenString_eq_template
       version: 0
@@ -4166,15 +4478,15 @@ Probes:
           dsl: len(s) == 5
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 497 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xbc39c", Frameless: false}]
+              Type: 506 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xbc7bc", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 498 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xbc430", Frameless: false}]
+              Type: 507 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xbc850", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: eq={len(s) == 5}
@@ -4196,15 +4508,15 @@ Probes:
         - name: s_isEmpty
           expr: {dsl: isEmpty(s), json: {isEmpty: {ref: s}}}
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 499 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xbc39c", Frameless: false}]
+              Type: 508 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xbc7bc", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 500 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xbc430", Frameless: false}]
+              Type: 509 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xbc850", Frameless: false}]
               Condition: null
     - id: lenString_isEmpty_cond
       version: 0
@@ -4216,16 +4528,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 501 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xbc39c", Frameless: false}]
+              Type: 510 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xbc7bc", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 37, index: 0, name: s}
+                      Variable: {subprogram: 39, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4236,8 +4548,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 502 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xbc430", Frameless: false}]
+              Type: 511 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xbc850", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4259,15 +4571,15 @@ Probes:
           dsl: isEmpty(s)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 503 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xbc39c", Frameless: false}]
+              Type: 512 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xbc7bc", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 504 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xbc430", Frameless: false}]
+              Type: 513 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xbc850", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: empty={isEmpty(s)}
@@ -4289,15 +4601,15 @@ Probes:
         - name: s_len
           expr: {dsl: len(s), json: {len: {ref: s}}}
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 505 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xbc39c", Frameless: false}]
+              Type: 514 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xbc7bc", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 506 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xbc430", Frameless: false}]
+              Type: 515 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xbc850", Frameless: false}]
               Condition: null
     - id: lenString_len_eq_cond
       version: 0
@@ -4311,16 +4623,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 507 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xbc39c", Frameless: false}]
+              Type: 516 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xbc7bc", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 37, index: 0, name: s}
+                      Variable: {subprogram: 39, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4331,8 +4643,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 508 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xbc430", Frameless: false}]
+              Type: 517 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xbc850", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4351,15 +4663,15 @@ Probes:
       segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 509 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xbc39c", Frameless: false}]
+              Type: 518 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xbc7bc", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 510 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xbc430", Frameless: false}]
+              Type: 519 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xbc850", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(s)}
@@ -4378,15 +4690,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 511 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xbc39c", Frameless: false}]
+              Type: 520 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xbc7bc", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 512 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xbc430", Frameless: false}]
+              Type: 521 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xbc850", Frameless: false}]
               Condition: null
     - id: lenStructFields_nocond
       version: 0
@@ -4397,15 +4709,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 543 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xbc72c", Frameless: false}]
+              Type: 552 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xbcb4c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 544 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xbc81c", Frameless: false}]
+              Type: 553 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xbcc3c", Frameless: false}]
               Condition: null
     - id: lenStruct_field_map
       version: 0
@@ -4419,15 +4731,15 @@ Probes:
           dsl: len(x.Dict)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 545 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xbc72c", Frameless: false}]
+              Type: 554 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xbcb4c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 546 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xbc81c", Frameless: false}]
+              Type: 555 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xbcc3c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.Dict)}
@@ -4449,15 +4761,15 @@ Probes:
           dsl: len(x.PtrSlice)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 547 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xbc72c", Frameless: false}]
+              Type: 556 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xbcb4c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 548 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xbc81c", Frameless: false}]
+              Type: 557 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xbcc3c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.PtrSlice)}
@@ -4479,15 +4791,15 @@ Probes:
           dsl: len(x.PtrStr)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 549 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xbc72c", Frameless: false}]
+              Type: 558 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xbcb4c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 550 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xbc81c", Frameless: false}]
+              Type: 559 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xbcc3c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.PtrStr)}
@@ -4509,15 +4821,15 @@ Probes:
           dsl: len(x.Items)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 551 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xbc72c", Frameless: false}]
+              Type: 560 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xbcb4c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 552 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xbc81c", Frameless: false}]
+              Type: 561 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xbcc3c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.Items)}
@@ -4539,15 +4851,15 @@ Probes:
           dsl: len(x.S)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 553 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xbc72c", Frameless: false}]
+              Type: 562 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xbcb4c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 554 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xbc81c", Frameless: false}]
+              Type: 563 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xbcc3c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.S)}
@@ -4569,16 +4881,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 555 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xbc72c", Frameless: false}]
+              Type: 564 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xbcb4c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 41, index: 0, name: x}
+                      Variable: {subprogram: 43, index: 0, name: x}
                       Offset: 40
                       ByteSize: 8
                     - __kind: DereferenceOp
@@ -4592,8 +4904,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 556 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xbc81c", Frameless: false}]
+              Type: 565 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xbcc3c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4615,16 +4927,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 557 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xbc72c", Frameless: false}]
+              Type: 566 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xbcb4c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 41, index: 0, name: x}
+                      Variable: {subprogram: 43, index: 0, name: x}
                       Offset: 24
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4635,8 +4947,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 558 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xbc81c", Frameless: false}]
+              Type: 567 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xbcc3c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4658,16 +4970,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 559 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xbc72c", Frameless: false}]
+              Type: 568 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xbcb4c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 41, index: 0, name: x}
+                      Variable: {subprogram: 43, index: 0, name: x}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4678,8 +4990,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 560 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xbc81c", Frameless: false}]
+              Type: 569 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xbcc3c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4701,11 +5013,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 333 EventRootType Probe[main.stringArg]
-              InjectionPoints: [{PC: "0xbac78", Frameless: false}]
+              InjectionPoints: [{PC: "0xbaea8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 334 EventRootType Probe[main.stringArg]Return
-              InjectionPoints: [{PC: "0xbacb0", Frameless: false}]
+              InjectionPoints: [{PC: "0xbaee0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's: {s}'
@@ -4727,11 +5039,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 335 EventRootType Probe[main.stringArg]
-              InjectionPoints: [{PC: "0xbac78", Frameless: false}]
+              InjectionPoints: [{PC: "0xbaea8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 336 EventRootType Probe[main.stringArg]Return
-              InjectionPoints: [{PC: "0xbacb0", Frameless: false}]
+              InjectionPoints: [{PC: "0xbaee0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 'x: {x}'
@@ -4751,11 +5063,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 372 EventRootType Probe[main.mapArg]
-              InjectionPoints: [{PC: "0xbaf98", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb1c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 373 EventRootType Probe[main.mapArg]Return
-              InjectionPoints: [{PC: "0xbafc4", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb1f4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 'm: {m}'
@@ -4780,15 +5092,15 @@ Probes:
         - name: false_val
           expr: {dsl: 'm[false]', json: {index: [{ref: m}, false]}}
       instances:
-        - subprogram: {subprogram: 68}
+        - subprogram: {subprogram: 70}
           events:
             - Kind: Entry
-              Type: 657 EventRootType Probe[main.mapIndexBoolKey]
-              InjectionPoints: [{PC: "0xbda78", Frameless: false}]
+              Type: 666 EventRootType Probe[main.mapIndexBoolKey]
+              InjectionPoints: [{PC: "0xbde98", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 658 EventRootType Probe[main.mapIndexBoolKey]Return
-              InjectionPoints: [{PC: "0xbdaa4", Frameless: false}]
+              Type: 667 EventRootType Probe[main.mapIndexBoolKey]Return
+              InjectionPoints: [{PC: "0xbdec4", Frameless: false}]
               Condition: null
     - id: mapIndex_boolKey_true
       version: 0
@@ -4805,15 +5117,15 @@ Probes:
         - name: true_val
           expr: {dsl: 'm[true]', json: {index: [{ref: m}, true]}}
       instances:
-        - subprogram: {subprogram: 68}
+        - subprogram: {subprogram: 70}
           events:
             - Kind: Entry
-              Type: 659 EventRootType Probe[main.mapIndexBoolKey]
-              InjectionPoints: [{PC: "0xbda78", Frameless: false}]
+              Type: 668 EventRootType Probe[main.mapIndexBoolKey]
+              InjectionPoints: [{PC: "0xbde98", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 660 EventRootType Probe[main.mapIndexBoolKey]Return
-              InjectionPoints: [{PC: "0xbdaa4", Frameless: false}]
+              Type: 669 EventRootType Probe[main.mapIndexBoolKey]Return
+              InjectionPoints: [{PC: "0xbdec4", Frameless: false}]
               Condition: null
     - id: mapIndex_emptyKey_capture
       version: 0
@@ -4830,15 +5142,15 @@ Probes:
         - name: empty_val
           expr: {dsl: 'm[""]', json: {index: [{ref: m}, ""]}}
       instances:
-        - subprogram: {subprogram: 65}
+        - subprogram: {subprogram: 67}
           events:
             - Kind: Entry
-              Type: 651 EventRootType Probe[main.mapIndexEmptyKey]
-              InjectionPoints: [{PC: "0xbd8e8", Frameless: false}]
+              Type: 660 EventRootType Probe[main.mapIndexEmptyKey]
+              InjectionPoints: [{PC: "0xbdd08", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 652 EventRootType Probe[main.mapIndexEmptyKey]Return
-              InjectionPoints: [{PC: "0xbd938", Frameless: false}]
+              Type: 661 EventRootType Probe[main.mapIndexEmptyKey]Return
+              InjectionPoints: [{PC: "0xbdd58", Frameless: false}]
               Condition: null
     - id: mapIndex_intKey_capture
       version: 0
@@ -4855,15 +5167,15 @@ Probes:
         - name: m_2
           expr: {dsl: 'm[2]', json: {index: [{ref: m}, 2]}}
       instances:
-        - subprogram: {subprogram: 54}
+        - subprogram: {subprogram: 56}
           events:
             - Kind: Entry
-              Type: 621 EventRootType Probe[main.mapIndexIntKey]
-              InjectionPoints: [{PC: "0xbd278", Frameless: false}]
+              Type: 630 EventRootType Probe[main.mapIndexIntKey]
+              InjectionPoints: [{PC: "0xbd698", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 622 EventRootType Probe[main.mapIndexIntKey]Return
-              InjectionPoints: [{PC: "0xbd2a4", Frameless: false}]
+              Type: 631 EventRootType Probe[main.mapIndexIntKey]Return
+              InjectionPoints: [{PC: "0xbd6c4", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen16
       version: 0
@@ -4882,15 +5194,15 @@ Probes:
             dsl: m["000000000000002a"]
             json: {index: [{ref: m}, 000000000000002a]}
       instances:
-        - subprogram: {subprogram: 66}
+        - subprogram: {subprogram: 68}
           events:
             - Kind: Entry
-              Type: 653 EventRootType Probe[main.mapIndexKeyLen16]
-              InjectionPoints: [{PC: "0xbd978", Frameless: false}]
+              Type: 662 EventRootType Probe[main.mapIndexKeyLen16]
+              InjectionPoints: [{PC: "0xbdd98", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 654 EventRootType Probe[main.mapIndexKeyLen16]Return
-              InjectionPoints: [{PC: "0xbd9c0", Frameless: false}]
+              Type: 663 EventRootType Probe[main.mapIndexKeyLen16]Return
+              InjectionPoints: [{PC: "0xbdde0", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen17
       version: 0
@@ -4909,15 +5221,15 @@ Probes:
             dsl: m["0000000000000002a"]
             json: {index: [{ref: m}, 0000000000000002a]}
       instances:
-        - subprogram: {subprogram: 67}
+        - subprogram: {subprogram: 69}
           events:
             - Kind: Entry
-              Type: 655 EventRootType Probe[main.mapIndexKeyLen17]
-              InjectionPoints: [{PC: "0xbd9f8", Frameless: false}]
+              Type: 664 EventRootType Probe[main.mapIndexKeyLen17]
+              InjectionPoints: [{PC: "0xbde18", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 656 EventRootType Probe[main.mapIndexKeyLen17]Return
-              InjectionPoints: [{PC: "0xbda40", Frameless: false}]
+              Type: 665 EventRootType Probe[main.mapIndexKeyLen17]Return
+              InjectionPoints: [{PC: "0xbde60", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen200
       version: 0
@@ -4939,15 +5251,15 @@ Probes:
                     - ref: m
                     - 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002a
       instances:
-        - subprogram: {subprogram: 62}
+        - subprogram: {subprogram: 64}
           events:
             - Kind: Entry
-              Type: 641 EventRootType Probe[main.mapIndexKeyLen200]
-              InjectionPoints: [{PC: "0xbd748", Frameless: false}]
+              Type: 650 EventRootType Probe[main.mapIndexKeyLen200]
+              InjectionPoints: [{PC: "0xbdb68", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 642 EventRootType Probe[main.mapIndexKeyLen200]Return
-              InjectionPoints: [{PC: "0xbd790", Frameless: false}]
+              Type: 651 EventRootType Probe[main.mapIndexKeyLen200]Return
+              InjectionPoints: [{PC: "0xbdbb0", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen24
       version: 0
@@ -4966,15 +5278,15 @@ Probes:
             dsl: m["00000000000000000000002a"]
             json: {index: [{ref: m}, 00000000000000000000002a]}
       instances:
-        - subprogram: {subprogram: 59}
+        - subprogram: {subprogram: 61}
           events:
             - Kind: Entry
-              Type: 635 EventRootType Probe[main.mapIndexKeyLen24]
-              InjectionPoints: [{PC: "0xbd5c8", Frameless: false}]
+              Type: 644 EventRootType Probe[main.mapIndexKeyLen24]
+              InjectionPoints: [{PC: "0xbd9e8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 636 EventRootType Probe[main.mapIndexKeyLen24]Return
-              InjectionPoints: [{PC: "0xbd610", Frameless: false}]
+              Type: 645 EventRootType Probe[main.mapIndexKeyLen24]Return
+              InjectionPoints: [{PC: "0xbda30", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen48
       version: 0
@@ -4996,15 +5308,15 @@ Probes:
                     - ref: m
                     - 00000000000000000000000000000000000000000000002a
       instances:
-        - subprogram: {subprogram: 60}
+        - subprogram: {subprogram: 62}
           events:
             - Kind: Entry
-              Type: 637 EventRootType Probe[main.mapIndexKeyLen48]
-              InjectionPoints: [{PC: "0xbd648", Frameless: false}]
+              Type: 646 EventRootType Probe[main.mapIndexKeyLen48]
+              InjectionPoints: [{PC: "0xbda68", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 638 EventRootType Probe[main.mapIndexKeyLen48]Return
-              InjectionPoints: [{PC: "0xbd690", Frameless: false}]
+              Type: 647 EventRootType Probe[main.mapIndexKeyLen48]Return
+              InjectionPoints: [{PC: "0xbdab0", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen8
       version: 0
@@ -5023,15 +5335,15 @@ Probes:
             dsl: m["0000002a"]
             json: {index: [{ref: m}, 0000002a]}
       instances:
-        - subprogram: {subprogram: 58}
+        - subprogram: {subprogram: 60}
           events:
             - Kind: Entry
-              Type: 633 EventRootType Probe[main.mapIndexKeyLen8]
-              InjectionPoints: [{PC: "0xbd548", Frameless: false}]
+              Type: 642 EventRootType Probe[main.mapIndexKeyLen8]
+              InjectionPoints: [{PC: "0xbd968", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 634 EventRootType Probe[main.mapIndexKeyLen8]Return
-              InjectionPoints: [{PC: "0xbd590", Frameless: false}]
+              Type: 643 EventRootType Probe[main.mapIndexKeyLen8]Return
+              InjectionPoints: [{PC: "0xbd9b0", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen96
       version: 0
@@ -5053,15 +5365,15 @@ Probes:
                     - ref: m
                     - 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002a
       instances:
-        - subprogram: {subprogram: 61}
+        - subprogram: {subprogram: 63}
           events:
             - Kind: Entry
-              Type: 639 EventRootType Probe[main.mapIndexKeyLen96]
-              InjectionPoints: [{PC: "0xbd6c8", Frameless: false}]
+              Type: 648 EventRootType Probe[main.mapIndexKeyLen96]
+              InjectionPoints: [{PC: "0xbdae8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 640 EventRootType Probe[main.mapIndexKeyLen96]Return
-              InjectionPoints: [{PC: "0xbd710", Frameless: false}]
+              Type: 649 EventRootType Probe[main.mapIndexKeyLen96]Return
+              InjectionPoints: [{PC: "0xbdb30", Frameless: false}]
               Condition: null
     - id: mapIndex_largeMap_capture
       version: 0
@@ -5080,15 +5392,15 @@ Probes:
             dsl: m["key42"]
             json: {index: [{ref: m}, key42]}
       instances:
-        - subprogram: {subprogram: 56}
+        - subprogram: {subprogram: 58}
           events:
             - Kind: Entry
-              Type: 629 EventRootType Probe[main.mapIndexLargeMap]
-              InjectionPoints: [{PC: "0xbd358", Frameless: false}]
+              Type: 638 EventRootType Probe[main.mapIndexLargeMap]
+              InjectionPoints: [{PC: "0xbd778", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 630 EventRootType Probe[main.mapIndexLargeMap]Return
-              InjectionPoints: [{PC: "0xbd3a0", Frameless: false}]
+              Type: 639 EventRootType Probe[main.mapIndexLargeMap]Return
+              InjectionPoints: [{PC: "0xbd7c0", Frameless: false}]
               Condition: null
     - id: mapIndex_largeValue_capture
       version: 0
@@ -5107,15 +5419,15 @@ Probes:
             dsl: m["k"].Val
             json: {getmember: [{index: [{ref: m}, k]}, Val]}
       instances:
-        - subprogram: {subprogram: 71}
+        - subprogram: {subprogram: 73}
           events:
             - Kind: Entry
-              Type: 665 EventRootType Probe[main.mapIndexLargeValue]
-              InjectionPoints: [{PC: "0xbdbc8", Frameless: false}]
+              Type: 674 EventRootType Probe[main.mapIndexLargeValue]
+              InjectionPoints: [{PC: "0xbdfe8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 666 EventRootType Probe[main.mapIndexLargeValue]Return
-              InjectionPoints: [{PC: "0xbdc18", Frameless: false}]
+              Type: 675 EventRootType Probe[main.mapIndexLargeValue]Return
+              InjectionPoints: [{PC: "0xbe038", Frameless: false}]
               Condition: null
     - id: mapIndex_missing_capture
       version: 0
@@ -5134,15 +5446,15 @@ Probes:
             dsl: m["missing"]
             json: {index: [{ref: m}, missing]}
       instances:
-        - subprogram: {subprogram: 57}
+        - subprogram: {subprogram: 59}
           events:
             - Kind: Entry
-              Type: 631 EventRootType Probe[main.mapIndexMissing]
-              InjectionPoints: [{PC: "0xbd3d8", Frameless: false}]
+              Type: 640 EventRootType Probe[main.mapIndexMissing]
+              InjectionPoints: [{PC: "0xbd7f8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 632 EventRootType Probe[main.mapIndexMissing]Return
-              InjectionPoints: [{PC: "0xbd404", Frameless: false}]
+              Type: 641 EventRootType Probe[main.mapIndexMissing]Return
+              InjectionPoints: [{PC: "0xbd824", Frameless: false}]
               Condition: null
     - id: mapIndex_nilPtrVal_capture
       version: 0
@@ -5161,15 +5473,15 @@ Probes:
             dsl: m["nil_key"].Val
             json: {getmember: [{index: [{ref: m}, nil_key]}, Val]}
       instances:
-        - subprogram: {subprogram: 70}
+        - subprogram: {subprogram: 72}
           events:
             - Kind: Entry
-              Type: 663 EventRootType Probe[main.mapIndexNilPtrVal]
-              InjectionPoints: [{PC: "0xbdb58", Frameless: false}]
+              Type: 672 EventRootType Probe[main.mapIndexNilPtrVal]
+              InjectionPoints: [{PC: "0xbdf78", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 664 EventRootType Probe[main.mapIndexNilPtrVal]Return
-              InjectionPoints: [{PC: "0xbdb84", Frameless: false}]
+              Type: 673 EventRootType Probe[main.mapIndexNilPtrVal]Return
+              InjectionPoints: [{PC: "0xbdfa4", Frameless: false}]
               Condition: null
     - id: mapIndex_ptrStructVal_capture_int
       version: 0
@@ -5188,15 +5500,15 @@ Probes:
             dsl: m["x"].Val
             json: {getmember: [{index: [{ref: m}, x]}, Val]}
       instances:
-        - subprogram: {subprogram: 64}
+        - subprogram: {subprogram: 66}
           events:
             - Kind: Entry
-              Type: 647 EventRootType Probe[main.mapIndexPtrStructVal]
-              InjectionPoints: [{PC: "0xbd858", Frameless: false}]
+              Type: 656 EventRootType Probe[main.mapIndexPtrStructVal]
+              InjectionPoints: [{PC: "0xbdc78", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 648 EventRootType Probe[main.mapIndexPtrStructVal]Return
-              InjectionPoints: [{PC: "0xbd8b0", Frameless: false}]
+              Type: 657 EventRootType Probe[main.mapIndexPtrStructVal]Return
+              InjectionPoints: [{PC: "0xbdcd0", Frameless: false}]
               Condition: null
     - id: mapIndex_ptrStructVal_capture_string
       version: 0
@@ -5215,15 +5527,15 @@ Probes:
             dsl: m["y"].Txt
             json: {getmember: [{index: [{ref: m}, "y"]}, Txt]}
       instances:
-        - subprogram: {subprogram: 64}
+        - subprogram: {subprogram: 66}
           events:
             - Kind: Entry
-              Type: 649 EventRootType Probe[main.mapIndexPtrStructVal]
-              InjectionPoints: [{PC: "0xbd858", Frameless: false}]
+              Type: 658 EventRootType Probe[main.mapIndexPtrStructVal]
+              InjectionPoints: [{PC: "0xbdc78", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 650 EventRootType Probe[main.mapIndexPtrStructVal]Return
-              InjectionPoints: [{PC: "0xbd8b0", Frameless: false}]
+              Type: 659 EventRootType Probe[main.mapIndexPtrStructVal]Return
+              InjectionPoints: [{PC: "0xbdcd0", Frameless: false}]
               Condition: null
     - id: mapIndex_stringKey_capture
       version: 0
@@ -5242,15 +5554,15 @@ Probes:
             dsl: m["beta"]
             json: {index: [{ref: m}, beta]}
       instances:
-        - subprogram: {subprogram: 55}
+        - subprogram: {subprogram: 57}
           events:
             - Kind: Entry
-              Type: 623 EventRootType Probe[main.mapIndexStringKey]
-              InjectionPoints: [{PC: "0xbd2e8", Frameless: false}]
+              Type: 632 EventRootType Probe[main.mapIndexStringKey]
+              InjectionPoints: [{PC: "0xbd708", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 624 EventRootType Probe[main.mapIndexStringKey]Return
-              InjectionPoints: [{PC: "0xbd314", Frameless: false}]
+              Type: 633 EventRootType Probe[main.mapIndexStringKey]Return
+              InjectionPoints: [{PC: "0xbd734", Frameless: false}]
               Condition: null
     - id: mapIndex_stringKey_cond
       version: 0
@@ -5267,16 +5579,16 @@ Probes:
       segments: [matched]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 55}
+        - subprogram: {subprogram: 57}
           events:
             - Kind: Entry
-              Type: 625 EventRootType Probe[main.mapIndexStringKey]
-              InjectionPoints: [{PC: "0xbd2e8", Frameless: false}]
+              Type: 634 EventRootType Probe[main.mapIndexStringKey]
+              InjectionPoints: [{PC: "0xbd708", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 55, index: 0, name: m}
+                      Variable: {subprogram: 57, index: 0, name: m}
                       Offset: 0
                       ByteSize: 8
                     - __kind: DereferenceOp
@@ -5309,8 +5621,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 626 EventRootType Probe[main.mapIndexStringKey]Return
-              InjectionPoints: [{PC: "0xbd314", Frameless: false}]
+              Type: 635 EventRootType Probe[main.mapIndexStringKey]Return
+              InjectionPoints: [{PC: "0xbd734", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: matched, Segments: [matched]}
     - id: mapIndex_stringKey_template
@@ -5328,15 +5640,15 @@ Probes:
           dsl: m["beta"]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 55}
+        - subprogram: {subprogram: 57}
           events:
             - Kind: Entry
-              Type: 627 EventRootType Probe[main.mapIndexStringKey]
-              InjectionPoints: [{PC: "0xbd2e8", Frameless: false}]
+              Type: 636 EventRootType Probe[main.mapIndexStringKey]
+              InjectionPoints: [{PC: "0xbd708", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 628 EventRootType Probe[main.mapIndexStringKey]Return
-              InjectionPoints: [{PC: "0xbd314", Frameless: false}]
+              Type: 637 EventRootType Probe[main.mapIndexStringKey]Return
+              InjectionPoints: [{PC: "0xbd734", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: beta={m["beta"]}
@@ -5363,15 +5675,15 @@ Probes:
             dsl: m["a"].Val
             json: {getmember: [{index: [{ref: m}, a]}, Val]}
       instances:
-        - subprogram: {subprogram: 63}
+        - subprogram: {subprogram: 65}
           events:
             - Kind: Entry
-              Type: 643 EventRootType Probe[main.mapIndexStructVal]
-              InjectionPoints: [{PC: "0xbd7c8", Frameless: false}]
+              Type: 652 EventRootType Probe[main.mapIndexStructVal]
+              InjectionPoints: [{PC: "0xbdbe8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 644 EventRootType Probe[main.mapIndexStructVal]Return
-              InjectionPoints: [{PC: "0xbd81c", Frameless: false}]
+              Type: 653 EventRootType Probe[main.mapIndexStructVal]Return
+              InjectionPoints: [{PC: "0xbdc3c", Frameless: false}]
               Condition: null
     - id: mapIndex_structVal_capture_string
       version: 0
@@ -5390,15 +5702,15 @@ Probes:
             dsl: m["b"].Txt
             json: {getmember: [{index: [{ref: m}, b]}, Txt]}
       instances:
-        - subprogram: {subprogram: 63}
+        - subprogram: {subprogram: 65}
           events:
             - Kind: Entry
-              Type: 645 EventRootType Probe[main.mapIndexStructVal]
-              InjectionPoints: [{PC: "0xbd7c8", Frameless: false}]
+              Type: 654 EventRootType Probe[main.mapIndexStructVal]
+              InjectionPoints: [{PC: "0xbdbe8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 646 EventRootType Probe[main.mapIndexStructVal]Return
-              InjectionPoints: [{PC: "0xbd81c", Frameless: false}]
+              Type: 655 EventRootType Probe[main.mapIndexStructVal]Return
+              InjectionPoints: [{PC: "0xbdc3c", Frameless: false}]
               Condition: null
     - id: mapIndex_zeroValue_capture
       version: 0
@@ -5417,15 +5729,15 @@ Probes:
             dsl: m["zero"]
             json: {index: [{ref: m}, zero]}
       instances:
-        - subprogram: {subprogram: 69}
+        - subprogram: {subprogram: 71}
           events:
             - Kind: Entry
-              Type: 661 EventRootType Probe[main.mapIndexZeroValue]
-              InjectionPoints: [{PC: "0xbdae8", Frameless: false}]
+              Type: 670 EventRootType Probe[main.mapIndexZeroValue]
+              InjectionPoints: [{PC: "0xbdf08", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 662 EventRootType Probe[main.mapIndexZeroValue]Return
-              InjectionPoints: [{PC: "0xbdb14", Frameless: false}]
+              Type: 671 EventRootType Probe[main.mapIndexZeroValue]Return
+              InjectionPoints: [{PC: "0xbdf34", Frameless: false}]
               Condition: null
     - id: noArgs
       version: 0
@@ -5439,11 +5751,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 376 EventRootType Probe[main.noArgs]
-              InjectionPoints: [{PC: "0xbb0b8", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb2e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 377 EventRootType Probe[main.noArgs]Return
-              InjectionPoints: [{PC: "0xbb0ec", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb31c", Frameless: false}]
               Condition: null
     - id: stringArg
       version: 0
@@ -5457,11 +5769,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 337 EventRootType Probe[main.stringArg]
-              InjectionPoints: [{PC: "0xbac78", Frameless: false}]
+              InjectionPoints: [{PC: "0xbaea8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 338 EventRootType Probe[main.stringArg]Return
-              InjectionPoints: [{PC: "0xbacb0", Frameless: false}]
+              InjectionPoints: [{PC: "0xbaee0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's: {s}'
@@ -5483,11 +5795,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 369 EventRootType Probe[main.stringArrayArg]
-              InjectionPoints: [{PC: "0xbae58", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb088", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 370 EventRootType Probe[main.stringArrayArg]Return
-              InjectionPoints: [{PC: "0xbae98", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb0c8", Frameless: false}]
               Condition: null
     - id: stringSliceArg
       version: 0
@@ -5501,11 +5813,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 365 EventRootType Probe[main.stringSliceArg]
-              InjectionPoints: [{PC: "0xbadd8", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb008", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 366 EventRootType Probe[main.stringSliceArg]Return
-              InjectionPoints: [{PC: "0xbae10", Frameless: false}]
+              InjectionPoints: [{PC: "0xbb040", Frameless: false}]
               Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
       version: 0
@@ -5516,39 +5828,39 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 46}
+        - subprogram: {subprogram: 48}
           events:
             - Kind: Entry
-              Type: 585 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
-              InjectionPoints: [{PC: "0xbcc00", Frameless: false}]
+              Type: 594 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+              InjectionPoints: [{PC: "0xbd020", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 586 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
-              InjectionPoints: [{PC: "0xbcd78", Frameless: false}]
+              Type: 595 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+              InjectionPoints: [{PC: "0xbd198", Frameless: false}]
               Condition: null
 Subprograms:
     - ID: 1
       Name: main.intArg
-      OutOfLinePCRanges: [0xbabf0..0xbac60]
+      OutOfLinePCRanges: [0xbae20..0xbae90]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xbabf0..0xbac10
+            - Range: 0xbae20..0xbae40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 2
       Name: main.stringArg
-      OutOfLinePCRanges: [0xbac60..0xbacd0]
+      OutOfLinePCRanges: [0xbae90..0xbaf00]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xbac60..0xbac84
+            - Range: 0xbae90..0xbaeb4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -5559,13 +5871,13 @@ Subprograms:
       DictRegister: null
     - ID: 3
       Name: main.intSliceArg
-      OutOfLinePCRanges: [0xbacd0..0xbad50]
+      OutOfLinePCRanges: [0xbaf00..0xbaf80]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 107 GoSliceHeaderType []int
           Locations:
-            - Range: 0xbacd0..0xbacf4
+            - Range: 0xbaf00..0xbaf24
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -5578,26 +5890,26 @@ Subprograms:
       DictRegister: null
     - ID: 4
       Name: main.intArrayArg
-      OutOfLinePCRanges: [0xbad50..0xbadc0]
+      OutOfLinePCRanges: [0xbaf80..0xbaff0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 108 ArrayType [3]int
           Locations:
-            - Range: 0xbad50..0xbadc0
+            - Range: 0xbaf80..0xbaff0
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 5
       Name: main.stringSliceArg
-      OutOfLinePCRanges: [0xbadc0..0xbae40]
+      OutOfLinePCRanges: [0xbaff0..0xbb070]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 109 GoSliceHeaderType []string
           Locations:
-            - Range: 0xbadc0..0xbade4
+            - Range: 0xbaff0..0xbb014
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -5610,86 +5922,86 @@ Subprograms:
       DictRegister: null
     - ID: 6
       Name: main.stringArrayArg
-      OutOfLinePCRanges: [0xbae40..0xbaeb0]
+      OutOfLinePCRanges: [0xbb070..0xbb0e0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 110 ArrayType [3]string
           Locations:
-            - Range: 0xbae40..0xbaeb0
+            - Range: 0xbb070..0xbb0e0
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 7
       Name: main.stringArrayArgFrameless
-      OutOfLinePCRanges: [0xbaeb0..0xbaec0]
+      OutOfLinePCRanges: [0xbb0e0..0xbb0f0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 110 ArrayType [3]string
           Locations:
-            - Range: 0xbaeb0..0xbaec0
+            - Range: 0xbb0e0..0xbb0f0
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 8
       Name: main.mapArg
-      OutOfLinePCRanges: [0xbaf80..0xbaff0]
+      OutOfLinePCRanges: [0xbb1b0..0xbb220]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 111 GoMapType map[string]int
           Locations:
-            - Range: 0xbaf80..0xbafb4
+            - Range: 0xbb1b0..0xbb1e4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 9
       Name: main.bigMapArg
-      OutOfLinePCRanges: [0xbaff0..0xbb0a0]
+      OutOfLinePCRanges: [0xbb220..0xbb2d0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 116 GoMapType map[string]main.bigStruct
           Locations:
-            - Range: 0xbaff0..0xbb028
+            - Range: 0xbb220..0xbb258
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xbb028..0xbb0a0
+            - Range: 0xbb258..0xbb2d0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 10
       Name: main.noArgs
-      OutOfLinePCRanges: [0xbb0a0..0xbb110]
+      OutOfLinePCRanges: [0xbb2d0..0xbb340]
       InlinePCRanges: []
       Variables: []
       DictRegister: null
     - ID: 11
       Name: main.condInt8
-      OutOfLinePCRanges: [0xbb110..0xbb1b0]
+      OutOfLinePCRanges: [0xbb340..0xbb3e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType int8
           Locations:
-            - Range: 0xbb110..0xbb154
+            - Range: 0xbb340..0xbb384
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xbb110..0xbb158
+            - Range: 0xbb340..0xbb388
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbb158..0xbb15c
+            - Range: 0xbb388..0xbb38c
               Pieces:
                 - Size: 8
                   Op: null
@@ -5700,26 +6012,26 @@ Subprograms:
       DictRegister: null
     - ID: 12
       Name: main.condInt16
-      OutOfLinePCRanges: [0xbb1b0..0xbb250]
+      OutOfLinePCRanges: [0xbb3e0..0xbb480]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 96 BaseType int16
           Locations:
-            - Range: 0xbb1b0..0xbb1dc
+            - Range: 0xbb3e0..0xbb40c
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xbb1b0..0xbb1dc
+            - Range: 0xbb3e0..0xbb40c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbb1dc..0xbb250
+            - Range: 0xbb40c..0xbb480
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -5730,26 +6042,26 @@ Subprograms:
       DictRegister: null
     - ID: 13
       Name: main.condInt32
-      OutOfLinePCRanges: [0xbb250..0xbb2f0]
+      OutOfLinePCRanges: [0xbb480..0xbb520]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType int32
           Locations:
-            - Range: 0xbb250..0xbb27c
+            - Range: 0xbb480..0xbb4ac
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xbb250..0xbb27c
+            - Range: 0xbb480..0xbb4ac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbb27c..0xbb2f0
+            - Range: 0xbb4ac..0xbb520
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -5760,26 +6072,26 @@ Subprograms:
       DictRegister: null
     - ID: 14
       Name: main.condInt64
-      OutOfLinePCRanges: [0xbb2f0..0xbb390]
+      OutOfLinePCRanges: [0xbb520..0xbb5c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType int64
           Locations:
-            - Range: 0xbb2f0..0xbb31c
+            - Range: 0xbb520..0xbb54c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xbb2f0..0xbb31c
+            - Range: 0xbb520..0xbb54c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbb31c..0xbb390
+            - Range: 0xbb54c..0xbb5c0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -5790,26 +6102,26 @@ Subprograms:
       DictRegister: null
     - ID: 15
       Name: main.condUint8
-      OutOfLinePCRanges: [0xbb390..0xbb430]
+      OutOfLinePCRanges: [0xbb5c0..0xbb660]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xbb390..0xbb3d4
+            - Range: 0xbb5c0..0xbb604
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xbb390..0xbb3d8
+            - Range: 0xbb5c0..0xbb608
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbb3d8..0xbb3dc
+            - Range: 0xbb608..0xbb60c
               Pieces:
                 - Size: 8
                   Op: null
@@ -5820,26 +6132,26 @@ Subprograms:
       DictRegister: null
     - ID: 16
       Name: main.condUint16
-      OutOfLinePCRanges: [0xbb430..0xbb4d0]
+      OutOfLinePCRanges: [0xbb660..0xbb700]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0xbb430..0xbb45c
+            - Range: 0xbb660..0xbb68c
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xbb430..0xbb45c
+            - Range: 0xbb660..0xbb68c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbb45c..0xbb4d0
+            - Range: 0xbb68c..0xbb700
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -5850,26 +6162,26 @@ Subprograms:
       DictRegister: null
     - ID: 17
       Name: main.condUint32
-      OutOfLinePCRanges: [0xbb4d0..0xbb570]
+      OutOfLinePCRanges: [0xbb700..0xbb7a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0xbb4d0..0xbb4fc
+            - Range: 0xbb700..0xbb72c
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xbb4d0..0xbb4fc
+            - Range: 0xbb700..0xbb72c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbb4fc..0xbb570
+            - Range: 0xbb72c..0xbb7a0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -5880,26 +6192,26 @@ Subprograms:
       DictRegister: null
     - ID: 18
       Name: main.condUint64
-      OutOfLinePCRanges: [0xbb570..0xbb610]
+      OutOfLinePCRanges: [0xbb7a0..0xbb840]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0xbb570..0xbb59c
+            - Range: 0xbb7a0..0xbb7cc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xbb570..0xbb59c
+            - Range: 0xbb7a0..0xbb7cc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbb59c..0xbb610
+            - Range: 0xbb7cc..0xbb840
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -5910,32 +6222,32 @@ Subprograms:
       DictRegister: null
     - ID: 19
       Name: main.condFloat32
-      OutOfLinePCRanges: [0xbb610..0xbb6b0]
+      OutOfLinePCRanges: [0xbb840..0xbb8e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 18 BaseType float32
           Locations:
-            - Range: 0xbb610..0xbb640
+            - Range: 0xbb840..0xbb870
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xbb610..0xbb63c
+            - Range: 0xbb840..0xbb86c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xbb63c..0xbb640
+            - Range: 0xbb86c..0xbb870
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xbb640..0xbb6b0
+            - Range: 0xbb870..0xbb8e0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -5946,32 +6258,32 @@ Subprograms:
       DictRegister: null
     - ID: 20
       Name: main.condFloat64
-      OutOfLinePCRanges: [0xbb6b0..0xbb750]
+      OutOfLinePCRanges: [0xbb8e0..0xbb980]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 BaseType float64
           Locations:
-            - Range: 0xbb6b0..0xbb6e0
+            - Range: 0xbb8e0..0xbb910
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xbb6b0..0xbb6dc
+            - Range: 0xbb8e0..0xbb90c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xbb6dc..0xbb6e0
+            - Range: 0xbb90c..0xbb910
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xbb6e0..0xbb750
+            - Range: 0xbb910..0xbb980
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -5982,116 +6294,14 @@ Subprograms:
       DictRegister: null
     - ID: 21
       Name: main.condBool
-      OutOfLinePCRanges: [0xbb750..0xbb7f0]
+      OutOfLinePCRanges: [0xbb980..0xbba20]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xbb750..0xbb794
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xbb750..0xbb798
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbb798..0xbb79c
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 22
-      Name: main.condString
-      OutOfLinePCRanges: [0xbb7f0..0xbb890]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xbb7f0..0xbb820
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xbb7f0..0xbb820
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xbb820..0xbb890
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 24}
-                - Size: 8
-                  Op: {CfaOffset: 32}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 23
-      Name: main.condStructArg
-      OutOfLinePCRanges: [0xbb890..0xbb980]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 121 StructureType main.condFields
-          Locations:
-            - Range: 0xbb890..0xbb980
-              Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xbb890..0xbb8d0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0xbb8d0..0xbb8d4
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 88}
-                - Size: 8
-                  Op: {CfaOffset: 96}
-            - Range: 0xbb8d4..0xbb980
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 88}
-                - Size: 8
-                  Op: {CfaOffset: 96}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 24
-      Name: main.condPtrStructArg
-      OutOfLinePCRanges: [0xbb980..0xbba90]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 123 PointerType *main.condFields
-          Locations:
             - Range: 0xbb980..0xbb9c4
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xbb9c4..0xbba90
-              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
@@ -6103,7 +6313,109 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbb9c8..0xbba90
+            - Range: 0xbb9c8..0xbb9cc
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 22
+      Name: main.condString
+      OutOfLinePCRanges: [0xbba20..0xbbac0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xbba20..0xbba50
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xbba20..0xbba50
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xbba50..0xbbac0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 24}
+                - Size: 8
+                  Op: {CfaOffset: 32}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 23
+      Name: main.condStructArg
+      OutOfLinePCRanges: [0xbbac0..0xbbbb0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 121 StructureType main.condFields
+          Locations:
+            - Range: 0xbbac0..0xbbbb0
+              Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xbbac0..0xbbb00
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0xbbb00..0xbbb04
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 88}
+                - Size: 8
+                  Op: {CfaOffset: 96}
+            - Range: 0xbbb04..0xbbbb0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 88}
+                - Size: 8
+                  Op: {CfaOffset: 96}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 24
+      Name: main.condPtrStructArg
+      OutOfLinePCRanges: [0xbbbb0..0xbbcc0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 123 PointerType *main.condFields
+          Locations:
+            - Range: 0xbbbb0..0xbbbf4
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xbbbf4..0xbbcc0
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xbbbb0..0xbbbf8
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xbbbf8..0xbbcc0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -6114,26 +6426,26 @@ Subprograms:
       DictRegister: null
     - ID: 25
       Name: main.condNilPtrStruct
-      OutOfLinePCRanges: [0xbba90..0xbbb40]
+      OutOfLinePCRanges: [0xbbcc0..0xbbd70]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 123 PointerType *main.condFields
           Locations:
-            - Range: 0xbba90..0xbbadc
+            - Range: 0xbbcc0..0xbbd0c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xbba90..0xbbae0
+            - Range: 0xbbcc0..0xbbd10
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbbae0..0xbbae4
+            - Range: 0xbbd10..0xbbd14
               Pieces:
                 - Size: 8
                   Op: null
@@ -6144,66 +6456,66 @@ Subprograms:
       DictRegister: null
     - ID: 26
       Name: main.condReturnAndLocal
-      OutOfLinePCRanges: [0xbbb40..0xbbbd0]
+      OutOfLinePCRanges: [0xbbd70..0xbbe00]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xbbb40..0xbbb5c
+            - Range: 0xbbd70..0xbbd8c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xbbb40..0xbbb70
+            - Range: 0xbbd70..0xbbda0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xbbb40..0xbbbb0
+            - Range: 0xbbd70..0xbbde0
               Pieces: []
-            - Range: 0xbbbb0..0xbbbb1
+            - Range: 0xbbde0..0xbbde1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xbbbb1..0xbbbd0
+            - Range: 0xbbde1..0xbbe00
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: sum
           Type: 7 BaseType int
           Locations:
-            - Range: 0xbbb5c..0xbbb80
+            - Range: 0xbbd8c..0xbbdb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xbbb80..0xbbbd0
+            - Range: 0xbbdb0..0xbbe00
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 27
       Name: main.condOnly
-      OutOfLinePCRanges: [0xbbbd0..0xbbc70]
+      OutOfLinePCRanges: [0xbbe00..0xbbea0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xbbbd0..0xbbbfc
+            - Range: 0xbbe00..0xbbe2c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xbbbd0..0xbbbfc
+            - Range: 0xbbe00..0xbbe2c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbbbfc..0xbbc70
+            - Range: 0xbbe2c..0xbbea0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -6214,28 +6526,28 @@ Subprograms:
       DictRegister: null
     - ID: 28
       Name: main.condLine
-      OutOfLinePCRanges: [0xbbc70..0xbbd30]
+      OutOfLinePCRanges: [0xbbea0..0xbbf60]
       InlinePCRanges: []
       Variables:
         - Name: "n"
           Type: 7 BaseType int
           Locations:
-            - Range: 0xbbc70..0xbbc98
+            - Range: 0xbbea0..0xbbec8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xbbc98..0xbbd30
+            - Range: 0xbbec8..0xbbf60
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xbbc70..0xbbca8
+            - Range: 0xbbea0..0xbbed8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbbca8..0xbbd30
+            - Range: 0xbbed8..0xbbf60
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -6246,20 +6558,122 @@ Subprograms:
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0xbbc98..0xbbca8
+            - Range: 0xbbec8..0xbbed8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 29
+      Name: main.condLineMixed
+      OutOfLinePCRanges: [0xbbf60..0xbc0d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xbbf60..0xbbfb4
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0xbbfb4..0xbbfb8
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 88}
+                - Size: 8
+                  Op: {CfaOffset: 96}
+            - Range: 0xbbfb8..0xbc0d0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 88}
+                - Size: 8
+                  Op: {CfaOffset: 96}
+          Role: Parameter
+          DictIndex: -1
+        - Name: b
+          Type: 4 BaseType bool
+          Locations:
+            - Range: 0xbbf60..0xbbfb8
+              Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xbbfb8..0xbc0d0
+              Pieces: [{Size: 1, Op: {CfaOffset: 104}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: x
+          Type: 121 StructureType main.condFields
+          Locations:
+            - Range: 0xbbf60..0xbc0d0
+              Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: p
+          Type: 123 PointerType *main.condFields
+          Locations:
+            - Range: 0xbbf60..0xbbfb8
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xbbfb8..0xbc0d0
+              Pieces: [{Size: 8, Op: {CfaOffset: 112}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: ss
+          Type: 107 GoSliceHeaderType []int
+          Locations:
+            - Range: 0xbbf60..0xbbfb8
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+            - Range: 0xbbfb8..0xbc0d0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 120}
+                - Size: 8
+                  Op: {CfaOffset: 128}
+                - Size: 8
+                  Op: {CfaOffset: 136}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 30
+      Name: main.condLineReturn
+      OutOfLinePCRanges: [0xbc0d0..0xbc150]
+      InlinePCRanges: []
+      Variables:
+        - Name: "n"
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xbc0d0..0xbc0ec
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations: [{Range: 0xbc0d0..0xbc150, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: doubled
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xbc0ec..0xbc0f8
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xbc0f8..0xbc150
+              Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
+          Role: Local
+          DictIndex: -1
+      DictRegister: null
+    - ID: 31
       Name: main.condSliceArg
-      OutOfLinePCRanges: [0xbbd30..0xbbde0]
+      OutOfLinePCRanges: [0xbc150..0xbc200]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 107 GoSliceHeaderType []int
           Locations:
-            - Range: 0xbbd30..0xbbd60
+            - Range: 0xbc150..0xbc180
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6272,13 +6686,13 @@ Subprograms:
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xbbd30..0xbbd60
+            - Range: 0xbc150..0xbc180
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
-            - Range: 0xbbd60..0xbbde0
+            - Range: 0xbc180..0xbc200
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
@@ -6287,28 +6701,28 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 30
+    - ID: 32
       Name: main.condMapArg
-      OutOfLinePCRanges: [0xbbde0..0xbbe70]
+      OutOfLinePCRanges: [0xbc200..0xbc290]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 111 GoMapType map[string]int
           Locations:
-            - Range: 0xbbde0..0xbbe14
+            - Range: 0xbc200..0xbc234
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xbbde0..0xbbe18
+            - Range: 0xbc200..0xbc238
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbbe18..0xbbe1c
+            - Range: 0xbc238..0xbc23c
               Pieces:
                 - Size: 8
                   Op: null
@@ -6317,34 +6731,34 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 31
+    - ID: 33
       Name: main.condStructDirect
-      OutOfLinePCRanges: [0xbbe70..0xbbf10]
+      OutOfLinePCRanges: [0xbc290..0xbc330]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 121 StructureType main.condFields
           Locations:
-            - Range: 0xbbe70..0xbbf10
+            - Range: 0xbc290..0xbc330
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xbbe70..0xbbea0
+            - Range: 0xbc290..0xbc2c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xbbea0..0xbbea4
+            - Range: 0xbc2c0..0xbc2c4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 88}
                 - Size: 8
                   Op: {CfaOffset: 96}
-            - Range: 0xbbea4..0xbbf10
+            - Range: 0xbc2c4..0xbc330
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 88}
@@ -6353,140 +6767,36 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 32
+    - ID: 34
       Name: main.condNullPtr
-      OutOfLinePCRanges: [0xbbf10..0xbbfe0]
+      OutOfLinePCRanges: [0xbc330..0xbc400]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 100 PointerType *int
           Locations:
-            - Range: 0xbbf10..0xbbf5c
+            - Range: 0xbc330..0xbc37c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xbbf5c..0xbbfe0
+            - Range: 0xbc37c..0xbc400
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xbbf10..0xbbf60
+            - Range: 0xbc330..0xbc380
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbbf60..0xbbf64
+            - Range: 0xbc380..0xbc384
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xbbf64..0xbbfe0
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 16}
-                - Size: 8
-                  Op: {CfaOffset: 24}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 33
-      Name: main.condNullSlice
-      OutOfLinePCRanges: [0xbbfe0..0xbc0e0]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 107 GoSliceHeaderType []int
-          Locations:
-            - Range: 0xbbfe0..0xbc040
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbc040..0xbc044
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-                - Size: 8
-                  Op: {CfaOffset: 24}
-            - Range: 0xbc044..0xbc048
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-                - Size: 8
-                  Op: {CfaOffset: 24}
-            - Range: 0xbc048..0xbc0e0
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-                - Size: 8
-                  Op: {CfaOffset: 24}
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xbbfe0..0xbc034
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-            - Range: 0xbc034..0xbc038
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 32}
-                - Size: 8
-                  Op: {CfaOffset: 40}
-            - Range: 0xbc038..0xbc0e0
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 32}
-                - Size: 8
-                  Op: {CfaOffset: 40}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 34
-      Name: main.condNullMap
-      OutOfLinePCRanges: [0xbc0e0..0xbc1b0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 111 GoMapType map[string]int
-          Locations:
-            - Range: 0xbc0e0..0xbc12c
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xbc12c..0xbc1b0
-              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xbc0e0..0xbc130
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbc130..0xbc134
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 16}
-                - Size: 8
-                  Op: {CfaOffset: 24}
-            - Range: 0xbc134..0xbc1b0
+            - Range: 0xbc384..0xbc400
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -6496,87 +6806,101 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 35
-      Name: main.condNullIface
-      OutOfLinePCRanges: [0xbc1b0..0xbc2a0]
+      Name: main.condNullSlice
+      OutOfLinePCRanges: [0xbc400..0xbc500]
       InlinePCRanges: []
       Variables:
-        - Name: i
-          Type: 14 GoInterfaceType error
+        - Name: s
+          Type: 107 GoSliceHeaderType []int
           Locations:
-            - Range: 0xbc1b0..0xbc218
+            - Range: 0xbc400..0xbc460
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xbc218..0xbc21c
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xbc460..0xbc464
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0xbc21c..0xbc2a0
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0xbc464..0xbc468
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0xbc468..0xbc500
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xbc1b0..0xbc20c
+            - Range: 0xbc400..0xbc454
               Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xbc20c..0xbc220
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+            - Range: 0xbc454..0xbc458
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 24}
-                - Size: 8
                   Op: {CfaOffset: 32}
-            - Range: 0xbc220..0xbc2a0
+                - Size: 8
+                  Op: {CfaOffset: 40}
+            - Range: 0xbc458..0xbc500
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 24}
-                - Size: 8
                   Op: {CfaOffset: 32}
+                - Size: 8
+                  Op: {CfaOffset: 40}
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 36
-      Name: main.condNullUnsafePtr
-      OutOfLinePCRanges: [0xbc2a0..0xbc370]
+      Name: main.condNullMap
+      OutOfLinePCRanges: [0xbc500..0xbc5d0]
       InlinePCRanges: []
       Variables:
-        - Name: p
-          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: m
+          Type: 111 GoMapType map[string]int
           Locations:
-            - Range: 0xbc2a0..0xbc2ec
+            - Range: 0xbc500..0xbc54c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xbc2ec..0xbc370
+            - Range: 0xbc54c..0xbc5d0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xbc2a0..0xbc2f0
+            - Range: 0xbc500..0xbc550
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbc2f0..0xbc2f4
+            - Range: 0xbc550..0xbc554
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xbc2f4..0xbc370
+            - Range: 0xbc554..0xbc5d0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -6586,41 +6910,49 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 37
-      Name: main.lenString
-      OutOfLinePCRanges: [0xbc380..0xbc460]
+      Name: main.condNullIface
+      OutOfLinePCRanges: [0xbc5d0..0xbc6c0]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 9 GoStringHeaderType string
+        - Name: i
+          Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0xbc380..0xbc3d0
+            - Range: 0xbc5d0..0xbc638
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xbc3d0..0xbc3d4
-              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0xbc3d4..0xbc460
-              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
+            - Range: 0xbc638..0xbc63c
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0xbc63c..0xbc6c0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xbc380..0xbc3c8
+            - Range: 0xbc5d0..0xbc62c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xbc3c8..0xbc3d8
+            - Range: 0xbc62c..0xbc640
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: {CfaOffset: 32}
-            - Range: 0xbc3d8..0xbc460
+            - Range: 0xbc640..0xbc6c0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
@@ -6630,14 +6962,96 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 38
+      Name: main.condNullUnsafePtr
+      OutOfLinePCRanges: [0xbc6c0..0xbc790]
+      InlinePCRanges: []
+      Variables:
+        - Name: p
+          Type: 15 VoidPointerType unsafe.Pointer
+          Locations:
+            - Range: 0xbc6c0..0xbc70c
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xbc70c..0xbc790
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xbc6c0..0xbc710
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xbc710..0xbc714
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0xbc714..0xbc790
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 39
+      Name: main.lenString
+      OutOfLinePCRanges: [0xbc7a0..0xbc880]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xbc7a0..0xbc7f0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0xbc7f0..0xbc7f4
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
+            - Range: 0xbc7f4..0xbc880
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xbc7a0..0xbc7e8
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xbc7e8..0xbc7f8
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 24}
+                - Size: 8
+                  Op: {CfaOffset: 32}
+            - Range: 0xbc7f8..0xbc880
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 24}
+                - Size: 8
+                  Op: {CfaOffset: 32}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 40
       Name: main.lenSlice
-      OutOfLinePCRanges: [0xbc460..0xbc550]
+      OutOfLinePCRanges: [0xbc880..0xbc970]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 107 GoSliceHeaderType []int
           Locations:
-            - Range: 0xbc460..0xbc4bc
+            - Range: 0xbc880..0xbc8dc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6645,7 +7059,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbc4bc..0xbc4c0
+            - Range: 0xbc8dc..0xbc8e0
               Pieces:
                 - Size: 8
                   Op: null
@@ -6653,7 +7067,7 @@ Subprograms:
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbc4c0..0xbc4c4
+            - Range: 0xbc8e0..0xbc8e4
               Pieces:
                 - Size: 8
                   Op: null
@@ -6661,7 +7075,7 @@ Subprograms:
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbc4c4..0xbc550
+            - Range: 0xbc8e4..0xbc970
               Pieces:
                 - Size: 8
                   Op: null
@@ -6674,19 +7088,19 @@ Subprograms:
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xbc460..0xbc4b0
+            - Range: 0xbc880..0xbc8d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
-            - Range: 0xbc4b0..0xbc4b4
+            - Range: 0xbc8d0..0xbc8d4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
                 - Size: 8
                   Op: {CfaOffset: 40}
-            - Range: 0xbc4b4..0xbc550
+            - Range: 0xbc8d4..0xbc970
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
@@ -6695,36 +7109,36 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 39
+    - ID: 41
       Name: main.lenMap
-      OutOfLinePCRanges: [0xbc550..0xbc640]
+      OutOfLinePCRanges: [0xbc970..0xbca60]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 111 GoMapType map[string]int
           Locations:
-            - Range: 0xbc550..0xbc59c
+            - Range: 0xbc970..0xbc9bc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xbc59c..0xbc640
+            - Range: 0xbc9bc..0xbca60
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xbc550..0xbc5a0
+            - Range: 0xbc970..0xbc9c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbc5a0..0xbc5a4
+            - Range: 0xbc9c0..0xbc9c4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xbc5a4..0xbc640
+            - Range: 0xbc9c4..0xbca60
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -6733,110 +7147,36 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 40
+    - ID: 42
       Name: main.lenPtrString
-      OutOfLinePCRanges: [0xbc640..0xbc710]
+      OutOfLinePCRanges: [0xbca60..0xbcb30]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 95 PointerType *string
           Locations:
-            - Range: 0xbc640..0xbc68c
+            - Range: 0xbca60..0xbcaac
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xbc68c..0xbc710
+            - Range: 0xbcaac..0xbcb30
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xbc640..0xbc690
+            - Range: 0xbca60..0xbcab0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbc690..0xbc694
+            - Range: 0xbcab0..0xbcab4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xbc694..0xbc710
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 16}
-                - Size: 8
-                  Op: {CfaOffset: 24}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 41
-      Name: main.lenStructFields
-      OutOfLinePCRanges: [0xbc710..0xbc840]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 124 StructureType main.lenFields
-          Locations:
-            - Range: 0xbc710..0xbc840
-              Pieces: [{Size: 72, Op: {CfaOffset: 8}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xbc710..0xbc78c
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0xbc78c..0xbc790
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 80}
-                - Size: 8
-                  Op: {CfaOffset: 88}
-            - Range: 0xbc790..0xbc840
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 80}
-                - Size: 8
-                  Op: {CfaOffset: 88}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 42
-      Name: main.lenPtrStructFields
-      OutOfLinePCRanges: [0xbc840..0xbc950]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 126 PointerType *main.lenFields
-          Locations:
-            - Range: 0xbc840..0xbc88c
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xbc88c..0xbc950
-              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xbc840..0xbc890
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbc890..0xbc894
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 16}
-                - Size: 8
-                  Op: {CfaOffset: 24}
-            - Range: 0xbc894..0xbc950
+            - Range: 0xbcab4..0xbcb30
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -6846,35 +7186,71 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 43
-      Name: main.lenErrInt
-      OutOfLinePCRanges: [0xbc950..0xbca30]
+      Name: main.lenStructFields
+      OutOfLinePCRanges: [0xbcb30..0xbcc60]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 7 BaseType int
+          Type: 124 StructureType main.lenFields
           Locations:
-            - Range: 0xbc950..0xbc9a4
+            - Range: 0xbcb30..0xbcc60
+              Pieces: [{Size: 72, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xbcb30..0xbcbac
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0xbcbac..0xbcbb0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 80}
+                - Size: 8
+                  Op: {CfaOffset: 88}
+            - Range: 0xbcbb0..0xbcc60
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 80}
+                - Size: 8
+                  Op: {CfaOffset: 88}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 44
+      Name: main.lenPtrStructFields
+      OutOfLinePCRanges: [0xbcc60..0xbcd70]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 126 PointerType *main.lenFields
+          Locations:
+            - Range: 0xbcc60..0xbccac
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xbc9a4..0xbca30
+            - Range: 0xbccac..0xbcd70
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xbc950..0xbc9a8
+            - Range: 0xbcc60..0xbccb0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbc9a8..0xbc9ac
+            - Range: 0xbccb0..0xbccb4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xbc9ac..0xbca30
+            - Range: 0xbccb4..0xbcd70
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -6883,34 +7259,72 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 44
+    - ID: 45
+      Name: main.lenErrInt
+      OutOfLinePCRanges: [0xbcd70..0xbce50]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xbcd70..0xbcdc4
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xbcdc4..0xbce50
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xbcd70..0xbcdc8
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xbcdc8..0xbcdcc
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0xbcdcc..0xbce50
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 46
       Name: main.lenErrStruct
-      OutOfLinePCRanges: [0xbca30..0xbcb30]
+      OutOfLinePCRanges: [0xbce50..0xbcf50]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 121 StructureType main.condFields
           Locations:
-            - Range: 0xbca30..0xbcb30
+            - Range: 0xbce50..0xbcf50
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xbca30..0xbcaa0
+            - Range: 0xbce50..0xbcec0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xbcaa0..0xbcaa4
+            - Range: 0xbcec0..0xbcec4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 88}
                 - Size: 8
                   Op: {CfaOffset: 96}
-            - Range: 0xbcaa4..0xbcb30
+            - Range: 0xbcec4..0xbcf50
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 88}
@@ -6919,28 +7333,28 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 45
+    - ID: 47
       Name: main.indexNilPtrSlice
-      OutOfLinePCRanges: [0xbcb30..0xbcbe0]
+      OutOfLinePCRanges: [0xbcf50..0xbd000]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 126 PointerType *main.lenFields
           Locations:
-            - Range: 0xbcb30..0xbcb7c
+            - Range: 0xbcf50..0xbcf9c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xbcb30..0xbcb80
+            - Range: 0xbcf50..0xbcfa0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbcb80..0xbcb84
+            - Range: 0xbcfa0..0xbcfa4
               Pieces:
                 - Size: 8
                   Op: null
@@ -6949,60 +7363,60 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 46
+    - ID: 48
       Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
-      OutOfLinePCRanges: [0xbcbe0..0xbcd90]
+      OutOfLinePCRanges: [0xbd000..0xbd1b0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 127 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
           Locations:
-            - Range: 0xbcbe0..0xbcd78
+            - Range: 0xbd000..0xbd198
               Pieces: []
-            - Range: 0xbcd78..0xbcd79
+            - Range: 0xbd198..0xbd199
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xbcd79..0xbcd90
+            - Range: 0xbd199..0xbd1b0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 47
+    - ID: 49
       Name: main.bigArrayArg
-      OutOfLinePCRanges: [0xbcd90..0xbce20]
+      OutOfLinePCRanges: [0xbd1b0..0xbd240]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 132 ArrayType [131072]int64
           Locations:
-            - Range: 0xbcd90..0xbce20
+            - Range: 0xbd1b0..0xbd240
               Pieces: [{Size: 1048576, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 48
+    - ID: 50
       Name: main.bigArrayStructArg
-      OutOfLinePCRanges: [0xbce20..0xbceb0]
+      OutOfLinePCRanges: [0xbd240..0xbd2d0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 133 PointerType *main.bigArrayStruct
           Locations:
-            - Range: 0xbce20..0xbce48
+            - Range: 0xbd240..0xbd268
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xbce48..0xbceb0
+            - Range: 0xbd268..0xbd2d0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 49
+    - ID: 51
       Name: main.structSliceArg
-      OutOfLinePCRanges: [0xbceb0..0xbcf80]
+      OutOfLinePCRanges: [0xbd2d0..0xbd3a0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 135 GoSliceHeaderType []main.indexMemberStruct
           Locations:
-            - Range: 0xbceb0..0xbceec
+            - Range: 0xbd2d0..0xbd30c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7010,7 +7424,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbceec..0xbcef0
+            - Range: 0xbd30c..0xbd310
               Pieces:
                 - Size: 8
                   Op: null
@@ -7018,7 +7432,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbcf44..0xbcf48
+            - Range: 0xbd364..0xbd368
               Pieces:
                 - Size: 8
                   Op: null
@@ -7026,7 +7440,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbcf48..0xbcf80
+            - Range: 0xbd368..0xbd3a0
               Pieces:
                 - Size: 8
                   Op: null
@@ -7039,129 +7453,19 @@ Subprograms:
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xbceb0..0xbcef0
+            - Range: 0xbd2d0..0xbd310
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
-            - Range: 0xbcef0..0xbcf40
+            - Range: 0xbd310..0xbd360
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
                 - Size: 8
                   Op: {CfaOffset: 40}
-            - Range: 0xbcf40..0xbcf80
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 50
-      Name: main.structArrayArg
-      OutOfLinePCRanges: [0xbcf80..0xbd020]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 138 ArrayType [2]main.indexMemberStruct
-          Locations:
-            - Range: 0xbcf80..0xbd020
-              Pieces: [{Size: 64, Op: {CfaOffset: 8}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xbcf80..0xbcfac
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0xbcfac..0xbcfb0
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 72}
-                - Size: 8
-                  Op: {CfaOffset: 80}
-            - Range: 0xbcfb0..0xbd020
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 72}
-                - Size: 8
-                  Op: {CfaOffset: 80}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 51
-      Name: main.ptrStructSliceArg
-      OutOfLinePCRanges: [0xbd020..0xbd0f0]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 139 GoSliceHeaderType []*main.indexMemberStruct
-          Locations:
-            - Range: 0xbd020..0xbd05c
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbd05c..0xbd060
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbd060..0xbd064
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbd0b8..0xbd0bc
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbd0bc..0xbd0f0
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xbd020..0xbd064
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-            - Range: 0xbd064..0xbd0b4
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 32}
-                - Size: 8
-                  Op: {CfaOffset: 40}
-            - Range: 0xbd0b4..0xbd0f0
+            - Range: 0xbd360..0xbd3a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -7171,33 +7475,143 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 52
+      Name: main.structArrayArg
+      OutOfLinePCRanges: [0xbd3a0..0xbd440]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 138 ArrayType [2]main.indexMemberStruct
+          Locations:
+            - Range: 0xbd3a0..0xbd440
+              Pieces: [{Size: 64, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xbd3a0..0xbd3cc
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0xbd3cc..0xbd3d0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 72}
+                - Size: 8
+                  Op: {CfaOffset: 80}
+            - Range: 0xbd3d0..0xbd440
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 72}
+                - Size: 8
+                  Op: {CfaOffset: 80}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 53
+      Name: main.ptrStructSliceArg
+      OutOfLinePCRanges: [0xbd440..0xbd510]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 139 GoSliceHeaderType []*main.indexMemberStruct
+          Locations:
+            - Range: 0xbd440..0xbd47c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xbd47c..0xbd480
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xbd480..0xbd484
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xbd4d8..0xbd4dc
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xbd4dc..0xbd510
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xbd440..0xbd484
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+            - Range: 0xbd484..0xbd4d4
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 32}
+                - Size: 8
+                  Op: {CfaOffset: 40}
+            - Range: 0xbd4d4..0xbd510
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 54
       Name: main.ptrStructArrayArg
-      OutOfLinePCRanges: [0xbd0f0..0xbd190]
+      OutOfLinePCRanges: [0xbd510..0xbd5b0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 141 ArrayType [2]*main.indexMemberStruct
           Locations:
-            - Range: 0xbd0f0..0xbd190
+            - Range: 0xbd510..0xbd5b0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xbd0f0..0xbd11c
+            - Range: 0xbd510..0xbd53c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xbd11c..0xbd120
+            - Range: 0xbd53c..0xbd540
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: {CfaOffset: 32}
-            - Range: 0xbd120..0xbd190
+            - Range: 0xbd540..0xbd5b0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
@@ -7206,36 +7620,36 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 53
+    - ID: 55
       Name: main.indexMemberWrapperArg
-      OutOfLinePCRanges: [0xbd190..0xbd260]
+      OutOfLinePCRanges: [0xbd5b0..0xbd680]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 142 PointerType *main.indexMemberWrapper
           Locations:
-            - Range: 0xbd190..0xbd1c8
+            - Range: 0xbd5b0..0xbd5e8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xbd1c8..0xbd260
+            - Range: 0xbd5e8..0xbd680
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xbd190..0xbd1c4
+            - Range: 0xbd5b0..0xbd5e4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbd1c4..0xbd1cc
+            - Range: 0xbd5e4..0xbd5ec
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xbd1cc..0xbd260
+            - Range: 0xbd5ec..0xbd680
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -7244,261 +7658,261 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 54
+    - ID: 56
       Name: main.mapIndexIntKey
-      OutOfLinePCRanges: [0xbd260..0xbd2d0]
+      OutOfLinePCRanges: [0xbd680..0xbd6f0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 144 GoMapType map[int]string
           Locations:
-            - Range: 0xbd260..0xbd294
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 55
-      Name: main.mapIndexStringKey
-      OutOfLinePCRanges: [0xbd2d0..0xbd340]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 111 GoMapType map[string]int
-          Locations:
-            - Range: 0xbd2d0..0xbd304
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 56
-      Name: main.mapIndexLargeMap
-      OutOfLinePCRanges: [0xbd340..0xbd3c0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 111 GoMapType map[string]int
-          Locations:
-            - Range: 0xbd340..0xbd370
+            - Range: 0xbd680..0xbd6b4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 57
-      Name: main.mapIndexMissing
-      OutOfLinePCRanges: [0xbd3c0..0xbd430]
+      Name: main.mapIndexStringKey
+      OutOfLinePCRanges: [0xbd6f0..0xbd760]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 111 GoMapType map[string]int
           Locations:
-            - Range: 0xbd3c0..0xbd3f4
+            - Range: 0xbd6f0..0xbd724
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 58
-      Name: main.mapIndexKeyLen8
-      OutOfLinePCRanges: [0xbd530..0xbd5b0]
+      Name: main.mapIndexLargeMap
+      OutOfLinePCRanges: [0xbd760..0xbd7e0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 111 GoMapType map[string]int
           Locations:
-            - Range: 0xbd530..0xbd560
+            - Range: 0xbd760..0xbd790
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 59
-      Name: main.mapIndexKeyLen24
-      OutOfLinePCRanges: [0xbd5b0..0xbd630]
+      Name: main.mapIndexMissing
+      OutOfLinePCRanges: [0xbd7e0..0xbd850]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 111 GoMapType map[string]int
           Locations:
-            - Range: 0xbd5b0..0xbd5e0
+            - Range: 0xbd7e0..0xbd814
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 60
-      Name: main.mapIndexKeyLen48
-      OutOfLinePCRanges: [0xbd630..0xbd6b0]
+      Name: main.mapIndexKeyLen8
+      OutOfLinePCRanges: [0xbd950..0xbd9d0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 111 GoMapType map[string]int
           Locations:
-            - Range: 0xbd630..0xbd660
+            - Range: 0xbd950..0xbd980
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 61
-      Name: main.mapIndexKeyLen96
-      OutOfLinePCRanges: [0xbd6b0..0xbd730]
+      Name: main.mapIndexKeyLen24
+      OutOfLinePCRanges: [0xbd9d0..0xbda50]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 111 GoMapType map[string]int
           Locations:
-            - Range: 0xbd6b0..0xbd6e0
+            - Range: 0xbd9d0..0xbda00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 62
-      Name: main.mapIndexKeyLen200
-      OutOfLinePCRanges: [0xbd730..0xbd7b0]
+      Name: main.mapIndexKeyLen48
+      OutOfLinePCRanges: [0xbda50..0xbdad0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 111 GoMapType map[string]int
           Locations:
-            - Range: 0xbd730..0xbd760
+            - Range: 0xbda50..0xbda80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 63
-      Name: main.mapIndexStructVal
-      OutOfLinePCRanges: [0xbd7b0..0xbd840]
+      Name: main.mapIndexKeyLen96
+      OutOfLinePCRanges: [0xbdad0..0xbdb50]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 149 GoMapType map[string]main.indexMemberStruct
+          Type: 111 GoMapType map[string]int
           Locations:
-            - Range: 0xbd7b0..0xbd7e4
+            - Range: 0xbdad0..0xbdb00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 64
-      Name: main.mapIndexPtrStructVal
-      OutOfLinePCRanges: [0xbd840..0xbd8d0]
+      Name: main.mapIndexKeyLen200
+      OutOfLinePCRanges: [0xbdb50..0xbdbd0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 154 GoMapType map[string]*main.indexMemberStruct
+          Type: 111 GoMapType map[string]int
           Locations:
-            - Range: 0xbd840..0xbd874
+            - Range: 0xbdb50..0xbdb80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 65
-      Name: main.mapIndexEmptyKey
-      OutOfLinePCRanges: [0xbd8d0..0xbd960]
+      Name: main.mapIndexStructVal
+      OutOfLinePCRanges: [0xbdbd0..0xbdc60]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 111 GoMapType map[string]int
+          Type: 149 GoMapType map[string]main.indexMemberStruct
           Locations:
-            - Range: 0xbd8d0..0xbd900
+            - Range: 0xbdbd0..0xbdc04
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 66
-      Name: main.mapIndexKeyLen16
-      OutOfLinePCRanges: [0xbd960..0xbd9e0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 111 GoMapType map[string]int
-          Locations:
-            - Range: 0xbd960..0xbd990
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 67
-      Name: main.mapIndexKeyLen17
-      OutOfLinePCRanges: [0xbd9e0..0xbda60]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 111 GoMapType map[string]int
-          Locations:
-            - Range: 0xbd9e0..0xbda10
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 68
-      Name: main.mapIndexBoolKey
-      OutOfLinePCRanges: [0xbda60..0xbdad0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 159 GoMapType map[bool]int
-          Locations:
-            - Range: 0xbda60..0xbda94
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 69
-      Name: main.mapIndexZeroValue
-      OutOfLinePCRanges: [0xbdad0..0xbdb40]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 111 GoMapType map[string]int
-          Locations:
-            - Range: 0xbdad0..0xbdb04
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 70
-      Name: main.mapIndexNilPtrVal
-      OutOfLinePCRanges: [0xbdb40..0xbdbb0]
+      Name: main.mapIndexPtrStructVal
+      OutOfLinePCRanges: [0xbdc60..0xbdcf0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 154 GoMapType map[string]*main.indexMemberStruct
           Locations:
-            - Range: 0xbdb40..0xbdb74
+            - Range: 0xbdc60..0xbdc94
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 67
+      Name: main.mapIndexEmptyKey
+      OutOfLinePCRanges: [0xbdcf0..0xbdd80]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 111 GoMapType map[string]int
+          Locations:
+            - Range: 0xbdcf0..0xbdd20
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 68
+      Name: main.mapIndexKeyLen16
+      OutOfLinePCRanges: [0xbdd80..0xbde00]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 111 GoMapType map[string]int
+          Locations:
+            - Range: 0xbdd80..0xbddb0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 69
+      Name: main.mapIndexKeyLen17
+      OutOfLinePCRanges: [0xbde00..0xbde80]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 111 GoMapType map[string]int
+          Locations:
+            - Range: 0xbde00..0xbde30
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 70
+      Name: main.mapIndexBoolKey
+      OutOfLinePCRanges: [0xbde80..0xbdef0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 159 GoMapType map[bool]int
+          Locations:
+            - Range: 0xbde80..0xbdeb4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 71
-      Name: main.mapIndexLargeValue
-      OutOfLinePCRanges: [0xbdbb0..0xbdc40]
+      Name: main.mapIndexZeroValue
+      OutOfLinePCRanges: [0xbdef0..0xbdf60]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 164 GoMapType map[string]main.largeValueStruct
+          Type: 111 GoMapType map[string]int
           Locations:
-            - Range: 0xbdbb0..0xbdbe0
+            - Range: 0xbdef0..0xbdf24
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 72
+      Name: main.mapIndexNilPtrVal
+      OutOfLinePCRanges: [0xbdf60..0xbdfd0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 154 GoMapType map[string]*main.indexMemberStruct
+          Locations:
+            - Range: 0xbdf60..0xbdf94
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 73
+      Name: main.mapIndexLargeValue
+      OutOfLinePCRanges: [0xbdfd0..0xbe060]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 164 GoMapType map[string]main.largeValueStruct
+          Locations:
+            - Range: 0xbdfd0..0xbe000
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 74
       Name: main.condMultiReturn
-      OutOfLinePCRanges: [0xbdcc0..0xbdd80]
+      OutOfLinePCRanges: [0xbe0e0..0xbe1a0]
       InlinePCRanges: []
       Variables:
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xbdcc0..0xbdd04
+            - Range: 0xbe0e0..0xbe124
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xbdd04..0xbdd08
+            - Range: 0xbe124..0xbe128
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0xbdd08..0xbdd80
+            - Range: 0xbe128..0xbe1a0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -7509,51 +7923,51 @@ Subprograms:
         - Name: r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xbdcc0..0xbdd58
+            - Range: 0xbe0e0..0xbe178
               Pieces: []
-            - Range: 0xbdd58..0xbdd59
+            - Range: 0xbe178..0xbe179
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xbdd59..0xbdd80
+            - Range: 0xbe179..0xbe1a0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: r1
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xbdcc0..0xbdd58
+            - Range: 0xbe0e0..0xbe178
               Pieces: []
-            - Range: 0xbdd58..0xbdd59
+            - Range: 0xbe178..0xbe179
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbdd59..0xbdd80
+            - Range: 0xbe179..0xbe1a0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 73
+    - ID: 75
       Name: main.genericIdentity[go.shape.string]
-      OutOfLinePCRanges: [0xbdd80..0xbde10]
+      OutOfLinePCRanges: [0xbe1a0..0xbe230]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 169 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xbdd80..0xbddb0
+            - Range: 0xbe1a0..0xbe1d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xbddb0..0xbddb4
+            - Range: 0xbe1d0..0xbe1d4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xbddb4..0xbde10
+            - Range: 0xbe1d4..0xbe230
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -7564,68 +7978,68 @@ Subprograms:
         - Name: ~r0
           Type: 169 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xbdd80..0xbdde8
+            - Range: 0xbe1a0..0xbe208
               Pieces: []
-            - Range: 0xbdde8..0xbdde9
+            - Range: 0xbe208..0xbe209
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xbdde9..0xbde10
+            - Range: 0xbe209..0xbe230
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 74
+    - ID: 76
       Name: main.genericIdentity[go.shape.int]
-      OutOfLinePCRanges: [0xbde10..0xbde90]
+      OutOfLinePCRanges: [0xbe230..0xbe2b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 170 BaseType go.shape.int
           Locations:
-            - Range: 0xbde10..0xbde3c
+            - Range: 0xbe230..0xbe25c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0xbde3c..0xbde90
+            - Range: 0xbe25c..0xbe2b0
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 170 BaseType go.shape.int
           Locations:
-            - Range: 0xbde10..0xbde6c
+            - Range: 0xbe230..0xbe28c
               Pieces: []
-            - Range: 0xbde6c..0xbde6d
+            - Range: 0xbe28c..0xbe28d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xbde6d..0xbde90
+            - Range: 0xbe28d..0xbe2b0
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 75
+    - ID: 77
       Name: main.inlined
-      OutOfLinePCRanges: [0xbaec0..0xbaf30]
+      OutOfLinePCRanges: [0xbb0f0..0xbb160]
       InlinePCRanges:
         - Ranges: [0xb88dc..0xb891c]
-          RootRanges: [0xb8730..0xbabf0]
+          RootRanges: [0xb8730..0xbae20]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
             - Range: 0xb88dc..0xb891c
               Pieces: []
-            - Range: 0xbaec0..0xbaee0
+            - Range: 0xbb0f0..0xbb110
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 76
+    - ID: 78
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xb8b20..0xb8b58]
-          RootRanges: [0xb8730..0xbabf0]
+          RootRanges: [0xb8730..0xbae20]
       Variables:
         - Name: ptr
           Type: 171 PointerType *****int
@@ -7635,12 +8049,12 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 77
+    - ID: 79
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xb8b64..0xb8b9c]
-          RootRanges: [0xb8730..0xbabf0]
+          RootRanges: [0xb8730..0xbae20]
       Variables:
         - Name: ptr
           Type: 173 PointerType **int
@@ -7650,17 +8064,17 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 78
+    - ID: 80
       Name: main.(*methodValueReceiver).inlinedMethod
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xbde94..0xbde98]
-          RootRanges: [0xbde90..0xbdea0]
+        - Ranges: [0xbe2b4..0xbe2b8]
+          RootRanges: [0xbe2b0..0xbe2c0]
       Variables:
         - Name: m
           Type: 174 PointerType *main.methodValueReceiver
           Locations:
-            - Range: 0xbde94..0xbdea0
+            - Range: 0xbe2b4..0xbe2c0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7829,7 +8243,7 @@ Types:
       ID: 283
       Name: '*errors.errorString'
       ByteSize: 8
-      GoRuntimeType: 62976
+      GoRuntimeType: 63072
       GoKind: 22
       Pointee: 284 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
@@ -7876,35 +8290,35 @@ Types:
       ID: 323
       Name: '*internal/abi.Type'
       ByteSize: 8
-      GoRuntimeType: 142304
+      GoRuntimeType: 142400
       GoKind: 22
       Pointee: 324 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
       ID: 291
       Name: '*internal/bisect.parseError'
       ByteSize: 8
-      GoRuntimeType: 66240
+      GoRuntimeType: 66336
       GoKind: 22
       Pointee: 292 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
       ID: 319
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 80768
+      GoRuntimeType: 80864
       GoKind: 22
       Pointee: 320 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 317
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
-      GoRuntimeType: 80640
+      GoRuntimeType: 80736
       GoKind: 22
       Pointee: 318 StructureType internal/poll.errNetClosing
     - __kind: PointerType
       ID: 290
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
-      GoRuntimeType: 66048
+      GoRuntimeType: 66144
       GoKind: 22
       Pointee: 280 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
@@ -7916,14 +8330,14 @@ Types:
       ID: 309
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
-      GoRuntimeType: 73344
+      GoRuntimeType: 73440
       GoKind: 22
       Pointee: 310 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
       ID: 315
       Name: '*io/fs.PathError'
       ByteSize: 8
-      GoRuntimeType: 80512
+      GoRuntimeType: 80608
       GoKind: 22
       Pointee: 316 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
@@ -8074,28 +8488,28 @@ Types:
       ID: 311
       Name: '*os.SyscallError'
       ByteSize: 8
-      GoRuntimeType: 77568
+      GoRuntimeType: 77664
       GoKind: 22
       Pointee: 312 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 285
       Name: '*reflect.ValueError'
       ByteSize: 8
-      GoRuntimeType: 63840
+      GoRuntimeType: 63936
       GoKind: 22
       Pointee: 286 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
       ID: 303
       Name: '*runtime.PanicNilError'
       ByteSize: 8
-      GoRuntimeType: 70656
+      GoRuntimeType: 70752
       GoKind: 22
       Pointee: 304 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
       ID: 307
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
-      GoRuntimeType: 72448
+      GoRuntimeType: 72544
       GoKind: 22
       Pointee: 308 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
@@ -8109,14 +8523,14 @@ Types:
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 89184
+      GoRuntimeType: 89280
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 305
       Name: '*runtime.boundsError'
       ByteSize: 8
-      GoRuntimeType: 70784
+      GoRuntimeType: 70880
       GoKind: 22
       Pointee: 306 StructureType runtime.boundsError
     - __kind: PointerType
@@ -8137,14 +8551,14 @@ Types:
       ID: 313
       Name: '*runtime.errorAddressString'
       ByteSize: 8
-      GoRuntimeType: 80000
+      GoRuntimeType: 80096
       GoKind: 22
       Pointee: 314 StructureType runtime.errorAddressString
     - __kind: PointerType
       ID: 301
       Name: '*runtime.errorString'
       ByteSize: 8
-      GoRuntimeType: 70272
+      GoRuntimeType: 70368
       GoKind: 22
       Pointee: 293 GoStringHeaderType runtime.errorString
     - __kind: PointerType
@@ -8156,28 +8570,28 @@ Types:
       ID: 55
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 64704
+      GoRuntimeType: 64800
       GoKind: 22
       Pointee: 22 StructureType runtime.g
     - __kind: PointerType
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 89824
+      GoRuntimeType: 89920
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
       ID: 64
       Name: '*runtime.p'
       ByteSize: 8
-      GoRuntimeType: 71808
+      GoRuntimeType: 71904
       GoKind: 22
       Pointee: 182 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 302
       Name: '*runtime.plainError'
       ByteSize: 8
-      GoRuntimeType: 70400
+      GoRuntimeType: 70496
       GoKind: 22
       Pointee: 296 GoStringHeaderType runtime.plainError
     - __kind: PointerType
@@ -8196,35 +8610,35 @@ Types:
       ID: 49
       Name: '*runtime.synctestBubble'
       ByteSize: 8
-      GoRuntimeType: 102432
+      GoRuntimeType: 102528
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
       ID: 287
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
-      GoRuntimeType: 65376
+      GoRuntimeType: 65472
       GoKind: 22
       Pointee: 288 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 134464
+      GoRuntimeType: 134560
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 79
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 108640
+      GoRuntimeType: 108736
       GoKind: 22
       Pointee: 80 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 299
       Name: '*strconv.NumError'
       ByteSize: 8
-      GoRuntimeType: 69376
+      GoRuntimeType: 69472
       GoKind: 22
       Pointee: 300 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
@@ -8243,7 +8657,7 @@ Types:
       ID: 322
       Name: '*syscall.Errno'
       ByteSize: 8
-      GoRuntimeType: 90784
+      GoRuntimeType: 90880
       GoKind: 22
       Pointee: 321 BaseType syscall.Errno
     - __kind: PointerType
@@ -8295,7 +8709,7 @@ Types:
       ID: 289
       Name: '*time.fileSizeError'
       ByteSize: 8
-      GoRuntimeType: 65568
+      GoRuntimeType: 65664
       GoKind: 22
       Pointee: 277 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
@@ -8346,7 +8760,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 677
+      ID: 686
       Name: Probe[main.(*methodValueReceiver).inlinedMethod]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8358,12 +8772,12 @@ Types:
             Type: 174 PointerType *main.methodValueReceiver
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: m}
+                  Variable: {subprogram: 80, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 675
+      ID: 684
       Name: Probe[main.PointerChainArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -8375,7 +8789,7 @@ Types:
             Type: 171 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: ptr}
+                  Variable: {subprogram: 78, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -8386,12 +8800,12 @@ Types:
             Type: 171 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: ptr}
+                  Variable: {subprogram: 78, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 676
+      ID: 685
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8403,12 +8817,12 @@ Types:
             Type: 173 PointerType **int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: ptr}
+                  Variable: {subprogram: 79, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 587
+      ID: 596
       Name: Probe[main.bigArrayArg]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8420,12 +8834,12 @@ Types:
             Type: 13 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: s}
+                  Variable: {subprogram: 49, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 589
+      ID: 598
       Name: Probe[main.bigArrayArg]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8437,18 +8851,18 @@ Types:
             Type: 13 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: s}
+                  Variable: {subprogram: 49, index: 0, name: s}
                   Offset: 1048568
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 588
+      ID: 597
       Name: Probe[main.bigArrayArg]Return
     - __kind: EventRootType
-      ID: 590
+      ID: 599
       Name: Probe[main.bigArrayArg]Return
     - __kind: EventRootType
-      ID: 591
+      ID: 600
       Name: Probe[main.bigArrayStructArg]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8460,7 +8874,7 @@ Types:
             Type: 13 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: s}
+                  Variable: {subprogram: 50, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -8468,7 +8882,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 592
+      ID: 601
       Name: Probe[main.bigArrayStructArg]Return
     - __kind: EventRootType
       ID: 374
@@ -8899,6 +9313,85 @@ Types:
       ID: 381
       Name: Probe[main.condInt8]Return
     - __kind: EventRootType
+      ID: 485
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 486
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 487
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 488
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 489
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 490
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 491
+      Name: Probe[main.condLineMixed]Line
+      ByteSize: 131
+      ExprStatusArraySize: 2
+      Expressions:
+        - Name: s
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: b
+          Offset: 18
+          Kind: local
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 1
+          DictIndex: -1
+        - Name: x
+          Offset: 19
+          Kind: local
+          Expression:
+            Type: 121 StructureType main.condFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 80
+          DictIndex: -1
+        - Name: p
+          Offset: 99
+          Kind: local
+          Expression:
+            Type: 123 PointerType *main.condFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 3, name: p}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: ss
+          Offset: 107
+          Kind: local
+          Expression:
+            Type: 107 GoSliceHeaderType []int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 4, name: ss}
+                  Offset: 0
+                  ByteSize: 24
+          DictIndex: -1
+    - __kind: EventRootType
       ID: 480
       Name: Probe[main.condLine]Line
       ByteSize: 25
@@ -8946,6 +9439,62 @@ Types:
     - __kind: EventRootType
       ID: 482
       Name: Probe[main.condLine]Line
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 483
+      Name: Probe[main.condLine]Line
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: "n"
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 0, name: "n"}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: tag
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: result
+          Offset: 25
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 2, name: result}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 484
+      Name: Probe[main.condLine]Line
       ByteSize: 25
       ExprStatusArraySize: 1
       Expressions:
@@ -8972,10 +9521,10 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 667
+      ID: 676
       Name: Probe[main.condMultiReturn]
     - __kind: EventRootType
-      ID: 668
+      ID: 677
       Name: Probe[main.condMultiReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -8987,7 +9536,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 1, name: r0}
+                  Variable: {subprogram: 74, index: 1, name: r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -8998,7 +9547,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 2, name: r1}
+                  Variable: {subprogram: 74, index: 2, name: r1}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -9094,7 +9643,7 @@ Types:
       ID: 469
       Name: Probe[main.condNilPtrStruct]Return
     - __kind: EventRootType
-      ID: 489
+      ID: 498
       Name: Probe[main.condNullIface]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -9106,76 +9655,16 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 35, index: 1, name: tag}
+                  Variable: {subprogram: 37, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 490
+      ID: 499
       Name: Probe[main.condNullIface]Return
     - __kind: EventRootType
-      ID: 487
+      ID: 496
       Name: Probe[main.condNullMap]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 34, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 488
-      Name: Probe[main.condNullMap]Return
-    - __kind: EventRootType
-      ID: 483
-      Name: Probe[main.condNullPtr]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 32, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 484
-      Name: Probe[main.condNullPtr]Return
-    - __kind: EventRootType
-      ID: 485
-      Name: Probe[main.condNullSlice]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 33, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 486
-      Name: Probe[main.condNullSlice]Return
-    - __kind: EventRootType
-      ID: 491
-      Name: Probe[main.condNullUnsafePtr]
       ByteSize: 17
       ExprStatusArraySize: 1
       Expressions:
@@ -9191,7 +9680,67 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
+      ID: 497
+      Name: Probe[main.condNullMap]Return
+    - __kind: EventRootType
       ID: 492
+      Name: Probe[main.condNullPtr]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 493
+      Name: Probe[main.condNullPtr]Return
+    - __kind: EventRootType
+      ID: 494
+      Name: Probe[main.condNullSlice]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 495
+      Name: Probe[main.condNullSlice]Return
+    - __kind: EventRootType
+      ID: 500
+      Name: Probe[main.condNullUnsafePtr]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 501
       Name: Probe[main.condNullUnsafePtr]Return
     - __kind: EventRootType
       ID: 476
@@ -10003,7 +10552,7 @@ Types:
       ID: 403
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 671
+      ID: 680
       Name: Probe[main.genericIdentity[go.shape.int]]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10016,12 +10565,12 @@ Types:
             Type: 170 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: x}
+                  Variable: {subprogram: 76, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 672
+      ID: 681
       Name: Probe[main.genericIdentity[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10034,12 +10583,12 @@ Types:
             Type: 170 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 1, name: ~r0}
+                  Variable: {subprogram: 76, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 669
+      ID: 678
       Name: Probe[main.genericIdentity[go.shape.string]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -10052,12 +10601,12 @@ Types:
             Type: 169 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: x}
+                  Variable: {subprogram: 75, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 670
+      ID: 679
       Name: Probe[main.genericIdentity[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -10070,12 +10619,12 @@ Types:
             Type: 169 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 1, name: ~r0}
+                  Variable: {subprogram: 75, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 613
+      ID: 622
       Name: Probe[main.indexMemberWrapperArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -10087,7 +10636,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
+                  Variable: {subprogram: 55, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10098,7 +10647,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 615
+      ID: 624
       Name: Probe[main.indexMemberWrapperArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10110,7 +10659,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
+                  Variable: {subprogram: 55, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10121,7 +10670,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 617
+      ID: 626
       Name: Probe[main.indexMemberWrapperArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -10133,7 +10682,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
+                  Variable: {subprogram: 55, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10147,7 +10696,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 619
+      ID: 628
       Name: Probe[main.indexMemberWrapperArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10159,7 +10708,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
+                  Variable: {subprogram: 55, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10173,19 +10722,19 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 614
+      ID: 623
       Name: Probe[main.indexMemberWrapperArg]Return
     - __kind: EventRootType
-      ID: 616
+      ID: 625
       Name: Probe[main.indexMemberWrapperArg]Return
     - __kind: EventRootType
-      ID: 618
+      ID: 627
       Name: Probe[main.indexMemberWrapperArg]Return
     - __kind: EventRootType
-      ID: 620
+      ID: 629
       Name: Probe[main.indexMemberWrapperArg]Return
     - __kind: EventRootType
-      ID: 579
+      ID: 588
       Name: Probe[main.indexNilPtrSlice]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10197,7 +10746,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: x}
+                  Variable: {subprogram: 47, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10210,7 +10759,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 581
+      ID: 590
       Name: Probe[main.indexNilPtrSlice]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10222,12 +10771,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 1, name: tag}
+                  Variable: {subprogram: 47, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 583
+      ID: 592
       Name: Probe[main.indexNilPtrSlice]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10239,7 +10788,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: x}
+                  Variable: {subprogram: 47, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10252,16 +10801,16 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 580
+      ID: 589
       Name: Probe[main.indexNilPtrSlice]Return
     - __kind: EventRootType
-      ID: 582
+      ID: 591
       Name: Probe[main.indexNilPtrSlice]Return
     - __kind: EventRootType
-      ID: 584
+      ID: 593
       Name: Probe[main.indexNilPtrSlice]Return
     - __kind: EventRootType
-      ID: 673
+      ID: 682
       Name: Probe[main.inlined]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10273,12 +10822,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: x}
+                  Variable: {subprogram: 77, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 674
+      ID: 683
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
       ID: 331
@@ -10491,7 +11040,7 @@ Types:
       ID: 352
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 571
+      ID: 580
       Name: Probe[main.lenErrInt]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -10503,7 +11052,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: x}
+                  Variable: {subprogram: 45, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -10514,21 +11063,21 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 1, name: tag}
+                  Variable: {subprogram: 45, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 573
+      ID: 582
       Name: Probe[main.lenErrInt]
     - __kind: EventRootType
-      ID: 572
+      ID: 581
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 574
+      ID: 583
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 575
+      ID: 584
       Name: Probe[main.lenErrStruct]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -10540,7 +11089,7 @@ Types:
             Type: 121 StructureType main.condFields
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: x}
+                  Variable: {subprogram: 46, index: 0, name: x}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -10551,21 +11100,21 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 1, name: tag}
+                  Variable: {subprogram: 46, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 577
+      ID: 586
       Name: Probe[main.lenErrStruct]
     - __kind: EventRootType
-      ID: 576
+      ID: 585
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 578
+      ID: 587
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 525
+      ID: 534
       Name: Probe[main.lenMap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10577,12 +11126,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Variable: {subprogram: 41, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 527
+      ID: 536
       Name: Probe[main.lenMap]
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -10594,7 +11143,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: m}
+                  Variable: {subprogram: 41, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10608,7 +11157,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 529
+      ID: 538
       Name: Probe[main.lenMap]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10620,845 +11169,16 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: m}
+                  Variable: {subprogram: 41, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
                   Bias: 0
                   ByteSize: 8
           DictIndex: -1
-    - __kind: EventRootType
-      ID: 531
-      Name: Probe[main.lenMap]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 533
-      Name: Probe[main.lenMap]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(m)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 8 BaseType uint64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 0
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 535
-      Name: Probe[main.lenMap]
-      ByteSize: 25
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 111 GoMapType map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-          DictIndex: -1
-        - Name: tag
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 526
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 528
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 530
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 532
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 534
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 536
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 537
-      Name: Probe[main.lenPtrString]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(s)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 539
-      Name: Probe[main.lenPtrString]
-      ByteSize: 25
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 95 PointerType *string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 8
-          DictIndex: -1
-        - Name: tag
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 538
-      Name: Probe[main.lenPtrString]Return
     - __kind: EventRootType
       ID: 540
-      Name: Probe[main.lenPtrString]Return
-    - __kind: EventRootType
-      ID: 561
-      Name: Probe[main.lenPtrStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: items_0
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 16
-                  ByteSize: 16
-                - __kind: SliceBoundsCheckOp
-                  Index: 0
-                - __kind: DereferenceOp
-                  Bias: 0
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 563
-      Name: Probe[main.lenPtrStructFields]
-      ByteSize: 25
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 126 PointerType *main.lenFields
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-          DictIndex: -1
-        - Name: tag
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 565
-      Name: Probe[main.lenPtrStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.Dict)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 8 BaseType uint64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 40
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 0
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 567
-      Name: Probe[main.lenPtrStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.Items)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 24
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 569
-      Name: Probe[main.lenPtrStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.S)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 562
-      Name: Probe[main.lenPtrStructFields]Return
-    - __kind: EventRootType
-      ID: 564
-      Name: Probe[main.lenPtrStructFields]Return
-    - __kind: EventRootType
-      ID: 566
-      Name: Probe[main.lenPtrStructFields]Return
-    - __kind: EventRootType
-      ID: 568
-      Name: Probe[main.lenPtrStructFields]Return
-    - __kind: EventRootType
-      ID: 570
-      Name: Probe[main.lenPtrStructFields]Return
-    - __kind: EventRootType
-      ID: 513
-      Name: Probe[main.lenSlice]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 515
-      Name: Probe[main.lenSlice]
-      ByteSize: 2
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: isEmpty(s)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-                - __kind: ExprPushOffsetOp
-                  ByteSize: 8
-                - __kind: ExprLoadLiteralOp
-                  Data: AAAAAAAAAAA=
-                - __kind: ExprCmpEqBaseOp
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 517
-      Name: Probe[main.lenSlice]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s_len
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 519
-      Name: Probe[main.lenSlice]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 521
-      Name: Probe[main.lenSlice]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(s)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 523
-      Name: Probe[main.lenSlice]
-      ByteSize: 41
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 107 GoSliceHeaderType []int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 24
-          DictIndex: -1
-        - Name: tag
-          Offset: 25
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 514
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 516
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 518
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 520
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 522
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 524
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 493
-      Name: Probe[main.lenString]
-      ByteSize: 33
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-        - Name: tag
-          Offset: 17
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 495
-      Name: Probe[main.lenString]
-      ByteSize: 2
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s_len_eq_5
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-                - __kind: ExprPushOffsetOp
-                  ByteSize: 8
-                - __kind: ExprLoadLiteralOp
-                  Data: BQAAAAAAAAA=
-                - __kind: ExprCmpEqBaseOp
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 497
-      Name: Probe[main.lenString]
-      ByteSize: 2
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(s) == 5
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-                - __kind: ExprPushOffsetOp
-                  ByteSize: 8
-                - __kind: ExprLoadLiteralOp
-                  Data: BQAAAAAAAAA=
-                - __kind: ExprCmpEqBaseOp
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 499
-      Name: Probe[main.lenString]
-      ByteSize: 2
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s_isEmpty
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-                - __kind: ExprPushOffsetOp
-                  ByteSize: 8
-                - __kind: ExprLoadLiteralOp
-                  Data: AAAAAAAAAAA=
-                - __kind: ExprCmpEqBaseOp
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 501
-      Name: Probe[main.lenString]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 503
-      Name: Probe[main.lenString]
-      ByteSize: 2
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: isEmpty(s)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-                - __kind: ExprPushOffsetOp
-                  ByteSize: 8
-                - __kind: ExprLoadLiteralOp
-                  Data: AAAAAAAAAAA=
-                - __kind: ExprCmpEqBaseOp
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 505
-      Name: Probe[main.lenString]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s_len
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 507
-      Name: Probe[main.lenString]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 509
-      Name: Probe[main.lenString]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(s)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 511
-      Name: Probe[main.lenString]
-      ByteSize: 33
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-        - Name: tag
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 494
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 496
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 498
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 500
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 502
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 504
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 506
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 508
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 510
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 512
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 541
-      Name: Probe[main.lenStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: items_2
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 16
-                  ByteSize: 16
-                - __kind: SliceBoundsCheckOp
-                  Index: 2
-                - __kind: DereferenceOp
-                  Bias: 16
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 543
-      Name: Probe[main.lenStructFields]
-      ByteSize: 89
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 124 StructureType main.lenFields
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 72
-          DictIndex: -1
-        - Name: tag
-          Offset: 73
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 545
-      Name: Probe[main.lenStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.Dict)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 8 BaseType uint64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 40
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 0
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 547
-      Name: Probe[main.lenStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.PtrSlice)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 56
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 549
-      Name: Probe[main.lenStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.PtrStr)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 48
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 551
-      Name: Probe[main.lenStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.Items)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 24
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 553
-      Name: Probe[main.lenStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.S)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 555
-      Name: Probe[main.lenStructFields]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 557
-      Name: Probe[main.lenStructFields]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 559
-      Name: Probe[main.lenStructFields]
+      Name: Probe[main.lenMap]
       ByteSize: 17
       ExprStatusArraySize: 1
       Expressions:
@@ -11475,33 +11195,862 @@ Types:
           DictIndex: -1
     - __kind: EventRootType
       ID: 542
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenMap]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(m)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 41, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+          DictIndex: -1
     - __kind: EventRootType
       ID: 544
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenMap]
+      ByteSize: 25
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 111 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 41, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 41, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 535
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 537
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 539
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 541
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 543
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 545
+      Name: Probe[main.lenMap]Return
     - __kind: EventRootType
       ID: 546
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenPtrString]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 42, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+          DictIndex: -1
     - __kind: EventRootType
       ID: 548
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenPtrString]
+      ByteSize: 25
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 95 PointerType *string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 42, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 42, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 547
+      Name: Probe[main.lenPtrString]Return
+    - __kind: EventRootType
+      ID: 549
+      Name: Probe[main.lenPtrString]Return
+    - __kind: EventRootType
+      ID: 570
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: items_0
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 16
+                  ByteSize: 16
+                - __kind: SliceBoundsCheckOp
+                  Index: 0
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 572
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 25
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 126 PointerType *main.lenFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 574
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.Dict)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 40
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 576
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.Items)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 24
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 578
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.S)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 571
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 573
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 575
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 577
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 579
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 522
+      Name: Probe[main.lenSlice]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 524
+      Name: Probe[main.lenSlice]
+      ByteSize: 2
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: isEmpty(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 526
+      Name: Probe[main.lenSlice]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s_len
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 528
+      Name: Probe[main.lenSlice]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 530
+      Name: Probe[main.lenSlice]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 532
+      Name: Probe[main.lenSlice]
+      ByteSize: 41
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 107 GoSliceHeaderType []int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+          DictIndex: -1
+        - Name: tag
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 523
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 525
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 527
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 529
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 531
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 533
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 502
+      Name: Probe[main.lenString]
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: tag
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 504
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s_len_eq_5
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 506
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(s) == 5
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 508
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s_isEmpty
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 510
+      Name: Probe[main.lenString]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 512
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: isEmpty(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 514
+      Name: Probe[main.lenString]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s_len
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 516
+      Name: Probe[main.lenString]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 518
+      Name: Probe[main.lenString]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 520
+      Name: Probe[main.lenString]
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: tag
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 503
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 505
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 507
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 509
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 511
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 513
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 515
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 517
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 519
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 521
+      Name: Probe[main.lenString]Return
     - __kind: EventRootType
       ID: 550
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: items_2
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 16
+                  ByteSize: 16
+                - __kind: SliceBoundsCheckOp
+                  Index: 2
+                - __kind: DereferenceOp
+                  Bias: 16
+                  ByteSize: 8
+          DictIndex: -1
     - __kind: EventRootType
       ID: 552
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenStructFields]
+      ByteSize: 89
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 124 StructureType main.lenFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 72
+          DictIndex: -1
+        - Name: tag
+          Offset: 73
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
     - __kind: EventRootType
       ID: 554
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.Dict)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 40
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+          DictIndex: -1
     - __kind: EventRootType
       ID: 556
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.PtrSlice)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 56
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+          DictIndex: -1
     - __kind: EventRootType
       ID: 558
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.PtrStr)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 48
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+          DictIndex: -1
     - __kind: EventRootType
       ID: 560
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.Items)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 24
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 562
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.S)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 8
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 564
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 566
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 568
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 551
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 553
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 555
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 557
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 559
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 561
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 563
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 565
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 567
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 569
       Name: Probe[main.lenStructFields]Return
     - __kind: EventRootType
       ID: 372
@@ -11535,7 +12084,7 @@ Types:
       ID: 373
       Name: Probe[main.mapArg]Return
     - __kind: EventRootType
-      ID: 657
+      ID: 666
       Name: Probe[main.mapIndexBoolKey]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11547,7 +12096,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11574,7 +12123,7 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 659
+      ID: 668
       Name: Probe[main.mapIndexBoolKey]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11586,7 +12135,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11613,13 +12162,13 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 658
+      ID: 667
+      Name: Probe[main.mapIndexBoolKey]Return
+    - __kind: EventRootType
+      ID: 669
       Name: Probe[main.mapIndexBoolKey]Return
     - __kind: EventRootType
       ID: 660
-      Name: Probe[main.mapIndexBoolKey]Return
-    - __kind: EventRootType
-      ID: 651
       Name: Probe[main.mapIndexEmptyKey]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11631,7 +12180,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11658,10 +12207,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 652
+      ID: 661
       Name: Probe[main.mapIndexEmptyKey]Return
     - __kind: EventRootType
-      ID: 621
+      ID: 630
       Name: Probe[main.mapIndexIntKey]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -11673,7 +12222,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: m}
+                  Variable: {subprogram: 56, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11700,10 +12249,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 622
+      ID: 631
       Name: Probe[main.mapIndexIntKey]Return
     - __kind: EventRootType
-      ID: 653
+      ID: 662
       Name: Probe[main.mapIndexKeyLen16]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11715,7 +12264,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11742,10 +12291,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 654
+      ID: 663
       Name: Probe[main.mapIndexKeyLen16]Return
     - __kind: EventRootType
-      ID: 655
+      ID: 664
       Name: Probe[main.mapIndexKeyLen17]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11757,7 +12306,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11784,10 +12333,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 656
+      ID: 665
       Name: Probe[main.mapIndexKeyLen17]Return
     - __kind: EventRootType
-      ID: 641
+      ID: 650
       Name: Probe[main.mapIndexKeyLen200]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11799,7 +12348,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
+                  Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11826,10 +12375,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 642
+      ID: 651
       Name: Probe[main.mapIndexKeyLen200]Return
     - __kind: EventRootType
-      ID: 635
+      ID: 644
       Name: Probe[main.mapIndexKeyLen24]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11841,7 +12390,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
+                  Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11868,10 +12417,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 636
+      ID: 645
       Name: Probe[main.mapIndexKeyLen24]Return
     - __kind: EventRootType
-      ID: 637
+      ID: 646
       Name: Probe[main.mapIndexKeyLen48]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11883,7 +12432,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
+                  Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11910,10 +12459,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 638
+      ID: 647
       Name: Probe[main.mapIndexKeyLen48]Return
     - __kind: EventRootType
-      ID: 633
+      ID: 642
       Name: Probe[main.mapIndexKeyLen8]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11925,7 +12474,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
+                  Variable: {subprogram: 60, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11952,10 +12501,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 634
+      ID: 643
       Name: Probe[main.mapIndexKeyLen8]Return
     - __kind: EventRootType
-      ID: 639
+      ID: 648
       Name: Probe[main.mapIndexKeyLen96]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11967,7 +12516,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11994,10 +12543,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 640
+      ID: 649
       Name: Probe[main.mapIndexKeyLen96]Return
     - __kind: EventRootType
-      ID: 629
+      ID: 638
       Name: Probe[main.mapIndexLargeMap]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12009,7 +12558,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: m}
+                  Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12036,10 +12585,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 630
+      ID: 639
       Name: Probe[main.mapIndexLargeMap]Return
     - __kind: EventRootType
-      ID: 665
+      ID: 674
       Name: Probe[main.mapIndexLargeValue]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12051,7 +12600,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12081,10 +12630,10 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 666
+      ID: 675
       Name: Probe[main.mapIndexLargeValue]Return
     - __kind: EventRootType
-      ID: 631
+      ID: 640
       Name: Probe[main.mapIndexMissing]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12096,7 +12645,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
+                  Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12123,10 +12672,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 632
+      ID: 641
       Name: Probe[main.mapIndexMissing]Return
     - __kind: EventRootType
-      ID: 663
+      ID: 672
       Name: Probe[main.mapIndexNilPtrVal]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12138,7 +12687,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 72, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12168,10 +12717,10 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 664
+      ID: 673
       Name: Probe[main.mapIndexNilPtrVal]Return
     - __kind: EventRootType
-      ID: 647
+      ID: 656
       Name: Probe[main.mapIndexPtrStructVal]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12183,7 +12732,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12213,7 +12762,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 649
+      ID: 658
       Name: Probe[main.mapIndexPtrStructVal]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12225,7 +12774,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12255,13 +12804,13 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 648
+      ID: 657
       Name: Probe[main.mapIndexPtrStructVal]Return
     - __kind: EventRootType
-      ID: 650
+      ID: 659
       Name: Probe[main.mapIndexPtrStructVal]Return
     - __kind: EventRootType
-      ID: 623
+      ID: 632
       Name: Probe[main.mapIndexStringKey]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12273,7 +12822,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12300,10 +12849,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 625
+      ID: 634
       Name: Probe[main.mapIndexStringKey]
     - __kind: EventRootType
-      ID: 627
+      ID: 636
       Name: Probe[main.mapIndexStringKey]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12315,7 +12864,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12342,16 +12891,16 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 624
+      ID: 633
       Name: Probe[main.mapIndexStringKey]Return
     - __kind: EventRootType
-      ID: 626
+      ID: 635
       Name: Probe[main.mapIndexStringKey]Return
     - __kind: EventRootType
-      ID: 628
+      ID: 637
       Name: Probe[main.mapIndexStringKey]Return
     - __kind: EventRootType
-      ID: 643
+      ID: 652
       Name: Probe[main.mapIndexStructVal]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12363,7 +12912,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12390,7 +12939,7 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 645
+      ID: 654
       Name: Probe[main.mapIndexStructVal]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12402,7 +12951,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12429,13 +12978,13 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 644
+      ID: 653
       Name: Probe[main.mapIndexStructVal]Return
     - __kind: EventRootType
-      ID: 646
+      ID: 655
       Name: Probe[main.mapIndexStructVal]Return
     - __kind: EventRootType
-      ID: 661
+      ID: 670
       Name: Probe[main.mapIndexZeroValue]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12447,7 +12996,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12474,7 +13023,7 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 662
+      ID: 671
       Name: Probe[main.mapIndexZeroValue]Return
     - __kind: EventRootType
       ID: 376
@@ -12483,7 +13032,7 @@ Types:
       ID: 377
       Name: Probe[main.noArgs]Return
     - __kind: EventRootType
-      ID: 609
+      ID: 618
       Name: Probe[main.ptrStructArrayArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12495,7 +13044,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: s}
+                  Variable: {subprogram: 54, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12503,7 +13052,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 611
+      ID: 620
       Name: Probe[main.ptrStructArrayArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12515,7 +13064,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: s}
+                  Variable: {subprogram: 54, index: 0, name: s}
                   Offset: 8
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12523,13 +13072,13 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 610
+      ID: 619
       Name: Probe[main.ptrStructArrayArg]Return
     - __kind: EventRootType
-      ID: 612
+      ID: 621
       Name: Probe[main.ptrStructArrayArg]Return
     - __kind: EventRootType
-      ID: 605
+      ID: 614
       Name: Probe[main.ptrStructSliceArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12541,7 +13090,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: s}
+                  Variable: {subprogram: 53, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -12554,7 +13103,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 607
+      ID: 616
       Name: Probe[main.ptrStructSliceArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12566,7 +13115,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: s}
+                  Variable: {subprogram: 53, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -12579,10 +13128,10 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 606
+      ID: 615
       Name: Probe[main.ptrStructSliceArg]Return
     - __kind: EventRootType
-      ID: 608
+      ID: 617
       Name: Probe[main.ptrStructSliceArg]Return
     - __kind: EventRootType
       ID: 333
@@ -12744,7 +13293,7 @@ Types:
       ID: 366
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 601
+      ID: 610
       Name: Probe[main.structArrayArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12756,12 +13305,12 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: s}
+                  Variable: {subprogram: 52, index: 0, name: s}
                   Offset: 0
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 603
+      ID: 612
       Name: Probe[main.structArrayArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12773,18 +13322,18 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: s}
+                  Variable: {subprogram: 52, index: 0, name: s}
                   Offset: 40
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
+      ID: 611
+      Name: Probe[main.structArrayArg]Return
+    - __kind: EventRootType
+      ID: 613
+      Name: Probe[main.structArrayArg]Return
+    - __kind: EventRootType
       ID: 602
-      Name: Probe[main.structArrayArg]Return
-    - __kind: EventRootType
-      ID: 604
-      Name: Probe[main.structArrayArg]Return
-    - __kind: EventRootType
-      ID: 593
       Name: Probe[main.structSliceArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12796,7 +13345,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: s}
+                  Variable: {subprogram: 51, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -12806,7 +13355,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 595
+      ID: 604
       Name: Probe[main.structSliceArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12818,7 +13367,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: s}
+                  Variable: {subprogram: 51, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -12828,7 +13377,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 597
+      ID: 606
       Name: Probe[main.structSliceArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12840,12 +13389,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 1, name: tag}
+                  Variable: {subprogram: 51, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 599
+      ID: 608
       Name: Probe[main.structSliceArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12857,7 +13406,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: s}
+                  Variable: {subprogram: 51, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -12867,22 +13416,22 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
+      ID: 603
+      Name: Probe[main.structSliceArg]Return
+    - __kind: EventRootType
+      ID: 605
+      Name: Probe[main.structSliceArg]Return
+    - __kind: EventRootType
+      ID: 607
+      Name: Probe[main.structSliceArg]Return
+    - __kind: EventRootType
+      ID: 609
+      Name: Probe[main.structSliceArg]Return
+    - __kind: EventRootType
       ID: 594
-      Name: Probe[main.structSliceArg]Return
-    - __kind: EventRootType
-      ID: 596
-      Name: Probe[main.structSliceArg]Return
-    - __kind: EventRootType
-      ID: 598
-      Name: Probe[main.structSliceArg]Return
-    - __kind: EventRootType
-      ID: 600
-      Name: Probe[main.structSliceArg]Return
-    - __kind: EventRootType
-      ID: 585
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 586
+      ID: 595
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12894,7 +13443,7 @@ Types:
             Type: 127 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: ~r0}
+                  Variable: {subprogram: 48, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -12902,7 +13451,7 @@ Types:
       ID: 92
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 57952
+      GoRuntimeType: 58048
       GoKind: 17
       Count: 10
       HasCount: true
@@ -12946,7 +13495,7 @@ Types:
       ID: 78
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 57568
+      GoRuntimeType: 57664
       GoKind: 17
       Count: 2
       HasCount: true
@@ -12955,7 +13504,7 @@ Types:
       ID: 77
       Name: '[2][2]*runtime.traceBuf'
       ByteSize: 32
-      GoRuntimeType: 57664
+      GoRuntimeType: 57760
       GoKind: 17
       Count: 2
       HasCount: true
@@ -12964,7 +13513,7 @@ Types:
       ID: 84
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 57856
+      GoRuntimeType: 57952
       GoKind: 17
       Count: 2
       HasCount: true
@@ -12981,7 +13530,7 @@ Types:
       ID: 54
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 53728
+      GoRuntimeType: 53824
       GoKind: 17
       Count: 2
       HasCount: true
@@ -12990,7 +13539,7 @@ Types:
       ID: 90
       Name: '[32]uint64'
       ByteSize: 256
-      GoRuntimeType: 60160
+      GoRuntimeType: 60256
       GoKind: 17
       Count: 32
       HasCount: true
@@ -12999,7 +13548,7 @@ Types:
       ID: 68
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 57376
+      GoRuntimeType: 57472
       GoKind: 17
       Count: 32
       HasCount: true
@@ -13026,7 +13575,7 @@ Types:
       ID: 53
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 56800
+      GoRuntimeType: 56896
       GoKind: 17
       Count: 3
       HasCount: true
@@ -13044,7 +13593,7 @@ Types:
       ID: 91
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 59392
+      GoRuntimeType: 59488
       GoKind: 17
       Count: 4
       HasCount: true
@@ -13053,7 +13602,7 @@ Types:
       ID: 58
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 56128
+      GoRuntimeType: 56224
       GoKind: 17
       Count: 6
       HasCount: true
@@ -13062,7 +13611,7 @@ Types:
       ID: 85
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 57760
+      GoRuntimeType: 57856
       GoKind: 17
       Count: 8
       HasCount: true
@@ -13360,7 +13909,7 @@ Types:
       ID: 14
       Name: error
       ByteSize: 16
-      GoRuntimeType: 70144
+      GoRuntimeType: 70240
       GoKind: 20
       RawFields:
         - Name: tab
@@ -13395,7 +13944,7 @@ Types:
       ID: 73
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 62528
+      GoRuntimeType: 62624
       GoKind: 19
     - __kind: BaseType
       ID: 170
@@ -13588,7 +14137,7 @@ Types:
       ID: 89
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 125248
+      GoRuntimeType: 125344
       GoKind: 25
       RawFields:
         - Name: buf
@@ -13613,14 +14162,14 @@ Types:
     - __kind: StructureType
       ID: 318
       Name: internal/poll.errNetClosing
-      GoRuntimeType: 99904
+      GoRuntimeType: 100000
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 81280
+      GoRuntimeType: 81376
       GoKind: 25
       RawFields:
         - Name: u
@@ -13630,7 +14179,7 @@ Types:
       ID: 71
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 111712
+      GoRuntimeType: 111808
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -13646,7 +14195,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 100704
+      GoRuntimeType: 100800
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -13659,7 +14208,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 100544
+      GoRuntimeType: 100640
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -13672,7 +14221,7 @@ Types:
       ID: 76
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 100864
+      GoRuntimeType: 100960
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -13684,20 +14233,20 @@ Types:
     - __kind: StructureType
       ID: 72
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 68448
+      GoRuntimeType: 68544
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 33
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 68352
+      GoRuntimeType: 68448
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
       ID: 280
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
-      GoRuntimeType: 61280
+      GoRuntimeType: 61376
       GoKind: 24
       RawFields:
         - Name: str
@@ -13716,7 +14265,7 @@ Types:
       ID: 310
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
-      GoRuntimeType: 103232
+      GoRuntimeType: 103328
       GoKind: 25
       RawFields:
         - Name: typ
@@ -13730,14 +14279,14 @@ Types:
       ID: 274
       Name: main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 76928
+      GoRuntimeType: 77024
       GoKind: 25
       RawFields: [{Name: a, Offset: 0, Type: 7 BaseType int}]
     - __kind: StructureType
       ID: 134
       Name: main.bigArrayStruct
       ByteSize: 1048584
-      GoRuntimeType: 92544
+      GoRuntimeType: 92640
       GoKind: 25
       RawFields:
         - Name: tag
@@ -13750,7 +14299,7 @@ Types:
       ID: 204
       Name: main.bigStruct
       ByteSize: 184
-      GoRuntimeType: 132992
+      GoRuntimeType: 133088
       GoKind: 25
       RawFields:
         - Name: Field1
@@ -13781,7 +14330,7 @@ Types:
       ID: 121
       Name: main.condFields
       ByteSize: 80
-      GoRuntimeType: 140608
+      GoRuntimeType: 140704
       GoKind: 25
       RawFields:
         - Name: I8
@@ -13827,7 +14376,7 @@ Types:
       ID: 137
       Name: main.indexMemberStruct
       ByteSize: 32
-      GoRuntimeType: 104992
+      GoRuntimeType: 105088
       GoKind: 25
       RawFields:
         - Name: Val
@@ -13858,7 +14407,7 @@ Types:
       ID: 263
       Name: main.largeValueStruct
       ByteSize: 264
-      GoRuntimeType: 92384
+      GoRuntimeType: 92480
       GoKind: 25
       RawFields:
         - Name: Pad
@@ -13871,7 +14420,7 @@ Types:
       ID: 124
       Name: main.lenFields
       ByteSize: 72
-      GoRuntimeType: 127136
+      GoRuntimeType: 127232
       GoKind: 25
       RawFields:
         - Name: S
@@ -14217,63 +14766,63 @@ Types:
       ID: 159
       Name: map[bool]int
       ByteSize: 8
-      GoRuntimeType: 74496
+      GoRuntimeType: 74592
       GoKind: 21
       HeaderType: 161 GoSwissMapHeaderType map<bool,int>
     - __kind: GoMapType
       ID: 213
       Name: map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 74624
+      GoRuntimeType: 74720
       GoKind: 21
       HeaderType: 215 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 144
       Name: map[int]string
       ByteSize: 8
-      GoRuntimeType: 74752
+      GoRuntimeType: 74848
       GoKind: 21
       HeaderType: 146 GoSwissMapHeaderType map<int,string>
     - __kind: GoMapType
       ID: 154
       Name: map[string]*main.indexMemberStruct
       ByteSize: 8
-      GoRuntimeType: 74880
+      GoRuntimeType: 74976
       GoKind: 21
       HeaderType: 156 GoSwissMapHeaderType map<string,*main.indexMemberStruct>
     - __kind: GoMapType
       ID: 111
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 74368
+      GoRuntimeType: 74464
       GoKind: 21
       HeaderType: 113 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 116
       Name: map[string]main.bigStruct
       ByteSize: 8
-      GoRuntimeType: 75008
+      GoRuntimeType: 75104
       GoKind: 21
       HeaderType: 118 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: GoMapType
       ID: 149
       Name: map[string]main.indexMemberStruct
       ByteSize: 8
-      GoRuntimeType: 75136
+      GoRuntimeType: 75232
       GoKind: 21
       HeaderType: 151 GoSwissMapHeaderType map<string,main.indexMemberStruct>
     - __kind: GoMapType
       ID: 164
       Name: map[string]main.largeValueStruct
       ByteSize: 8
-      GoRuntimeType: 75264
+      GoRuntimeType: 75360
       GoKind: 21
       HeaderType: 166 GoSwissMapHeaderType map<string,main.largeValueStruct>
     - __kind: GoMapType
       ID: 127
       Name: map[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 75520
+      GoRuntimeType: 75616
       GoKind: 21
       HeaderType: 129 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: ArrayType
@@ -14361,7 +14910,7 @@ Types:
       ID: 251
       Name: noalg.map.group[bool]int
       ByteSize: 136
-      GoRuntimeType: 82944
+      GoRuntimeType: 83040
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14374,7 +14923,7 @@ Types:
       ID: 271
       Name: noalg.map.group[int]main.aStructNotUsedAsAnArgument
       ByteSize: 136
-      GoRuntimeType: 83200
+      GoRuntimeType: 83296
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14387,7 +14936,7 @@ Types:
       ID: 227
       Name: noalg.map.group[int]string
       ByteSize: 200
-      GoRuntimeType: 83456
+      GoRuntimeType: 83552
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14400,7 +14949,7 @@ Types:
       ID: 243
       Name: noalg.map.group[string]*main.indexMemberStruct
       ByteSize: 200
-      GoRuntimeType: 83712
+      GoRuntimeType: 83808
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14413,7 +14962,7 @@ Types:
       ID: 192
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 82688
+      GoRuntimeType: 82784
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14426,7 +14975,7 @@ Types:
       ID: 200
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
-      GoRuntimeType: 83968
+      GoRuntimeType: 84064
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14439,7 +14988,7 @@ Types:
       ID: 235
       Name: noalg.map.group[string]main.indexMemberStruct
       ByteSize: 392
-      GoRuntimeType: 84224
+      GoRuntimeType: 84320
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14452,7 +15001,7 @@ Types:
       ID: 259
       Name: noalg.map.group[string]main.largeValueStruct
       ByteSize: 200
-      GoRuntimeType: 84480
+      GoRuntimeType: 84576
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14465,7 +15014,7 @@ Types:
       ID: 210
       Name: noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 136
-      GoRuntimeType: 84992
+      GoRuntimeType: 85088
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14478,7 +15027,7 @@ Types:
       ID: 253
       Name: noalg.struct { key bool; elem int }
       ByteSize: 16
-      GoRuntimeType: 82816
+      GoRuntimeType: 82912
       GoKind: 25
       RawFields:
         - Name: key
@@ -14491,7 +15040,7 @@ Types:
       ID: 273
       Name: noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
       ByteSize: 16
-      GoRuntimeType: 83072
+      GoRuntimeType: 83168
       GoKind: 25
       RawFields:
         - Name: key
@@ -14504,7 +15053,7 @@ Types:
       ID: 229
       Name: noalg.struct { key int; elem string }
       ByteSize: 24
-      GoRuntimeType: 83328
+      GoRuntimeType: 83424
       GoKind: 25
       RawFields:
         - Name: key
@@ -14517,7 +15066,7 @@ Types:
       ID: 202
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
-      GoRuntimeType: 83840
+      GoRuntimeType: 83936
       GoKind: 25
       RawFields:
         - Name: key
@@ -14530,7 +15079,7 @@ Types:
       ID: 245
       Name: noalg.struct { key string; elem *main.indexMemberStruct }
       ByteSize: 24
-      GoRuntimeType: 83584
+      GoRuntimeType: 83680
       GoKind: 25
       RawFields:
         - Name: key
@@ -14543,7 +15092,7 @@ Types:
       ID: 261
       Name: noalg.struct { key string; elem *main.largeValueStruct }
       ByteSize: 24
-      GoRuntimeType: 84352
+      GoRuntimeType: 84448
       GoKind: 25
       RawFields:
         - Name: key
@@ -14556,7 +15105,7 @@ Types:
       ID: 194
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 82560
+      GoRuntimeType: 82656
       GoKind: 25
       RawFields:
         - Name: key
@@ -14569,7 +15118,7 @@ Types:
       ID: 237
       Name: noalg.struct { key string; elem main.indexMemberStruct }
       ByteSize: 48
-      GoRuntimeType: 84096
+      GoRuntimeType: 84192
       GoKind: 25
       RawFields:
         - Name: key
@@ -14582,7 +15131,7 @@ Types:
       ID: 212
       Name: noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
       ByteSize: 16
-      GoRuntimeType: 84864
+      GoRuntimeType: 84960
       GoKind: 25
       RawFields:
         - Name: key
@@ -14619,7 +15168,7 @@ Types:
       ID: 306
       Name: runtime.boundsError
       ByteSize: 24
-      GoRuntimeType: 126144
+      GoRuntimeType: 126240
       GoKind: 25
       RawFields:
         - Name: x
@@ -14651,14 +15200,14 @@ Types:
     - __kind: StructureType
       ID: 87
       Name: runtime.dlogPerM
-      GoRuntimeType: 67584
+      GoRuntimeType: 67680
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 314
       Name: runtime.errorAddressString
       ByteSize: 24
-      GoRuntimeType: 118240
+      GoRuntimeType: 118336
       GoKind: 25
       RawFields:
         - Name: msg
@@ -14671,7 +15220,7 @@ Types:
       ID: 293
       Name: runtime.errorString
       ByteSize: 16
-      GoRuntimeType: 67008
+      GoRuntimeType: 67104
       GoKind: 24
       RawFields:
         - Name: str
@@ -14690,7 +15239,7 @@ Types:
       ID: 22
       Name: runtime.g
       ByteSize: 440
-      GoRuntimeType: 155680
+      GoRuntimeType: 155776
       GoKind: 25
       RawFields:
         - Name: stack
@@ -14880,7 +15429,7 @@ Types:
       ID: 51
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 79744
+      GoRuntimeType: 79840
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -14890,7 +15439,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 48
-      GoRuntimeType: 128672
+      GoRuntimeType: 128768
       GoKind: 25
       RawFields:
         - Name: sp
@@ -14915,7 +15464,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 97824
+      GoRuntimeType: 97920
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -14928,7 +15477,7 @@ Types:
       ID: 56
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 117088
+      GoRuntimeType: 117184
       GoKind: 25
       RawFields:
         - Name: stack
@@ -14947,13 +15496,13 @@ Types:
       ID: 31
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 60992
+      GoRuntimeType: 61088
       GoKind: 12
     - __kind: StructureType
       ID: 93
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 97664
+      GoRuntimeType: 97760
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -14966,7 +15515,7 @@ Types:
       ID: 81
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 129440
+      GoRuntimeType: 129536
       GoKind: 25
       RawFields:
         - Name: fn
@@ -14991,13 +15540,13 @@ Types:
       ID: 94
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 60896
+      GoRuntimeType: 60992
       GoKind: 2
     - __kind: StructureType
       ID: 29
       Name: runtime.m
       ByteSize: 1816
-      GoRuntimeType: 158976
+      GoRuntimeType: 159072
       GoKind: 25
       RawFields:
         - Name: g0
@@ -15217,7 +15766,7 @@ Types:
       ID: 70
       Name: runtime.mLockProfile
       ByteSize: 56
-      GoRuntimeType: 129184
+      GoRuntimeType: 129280
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -15242,7 +15791,7 @@ Types:
       ID: 88
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 124128
+      GoRuntimeType: 124224
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -15264,7 +15813,7 @@ Types:
       ID: 75
       Name: runtime.mTraceState
       ByteSize: 56
-      GoRuntimeType: 123904
+      GoRuntimeType: 124000
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -15286,7 +15835,7 @@ Types:
       ID: 69
       Name: runtime.mWaitList
       ByteSize: 16
-      GoRuntimeType: 97344
+      GoRuntimeType: 97440
       GoKind: 25
       RawFields:
         - Name: next
@@ -15299,13 +15848,13 @@ Types:
       ID: 37
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 60608
+      GoRuntimeType: 60704
       GoKind: 12
     - __kind: StructureType
       ID: 67
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 79488
+      GoRuntimeType: 79584
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
@@ -15316,7 +15865,7 @@ Types:
       ID: 83
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 97504
+      GoRuntimeType: 97600
       GoKind: 25
       RawFields:
         - Name: entries
@@ -15329,7 +15878,7 @@ Types:
       ID: 86
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 118048
+      GoRuntimeType: 118144
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -15348,7 +15897,7 @@ Types:
       ID: 296
       Name: runtime.plainError
       ByteSize: 16
-      GoRuntimeType: 67104
+      GoRuntimeType: 67200
       GoKind: 24
       RawFields:
         - Name: str
@@ -15367,13 +15916,13 @@ Types:
       ID: 60
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 60800
+      GoRuntimeType: 60896
       GoKind: 12
     - __kind: ArrayType
       ID: 57
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 64224
+      GoRuntimeType: 64320
       GoKind: 17
       Count: 2
       HasCount: true
@@ -15382,7 +15931,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 95584
+      GoRuntimeType: 95680
       GoKind: 25
       RawFields:
         - Name: lo
@@ -15403,7 +15952,7 @@ Types:
       ID: 288
       Name: runtime.synctestDeadlockError
       ByteSize: 24
-      GoRuntimeType: 104832
+      GoRuntimeType: 104928
       GoKind: 25
       RawFields:
         - Name: reason
@@ -15436,7 +15985,7 @@ Types:
       ID: 52
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 96544
+      GoRuntimeType: 96640
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -15449,12 +15998,12 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 82304
+      GoRuntimeType: 82400
       GoKind: 8
     - __kind: StructureType
       ID: 82
       Name: runtime.winlibcall
-      GoRuntimeType: 67488
+      GoRuntimeType: 67584
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -15484,7 +16033,7 @@ Types:
       ID: 321
       Name: syscall.Errno
       ByteSize: 8
-      GoRuntimeType: 82432
+      GoRuntimeType: 82528
       GoKind: 12
     - __kind: StructureType
       ID: 248
@@ -15706,7 +16255,7 @@ Types:
       ID: 277
       Name: time.fileSizeError
       ByteSize: 16
-      GoRuntimeType: 61088
+      GoRuntimeType: 61184
       GoKind: 24
       RawFields:
         - Name: str
@@ -15763,7 +16312,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 46752
       GoKind: 26
-MaxTypeID: 677
+MaxTypeID: 686
 Issues:
     - probe_definition:
         id: condCompound_eq_of_eq
@@ -16071,6 +16620,26 @@ Issues:
       issue:
         Kind: 7
         Message: condition variable "x" not available at any event
+    - probe_definition:
+        id: condLineReturn_cond_return
+        version: 0
+        type: LOG_PROBE
+        where:
+            methodName: main.condLineReturn
+            sourceFile: main.go
+            lines: ["571"]
+        tags: ['issue:ConditionVariableUnavailable']
+        when:
+            dsl: '@return == 14'
+            json: {eq: [{ref: '@return'}, 14]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: matched
+        segments: [matched]
+        captureSnapshot: false
+      issue:
+        Kind: 7
+        Message: condition variable "@return" not found
     - probe_definition:
         id: condNull_int_vs_null
         version: 0

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.26rc1.yaml
@@ -9,10 +9,10 @@ Probes:
       segments: ['ptr: ', {json: {ref: ptr}, dsl: ptr}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 76}
+        - subprogram: {subprogram: 78}
           events:
             - Kind: Entry
-              Type: 682 EventRootType Probe[main.PointerChainArg]
+              Type: 691 EventRootType Probe[main.PointerChainArg]
               InjectionPoints: [{PC: "0xc8da4", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -32,10 +32,10 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 77}
+        - subprogram: {subprogram: 79}
           events:
             - Kind: Entry
-              Type: 683 EventRootType Probe[main.PointerSmallChainArg]
+              Type: 692 EventRootType Probe[main.PointerSmallChainArg]
               InjectionPoints: [{PC: "0xc8de8", Frameless: false}]
               Condition: null
     - id: bigMapArg
@@ -50,11 +50,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 381 EventRootType Probe[main.bigMapArg]
-              InjectionPoints: [{PC: "0xcb018", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb258", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 382 EventRootType Probe[main.bigMapArg]Return
-              InjectionPoints: [{PC: "0xcb064", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb2a4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 'm: {m}'
@@ -78,7 +78,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 427 EventRootType Probe[main.condBool]
-              InjectionPoints: [{PC: "0xcb778", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb9b8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -95,7 +95,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 428 EventRootType Probe[main.condBool]Return
-              InjectionPoints: [{PC: "0xcb7dc", Frameless: false}]
+              InjectionPoints: [{PC: "0xcba1c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -119,7 +119,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 429 EventRootType Probe[main.condBool]
-              InjectionPoints: [{PC: "0xcb778", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb9b8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -136,7 +136,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 430 EventRootType Probe[main.condBool]Return
-              InjectionPoints: [{PC: "0xcb7dc", Frameless: false}]
+              InjectionPoints: [{PC: "0xcba1c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -159,11 +159,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 431 EventRootType Probe[main.condBool]
-              InjectionPoints: [{PC: "0xcb778", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb9b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 432 EventRootType Probe[main.condBool]Return
-              InjectionPoints: [{PC: "0xcb7dc", Frameless: false}]
+              InjectionPoints: [{PC: "0xcba1c", Frameless: false}]
               Condition: null
     - id: condCompound_and
       version: 0
@@ -188,7 +188,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 477 EventRootType Probe[main.condReturnAndLocal]
-              InjectionPoints: [{PC: "0xcbb78", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbdb8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -220,7 +220,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 478 EventRootType Probe[main.condReturnAndLocal]Return
-              InjectionPoints: [{PC: "0xcbbd4", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbe14", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: a == 1 && b == 1 [a={a}, b={b}]
@@ -262,7 +262,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 447 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0xcb8cc", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbb0c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -292,7 +292,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 448 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0xcb980", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbbc0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x.S == "world" && tag == "match" [x.S={x.S}, tag={tag}]
@@ -314,7 +314,7 @@ Probes:
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["519"]
+        lines: ["547"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -338,7 +338,7 @@ Probes:
           events:
             - Kind: Line
               Type: 487 EventRootType Probe[main.condLine]Line
-              InjectionPoints: [{PC: "0xcbcc4", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbf04", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -412,7 +412,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 449 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0xcb8cc", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbb0c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -460,7 +460,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 450 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0xcb980", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbbc0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: (x.I32 == 300 || x.I32 == 999) && !isEmpty(x.S) [x.I32={x.I32}, x.S={x.S}, tag={tag}]
@@ -502,7 +502,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 433 EventRootType Probe[main.condBool]
-              InjectionPoints: [{PC: "0xcb778", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb9b8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -520,7 +520,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 434 EventRootType Probe[main.condBool]Return
-              InjectionPoints: [{PC: "0xcb7dc", Frameless: false}]
+              InjectionPoints: [{PC: "0xcba1c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '!x [x={x}, tag={tag}]'
@@ -559,7 +559,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 393 EventRootType Probe[main.condInt32]
-              InjectionPoints: [{PC: "0xcb268", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb4a8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -591,7 +591,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 394 EventRootType Probe[main.condInt32]Return
-              InjectionPoints: [{PC: "0xcb2c4", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb504", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x == 42 || x == 100 [x={x}, tag={tag}]
@@ -629,16 +629,16 @@ Probes:
         - ']'
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 500 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xcc41c", Frameless: false}]
+              Type: 509 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xcc84c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 37, index: 1, name: tag}
+                      Variable: {subprogram: 39, index: 1, name: tag}
                       Offset: 0
                       ByteSize: 16
                     - __kind: ExprReadStringOp
@@ -650,7 +650,7 @@ Probes:
                       Cond: true
                       Target: 1
                     - __kind: LocationOp
-                      Variable: {subprogram: 37, index: 0, name: s}
+                      Variable: {subprogram: 39, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -664,8 +664,8 @@ Probes:
                       ID: 1
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 501 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xcc4b4", Frameless: false}]
+              Type: 510 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xcc8e4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag == "match" || !isEmpty(s) [s={s}, tag={tag}]
@@ -703,20 +703,20 @@ Probes:
         - ']'
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 72}
+        - subprogram: {subprogram: 74}
           events:
             - Kind: Entry
-              Type: 674 EventRootType Probe[main.condMultiReturn]
-              InjectionPoints: [{PC: "0xcdd78", Frameless: false}]
+              Type: 683 EventRootType Probe[main.condMultiReturn]
+              InjectionPoints: [{PC: "0xce1a8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 675 EventRootType Probe[main.condMultiReturn]Return
-              InjectionPoints: [{PC: "0xcddfc", Frameless: false}]
+              Type: 684 EventRootType Probe[main.condMultiReturn]Return
+              InjectionPoints: [{PC: "0xce22c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 72, index: 1, name: r0}
+                      Variable: {subprogram: 74, index: 1, name: r0}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -729,7 +729,7 @@ Probes:
                       Cond: false
                       Target: 1
                     - __kind: LocationOp
-                      Variable: {subprogram: 72, index: 2, name: r1}
+                      Variable: {subprogram: 74, index: 2, name: r1}
                       Offset: 0
                       ByteSize: 16
                     - __kind: ExprReadStringOp
@@ -777,7 +777,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 469 EventRootType Probe[main.condNilPtrStruct]
-              InjectionPoints: [{PC: "0xcbac8", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbd08", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -811,7 +811,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 470 EventRootType Probe[main.condNilPtrStruct]Return
-              InjectionPoints: [{PC: "0xcbb34", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbd74", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag == "nilptr" && x.I32 == 300 [tag={tag}]
@@ -845,7 +845,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 471 EventRootType Probe[main.condNilPtrStruct]
-              InjectionPoints: [{PC: "0xcbac8", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbd08", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -879,7 +879,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 472 EventRootType Probe[main.condNilPtrStruct]Return
-              InjectionPoints: [{PC: "0xcbb34", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbd74", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag == "nilptr" || x.I32 == 300 [tag={tag}]
@@ -903,11 +903,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 423 EventRootType Probe[main.condFloat32]
-              InjectionPoints: [{PC: "0xcb638", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb878", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 424 EventRootType Probe[main.condFloat32]Return
-              InjectionPoints: [{PC: "0xcb698", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb8d8", Frameless: false}]
               Condition: null
     - id: condFloat64_nocond
       version: 0
@@ -922,11 +922,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 425 EventRootType Probe[main.condFloat64]
-              InjectionPoints: [{PC: "0xcb6d8", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb918", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 426 EventRootType Probe[main.condFloat64]Return
-              InjectionPoints: [{PC: "0xcb738", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb978", Frameless: false}]
               Condition: null
     - id: condInt16_cond
       version: 0
@@ -942,7 +942,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 389 EventRootType Probe[main.condInt16]
-              InjectionPoints: [{PC: "0xcb1c8", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb408", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -959,7 +959,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 390 EventRootType Probe[main.condInt16]Return
-              InjectionPoints: [{PC: "0xcb224", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb464", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -982,11 +982,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 391 EventRootType Probe[main.condInt16]
-              InjectionPoints: [{PC: "0xcb1c8", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb408", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 392 EventRootType Probe[main.condInt16]Return
-              InjectionPoints: [{PC: "0xcb224", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb464", Frameless: false}]
               Condition: null
     - id: condInt32_cond
       version: 0
@@ -1002,7 +1002,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 395 EventRootType Probe[main.condInt32]
-              InjectionPoints: [{PC: "0xcb268", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb4a8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1019,7 +1019,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 396 EventRootType Probe[main.condInt32]Return
-              InjectionPoints: [{PC: "0xcb2c4", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb504", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1046,7 +1046,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 397 EventRootType Probe[main.condInt32]
-              InjectionPoints: [{PC: "0xcb268", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb4a8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1063,7 +1063,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 398 EventRootType Probe[main.condInt32]Return
-              InjectionPoints: [{PC: "0xcb2c4", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb504", Frameless: false}]
               Condition: null
     - id: condInt32_nocond
       version: 0
@@ -1078,11 +1078,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 399 EventRootType Probe[main.condInt32]
-              InjectionPoints: [{PC: "0xcb268", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb4a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 400 EventRootType Probe[main.condInt32]Return
-              InjectionPoints: [{PC: "0xcb2c4", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb504", Frameless: false}]
               Condition: null
     - id: condInt64_cond
       version: 0
@@ -1098,7 +1098,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 401 EventRootType Probe[main.condInt64]
-              InjectionPoints: [{PC: "0xcb308", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb548", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1115,7 +1115,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 402 EventRootType Probe[main.condInt64]Return
-              InjectionPoints: [{PC: "0xcb364", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb5a4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1138,11 +1138,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 403 EventRootType Probe[main.condInt64]
-              InjectionPoints: [{PC: "0xcb308", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb548", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 404 EventRootType Probe[main.condInt64]Return
-              InjectionPoints: [{PC: "0xcb364", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb5a4", Frameless: false}]
               Condition: null
     - id: condInt8_cond
       version: 0
@@ -1158,7 +1158,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 385 EventRootType Probe[main.condInt8]
-              InjectionPoints: [{PC: "0xcb118", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb358", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1175,7 +1175,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 386 EventRootType Probe[main.condInt8]Return
-              InjectionPoints: [{PC: "0xcb17c", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb3bc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1198,11 +1198,257 @@ Probes:
           events:
             - Kind: Entry
               Type: 387 EventRootType Probe[main.condInt8]
-              InjectionPoints: [{PC: "0xcb118", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb358", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 388 EventRootType Probe[main.condInt8]Return
-              InjectionPoints: [{PC: "0xcb17c", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb3bc", Frameless: false}]
+              Condition: null
+    - id: condLineMixed_cond_bool
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when: {dsl: b == true, json: {eq: [{ref: b}, true]}}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 492 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0xcbfd8", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 1, name: b}
+                      Offset: 0
+                      ByteSize: 1
+                    - __kind: ExprPushOffsetOp
+                      ByteSize: 1
+                    - __kind: ExprLoadLiteralOp
+                      Data: AQ==
+                    - __kind: ExprCmpEqBaseOp
+                      ByteSize: 1
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_isEmpty_slice
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when: {dsl: isEmpty(ss), json: {isEmpty: {ref: ss}}}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 493 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0xcbfd8", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 4, name: ss}
+                      Offset: 8
+                      ByteSize: 8
+                    - __kind: ExprPushOffsetOp
+                      ByteSize: 8
+                    - __kind: ExprLoadLiteralOp
+                      Data: AAAAAAAAAAA=
+                    - __kind: ExprCmpEqBaseOp
+                      ByteSize: 8
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_len_string
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when:
+        dsl: len(s) == 5
+        json: {eq: [{len: {ref: s}}, 5]}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 494 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0xcbfd8", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 0, name: s}
+                      Offset: 8
+                      ByteSize: 8
+                    - __kind: ExprPushOffsetOp
+                      ByteSize: 8
+                    - __kind: ExprLoadLiteralOp
+                      Data: BQAAAAAAAAA=
+                    - __kind: ExprCmpEqBaseOp
+                      ByteSize: 8
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_ptrstruct_field
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when:
+        dsl: p.S == "world"
+        json: {eq: [{getmember: [{ref: p}, S]}, world]}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 495 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0xcbfd8", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 3, name: p}
+                      Offset: 0
+                      ByteSize: 8
+                    - __kind: DereferenceOp
+                      Bias: 56
+                      ByteSize: 16
+                    - __kind: ExprReadStringOp
+                      MaxLen: 255
+                    - __kind: ExprLoadLiteralOp
+                      Data: BQAAAHdvcmxk
+                    - __kind: ExprCmpEqStringOp
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_string
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when:
+        dsl: s == "hello"
+        json: {eq: [{ref: s}, hello]}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 496 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0xcbfd8", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 0, name: s}
+                      Offset: 0
+                      ByteSize: 16
+                    - __kind: ExprReadStringOp
+                      MaxLen: 255
+                    - __kind: ExprLoadLiteralOp
+                      Data: BQAAAGhlbGxv
+                    - __kind: ExprCmpEqStringOp
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_cond_struct_field
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      when:
+        dsl: x.I32 == 300
+        json: {eq: [{getmember: [{ref: x}, I32]}, 300]}
+      sampling: {snapshotsPerSecond: 10}
+      template: matched
+      segments: [matched]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 497 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0xcbfd8", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 29, index: 2, name: x}
+                      Offset: 4
+                      ByteSize: 4
+                    - __kind: ExprPushOffsetOp
+                      ByteSize: 4
+                    - __kind: ExprLoadLiteralOp
+                      Data: LAEAAA==
+                    - __kind: ExprCmpEqBaseOp
+                      ByteSize: 4
+                    - __kind: ConditionCheckOp
+          probeTemplate: {TemplateString: matched, Segments: [matched]}
+    - id: condLineMixed_nocond
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLineMixed
+        sourceFile: main.go
+        lines: ["561"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 29}
+          events:
+            - Kind: Line
+              Type: 498 EventRootType Probe[main.condLineMixed]Line
+              InjectionPoints: [{PC: "0xcbfd8", Frameless: false}]
               Condition: null
     - id: condLine_cond
       version: 0
@@ -1210,7 +1456,7 @@ Probes:
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["519"]
+        lines: ["547"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -1227,7 +1473,7 @@ Probes:
           events:
             - Kind: Line
               Type: 488 EventRootType Probe[main.condLine]Line
-              InjectionPoints: [{PC: "0xcbcc4", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbf04", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1242,13 +1488,58 @@ Probes:
                     - __kind: ExprCmpEqBaseOp
                       ByteSize: 8
                     - __kind: ConditionCheckOp
-    - id: condLine_nocond
+    - id: condLine_local_cond
       version: 0
       type: LOG_PROBE
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["519"]
+        lines: ["548"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+        - issue:ConditionVariableUnavailable@arch=arm64,toolchain=go1.23.11
+        - issue:ConditionVariableUnavailable@arch=amd64,toolchain=go1.23.11
+      when: {dsl: result == 14, json: {eq: [{ref: result}, 14]}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      instances:
+        - subprogram: {subprogram: 28}
+          events:
+            - Kind: Line
+              Type: 489 EventRootType Probe[main.condLine]Line
+              InjectionPoints: [{PC: "0xcbf08", Frameless: false}]
+              Condition:
+                Type: 4 BaseType bool
+                Operations:
+                    - __kind: LocationOp
+                      Variable: {subprogram: 28, index: 2, name: result}
+                      Offset: 0
+                      ByteSize: 8
+                    - __kind: ExprPushOffsetOp
+                      ByteSize: 8
+                    - __kind: ExprLoadLiteralOp
+                      Data: DgAAAAAAAAA=
+                    - __kind: ExprCmpEqBaseOp
+                      ByteSize: 8
+                    - __kind: ConditionCheckOp
+          probeTemplate:
+            TemplateString: tag={tag}
+            Segments:
+                - tag=
+                - JSON: {Ref: tag}
+                  DSL: tag
+                  EventKind: Line
+                  EventExpressionIndex: 0
+    - id: condLine_local_nocond
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLine
+        sourceFile: main.go
+        lines: ["548"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -1260,8 +1551,29 @@ Probes:
         - subprogram: {subprogram: 28}
           events:
             - Kind: Line
-              Type: 489 EventRootType Probe[main.condLine]Line
-              InjectionPoints: [{PC: "0xcbcc4", Frameless: false}]
+              Type: 490 EventRootType Probe[main.condLine]Line
+              InjectionPoints: [{PC: "0xcbf08", Frameless: false}]
+              Condition: null
+    - id: condLine_nocond
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.condLine
+        sourceFile: main.go
+        lines: ["547"]
+      tags:
+        - skip_integration:arch=arm64,toolchain=go1.23.11
+        - skip_integration:arch=amd64,toolchain=go1.23.11
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 28}
+          events:
+            - Kind: Line
+              Type: 491 EventRootType Probe[main.condLine]Line
+              InjectionPoints: [{PC: "0xcbf04", Frameless: false}]
               Condition: null
     - id: condNilPtr_cond
       version: 0
@@ -1279,7 +1591,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 473 EventRootType Probe[main.condNilPtrStruct]
-              InjectionPoints: [{PC: "0xcbac8", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbd08", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1299,7 +1611,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 474 EventRootType Probe[main.condNilPtrStruct]Return
-              InjectionPoints: [{PC: "0xcbb34", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbd74", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: condNilPtr {tag}
@@ -1322,11 +1634,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 475 EventRootType Probe[main.condNilPtrStruct]
-              InjectionPoints: [{PC: "0xcbac8", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbd08", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 476 EventRootType Probe[main.condNilPtrStruct]Return
-              InjectionPoints: [{PC: "0xcbb34", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbd74", Frameless: false}]
               Condition: null
     - id: condNull_iface
       version: 0
@@ -1338,16 +1650,16 @@ Probes:
       segments: ['i == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 35}
+        - subprogram: {subprogram: 37}
           events:
             - Kind: Entry
-              Type: 496 EventRootType Probe[main.condNullIface]
-              InjectionPoints: [{PC: "0xcc22c", Frameless: false}]
+              Type: 505 EventRootType Probe[main.condNullIface]
+              InjectionPoints: [{PC: "0xcc65c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 35, index: 0, name: i}
+                      Variable: {subprogram: 37, index: 0, name: i}
                       Offset: 0
                       ByteSize: 16
                     - __kind: ExprPushOffsetOp
@@ -1358,8 +1670,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 497 EventRootType Probe[main.condNullIface]Return
-              InjectionPoints: [{PC: "0xcc2e0", Frameless: false}]
+              Type: 506 EventRootType Probe[main.condNullIface]Return
+              InjectionPoints: [{PC: "0xcc710", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: i == nil [tag={tag}]
@@ -1380,16 +1692,16 @@ Probes:
       segments: ['m == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 34}
+        - subprogram: {subprogram: 36}
           events:
             - Kind: Entry
-              Type: 494 EventRootType Probe[main.condNullMap]
-              InjectionPoints: [{PC: "0xcc14c", Frameless: false}]
+              Type: 503 EventRootType Probe[main.condNullMap]
+              InjectionPoints: [{PC: "0xcc57c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 34, index: 0, name: m}
+                      Variable: {subprogram: 36, index: 0, name: m}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -1400,8 +1712,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 495 EventRootType Probe[main.condNullMap]Return
-              InjectionPoints: [{PC: "0xcc1dc", Frameless: false}]
+              Type: 504 EventRootType Probe[main.condNullMap]Return
+              InjectionPoints: [{PC: "0xcc60c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: m == nil [tag={tag}]
@@ -1422,16 +1734,16 @@ Probes:
       segments: ['p == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 32}
+        - subprogram: {subprogram: 34}
           events:
             - Kind: Entry
-              Type: 490 EventRootType Probe[main.condNullPtr]
-              InjectionPoints: [{PC: "0xcbf6c", Frameless: false}]
+              Type: 499 EventRootType Probe[main.condNullPtr]
+              InjectionPoints: [{PC: "0xcc39c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 32, index: 0, name: p}
+                      Variable: {subprogram: 34, index: 0, name: p}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -1442,8 +1754,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 491 EventRootType Probe[main.condNullPtr]Return
-              InjectionPoints: [{PC: "0xcbffc", Frameless: false}]
+              Type: 500 EventRootType Probe[main.condNullPtr]Return
+              InjectionPoints: [{PC: "0xcc42c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p == nil [tag={tag}]
@@ -1464,16 +1776,16 @@ Probes:
       segments: ['s == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 33}
+        - subprogram: {subprogram: 35}
           events:
             - Kind: Entry
-              Type: 492 EventRootType Probe[main.condNullSlice]
-              InjectionPoints: [{PC: "0xcc04c", Frameless: false}]
+              Type: 501 EventRootType Probe[main.condNullSlice]
+              InjectionPoints: [{PC: "0xcc47c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 33, index: 0, name: s}
+                      Variable: {subprogram: 35, index: 0, name: s}
                       Offset: 0
                       ByteSize: 24
                     - __kind: ExprPushOffsetOp
@@ -1484,8 +1796,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 493 EventRootType Probe[main.condNullSlice]Return
-              InjectionPoints: [{PC: "0xcc0fc", Frameless: false}]
+              Type: 502 EventRootType Probe[main.condNullSlice]Return
+              InjectionPoints: [{PC: "0xcc52c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: s == nil [tag={tag}]
@@ -1506,16 +1818,16 @@ Probes:
       segments: ['p == nil [tag=', {json: {ref: tag}, dsl: tag}, ']']
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 36}
+        - subprogram: {subprogram: 38}
           events:
             - Kind: Entry
-              Type: 498 EventRootType Probe[main.condNullUnsafePtr]
-              InjectionPoints: [{PC: "0xcc32c", Frameless: false}]
+              Type: 507 EventRootType Probe[main.condNullUnsafePtr]
+              InjectionPoints: [{PC: "0xcc75c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 36, index: 0, name: p}
+                      Variable: {subprogram: 38, index: 0, name: p}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -1526,8 +1838,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 499 EventRootType Probe[main.condNullUnsafePtr]Return
-              InjectionPoints: [{PC: "0xcc3bc", Frameless: false}]
+              Type: 508 EventRootType Probe[main.condNullUnsafePtr]Return
+              InjectionPoints: [{PC: "0xcc7ec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p == nil [tag={tag}]
@@ -1552,7 +1864,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 483 EventRootType Probe[main.condOnly]
-              InjectionPoints: [{PC: "0xcbc18", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbe58", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1569,7 +1881,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 484 EventRootType Probe[main.condOnly]Return
-              InjectionPoints: [{PC: "0xcbc74", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbeb4", Frameless: false}]
               Condition: null
     - id: condOnly_nocond
       version: 0
@@ -1584,11 +1896,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 485 EventRootType Probe[main.condOnly]
-              InjectionPoints: [{PC: "0xcbc18", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbe58", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 486 EventRootType Probe[main.condOnly]Return
-              InjectionPoints: [{PC: "0xcbc74", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbeb4", Frameless: false}]
               Condition: null
     - id: condPtrStruct_field_i32
       version: 0
@@ -1606,7 +1918,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 463 EventRootType Probe[main.condPtrStructArg]
-              InjectionPoints: [{PC: "0xcb9bc", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbbfc", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1626,7 +1938,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 464 EventRootType Probe[main.condPtrStructArg]Return
-              InjectionPoints: [{PC: "0xcba7c", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbcbc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1652,7 +1964,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 465 EventRootType Probe[main.condPtrStructArg]
-              InjectionPoints: [{PC: "0xcb9bc", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbbfc", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1671,7 +1983,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 466 EventRootType Probe[main.condPtrStructArg]Return
-              InjectionPoints: [{PC: "0xcba7c", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbcbc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1694,11 +2006,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 467 EventRootType Probe[main.condPtrStructArg]
-              InjectionPoints: [{PC: "0xcb9bc", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbbfc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 468 EventRootType Probe[main.condPtrStructArg]Return
-              InjectionPoints: [{PC: "0xcba7c", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbcbc", Frameless: false}]
               Condition: null
     - id: condReturnAndLocal_cond_param
       version: 0
@@ -1714,7 +2026,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 479 EventRootType Probe[main.condReturnAndLocal]
-              InjectionPoints: [{PC: "0xcbb78", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbdb8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1731,7 +2043,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 480 EventRootType Probe[main.condReturnAndLocal]Return
-              InjectionPoints: [{PC: "0xcbbd4", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbe14", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: b={b}
@@ -1754,11 +2066,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 481 EventRootType Probe[main.condReturnAndLocal]
-              InjectionPoints: [{PC: "0xcbb78", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbdb8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 482 EventRootType Probe[main.condReturnAndLocal]Return
-              InjectionPoints: [{PC: "0xcbbd4", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbe14", Frameless: false}]
               Condition: null
     - id: condString_cond
       version: 0
@@ -1776,7 +2088,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 435 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0xcb828", Frameless: false}]
+              InjectionPoints: [{PC: "0xcba68", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1792,7 +2104,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 436 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0xcb888", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbac8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1816,7 +2128,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 437 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0xcb828", Frameless: false}]
+              InjectionPoints: [{PC: "0xcba68", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1832,7 +2144,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 438 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0xcb888", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbac8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -1860,11 +2172,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 439 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0xcb828", Frameless: false}]
+              InjectionPoints: [{PC: "0xcba68", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 440 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0xcb888", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbac8", Frameless: false}]
               Condition: null
     - id: condString_eq_template
       version: 0
@@ -1882,11 +2194,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 441 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0xcb828", Frameless: false}]
+              InjectionPoints: [{PC: "0xcba68", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 442 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0xcb888", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbac8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: eq={x == "hello"}
@@ -1909,11 +2221,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 443 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0xcb828", Frameless: false}]
+              InjectionPoints: [{PC: "0xcba68", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 444 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0xcb888", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbac8", Frameless: false}]
               Condition: null
     - id: condString_snapshot_with_cond
       version: 0
@@ -1931,7 +2243,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 445 EventRootType Probe[main.condString]
-              InjectionPoints: [{PC: "0xcb828", Frameless: false}]
+              InjectionPoints: [{PC: "0xcba68", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1947,7 +2259,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 446 EventRootType Probe[main.condString]Return
-              InjectionPoints: [{PC: "0xcb888", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbac8", Frameless: false}]
               Condition: null
     - id: condStruct_cond_i32_capture_tag
       version: 0
@@ -1968,7 +2280,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 451 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0xcb8cc", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbb0c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -1985,7 +2297,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 452 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0xcb980", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbbc0", Frameless: false}]
               Condition: null
     - id: condStruct_field_bool
       version: 0
@@ -2003,7 +2315,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 453 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0xcb8cc", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbb0c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2020,7 +2332,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 454 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0xcb980", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbbc0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2046,7 +2358,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 455 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0xcb8cc", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbb0c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2063,7 +2375,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 456 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0xcb980", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbbc0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2089,7 +2401,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 457 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0xcb8cc", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbb0c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2106,7 +2418,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 458 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0xcb980", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbbc0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2132,7 +2444,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 459 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0xcb8cc", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbb0c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2148,7 +2460,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 460 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0xcb980", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbbc0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2171,11 +2483,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 461 EventRootType Probe[main.condStructArg]
-              InjectionPoints: [{PC: "0xcb8cc", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbb0c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 462 EventRootType Probe[main.condStructArg]Return
-              InjectionPoints: [{PC: "0xcb980", Frameless: false}]
+              InjectionPoints: [{PC: "0xcbbc0", Frameless: false}]
               Condition: null
     - id: condUint16_cond
       version: 0
@@ -2191,7 +2503,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 411 EventRootType Probe[main.condUint16]
-              InjectionPoints: [{PC: "0xcb458", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb698", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2208,7 +2520,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 412 EventRootType Probe[main.condUint16]Return
-              InjectionPoints: [{PC: "0xcb4b4", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb6f4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2231,11 +2543,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 413 EventRootType Probe[main.condUint16]
-              InjectionPoints: [{PC: "0xcb458", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb698", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 414 EventRootType Probe[main.condUint16]Return
-              InjectionPoints: [{PC: "0xcb4b4", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb6f4", Frameless: false}]
               Condition: null
     - id: condUint32_cond
       version: 0
@@ -2251,7 +2563,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 415 EventRootType Probe[main.condUint32]
-              InjectionPoints: [{PC: "0xcb4f8", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb738", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2268,7 +2580,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 416 EventRootType Probe[main.condUint32]Return
-              InjectionPoints: [{PC: "0xcb554", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb794", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2291,11 +2603,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 417 EventRootType Probe[main.condUint32]
-              InjectionPoints: [{PC: "0xcb4f8", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb738", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 418 EventRootType Probe[main.condUint32]Return
-              InjectionPoints: [{PC: "0xcb554", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb794", Frameless: false}]
               Condition: null
     - id: condUint64_cond
       version: 0
@@ -2311,7 +2623,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 419 EventRootType Probe[main.condUint64]
-              InjectionPoints: [{PC: "0xcb598", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb7d8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2328,7 +2640,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 420 EventRootType Probe[main.condUint64]Return
-              InjectionPoints: [{PC: "0xcb5f4", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb834", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2351,11 +2663,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 421 EventRootType Probe[main.condUint64]
-              InjectionPoints: [{PC: "0xcb598", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb7d8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 422 EventRootType Probe[main.condUint64]Return
-              InjectionPoints: [{PC: "0xcb5f4", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb834", Frameless: false}]
               Condition: null
     - id: condUint8_cond
       version: 0
@@ -2371,7 +2683,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 405 EventRootType Probe[main.condUint8]
-              InjectionPoints: [{PC: "0xcb3a8", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb5e8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2388,7 +2700,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 406 EventRootType Probe[main.condUint8]Return
-              InjectionPoints: [{PC: "0xcb40c", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb64c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2412,7 +2724,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 407 EventRootType Probe[main.condUint8]
-              InjectionPoints: [{PC: "0xcb3a8", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb5e8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2429,7 +2741,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 408 EventRootType Probe[main.condUint8]Return
-              InjectionPoints: [{PC: "0xcb40c", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb64c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -2452,11 +2764,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 409 EventRootType Probe[main.condUint8]
-              InjectionPoints: [{PC: "0xcb3a8", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb5e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 410 EventRootType Probe[main.condUint8]Return
-              InjectionPoints: [{PC: "0xcb40c", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb64c", Frameless: false}]
               Condition: null
     - id: genericIdentity
       version: 0
@@ -2466,25 +2778,25 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 73}
+        - subprogram: {subprogram: 75}
           events:
             - Kind: Entry
-              Type: 676 EventRootType Probe[main.genericIdentity[go.shape.string]]
-              InjectionPoints: [{PC: "0xcde38", Frameless: false}]
+              Type: 685 EventRootType Probe[main.genericIdentity[go.shape.string]]
+              InjectionPoints: [{PC: "0xce268", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 677 EventRootType Probe[main.genericIdentity[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xcde88", Frameless: false}]
+              Type: 686 EventRootType Probe[main.genericIdentity[go.shape.string]]Return
+              InjectionPoints: [{PC: "0xce2b8", Frameless: false}]
               Condition: null
-        - subprogram: {subprogram: 74}
+        - subprogram: {subprogram: 76}
           events:
             - Kind: Entry
-              Type: 678 EventRootType Probe[main.genericIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0xcdec8", Frameless: false}]
+              Type: 687 EventRootType Probe[main.genericIdentity[go.shape.int]]
+              InjectionPoints: [{PC: "0xce2f8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 679 EventRootType Probe[main.genericIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xcdf0c", Frameless: false}]
+              Type: 688 EventRootType Probe[main.genericIdentity[go.shape.int]]Return
+              InjectionPoints: [{PC: "0xce33c", Frameless: false}]
               Condition: null
     - id: indexBigArrayStruct_last
       version: 0
@@ -2500,15 +2812,15 @@ Probes:
             dsl: s.data[131071]
             json: {index: [{getmember: [{ref: s}, data]}, 131071]}
       instances:
-        - subprogram: {subprogram: 48}
+        - subprogram: {subprogram: 50}
           events:
             - Kind: Entry
-              Type: 598 EventRootType Probe[main.bigArrayStructArg]
-              InjectionPoints: [{PC: "0xccee8", Frameless: false}]
+              Type: 607 EventRootType Probe[main.bigArrayStructArg]
+              InjectionPoints: [{PC: "0xcd318", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 599 EventRootType Probe[main.bigArrayStructArg]Return
-              InjectionPoints: [{PC: "0xccf44", Frameless: false}]
+              Type: 608 EventRootType Probe[main.bigArrayStructArg]Return
+              InjectionPoints: [{PC: "0xcd374", Frameless: false}]
               Condition: null
     - id: indexBigArray_first
       version: 0
@@ -2522,15 +2834,15 @@ Probes:
         - name: s_0
           expr: {dsl: 's[0]', json: {index: [{ref: s}, 0]}}
       instances:
-        - subprogram: {subprogram: 47}
+        - subprogram: {subprogram: 49}
           events:
             - Kind: Entry
-              Type: 594 EventRootType Probe[main.bigArrayArg]
-              InjectionPoints: [{PC: "0xcce58", Frameless: false}]
+              Type: 603 EventRootType Probe[main.bigArrayArg]
+              InjectionPoints: [{PC: "0xcd288", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 595 EventRootType Probe[main.bigArrayArg]Return
-              InjectionPoints: [{PC: "0xcceb0", Frameless: false}]
+              Type: 604 EventRootType Probe[main.bigArrayArg]Return
+              InjectionPoints: [{PC: "0xcd2e0", Frameless: false}]
               Condition: null
     - id: indexBigArray_last
       version: 0
@@ -2544,15 +2856,15 @@ Probes:
         - name: s_131071
           expr: {dsl: 's[131071]', json: {index: [{ref: s}, 131071]}}
       instances:
-        - subprogram: {subprogram: 47}
+        - subprogram: {subprogram: 49}
           events:
             - Kind: Entry
-              Type: 596 EventRootType Probe[main.bigArrayArg]
-              InjectionPoints: [{PC: "0xcce58", Frameless: false}]
+              Type: 605 EventRootType Probe[main.bigArrayArg]
+              InjectionPoints: [{PC: "0xcd288", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 597 EventRootType Probe[main.bigArrayArg]Return
-              InjectionPoints: [{PC: "0xcceb0", Frameless: false}]
+              Type: 606 EventRootType Probe[main.bigArrayArg]Return
+              InjectionPoints: [{PC: "0xcd2e0", Frameless: false}]
               Condition: null
     - id: indexErr_array_oob_capture
       version: 0
@@ -2570,11 +2882,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 360 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0xcad78", Frameless: false}]
+              InjectionPoints: [{PC: "0xcafb8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 361 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0xcadb8", Frameless: false}]
+              InjectionPoints: [{PC: "0xcaff8", Frameless: false}]
               Condition: null
     - id: indexErr_array_oob_template
       version: 0
@@ -2589,11 +2901,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 362 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0xcad78", Frameless: false}]
+              InjectionPoints: [{PC: "0xcafb8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 363 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0xcadb8", Frameless: false}]
+              InjectionPoints: [{PC: "0xcaff8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's[3]: {s[3]}'
@@ -2617,11 +2929,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 346 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0xcacf8", Frameless: false}]
+              InjectionPoints: [{PC: "0xcaf38", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 347 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0xcad30", Frameless: false}]
+              InjectionPoints: [{PC: "0xcaf70", Frameless: false}]
               Condition: null
     - id: indexErr_slice_oob_cond
       version: 0
@@ -2639,7 +2951,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 348 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0xcacf8", Frameless: false}]
+              InjectionPoints: [{PC: "0xcaf38", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2661,7 +2973,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 349 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0xcad30", Frameless: false}]
+              InjectionPoints: [{PC: "0xcaf70", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: matched, Segments: [matched]}
     - id: indexErr_slice_oob_template
@@ -2677,11 +2989,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 350 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0xcacf8", Frameless: false}]
+              InjectionPoints: [{PC: "0xcaf38", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 351 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0xcad30", Frameless: false}]
+              InjectionPoints: [{PC: "0xcaf70", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's[5]: {s[5]}'
@@ -2707,11 +3019,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 364 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0xcad78", Frameless: false}]
+              InjectionPoints: [{PC: "0xcafb8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 365 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0xcadb8", Frameless: false}]
+              InjectionPoints: [{PC: "0xcaff8", Frameless: false}]
               Condition: null
     - id: indexIntArray_cond
       version: 0
@@ -2729,7 +3041,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 366 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0xcad78", Frameless: false}]
+              InjectionPoints: [{PC: "0xcafb8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2746,7 +3058,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 367 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0xcadb8", Frameless: false}]
+              InjectionPoints: [{PC: "0xcaff8", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: matched, Segments: [matched]}
     - id: indexIntSlice_capture
@@ -2765,11 +3077,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 352 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0xcacf8", Frameless: false}]
+              InjectionPoints: [{PC: "0xcaf38", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 353 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0xcad30", Frameless: false}]
+              InjectionPoints: [{PC: "0xcaf70", Frameless: false}]
               Condition: null
     - id: indexIntSlice_cond
       version: 0
@@ -2787,7 +3099,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 354 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0xcacf8", Frameless: false}]
+              InjectionPoints: [{PC: "0xcaf38", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
@@ -2809,7 +3121,7 @@ Probes:
                     - __kind: ConditionCheckOp
             - Kind: Return
               Type: 355 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0xcad30", Frameless: false}]
+              InjectionPoints: [{PC: "0xcaf70", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: matched, Segments: [matched]}
     - id: indexIntSlice_template
@@ -2825,11 +3137,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 356 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0xcacf8", Frameless: false}]
+              InjectionPoints: [{PC: "0xcaf38", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 357 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0xcad30", Frameless: false}]
+              InjectionPoints: [{PC: "0xcaf70", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's[1]: {s[1]}'
@@ -2853,15 +3165,15 @@ Probes:
             dsl: s[0].Val
             json: {getmember: [{index: [{ref: s}, 0]}, Val]}
       instances:
-        - subprogram: {subprogram: 50}
+        - subprogram: {subprogram: 52}
           events:
             - Kind: Entry
-              Type: 608 EventRootType Probe[main.structArrayArg]
-              InjectionPoints: [{PC: "0xcd048", Frameless: false}]
+              Type: 617 EventRootType Probe[main.structArrayArg]
+              InjectionPoints: [{PC: "0xcd478", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 609 EventRootType Probe[main.structArrayArg]Return
-              InjectionPoints: [{PC: "0xcd0a8", Frameless: false}]
+              Type: 618 EventRootType Probe[main.structArrayArg]Return
+              InjectionPoints: [{PC: "0xcd4d8", Frameless: false}]
               Condition: null
     - id: indexMember_arrayStruct_capture_string
       version: 0
@@ -2877,15 +3189,15 @@ Probes:
             dsl: s[1].Txt
             json: {getmember: [{index: [{ref: s}, 1]}, Txt]}
       instances:
-        - subprogram: {subprogram: 50}
+        - subprogram: {subprogram: 52}
           events:
             - Kind: Entry
-              Type: 610 EventRootType Probe[main.structArrayArg]
-              InjectionPoints: [{PC: "0xcd048", Frameless: false}]
+              Type: 619 EventRootType Probe[main.structArrayArg]
+              InjectionPoints: [{PC: "0xcd478", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 611 EventRootType Probe[main.structArrayArg]Return
-              InjectionPoints: [{PC: "0xcd0a8", Frameless: false}]
+              Type: 620 EventRootType Probe[main.structArrayArg]Return
+              InjectionPoints: [{PC: "0xcd4d8", Frameless: false}]
               Condition: null
     - id: indexMember_ptrArrayStruct_capture_int
       version: 0
@@ -2901,15 +3213,15 @@ Probes:
             dsl: s[0].Val
             json: {getmember: [{index: [{ref: s}, 0]}, Val]}
       instances:
-        - subprogram: {subprogram: 52}
+        - subprogram: {subprogram: 54}
           events:
             - Kind: Entry
-              Type: 616 EventRootType Probe[main.ptrStructArrayArg]
-              InjectionPoints: [{PC: "0xcd1a8", Frameless: false}]
+              Type: 625 EventRootType Probe[main.ptrStructArrayArg]
+              InjectionPoints: [{PC: "0xcd5d8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 617 EventRootType Probe[main.ptrStructArrayArg]Return
-              InjectionPoints: [{PC: "0xcd20c", Frameless: false}]
+              Type: 626 EventRootType Probe[main.ptrStructArrayArg]Return
+              InjectionPoints: [{PC: "0xcd63c", Frameless: false}]
               Condition: null
     - id: indexMember_ptrArrayStruct_capture_string
       version: 0
@@ -2925,15 +3237,15 @@ Probes:
             dsl: s[1].Txt
             json: {getmember: [{index: [{ref: s}, 1]}, Txt]}
       instances:
-        - subprogram: {subprogram: 52}
+        - subprogram: {subprogram: 54}
           events:
             - Kind: Entry
-              Type: 618 EventRootType Probe[main.ptrStructArrayArg]
-              InjectionPoints: [{PC: "0xcd1a8", Frameless: false}]
+              Type: 627 EventRootType Probe[main.ptrStructArrayArg]
+              InjectionPoints: [{PC: "0xcd5d8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 619 EventRootType Probe[main.ptrStructArrayArg]Return
-              InjectionPoints: [{PC: "0xcd20c", Frameless: false}]
+              Type: 628 EventRootType Probe[main.ptrStructArrayArg]Return
+              InjectionPoints: [{PC: "0xcd63c", Frameless: false}]
               Condition: null
     - id: indexMember_ptrSliceStruct_capture_int
       version: 0
@@ -2949,15 +3261,15 @@ Probes:
             dsl: s[0].Val
             json: {getmember: [{index: [{ref: s}, 0]}, Val]}
       instances:
-        - subprogram: {subprogram: 51}
+        - subprogram: {subprogram: 53}
           events:
             - Kind: Entry
-              Type: 612 EventRootType Probe[main.ptrStructSliceArg]
-              InjectionPoints: [{PC: "0xcd0e8", Frameless: false}]
+              Type: 621 EventRootType Probe[main.ptrStructSliceArg]
+              InjectionPoints: [{PC: "0xcd518", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 613 EventRootType Probe[main.ptrStructSliceArg]Return
-              InjectionPoints: [{PC: "0xcd158", Frameless: false}]
+              Type: 622 EventRootType Probe[main.ptrStructSliceArg]Return
+              InjectionPoints: [{PC: "0xcd588", Frameless: false}]
               Condition: null
     - id: indexMember_ptrSliceStruct_capture_string
       version: 0
@@ -2973,15 +3285,15 @@ Probes:
             dsl: s[1].Txt
             json: {getmember: [{index: [{ref: s}, 1]}, Txt]}
       instances:
-        - subprogram: {subprogram: 51}
+        - subprogram: {subprogram: 53}
           events:
             - Kind: Entry
-              Type: 614 EventRootType Probe[main.ptrStructSliceArg]
-              InjectionPoints: [{PC: "0xcd0e8", Frameless: false}]
+              Type: 623 EventRootType Probe[main.ptrStructSliceArg]
+              InjectionPoints: [{PC: "0xcd518", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 615 EventRootType Probe[main.ptrStructSliceArg]Return
-              InjectionPoints: [{PC: "0xcd158", Frameless: false}]
+              Type: 624 EventRootType Probe[main.ptrStructSliceArg]Return
+              InjectionPoints: [{PC: "0xcd588", Frameless: false}]
               Condition: null
     - id: indexMember_sliceStruct_capture_int
       version: 0
@@ -2997,15 +3309,15 @@ Probes:
             dsl: s[0].Val
             json: {getmember: [{index: [{ref: s}, 0]}, Val]}
       instances:
-        - subprogram: {subprogram: 49}
+        - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 600 EventRootType Probe[main.structSliceArg]
-              InjectionPoints: [{PC: "0xccf88", Frameless: false}]
+              Type: 609 EventRootType Probe[main.structSliceArg]
+              InjectionPoints: [{PC: "0xcd3b8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 601 EventRootType Probe[main.structSliceArg]Return
-              InjectionPoints: [{PC: "0xccff4", Frameless: false}]
+              Type: 610 EventRootType Probe[main.structSliceArg]Return
+              InjectionPoints: [{PC: "0xcd424", Frameless: false}]
               Condition: null
     - id: indexMember_sliceStruct_capture_string
       version: 0
@@ -3021,15 +3333,15 @@ Probes:
             dsl: s[1].Txt
             json: {getmember: [{index: [{ref: s}, 1]}, Txt]}
       instances:
-        - subprogram: {subprogram: 49}
+        - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 602 EventRootType Probe[main.structSliceArg]
-              InjectionPoints: [{PC: "0xccf88", Frameless: false}]
+              Type: 611 EventRootType Probe[main.structSliceArg]
+              InjectionPoints: [{PC: "0xcd3b8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 603 EventRootType Probe[main.structSliceArg]Return
-              InjectionPoints: [{PC: "0xccff4", Frameless: false}]
+              Type: 612 EventRootType Probe[main.structSliceArg]Return
+              InjectionPoints: [{PC: "0xcd424", Frameless: false}]
               Condition: null
     - id: indexMember_sliceStruct_cond
       version: 0
@@ -3044,16 +3356,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 49}
+        - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 604 EventRootType Probe[main.structSliceArg]
-              InjectionPoints: [{PC: "0xccf88", Frameless: false}]
+              Type: 613 EventRootType Probe[main.structSliceArg]
+              InjectionPoints: [{PC: "0xcd3b8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 49, index: 0, name: s}
+                      Variable: {subprogram: 51, index: 0, name: s}
                       Offset: 0
                       ByteSize: 16
                     - __kind: SliceBoundsCheckOp
@@ -3069,8 +3381,8 @@ Probes:
                       ByteSize: 4
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 605 EventRootType Probe[main.structSliceArg]Return
-              InjectionPoints: [{PC: "0xccff4", Frameless: false}]
+              Type: 614 EventRootType Probe[main.structSliceArg]Return
+              InjectionPoints: [{PC: "0xcd424", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -3092,15 +3404,15 @@ Probes:
           dsl: s[0].Val
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 49}
+        - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 606 EventRootType Probe[main.structSliceArg]
-              InjectionPoints: [{PC: "0xccf88", Frameless: false}]
+              Type: 615 EventRootType Probe[main.structSliceArg]
+              InjectionPoints: [{PC: "0xcd3b8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 607 EventRootType Probe[main.structSliceArg]Return
-              InjectionPoints: [{PC: "0xccff4", Frameless: false}]
+              Type: 616 EventRootType Probe[main.structSliceArg]Return
+              InjectionPoints: [{PC: "0xcd424", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: s[0].Val={s[0].Val}
@@ -3127,15 +3439,15 @@ Probes:
             json:
                 getmember: [{index: [{getmember: [{ref: s}, Arr]}, 0]}, Val]
       instances:
-        - subprogram: {subprogram: 53}
+        - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 620 EventRootType Probe[main.indexMemberWrapperArg]
-              InjectionPoints: [{PC: "0xcd248", Frameless: false}]
+              Type: 629 EventRootType Probe[main.indexMemberWrapperArg]
+              InjectionPoints: [{PC: "0xcd678", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 621 EventRootType Probe[main.indexMemberWrapperArg]Return
-              InjectionPoints: [{PC: "0xcd2d4", Frameless: false}]
+              Type: 630 EventRootType Probe[main.indexMemberWrapperArg]Return
+              InjectionPoints: [{PC: "0xcd704", Frameless: false}]
               Condition: null
     - id: indexMember_wrapper_arr_capture_1
       version: 0
@@ -3152,15 +3464,15 @@ Probes:
             json:
                 getmember: [{index: [{getmember: [{ref: s}, Arr]}, 1]}, Txt]
       instances:
-        - subprogram: {subprogram: 53}
+        - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 622 EventRootType Probe[main.indexMemberWrapperArg]
-              InjectionPoints: [{PC: "0xcd248", Frameless: false}]
+              Type: 631 EventRootType Probe[main.indexMemberWrapperArg]
+              InjectionPoints: [{PC: "0xcd678", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 623 EventRootType Probe[main.indexMemberWrapperArg]Return
-              InjectionPoints: [{PC: "0xcd2d4", Frameless: false}]
+              Type: 632 EventRootType Probe[main.indexMemberWrapperArg]Return
+              InjectionPoints: [{PC: "0xcd704", Frameless: false}]
               Condition: null
     - id: indexMember_wrapper_ptrArr_capture
       version: 0
@@ -3177,15 +3489,15 @@ Probes:
             json:
                 getmember: [{index: [{getmember: [{ref: s}, PtrArr]}, 0]}, Val]
       instances:
-        - subprogram: {subprogram: 53}
+        - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 624 EventRootType Probe[main.indexMemberWrapperArg]
-              InjectionPoints: [{PC: "0xcd248", Frameless: false}]
+              Type: 633 EventRootType Probe[main.indexMemberWrapperArg]
+              InjectionPoints: [{PC: "0xcd678", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 625 EventRootType Probe[main.indexMemberWrapperArg]Return
-              InjectionPoints: [{PC: "0xcd2d4", Frameless: false}]
+              Type: 634 EventRootType Probe[main.indexMemberWrapperArg]Return
+              InjectionPoints: [{PC: "0xcd704", Frameless: false}]
               Condition: null
     - id: indexMember_wrapper_ptrArr_capture_1
       version: 0
@@ -3202,15 +3514,15 @@ Probes:
             json:
                 getmember: [{index: [{getmember: [{ref: s}, PtrArr]}, 1]}, Txt]
       instances:
-        - subprogram: {subprogram: 53}
+        - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 626 EventRootType Probe[main.indexMemberWrapperArg]
-              InjectionPoints: [{PC: "0xcd248", Frameless: false}]
+              Type: 635 EventRootType Probe[main.indexMemberWrapperArg]
+              InjectionPoints: [{PC: "0xcd678", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 627 EventRootType Probe[main.indexMemberWrapperArg]Return
-              InjectionPoints: [{PC: "0xcd2d4", Frameless: false}]
+              Type: 636 EventRootType Probe[main.indexMemberWrapperArg]Return
+              InjectionPoints: [{PC: "0xcd704", Frameless: false}]
               Condition: null
     - id: indexNilPtr_capture
       version: 0
@@ -3226,15 +3538,15 @@ Probes:
             dsl: x.Items[0]
             json: {index: [{getmember: [{ref: x}, Items]}, 0]}
       instances:
-        - subprogram: {subprogram: 45}
+        - subprogram: {subprogram: 47}
           events:
             - Kind: Entry
-              Type: 586 EventRootType Probe[main.indexNilPtrSlice]
-              InjectionPoints: [{PC: "0xccbe8", Frameless: false}]
+              Type: 595 EventRootType Probe[main.indexNilPtrSlice]
+              InjectionPoints: [{PC: "0xcd018", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 587 EventRootType Probe[main.indexNilPtrSlice]Return
-              InjectionPoints: [{PC: "0xccc54", Frameless: false}]
+              Type: 596 EventRootType Probe[main.indexNilPtrSlice]Return
+              InjectionPoints: [{PC: "0xcd084", Frameless: false}]
               Condition: null
     - id: indexNilPtr_cond
       version: 0
@@ -3249,16 +3561,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 45}
+        - subprogram: {subprogram: 47}
           events:
             - Kind: Entry
-              Type: 588 EventRootType Probe[main.indexNilPtrSlice]
-              InjectionPoints: [{PC: "0xccbe8", Frameless: false}]
+              Type: 597 EventRootType Probe[main.indexNilPtrSlice]
+              InjectionPoints: [{PC: "0xcd018", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 45, index: 0, name: x}
+                      Variable: {subprogram: 47, index: 0, name: x}
                       Offset: 0
                       ByteSize: 8
                     - __kind: DereferenceOp
@@ -3277,8 +3589,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 589 EventRootType Probe[main.indexNilPtrSlice]Return
-              InjectionPoints: [{PC: "0xccc54", Frameless: false}]
+              Type: 598 EventRootType Probe[main.indexNilPtrSlice]Return
+              InjectionPoints: [{PC: "0xcd084", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -3300,15 +3612,15 @@ Probes:
           dsl: x.Items[0]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 45}
+        - subprogram: {subprogram: 47}
           events:
             - Kind: Entry
-              Type: 590 EventRootType Probe[main.indexNilPtrSlice]
-              InjectionPoints: [{PC: "0xccbe8", Frameless: false}]
+              Type: 599 EventRootType Probe[main.indexNilPtrSlice]
+              InjectionPoints: [{PC: "0xcd018", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 591 EventRootType Probe[main.indexNilPtrSlice]Return
-              InjectionPoints: [{PC: "0xccc54", Frameless: false}]
+              Type: 600 EventRootType Probe[main.indexNilPtrSlice]Return
+              InjectionPoints: [{PC: "0xcd084", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 'items[0]: {x.Items[0]}'
@@ -3334,15 +3646,15 @@ Probes:
             dsl: x.Items[0]
             json: {index: [{getmember: [{ref: x}, Items]}, 0]}
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 568 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0xcc8ec", Frameless: false}]
+              Type: 577 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0xccd1c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 569 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0xcc9bc", Frameless: false}]
+              Type: 578 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0xccdec", Frameless: false}]
               Condition: null
     - id: indexStringArray_capture
       version: 0
@@ -3360,11 +3672,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 374 EventRootType Probe[main.stringArrayArg]
-              InjectionPoints: [{PC: "0xcae68", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb0a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 375 EventRootType Probe[main.stringArrayArg]Return
-              InjectionPoints: [{PC: "0xcaea8", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb0e8", Frameless: false}]
               Condition: null
     - id: indexStringSlice_capture
       version: 0
@@ -3382,11 +3694,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 370 EventRootType Probe[main.stringSliceArg]
-              InjectionPoints: [{PC: "0xcade8", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb028", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 371 EventRootType Probe[main.stringSliceArg]Return
-              InjectionPoints: [{PC: "0xcae20", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb060", Frameless: false}]
               Condition: null
     - id: indexStructSliceField_capture
       version: 0
@@ -3402,15 +3714,15 @@ Probes:
             dsl: x.Items[2]
             json: {index: [{getmember: [{ref: x}, Items]}, 2]}
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 548 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xcc7bc", Frameless: false}]
+              Type: 557 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xccbec", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 549 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xcc8a8", Frameless: false}]
+              Type: 558 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xcccd8", Frameless: false}]
               Condition: null
     - id: inlined
       version: 0
@@ -3421,19 +3733,19 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 75}
+        - subprogram: {subprogram: 77}
           events:
             - Kind: Entry
-              Type: 680 EventRootType Probe[main.inlined]
+              Type: 689 EventRootType Probe[main.inlined]
               InjectionPoints:
                 - PC: "0xc8b1c"
                   Frameless: false
-                - PC: "0xcaee8"
+                - PC: "0xcb128"
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 681 EventRootType Probe[main.inlined]Return
-              InjectionPoints: [{PC: "0xcaf1c", Frameless: false}]
+              Type: 690 EventRootType Probe[main.inlined]Return
+              InjectionPoints: [{PC: "0xcb15c", Frameless: false}]
               Condition: null
     - id: inlinedMethod
       version: 0
@@ -3443,11 +3755,11 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 78}
+        - subprogram: {subprogram: 80}
           events:
             - Kind: Entry
-              Type: 684 EventRootType Probe[main.(*methodValueReceiver).inlinedMethod]
-              InjectionPoints: [{PC: "0xcdf34", Frameless: true}]
+              Type: 693 EventRootType Probe[main.(*methodValueReceiver).inlinedMethod]
+              InjectionPoints: [{PC: "0xce364", Frameless: true}]
               Condition: null
     - id: intArg
       version: 0
@@ -3461,11 +3773,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 338 EventRootType Probe[main.intArg]
-              InjectionPoints: [{PC: "0xcac18", Frameless: false}]
+              InjectionPoints: [{PC: "0xcae58", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 339 EventRootType Probe[main.intArg]Return
-              InjectionPoints: [{PC: "0xcac4c", Frameless: false}]
+              InjectionPoints: [{PC: "0xcae8c", Frameless: false}]
               Condition: null
     - id: intArrayArg
       version: 0
@@ -3479,11 +3791,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 368 EventRootType Probe[main.intArrayArg]
-              InjectionPoints: [{PC: "0xcad78", Frameless: false}]
+              InjectionPoints: [{PC: "0xcafb8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 369 EventRootType Probe[main.intArrayArg]Return
-              InjectionPoints: [{PC: "0xcadb8", Frameless: false}]
+              InjectionPoints: [{PC: "0xcaff8", Frameless: false}]
               Condition: null
     - id: intArrayArgFrameless
       version: 0
@@ -3497,7 +3809,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 378 EventRootType Probe[main.stringArrayArgFrameless]
-              InjectionPoints: [{PC: "0xcaec0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcb100", Frameless: true}]
               Condition: null
     - id: intSliceArg
       version: 0
@@ -3511,11 +3823,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 358 EventRootType Probe[main.intSliceArg]
-              InjectionPoints: [{PC: "0xcacf8", Frameless: false}]
+              InjectionPoints: [{PC: "0xcaf38", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 359 EventRootType Probe[main.intSliceArg]Return
-              InjectionPoints: [{PC: "0xcad30", Frameless: false}]
+              InjectionPoints: [{PC: "0xcaf70", Frameless: false}]
               Condition: null
     - id: lenErrInt_nocond
       version: 0
@@ -3526,15 +3838,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 43}
+        - subprogram: {subprogram: 45}
           events:
             - Kind: Entry
-              Type: 578 EventRootType Probe[main.lenErrInt]
-              InjectionPoints: [{PC: "0xcca0c", Frameless: false}]
+              Type: 587 EventRootType Probe[main.lenErrInt]
+              InjectionPoints: [{PC: "0xcce3c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 579 EventRootType Probe[main.lenErrInt]Return
-              InjectionPoints: [{PC: "0xccaa8", Frameless: false}]
+              Type: 588 EventRootType Probe[main.lenErrInt]Return
+              InjectionPoints: [{PC: "0xcced8", Frameless: false}]
               Condition: null
     - id: lenErrStruct_nocond
       version: 0
@@ -3545,15 +3857,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 44}
+        - subprogram: {subprogram: 46}
           events:
             - Kind: Entry
-              Type: 582 EventRootType Probe[main.lenErrStruct]
-              InjectionPoints: [{PC: "0xccaec", Frameless: false}]
+              Type: 591 EventRootType Probe[main.lenErrStruct]
+              InjectionPoints: [{PC: "0xccf1c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 583 EventRootType Probe[main.lenErrStruct]Return
-              InjectionPoints: [{PC: "0xccbb0", Frameless: false}]
+              Type: 592 EventRootType Probe[main.lenErrStruct]Return
+              InjectionPoints: [{PC: "0xccfe0", Frameless: false}]
               Condition: null
     - id: lenErr_int
       version: 0
@@ -3564,15 +3876,15 @@ Probes:
       segments: [len=, {json: {len: {ref: x}}, dsl: len(x)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 43}
+        - subprogram: {subprogram: 45}
           events:
             - Kind: Entry
-              Type: 580 EventRootType Probe[main.lenErrInt]
-              InjectionPoints: [{PC: "0xcca0c", Frameless: false}]
+              Type: 589 EventRootType Probe[main.lenErrInt]
+              InjectionPoints: [{PC: "0xcce3c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 581 EventRootType Probe[main.lenErrInt]Return
-              InjectionPoints: [{PC: "0xccaa8", Frameless: false}]
+              Type: 590 EventRootType Probe[main.lenErrInt]Return
+              InjectionPoints: [{PC: "0xcced8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x)}
@@ -3589,15 +3901,15 @@ Probes:
       segments: [len=, {json: {len: {ref: x}}, dsl: len(x)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 44}
+        - subprogram: {subprogram: 46}
           events:
             - Kind: Entry
-              Type: 584 EventRootType Probe[main.lenErrStruct]
-              InjectionPoints: [{PC: "0xccaec", Frameless: false}]
+              Type: 593 EventRootType Probe[main.lenErrStruct]
+              InjectionPoints: [{PC: "0xccf1c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 585 EventRootType Probe[main.lenErrStruct]Return
-              InjectionPoints: [{PC: "0xccbb0", Frameless: false}]
+              Type: 594 EventRootType Probe[main.lenErrStruct]Return
+              InjectionPoints: [{PC: "0xccfe0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x)}
@@ -3615,16 +3927,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 532 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0xcc5ec", Frameless: false}]
+              Type: 541 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0xcca1c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 39, index: 0, name: m}
+                      Variable: {subprogram: 41, index: 0, name: m}
                       Offset: 0
                       ByteSize: 8
                     - __kind: DereferenceOp
@@ -3638,8 +3950,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 533 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0xcc694", Frameless: false}]
+              Type: 542 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0xccac4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -3661,15 +3973,15 @@ Probes:
           dsl: isEmpty(m)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 534 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0xcc5ec", Frameless: false}]
+              Type: 543 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0xcca1c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 535 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0xcc694", Frameless: false}]
+              Type: 544 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0xccac4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: empty={isEmpty(m)}
@@ -3691,15 +4003,15 @@ Probes:
         - name: m_len
           expr: {dsl: len(m), json: {len: {ref: m}}}
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 536 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0xcc5ec", Frameless: false}]
+              Type: 545 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0xcca1c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 537 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0xcc694", Frameless: false}]
+              Type: 546 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0xccac4", Frameless: false}]
               Condition: null
     - id: lenMap_len_eq_cond
       version: 0
@@ -3713,16 +4025,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 538 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0xcc5ec", Frameless: false}]
+              Type: 547 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0xcca1c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 39, index: 0, name: m}
+                      Variable: {subprogram: 41, index: 0, name: m}
                       Offset: 0
                       ByteSize: 8
                     - __kind: DereferenceOp
@@ -3736,8 +4048,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 539 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0xcc694", Frameless: false}]
+              Type: 548 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0xccac4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -3756,15 +4068,15 @@ Probes:
       segments: [len=, {json: {len: {ref: m}}, dsl: len(m)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 540 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0xcc5ec", Frameless: false}]
+              Type: 549 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0xcca1c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 541 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0xcc694", Frameless: false}]
+              Type: 550 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0xccac4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(m)}
@@ -3783,15 +4095,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 39}
+        - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 542 EventRootType Probe[main.lenMap]
-              InjectionPoints: [{PC: "0xcc5ec", Frameless: false}]
+              Type: 551 EventRootType Probe[main.lenMap]
+              InjectionPoints: [{PC: "0xcca1c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 543 EventRootType Probe[main.lenMap]Return
-              InjectionPoints: [{PC: "0xcc694", Frameless: false}]
+              Type: 552 EventRootType Probe[main.lenMap]Return
+              InjectionPoints: [{PC: "0xccac4", Frameless: false}]
               Condition: null
     - id: lenPtrString_len_template
       version: 0
@@ -3802,15 +4114,15 @@ Probes:
       segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 40}
+        - subprogram: {subprogram: 42}
           events:
             - Kind: Entry
-              Type: 544 EventRootType Probe[main.lenPtrString]
-              InjectionPoints: [{PC: "0xcc6dc", Frameless: false}]
+              Type: 553 EventRootType Probe[main.lenPtrString]
+              InjectionPoints: [{PC: "0xccb0c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 545 EventRootType Probe[main.lenPtrString]Return
-              InjectionPoints: [{PC: "0xcc76c", Frameless: false}]
+              Type: 554 EventRootType Probe[main.lenPtrString]Return
+              InjectionPoints: [{PC: "0xccb9c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(s)}
@@ -3829,15 +4141,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 40}
+        - subprogram: {subprogram: 42}
           events:
             - Kind: Entry
-              Type: 546 EventRootType Probe[main.lenPtrString]
-              InjectionPoints: [{PC: "0xcc6dc", Frameless: false}]
+              Type: 555 EventRootType Probe[main.lenPtrString]
+              InjectionPoints: [{PC: "0xccb0c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 547 EventRootType Probe[main.lenPtrString]Return
-              InjectionPoints: [{PC: "0xcc76c", Frameless: false}]
+              Type: 556 EventRootType Probe[main.lenPtrString]Return
+              InjectionPoints: [{PC: "0xccb9c", Frameless: false}]
               Condition: null
     - id: lenPtrStructFields_nocond
       version: 0
@@ -3848,15 +4160,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 570 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0xcc8ec", Frameless: false}]
+              Type: 579 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0xccd1c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 571 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0xcc9bc", Frameless: false}]
+              Type: 580 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0xccdec", Frameless: false}]
               Condition: null
     - id: lenPtrStruct_field_map
       version: 0
@@ -3870,15 +4182,15 @@ Probes:
           dsl: len(x.Dict)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 572 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0xcc8ec", Frameless: false}]
+              Type: 581 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0xccd1c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 573 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0xcc9bc", Frameless: false}]
+              Type: 582 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0xccdec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.Dict)}
@@ -3900,15 +4212,15 @@ Probes:
           dsl: len(x.Items)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 574 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0xcc8ec", Frameless: false}]
+              Type: 583 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0xccd1c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 575 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0xcc9bc", Frameless: false}]
+              Type: 584 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0xccdec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.Items)}
@@ -3930,15 +4242,15 @@ Probes:
           dsl: len(x.S)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 42}
+        - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 576 EventRootType Probe[main.lenPtrStructFields]
-              InjectionPoints: [{PC: "0xcc8ec", Frameless: false}]
+              Type: 585 EventRootType Probe[main.lenPtrStructFields]
+              InjectionPoints: [{PC: "0xccd1c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 577 EventRootType Probe[main.lenPtrStructFields]Return
-              InjectionPoints: [{PC: "0xcc9bc", Frameless: false}]
+              Type: 586 EventRootType Probe[main.lenPtrStructFields]Return
+              InjectionPoints: [{PC: "0xccdec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.S)}
@@ -3958,16 +4270,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 520 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0xcc4fc", Frameless: false}]
+              Type: 529 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0xcc92c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 38, index: 0, name: s}
+                      Variable: {subprogram: 40, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -3978,8 +4290,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 521 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0xcc5a0", Frameless: false}]
+              Type: 530 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0xcc9d0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4001,15 +4313,15 @@ Probes:
           dsl: isEmpty(s)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 522 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0xcc4fc", Frameless: false}]
+              Type: 531 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0xcc92c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 523 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0xcc5a0", Frameless: false}]
+              Type: 532 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0xcc9d0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: empty={isEmpty(s)}
@@ -4031,15 +4343,15 @@ Probes:
         - name: s_len
           expr: {dsl: len(s), json: {len: {ref: s}}}
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 524 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0xcc4fc", Frameless: false}]
+              Type: 533 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0xcc92c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 525 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0xcc5a0", Frameless: false}]
+              Type: 534 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0xcc9d0", Frameless: false}]
               Condition: null
     - id: lenSlice_len_eq_cond
       version: 0
@@ -4053,16 +4365,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 526 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0xcc4fc", Frameless: false}]
+              Type: 535 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0xcc92c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 38, index: 0, name: s}
+                      Variable: {subprogram: 40, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4073,8 +4385,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 527 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0xcc5a0", Frameless: false}]
+              Type: 536 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0xcc9d0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4093,15 +4405,15 @@ Probes:
       segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 528 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0xcc4fc", Frameless: false}]
+              Type: 537 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0xcc92c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 529 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0xcc5a0", Frameless: false}]
+              Type: 538 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0xcc9d0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(s)}
@@ -4120,15 +4432,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 38}
+        - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 530 EventRootType Probe[main.lenSlice]
-              InjectionPoints: [{PC: "0xcc4fc", Frameless: false}]
+              Type: 539 EventRootType Probe[main.lenSlice]
+              InjectionPoints: [{PC: "0xcc92c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 531 EventRootType Probe[main.lenSlice]Return
-              InjectionPoints: [{PC: "0xcc5a0", Frameless: false}]
+              Type: 540 EventRootType Probe[main.lenSlice]Return
+              InjectionPoints: [{PC: "0xcc9d0", Frameless: false}]
               Condition: null
     - id: lenString_eq_capture
       version: 0
@@ -4144,15 +4456,15 @@ Probes:
             dsl: len(s) == 5
             json: {eq: [{len: {ref: s}}, 5]}
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 502 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xcc41c", Frameless: false}]
+              Type: 511 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xcc84c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 503 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xcc4b4", Frameless: false}]
+              Type: 512 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xcc8e4", Frameless: false}]
               Condition: null
     - id: lenString_eq_template
       version: 0
@@ -4166,15 +4478,15 @@ Probes:
           dsl: len(s) == 5
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 504 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xcc41c", Frameless: false}]
+              Type: 513 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xcc84c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 505 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xcc4b4", Frameless: false}]
+              Type: 514 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xcc8e4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: eq={len(s) == 5}
@@ -4196,15 +4508,15 @@ Probes:
         - name: s_isEmpty
           expr: {dsl: isEmpty(s), json: {isEmpty: {ref: s}}}
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 506 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xcc41c", Frameless: false}]
+              Type: 515 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xcc84c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 507 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xcc4b4", Frameless: false}]
+              Type: 516 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xcc8e4", Frameless: false}]
               Condition: null
     - id: lenString_isEmpty_cond
       version: 0
@@ -4216,16 +4528,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 508 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xcc41c", Frameless: false}]
+              Type: 517 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xcc84c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 37, index: 0, name: s}
+                      Variable: {subprogram: 39, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4236,8 +4548,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 509 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xcc4b4", Frameless: false}]
+              Type: 518 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xcc8e4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4259,15 +4571,15 @@ Probes:
           dsl: isEmpty(s)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 510 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xcc41c", Frameless: false}]
+              Type: 519 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xcc84c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 511 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xcc4b4", Frameless: false}]
+              Type: 520 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xcc8e4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: empty={isEmpty(s)}
@@ -4289,15 +4601,15 @@ Probes:
         - name: s_len
           expr: {dsl: len(s), json: {len: {ref: s}}}
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 512 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xcc41c", Frameless: false}]
+              Type: 521 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xcc84c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 513 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xcc4b4", Frameless: false}]
+              Type: 522 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xcc8e4", Frameless: false}]
               Condition: null
     - id: lenString_len_eq_cond
       version: 0
@@ -4311,16 +4623,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 514 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xcc41c", Frameless: false}]
+              Type: 523 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xcc84c", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 37, index: 0, name: s}
+                      Variable: {subprogram: 39, index: 0, name: s}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4331,8 +4643,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 515 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xcc4b4", Frameless: false}]
+              Type: 524 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xcc8e4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4351,15 +4663,15 @@ Probes:
       segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 516 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xcc41c", Frameless: false}]
+              Type: 525 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xcc84c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 517 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xcc4b4", Frameless: false}]
+              Type: 526 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xcc8e4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(s)}
@@ -4378,15 +4690,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 37}
+        - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 518 EventRootType Probe[main.lenString]
-              InjectionPoints: [{PC: "0xcc41c", Frameless: false}]
+              Type: 527 EventRootType Probe[main.lenString]
+              InjectionPoints: [{PC: "0xcc84c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 519 EventRootType Probe[main.lenString]Return
-              InjectionPoints: [{PC: "0xcc4b4", Frameless: false}]
+              Type: 528 EventRootType Probe[main.lenString]Return
+              InjectionPoints: [{PC: "0xcc8e4", Frameless: false}]
               Condition: null
     - id: lenStructFields_nocond
       version: 0
@@ -4397,15 +4709,15 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 550 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xcc7bc", Frameless: false}]
+              Type: 559 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xccbec", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 551 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xcc8a8", Frameless: false}]
+              Type: 560 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xcccd8", Frameless: false}]
               Condition: null
     - id: lenStruct_field_map
       version: 0
@@ -4419,15 +4731,15 @@ Probes:
           dsl: len(x.Dict)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 552 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xcc7bc", Frameless: false}]
+              Type: 561 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xccbec", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 553 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xcc8a8", Frameless: false}]
+              Type: 562 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xcccd8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.Dict)}
@@ -4449,15 +4761,15 @@ Probes:
           dsl: len(x.PtrSlice)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 554 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xcc7bc", Frameless: false}]
+              Type: 563 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xccbec", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 555 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xcc8a8", Frameless: false}]
+              Type: 564 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xcccd8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.PtrSlice)}
@@ -4479,15 +4791,15 @@ Probes:
           dsl: len(x.PtrStr)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 556 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xcc7bc", Frameless: false}]
+              Type: 565 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xccbec", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 557 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xcc8a8", Frameless: false}]
+              Type: 566 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xcccd8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.PtrStr)}
@@ -4509,15 +4821,15 @@ Probes:
           dsl: len(x.Items)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 558 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xcc7bc", Frameless: false}]
+              Type: 567 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xccbec", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 559 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xcc8a8", Frameless: false}]
+              Type: 568 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xcccd8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.Items)}
@@ -4539,15 +4851,15 @@ Probes:
           dsl: len(x.S)
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 560 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xcc7bc", Frameless: false}]
+              Type: 569 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xccbec", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 561 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xcc8a8", Frameless: false}]
+              Type: 570 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xcccd8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: len={len(x.S)}
@@ -4569,16 +4881,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 562 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xcc7bc", Frameless: false}]
+              Type: 571 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xccbec", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 41, index: 0, name: x}
+                      Variable: {subprogram: 43, index: 0, name: x}
                       Offset: 40
                       ByteSize: 8
                     - __kind: DereferenceOp
@@ -4592,8 +4904,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 563 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xcc8a8", Frameless: false}]
+              Type: 572 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xcccd8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4615,16 +4927,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 564 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xcc7bc", Frameless: false}]
+              Type: 573 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xccbec", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 41, index: 0, name: x}
+                      Variable: {subprogram: 43, index: 0, name: x}
                       Offset: 24
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4635,8 +4947,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 565 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xcc8a8", Frameless: false}]
+              Type: 574 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xcccd8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4658,16 +4970,16 @@ Probes:
       segments: [tag=, {json: {ref: tag}, dsl: tag}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 41}
+        - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 566 EventRootType Probe[main.lenStructFields]
-              InjectionPoints: [{PC: "0xcc7bc", Frameless: false}]
+              Type: 575 EventRootType Probe[main.lenStructFields]
+              InjectionPoints: [{PC: "0xccbec", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 41, index: 0, name: x}
+                      Variable: {subprogram: 43, index: 0, name: x}
                       Offset: 8
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -4678,8 +4990,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 567 EventRootType Probe[main.lenStructFields]Return
-              InjectionPoints: [{PC: "0xcc8a8", Frameless: false}]
+              Type: 576 EventRootType Probe[main.lenStructFields]Return
+              InjectionPoints: [{PC: "0xcccd8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: tag={tag}
@@ -4701,11 +5013,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 340 EventRootType Probe[main.stringArg]
-              InjectionPoints: [{PC: "0xcac88", Frameless: false}]
+              InjectionPoints: [{PC: "0xcaec8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 341 EventRootType Probe[main.stringArg]Return
-              InjectionPoints: [{PC: "0xcacc0", Frameless: false}]
+              InjectionPoints: [{PC: "0xcaf00", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's: {s}'
@@ -4727,11 +5039,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 342 EventRootType Probe[main.stringArg]
-              InjectionPoints: [{PC: "0xcac88", Frameless: false}]
+              InjectionPoints: [{PC: "0xcaec8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 343 EventRootType Probe[main.stringArg]Return
-              InjectionPoints: [{PC: "0xcacc0", Frameless: false}]
+              InjectionPoints: [{PC: "0xcaf00", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 'x: {x}'
@@ -4751,11 +5063,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 379 EventRootType Probe[main.mapArg]
-              InjectionPoints: [{PC: "0xcafa8", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb1e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 380 EventRootType Probe[main.mapArg]Return
-              InjectionPoints: [{PC: "0xcafd4", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb214", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 'm: {m}'
@@ -4780,15 +5092,15 @@ Probes:
         - name: false_val
           expr: {dsl: 'm[false]', json: {index: [{ref: m}, false]}}
       instances:
-        - subprogram: {subprogram: 68}
+        - subprogram: {subprogram: 70}
           events:
             - Kind: Entry
-              Type: 664 EventRootType Probe[main.mapIndexBoolKey]
-              InjectionPoints: [{PC: "0xcdb18", Frameless: false}]
+              Type: 673 EventRootType Probe[main.mapIndexBoolKey]
+              InjectionPoints: [{PC: "0xcdf48", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 665 EventRootType Probe[main.mapIndexBoolKey]Return
-              InjectionPoints: [{PC: "0xcdb44", Frameless: false}]
+              Type: 674 EventRootType Probe[main.mapIndexBoolKey]Return
+              InjectionPoints: [{PC: "0xcdf74", Frameless: false}]
               Condition: null
     - id: mapIndex_boolKey_true
       version: 0
@@ -4805,15 +5117,15 @@ Probes:
         - name: true_val
           expr: {dsl: 'm[true]', json: {index: [{ref: m}, true]}}
       instances:
-        - subprogram: {subprogram: 68}
+        - subprogram: {subprogram: 70}
           events:
             - Kind: Entry
-              Type: 666 EventRootType Probe[main.mapIndexBoolKey]
-              InjectionPoints: [{PC: "0xcdb18", Frameless: false}]
+              Type: 675 EventRootType Probe[main.mapIndexBoolKey]
+              InjectionPoints: [{PC: "0xcdf48", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 667 EventRootType Probe[main.mapIndexBoolKey]Return
-              InjectionPoints: [{PC: "0xcdb44", Frameless: false}]
+              Type: 676 EventRootType Probe[main.mapIndexBoolKey]Return
+              InjectionPoints: [{PC: "0xcdf74", Frameless: false}]
               Condition: null
     - id: mapIndex_emptyKey_capture
       version: 0
@@ -4830,15 +5142,15 @@ Probes:
         - name: empty_val
           expr: {dsl: 'm[""]', json: {index: [{ref: m}, ""]}}
       instances:
-        - subprogram: {subprogram: 65}
+        - subprogram: {subprogram: 67}
           events:
             - Kind: Entry
-              Type: 658 EventRootType Probe[main.mapIndexEmptyKey]
-              InjectionPoints: [{PC: "0xcd988", Frameless: false}]
+              Type: 667 EventRootType Probe[main.mapIndexEmptyKey]
+              InjectionPoints: [{PC: "0xcddb8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 659 EventRootType Probe[main.mapIndexEmptyKey]Return
-              InjectionPoints: [{PC: "0xcd9d8", Frameless: false}]
+              Type: 668 EventRootType Probe[main.mapIndexEmptyKey]Return
+              InjectionPoints: [{PC: "0xcde08", Frameless: false}]
               Condition: null
     - id: mapIndex_intKey_capture
       version: 0
@@ -4855,15 +5167,15 @@ Probes:
         - name: m_2
           expr: {dsl: 'm[2]', json: {index: [{ref: m}, 2]}}
       instances:
-        - subprogram: {subprogram: 54}
+        - subprogram: {subprogram: 56}
           events:
             - Kind: Entry
-              Type: 628 EventRootType Probe[main.mapIndexIntKey]
-              InjectionPoints: [{PC: "0xcd318", Frameless: false}]
+              Type: 637 EventRootType Probe[main.mapIndexIntKey]
+              InjectionPoints: [{PC: "0xcd748", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 629 EventRootType Probe[main.mapIndexIntKey]Return
-              InjectionPoints: [{PC: "0xcd344", Frameless: false}]
+              Type: 638 EventRootType Probe[main.mapIndexIntKey]Return
+              InjectionPoints: [{PC: "0xcd774", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen16
       version: 0
@@ -4882,15 +5194,15 @@ Probes:
             dsl: m["000000000000002a"]
             json: {index: [{ref: m}, 000000000000002a]}
       instances:
-        - subprogram: {subprogram: 66}
+        - subprogram: {subprogram: 68}
           events:
             - Kind: Entry
-              Type: 660 EventRootType Probe[main.mapIndexKeyLen16]
-              InjectionPoints: [{PC: "0xcda18", Frameless: false}]
+              Type: 669 EventRootType Probe[main.mapIndexKeyLen16]
+              InjectionPoints: [{PC: "0xcde48", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 661 EventRootType Probe[main.mapIndexKeyLen16]Return
-              InjectionPoints: [{PC: "0xcda60", Frameless: false}]
+              Type: 670 EventRootType Probe[main.mapIndexKeyLen16]Return
+              InjectionPoints: [{PC: "0xcde90", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen17
       version: 0
@@ -4909,15 +5221,15 @@ Probes:
             dsl: m["0000000000000002a"]
             json: {index: [{ref: m}, 0000000000000002a]}
       instances:
-        - subprogram: {subprogram: 67}
+        - subprogram: {subprogram: 69}
           events:
             - Kind: Entry
-              Type: 662 EventRootType Probe[main.mapIndexKeyLen17]
-              InjectionPoints: [{PC: "0xcda98", Frameless: false}]
+              Type: 671 EventRootType Probe[main.mapIndexKeyLen17]
+              InjectionPoints: [{PC: "0xcdec8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 663 EventRootType Probe[main.mapIndexKeyLen17]Return
-              InjectionPoints: [{PC: "0xcdae0", Frameless: false}]
+              Type: 672 EventRootType Probe[main.mapIndexKeyLen17]Return
+              InjectionPoints: [{PC: "0xcdf10", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen200
       version: 0
@@ -4939,15 +5251,15 @@ Probes:
                     - ref: m
                     - 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002a
       instances:
-        - subprogram: {subprogram: 62}
+        - subprogram: {subprogram: 64}
           events:
             - Kind: Entry
-              Type: 648 EventRootType Probe[main.mapIndexKeyLen200]
-              InjectionPoints: [{PC: "0xcd7e8", Frameless: false}]
+              Type: 657 EventRootType Probe[main.mapIndexKeyLen200]
+              InjectionPoints: [{PC: "0xcdc18", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 649 EventRootType Probe[main.mapIndexKeyLen200]Return
-              InjectionPoints: [{PC: "0xcd830", Frameless: false}]
+              Type: 658 EventRootType Probe[main.mapIndexKeyLen200]Return
+              InjectionPoints: [{PC: "0xcdc60", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen24
       version: 0
@@ -4966,15 +5278,15 @@ Probes:
             dsl: m["00000000000000000000002a"]
             json: {index: [{ref: m}, 00000000000000000000002a]}
       instances:
-        - subprogram: {subprogram: 59}
+        - subprogram: {subprogram: 61}
           events:
             - Kind: Entry
-              Type: 642 EventRootType Probe[main.mapIndexKeyLen24]
-              InjectionPoints: [{PC: "0xcd668", Frameless: false}]
+              Type: 651 EventRootType Probe[main.mapIndexKeyLen24]
+              InjectionPoints: [{PC: "0xcda98", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 643 EventRootType Probe[main.mapIndexKeyLen24]Return
-              InjectionPoints: [{PC: "0xcd6b0", Frameless: false}]
+              Type: 652 EventRootType Probe[main.mapIndexKeyLen24]Return
+              InjectionPoints: [{PC: "0xcdae0", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen48
       version: 0
@@ -4996,15 +5308,15 @@ Probes:
                     - ref: m
                     - 00000000000000000000000000000000000000000000002a
       instances:
-        - subprogram: {subprogram: 60}
+        - subprogram: {subprogram: 62}
           events:
             - Kind: Entry
-              Type: 644 EventRootType Probe[main.mapIndexKeyLen48]
-              InjectionPoints: [{PC: "0xcd6e8", Frameless: false}]
+              Type: 653 EventRootType Probe[main.mapIndexKeyLen48]
+              InjectionPoints: [{PC: "0xcdb18", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 645 EventRootType Probe[main.mapIndexKeyLen48]Return
-              InjectionPoints: [{PC: "0xcd730", Frameless: false}]
+              Type: 654 EventRootType Probe[main.mapIndexKeyLen48]Return
+              InjectionPoints: [{PC: "0xcdb60", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen8
       version: 0
@@ -5023,15 +5335,15 @@ Probes:
             dsl: m["0000002a"]
             json: {index: [{ref: m}, 0000002a]}
       instances:
-        - subprogram: {subprogram: 58}
+        - subprogram: {subprogram: 60}
           events:
             - Kind: Entry
-              Type: 640 EventRootType Probe[main.mapIndexKeyLen8]
-              InjectionPoints: [{PC: "0xcd5e8", Frameless: false}]
+              Type: 649 EventRootType Probe[main.mapIndexKeyLen8]
+              InjectionPoints: [{PC: "0xcda18", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 641 EventRootType Probe[main.mapIndexKeyLen8]Return
-              InjectionPoints: [{PC: "0xcd630", Frameless: false}]
+              Type: 650 EventRootType Probe[main.mapIndexKeyLen8]Return
+              InjectionPoints: [{PC: "0xcda60", Frameless: false}]
               Condition: null
     - id: mapIndex_keyLen96
       version: 0
@@ -5053,15 +5365,15 @@ Probes:
                     - ref: m
                     - 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002a
       instances:
-        - subprogram: {subprogram: 61}
+        - subprogram: {subprogram: 63}
           events:
             - Kind: Entry
-              Type: 646 EventRootType Probe[main.mapIndexKeyLen96]
-              InjectionPoints: [{PC: "0xcd768", Frameless: false}]
+              Type: 655 EventRootType Probe[main.mapIndexKeyLen96]
+              InjectionPoints: [{PC: "0xcdb98", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 647 EventRootType Probe[main.mapIndexKeyLen96]Return
-              InjectionPoints: [{PC: "0xcd7b0", Frameless: false}]
+              Type: 656 EventRootType Probe[main.mapIndexKeyLen96]Return
+              InjectionPoints: [{PC: "0xcdbe0", Frameless: false}]
               Condition: null
     - id: mapIndex_largeMap_capture
       version: 0
@@ -5080,15 +5392,15 @@ Probes:
             dsl: m["key42"]
             json: {index: [{ref: m}, key42]}
       instances:
-        - subprogram: {subprogram: 56}
+        - subprogram: {subprogram: 58}
           events:
             - Kind: Entry
-              Type: 636 EventRootType Probe[main.mapIndexLargeMap]
-              InjectionPoints: [{PC: "0xcd3f8", Frameless: false}]
+              Type: 645 EventRootType Probe[main.mapIndexLargeMap]
+              InjectionPoints: [{PC: "0xcd828", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 637 EventRootType Probe[main.mapIndexLargeMap]Return
-              InjectionPoints: [{PC: "0xcd440", Frameless: false}]
+              Type: 646 EventRootType Probe[main.mapIndexLargeMap]Return
+              InjectionPoints: [{PC: "0xcd870", Frameless: false}]
               Condition: null
     - id: mapIndex_largeValue_capture
       version: 0
@@ -5107,15 +5419,15 @@ Probes:
             dsl: m["k"].Val
             json: {getmember: [{index: [{ref: m}, k]}, Val]}
       instances:
-        - subprogram: {subprogram: 71}
+        - subprogram: {subprogram: 73}
           events:
             - Kind: Entry
-              Type: 672 EventRootType Probe[main.mapIndexLargeValue]
-              InjectionPoints: [{PC: "0xcdc68", Frameless: false}]
+              Type: 681 EventRootType Probe[main.mapIndexLargeValue]
+              InjectionPoints: [{PC: "0xce098", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 673 EventRootType Probe[main.mapIndexLargeValue]Return
-              InjectionPoints: [{PC: "0xcdcb8", Frameless: false}]
+              Type: 682 EventRootType Probe[main.mapIndexLargeValue]Return
+              InjectionPoints: [{PC: "0xce0e8", Frameless: false}]
               Condition: null
     - id: mapIndex_missing_capture
       version: 0
@@ -5134,15 +5446,15 @@ Probes:
             dsl: m["missing"]
             json: {index: [{ref: m}, missing]}
       instances:
-        - subprogram: {subprogram: 57}
+        - subprogram: {subprogram: 59}
           events:
             - Kind: Entry
-              Type: 638 EventRootType Probe[main.mapIndexMissing]
-              InjectionPoints: [{PC: "0xcd478", Frameless: false}]
+              Type: 647 EventRootType Probe[main.mapIndexMissing]
+              InjectionPoints: [{PC: "0xcd8a8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 639 EventRootType Probe[main.mapIndexMissing]Return
-              InjectionPoints: [{PC: "0xcd4a4", Frameless: false}]
+              Type: 648 EventRootType Probe[main.mapIndexMissing]Return
+              InjectionPoints: [{PC: "0xcd8d4", Frameless: false}]
               Condition: null
     - id: mapIndex_nilPtrVal_capture
       version: 0
@@ -5161,15 +5473,15 @@ Probes:
             dsl: m["nil_key"].Val
             json: {getmember: [{index: [{ref: m}, nil_key]}, Val]}
       instances:
-        - subprogram: {subprogram: 70}
+        - subprogram: {subprogram: 72}
           events:
             - Kind: Entry
-              Type: 670 EventRootType Probe[main.mapIndexNilPtrVal]
-              InjectionPoints: [{PC: "0xcdbf8", Frameless: false}]
+              Type: 679 EventRootType Probe[main.mapIndexNilPtrVal]
+              InjectionPoints: [{PC: "0xce028", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 671 EventRootType Probe[main.mapIndexNilPtrVal]Return
-              InjectionPoints: [{PC: "0xcdc24", Frameless: false}]
+              Type: 680 EventRootType Probe[main.mapIndexNilPtrVal]Return
+              InjectionPoints: [{PC: "0xce054", Frameless: false}]
               Condition: null
     - id: mapIndex_ptrStructVal_capture_int
       version: 0
@@ -5188,15 +5500,15 @@ Probes:
             dsl: m["x"].Val
             json: {getmember: [{index: [{ref: m}, x]}, Val]}
       instances:
-        - subprogram: {subprogram: 64}
+        - subprogram: {subprogram: 66}
           events:
             - Kind: Entry
-              Type: 654 EventRootType Probe[main.mapIndexPtrStructVal]
-              InjectionPoints: [{PC: "0xcd8f8", Frameless: false}]
+              Type: 663 EventRootType Probe[main.mapIndexPtrStructVal]
+              InjectionPoints: [{PC: "0xcdd28", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 655 EventRootType Probe[main.mapIndexPtrStructVal]Return
-              InjectionPoints: [{PC: "0xcd950", Frameless: false}]
+              Type: 664 EventRootType Probe[main.mapIndexPtrStructVal]Return
+              InjectionPoints: [{PC: "0xcdd80", Frameless: false}]
               Condition: null
     - id: mapIndex_ptrStructVal_capture_string
       version: 0
@@ -5215,15 +5527,15 @@ Probes:
             dsl: m["y"].Txt
             json: {getmember: [{index: [{ref: m}, "y"]}, Txt]}
       instances:
-        - subprogram: {subprogram: 64}
+        - subprogram: {subprogram: 66}
           events:
             - Kind: Entry
-              Type: 656 EventRootType Probe[main.mapIndexPtrStructVal]
-              InjectionPoints: [{PC: "0xcd8f8", Frameless: false}]
+              Type: 665 EventRootType Probe[main.mapIndexPtrStructVal]
+              InjectionPoints: [{PC: "0xcdd28", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 657 EventRootType Probe[main.mapIndexPtrStructVal]Return
-              InjectionPoints: [{PC: "0xcd950", Frameless: false}]
+              Type: 666 EventRootType Probe[main.mapIndexPtrStructVal]Return
+              InjectionPoints: [{PC: "0xcdd80", Frameless: false}]
               Condition: null
     - id: mapIndex_stringKey_capture
       version: 0
@@ -5242,15 +5554,15 @@ Probes:
             dsl: m["beta"]
             json: {index: [{ref: m}, beta]}
       instances:
-        - subprogram: {subprogram: 55}
+        - subprogram: {subprogram: 57}
           events:
             - Kind: Entry
-              Type: 630 EventRootType Probe[main.mapIndexStringKey]
-              InjectionPoints: [{PC: "0xcd388", Frameless: false}]
+              Type: 639 EventRootType Probe[main.mapIndexStringKey]
+              InjectionPoints: [{PC: "0xcd7b8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 631 EventRootType Probe[main.mapIndexStringKey]Return
-              InjectionPoints: [{PC: "0xcd3b4", Frameless: false}]
+              Type: 640 EventRootType Probe[main.mapIndexStringKey]Return
+              InjectionPoints: [{PC: "0xcd7e4", Frameless: false}]
               Condition: null
     - id: mapIndex_stringKey_cond
       version: 0
@@ -5267,16 +5579,16 @@ Probes:
       segments: [matched]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 55}
+        - subprogram: {subprogram: 57}
           events:
             - Kind: Entry
-              Type: 632 EventRootType Probe[main.mapIndexStringKey]
-              InjectionPoints: [{PC: "0xcd388", Frameless: false}]
+              Type: 641 EventRootType Probe[main.mapIndexStringKey]
+              InjectionPoints: [{PC: "0xcd7b8", Frameless: false}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 55, index: 0, name: m}
+                      Variable: {subprogram: 57, index: 0, name: m}
                       Offset: 0
                       ByteSize: 8
                     - __kind: DereferenceOp
@@ -5309,8 +5621,8 @@ Probes:
                       ByteSize: 8
                     - __kind: ConditionCheckOp
             - Kind: Return
-              Type: 633 EventRootType Probe[main.mapIndexStringKey]Return
-              InjectionPoints: [{PC: "0xcd3b4", Frameless: false}]
+              Type: 642 EventRootType Probe[main.mapIndexStringKey]Return
+              InjectionPoints: [{PC: "0xcd7e4", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: matched, Segments: [matched]}
     - id: mapIndex_stringKey_template
@@ -5328,15 +5640,15 @@ Probes:
           dsl: m["beta"]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 55}
+        - subprogram: {subprogram: 57}
           events:
             - Kind: Entry
-              Type: 634 EventRootType Probe[main.mapIndexStringKey]
-              InjectionPoints: [{PC: "0xcd388", Frameless: false}]
+              Type: 643 EventRootType Probe[main.mapIndexStringKey]
+              InjectionPoints: [{PC: "0xcd7b8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 635 EventRootType Probe[main.mapIndexStringKey]Return
-              InjectionPoints: [{PC: "0xcd3b4", Frameless: false}]
+              Type: 644 EventRootType Probe[main.mapIndexStringKey]Return
+              InjectionPoints: [{PC: "0xcd7e4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: beta={m["beta"]}
@@ -5363,15 +5675,15 @@ Probes:
             dsl: m["a"].Val
             json: {getmember: [{index: [{ref: m}, a]}, Val]}
       instances:
-        - subprogram: {subprogram: 63}
+        - subprogram: {subprogram: 65}
           events:
             - Kind: Entry
-              Type: 650 EventRootType Probe[main.mapIndexStructVal]
-              InjectionPoints: [{PC: "0xcd868", Frameless: false}]
+              Type: 659 EventRootType Probe[main.mapIndexStructVal]
+              InjectionPoints: [{PC: "0xcdc98", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 651 EventRootType Probe[main.mapIndexStructVal]Return
-              InjectionPoints: [{PC: "0xcd8bc", Frameless: false}]
+              Type: 660 EventRootType Probe[main.mapIndexStructVal]Return
+              InjectionPoints: [{PC: "0xcdcec", Frameless: false}]
               Condition: null
     - id: mapIndex_structVal_capture_string
       version: 0
@@ -5390,15 +5702,15 @@ Probes:
             dsl: m["b"].Txt
             json: {getmember: [{index: [{ref: m}, b]}, Txt]}
       instances:
-        - subprogram: {subprogram: 63}
+        - subprogram: {subprogram: 65}
           events:
             - Kind: Entry
-              Type: 652 EventRootType Probe[main.mapIndexStructVal]
-              InjectionPoints: [{PC: "0xcd868", Frameless: false}]
+              Type: 661 EventRootType Probe[main.mapIndexStructVal]
+              InjectionPoints: [{PC: "0xcdc98", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 653 EventRootType Probe[main.mapIndexStructVal]Return
-              InjectionPoints: [{PC: "0xcd8bc", Frameless: false}]
+              Type: 662 EventRootType Probe[main.mapIndexStructVal]Return
+              InjectionPoints: [{PC: "0xcdcec", Frameless: false}]
               Condition: null
     - id: mapIndex_zeroValue_capture
       version: 0
@@ -5417,15 +5729,15 @@ Probes:
             dsl: m["zero"]
             json: {index: [{ref: m}, zero]}
       instances:
-        - subprogram: {subprogram: 69}
+        - subprogram: {subprogram: 71}
           events:
             - Kind: Entry
-              Type: 668 EventRootType Probe[main.mapIndexZeroValue]
-              InjectionPoints: [{PC: "0xcdb88", Frameless: false}]
+              Type: 677 EventRootType Probe[main.mapIndexZeroValue]
+              InjectionPoints: [{PC: "0xcdfb8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 669 EventRootType Probe[main.mapIndexZeroValue]Return
-              InjectionPoints: [{PC: "0xcdbb4", Frameless: false}]
+              Type: 678 EventRootType Probe[main.mapIndexZeroValue]Return
+              InjectionPoints: [{PC: "0xcdfe4", Frameless: false}]
               Condition: null
     - id: noArgs
       version: 0
@@ -5439,11 +5751,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 383 EventRootType Probe[main.noArgs]
-              InjectionPoints: [{PC: "0xcb0a8", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb2e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 384 EventRootType Probe[main.noArgs]Return
-              InjectionPoints: [{PC: "0xcb0dc", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb31c", Frameless: false}]
               Condition: null
     - id: stringArg
       version: 0
@@ -5457,11 +5769,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 344 EventRootType Probe[main.stringArg]
-              InjectionPoints: [{PC: "0xcac88", Frameless: false}]
+              InjectionPoints: [{PC: "0xcaec8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 345 EventRootType Probe[main.stringArg]Return
-              InjectionPoints: [{PC: "0xcacc0", Frameless: false}]
+              InjectionPoints: [{PC: "0xcaf00", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: 's: {s}'
@@ -5483,11 +5795,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 376 EventRootType Probe[main.stringArrayArg]
-              InjectionPoints: [{PC: "0xcae68", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb0a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 377 EventRootType Probe[main.stringArrayArg]Return
-              InjectionPoints: [{PC: "0xcaea8", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb0e8", Frameless: false}]
               Condition: null
     - id: stringSliceArg
       version: 0
@@ -5501,11 +5813,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 372 EventRootType Probe[main.stringSliceArg]
-              InjectionPoints: [{PC: "0xcade8", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb028", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 373 EventRootType Probe[main.stringSliceArg]Return
-              InjectionPoints: [{PC: "0xcae20", Frameless: false}]
+              InjectionPoints: [{PC: "0xcb060", Frameless: false}]
               Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
       version: 0
@@ -5516,39 +5828,39 @@ Probes:
       segments: []
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 46}
+        - subprogram: {subprogram: 48}
           events:
             - Kind: Entry
-              Type: 592 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
-              InjectionPoints: [{PC: "0xccca0", Frameless: false}]
+              Type: 601 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+              InjectionPoints: [{PC: "0xcd0d0", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 593 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
-              InjectionPoints: [{PC: "0xcce1c", Frameless: false}]
+              Type: 602 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+              InjectionPoints: [{PC: "0xcd24c", Frameless: false}]
               Condition: null
 Subprograms:
     - ID: 1
       Name: main.intArg
-      OutOfLinePCRanges: [0xcac00..0xcac70]
+      OutOfLinePCRanges: [0xcae40..0xcaeb0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcac00..0xcac20
+            - Range: 0xcae40..0xcae60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 2
       Name: main.stringArg
-      OutOfLinePCRanges: [0xcac70..0xcace0]
+      OutOfLinePCRanges: [0xcaeb0..0xcaf20]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcac70..0xcac94
+            - Range: 0xcaeb0..0xcaed4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -5559,13 +5871,13 @@ Subprograms:
       DictRegister: null
     - ID: 3
       Name: main.intSliceArg
-      OutOfLinePCRanges: [0xcace0..0xcad60]
+      OutOfLinePCRanges: [0xcaf20..0xcafa0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 112 GoSliceHeaderType []int
           Locations:
-            - Range: 0xcace0..0xcad04
+            - Range: 0xcaf20..0xcaf44
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -5578,26 +5890,26 @@ Subprograms:
       DictRegister: null
     - ID: 4
       Name: main.intArrayArg
-      OutOfLinePCRanges: [0xcad60..0xcadd0]
+      OutOfLinePCRanges: [0xcafa0..0xcb010]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 113 ArrayType [3]int
           Locations:
-            - Range: 0xcad60..0xcadd0
+            - Range: 0xcafa0..0xcb010
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 5
       Name: main.stringSliceArg
-      OutOfLinePCRanges: [0xcadd0..0xcae50]
+      OutOfLinePCRanges: [0xcb010..0xcb090]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 114 GoSliceHeaderType []string
           Locations:
-            - Range: 0xcadd0..0xcadf4
+            - Range: 0xcb010..0xcb034
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -5610,86 +5922,86 @@ Subprograms:
       DictRegister: null
     - ID: 6
       Name: main.stringArrayArg
-      OutOfLinePCRanges: [0xcae50..0xcaec0]
+      OutOfLinePCRanges: [0xcb090..0xcb100]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 115 ArrayType [3]string
           Locations:
-            - Range: 0xcae50..0xcaec0
+            - Range: 0xcb090..0xcb100
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 7
       Name: main.stringArrayArgFrameless
-      OutOfLinePCRanges: [0xcaec0..0xcaed0]
+      OutOfLinePCRanges: [0xcb100..0xcb110]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 115 ArrayType [3]string
           Locations:
-            - Range: 0xcaec0..0xcaed0
+            - Range: 0xcb100..0xcb110
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 8
       Name: main.mapArg
-      OutOfLinePCRanges: [0xcaf90..0xcb000]
+      OutOfLinePCRanges: [0xcb1d0..0xcb240]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 116 GoMapType map[string]int
           Locations:
-            - Range: 0xcaf90..0xcafc4
+            - Range: 0xcb1d0..0xcb204
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 9
       Name: main.bigMapArg
-      OutOfLinePCRanges: [0xcb000..0xcb090]
+      OutOfLinePCRanges: [0xcb240..0xcb2d0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 121 GoMapType map[string]main.bigStruct
           Locations:
-            - Range: 0xcb000..0xcb030
+            - Range: 0xcb240..0xcb270
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcb030..0xcb090
+            - Range: 0xcb270..0xcb2d0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 10
       Name: main.noArgs
-      OutOfLinePCRanges: [0xcb090..0xcb100]
+      OutOfLinePCRanges: [0xcb2d0..0xcb340]
       InlinePCRanges: []
       Variables: []
       DictRegister: null
     - ID: 11
       Name: main.condInt8
-      OutOfLinePCRanges: [0xcb100..0xcb1b0]
+      OutOfLinePCRanges: [0xcb340..0xcb3f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 19 BaseType int8
           Locations:
-            - Range: 0xcb100..0xcb148
+            - Range: 0xcb340..0xcb388
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcb100..0xcb14c
+            - Range: 0xcb340..0xcb38c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcb14c..0xcb150
+            - Range: 0xcb38c..0xcb390
               Pieces:
                 - Size: 8
                   Op: null
@@ -5700,32 +6012,32 @@ Subprograms:
       DictRegister: null
     - ID: 12
       Name: main.condInt16
-      OutOfLinePCRanges: [0xcb1b0..0xcb250]
+      OutOfLinePCRanges: [0xcb3f0..0xcb490]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 102 BaseType int16
           Locations:
-            - Range: 0xcb1b0..0xcb1e0
+            - Range: 0xcb3f0..0xcb420
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcb1b0..0xcb1d4
+            - Range: 0xcb3f0..0xcb414
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcb1d4..0xcb1e0
+            - Range: 0xcb414..0xcb420
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xcb1e0..0xcb250
+            - Range: 0xcb420..0xcb490
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -5736,32 +6048,32 @@ Subprograms:
       DictRegister: null
     - ID: 13
       Name: main.condInt32
-      OutOfLinePCRanges: [0xcb250..0xcb2f0]
+      OutOfLinePCRanges: [0xcb490..0xcb530]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType int32
           Locations:
-            - Range: 0xcb250..0xcb280
+            - Range: 0xcb490..0xcb4c0
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcb250..0xcb274
+            - Range: 0xcb490..0xcb4b4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcb274..0xcb280
+            - Range: 0xcb4b4..0xcb4c0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xcb280..0xcb2f0
+            - Range: 0xcb4c0..0xcb530
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -5772,32 +6084,32 @@ Subprograms:
       DictRegister: null
     - ID: 14
       Name: main.condInt64
-      OutOfLinePCRanges: [0xcb2f0..0xcb390]
+      OutOfLinePCRanges: [0xcb530..0xcb5d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType int64
           Locations:
-            - Range: 0xcb2f0..0xcb320
+            - Range: 0xcb530..0xcb560
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcb2f0..0xcb314
+            - Range: 0xcb530..0xcb554
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcb314..0xcb320
+            - Range: 0xcb554..0xcb560
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xcb320..0xcb390
+            - Range: 0xcb560..0xcb5d0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -5808,26 +6120,26 @@ Subprograms:
       DictRegister: null
     - ID: 15
       Name: main.condUint8
-      OutOfLinePCRanges: [0xcb390..0xcb440]
+      OutOfLinePCRanges: [0xcb5d0..0xcb680]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcb390..0xcb3d8
+            - Range: 0xcb5d0..0xcb618
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcb390..0xcb3dc
+            - Range: 0xcb5d0..0xcb61c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcb3dc..0xcb3e0
+            - Range: 0xcb61c..0xcb620
               Pieces:
                 - Size: 8
                   Op: null
@@ -5838,32 +6150,32 @@ Subprograms:
       DictRegister: null
     - ID: 16
       Name: main.condUint16
-      OutOfLinePCRanges: [0xcb440..0xcb4e0]
+      OutOfLinePCRanges: [0xcb680..0xcb720]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0xcb440..0xcb470
+            - Range: 0xcb680..0xcb6b0
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcb440..0xcb464
+            - Range: 0xcb680..0xcb6a4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcb464..0xcb470
+            - Range: 0xcb6a4..0xcb6b0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xcb470..0xcb4e0
+            - Range: 0xcb6b0..0xcb720
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -5874,32 +6186,32 @@ Subprograms:
       DictRegister: null
     - ID: 17
       Name: main.condUint32
-      OutOfLinePCRanges: [0xcb4e0..0xcb580]
+      OutOfLinePCRanges: [0xcb720..0xcb7c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0xcb4e0..0xcb510
+            - Range: 0xcb720..0xcb750
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcb4e0..0xcb504
+            - Range: 0xcb720..0xcb744
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcb504..0xcb510
+            - Range: 0xcb744..0xcb750
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xcb510..0xcb580
+            - Range: 0xcb750..0xcb7c0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -5910,32 +6222,32 @@ Subprograms:
       DictRegister: null
     - ID: 18
       Name: main.condUint64
-      OutOfLinePCRanges: [0xcb580..0xcb620]
+      OutOfLinePCRanges: [0xcb7c0..0xcb860]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0xcb580..0xcb5b0
+            - Range: 0xcb7c0..0xcb7f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcb580..0xcb5a4
+            - Range: 0xcb7c0..0xcb7e4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcb5a4..0xcb5b0
+            - Range: 0xcb7e4..0xcb7f0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xcb5b0..0xcb620
+            - Range: 0xcb7f0..0xcb860
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -5946,32 +6258,32 @@ Subprograms:
       DictRegister: null
     - ID: 19
       Name: main.condFloat32
-      OutOfLinePCRanges: [0xcb620..0xcb6c0]
+      OutOfLinePCRanges: [0xcb860..0xcb900]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType float32
           Locations:
-            - Range: 0xcb620..0xcb654
+            - Range: 0xcb860..0xcb894
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcb620..0xcb644
+            - Range: 0xcb860..0xcb884
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xcb644..0xcb650
+            - Range: 0xcb884..0xcb890
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xcb650..0xcb6c0
+            - Range: 0xcb890..0xcb900
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -5982,32 +6294,32 @@ Subprograms:
       DictRegister: null
     - ID: 20
       Name: main.condFloat64
-      OutOfLinePCRanges: [0xcb6c0..0xcb760]
+      OutOfLinePCRanges: [0xcb900..0xcb9a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 BaseType float64
           Locations:
-            - Range: 0xcb6c0..0xcb6f4
+            - Range: 0xcb900..0xcb934
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcb6c0..0xcb6e4
+            - Range: 0xcb900..0xcb924
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xcb6e4..0xcb6f0
+            - Range: 0xcb924..0xcb930
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xcb6f0..0xcb760
+            - Range: 0xcb930..0xcb9a0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -6018,26 +6330,26 @@ Subprograms:
       DictRegister: null
     - ID: 21
       Name: main.condBool
-      OutOfLinePCRanges: [0xcb760..0xcb810]
+      OutOfLinePCRanges: [0xcb9a0..0xcba50]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcb760..0xcb7a8
+            - Range: 0xcb9a0..0xcb9e8
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcb760..0xcb7ac
+            - Range: 0xcb9a0..0xcb9ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcb7ac..0xcb7b0
+            - Range: 0xcb9ec..0xcb9f0
               Pieces:
                 - Size: 8
                   Op: null
@@ -6048,13 +6360,13 @@ Subprograms:
       DictRegister: null
     - ID: 22
       Name: main.condString
-      OutOfLinePCRanges: [0xcb810..0xcb8b0]
+      OutOfLinePCRanges: [0xcba50..0xcbaf0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcb810..0xcb844
+            - Range: 0xcba50..0xcba84
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6065,19 +6377,19 @@ Subprograms:
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcb810..0xcb838
+            - Range: 0xcba50..0xcba78
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcb838..0xcb844
+            - Range: 0xcba78..0xcba84
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: {CfaOffset: 32}
-            - Range: 0xcb844..0xcb8b0
+            - Range: 0xcba84..0xcbaf0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
@@ -6088,32 +6400,32 @@ Subprograms:
       DictRegister: null
     - ID: 23
       Name: main.condStructArg
-      OutOfLinePCRanges: [0xcb8b0..0xcb9a0]
+      OutOfLinePCRanges: [0xcbaf0..0xcbbe0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 126 StructureType main.condFields
           Locations:
-            - Range: 0xcb8b0..0xcb9a0
+            - Range: 0xcbaf0..0xcbbe0
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcb8b0..0xcb8d8
+            - Range: 0xcbaf0..0xcbb18
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xcb8d8..0xcb8f0
+            - Range: 0xcbb18..0xcbb30
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 88}
                 - Size: 8
                   Op: {CfaOffset: 96}
-            - Range: 0xcb8f0..0xcb9a0
+            - Range: 0xcbb30..0xcbbe0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 88}
@@ -6124,34 +6436,34 @@ Subprograms:
       DictRegister: null
     - ID: 24
       Name: main.condPtrStructArg
-      OutOfLinePCRanges: [0xcb9a0..0xcbab0]
+      OutOfLinePCRanges: [0xcbbe0..0xcbcf0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 128 PointerType *main.condFields
           Locations:
-            - Range: 0xcb9a0..0xcb9e4
+            - Range: 0xcbbe0..0xcbc24
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcb9e4..0xcbab0
+            - Range: 0xcbc24..0xcbcf0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcb9a0..0xcb9cc
+            - Range: 0xcbbe0..0xcbc0c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcb9cc..0xcb9e8
+            - Range: 0xcbc0c..0xcbc28
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xcb9e8..0xcbab0
+            - Range: 0xcbc28..0xcbcf0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -6162,26 +6474,26 @@ Subprograms:
       DictRegister: null
     - ID: 25
       Name: main.condNilPtrStruct
-      OutOfLinePCRanges: [0xcbab0..0xcbb60]
+      OutOfLinePCRanges: [0xcbcf0..0xcbda0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 128 PointerType *main.condFields
           Locations:
-            - Range: 0xcbab0..0xcbb00
+            - Range: 0xcbcf0..0xcbd40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcbab0..0xcbb04
+            - Range: 0xcbcf0..0xcbd44
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcbb04..0xcbb08
+            - Range: 0xcbd44..0xcbd48
               Pieces:
                 - Size: 8
                   Op: null
@@ -6192,72 +6504,72 @@ Subprograms:
       DictRegister: null
     - ID: 26
       Name: main.condReturnAndLocal
-      OutOfLinePCRanges: [0xcbb60..0xcbc00]
+      OutOfLinePCRanges: [0xcbda0..0xcbe40]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcbb60..0xcbb7c
+            - Range: 0xcbda0..0xcbdbc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcbb60..0xcbb84
+            - Range: 0xcbda0..0xcbdc4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcbb60..0xcbbd4
+            - Range: 0xcbda0..0xcbe14
               Pieces: []
-            - Range: 0xcbbd4..0xcbbd5
+            - Range: 0xcbe14..0xcbe15
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcbbd5..0xcbc00
+            - Range: 0xcbe15..0xcbe40
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: sum
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcbb7c..0xcbba4
+            - Range: 0xcbdbc..0xcbde4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcbba4..0xcbc00
+            - Range: 0xcbde4..0xcbe40
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 27
       Name: main.condOnly
-      OutOfLinePCRanges: [0xcbc00..0xcbca0]
+      OutOfLinePCRanges: [0xcbe40..0xcbee0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcbc00..0xcbc30
+            - Range: 0xcbe40..0xcbe70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcbc00..0xcbc24
+            - Range: 0xcbe40..0xcbe64
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcbc24..0xcbc30
+            - Range: 0xcbe64..0xcbe70
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xcbc30..0xcbca0
+            - Range: 0xcbe70..0xcbee0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -6268,34 +6580,34 @@ Subprograms:
       DictRegister: null
     - ID: 28
       Name: main.condLine
-      OutOfLinePCRanges: [0xcbca0..0xcbd60]
+      OutOfLinePCRanges: [0xcbee0..0xcbfa0]
       InlinePCRanges: []
       Variables:
         - Name: "n"
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcbca0..0xcbcc8
+            - Range: 0xcbee0..0xcbf08
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcbcc8..0xcbd60
+            - Range: 0xcbf08..0xcbfa0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcbca0..0xcbccc
+            - Range: 0xcbee0..0xcbf0c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcbccc..0xcbcdc
+            - Range: 0xcbf0c..0xcbf1c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xcbcdc..0xcbd60
+            - Range: 0xcbf1c..0xcbfa0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -6306,20 +6618,122 @@ Subprograms:
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcbcc8..0xcbcdc
+            - Range: 0xcbf08..0xcbf1c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 29
+      Name: main.condLineMixed
+      OutOfLinePCRanges: [0xcbfa0..0xcc110]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcbfa0..0xcc000
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0xcc000..0xcc004
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 88}
+                - Size: 8
+                  Op: {CfaOffset: 96}
+            - Range: 0xcc004..0xcc110
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 88}
+                - Size: 8
+                  Op: {CfaOffset: 96}
+          Role: Parameter
+          DictIndex: -1
+        - Name: b
+          Type: 4 BaseType bool
+          Locations:
+            - Range: 0xcbfa0..0xcbfdc
+              Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xcbfdc..0xcc110
+              Pieces: [{Size: 1, Op: {CfaOffset: 104}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: x
+          Type: 126 StructureType main.condFields
+          Locations:
+            - Range: 0xcbfa0..0xcc110
+              Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: p
+          Type: 128 PointerType *main.condFields
+          Locations:
+            - Range: 0xcbfa0..0xcc004
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xcc004..0xcc110
+              Pieces: [{Size: 8, Op: {CfaOffset: 112}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: ss
+          Type: 112 GoSliceHeaderType []int
+          Locations:
+            - Range: 0xcbfa0..0xcc004
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+            - Range: 0xcc004..0xcc110
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 120}
+                - Size: 8
+                  Op: {CfaOffset: 128}
+                - Size: 8
+                  Op: {CfaOffset: 136}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 30
+      Name: main.condLineReturn
+      OutOfLinePCRanges: [0xcc110..0xcc190]
+      InlinePCRanges: []
+      Variables:
+        - Name: "n"
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcc110..0xcc12c
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations: [{Range: 0xcc110..0xcc190, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: doubled
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcc12c..0xcc138
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcc138..0xcc190
+              Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
+          Role: Local
+          DictIndex: -1
+      DictRegister: null
+    - ID: 31
       Name: main.condSliceArg
-      OutOfLinePCRanges: [0xcbd60..0xcbe10]
+      OutOfLinePCRanges: [0xcc190..0xcc240]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 112 GoSliceHeaderType []int
           Locations:
-            - Range: 0xcbd60..0xcbd94
+            - Range: 0xcc190..0xcc1c4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6332,19 +6746,19 @@ Subprograms:
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcbd60..0xcbd88
+            - Range: 0xcc190..0xcc1b8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
-            - Range: 0xcbd88..0xcbd94
+            - Range: 0xcc1b8..0xcc1c4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
                 - Size: 8
                   Op: {CfaOffset: 40}
-            - Range: 0xcbd94..0xcbe10
+            - Range: 0xcc1c4..0xcc240
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
@@ -6353,28 +6767,28 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 30
+    - ID: 32
       Name: main.condMapArg
-      OutOfLinePCRanges: [0xcbe10..0xcbeb0]
+      OutOfLinePCRanges: [0xcc240..0xcc2e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 116 GoMapType map[string]int
           Locations:
-            - Range: 0xcbe10..0xcbe48
+            - Range: 0xcc240..0xcc278
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcbe10..0xcbe4c
+            - Range: 0xcc240..0xcc27c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcbe4c..0xcbe50
+            - Range: 0xcc27c..0xcc280
               Pieces:
                 - Size: 8
                   Op: null
@@ -6383,34 +6797,34 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 31
+    - ID: 33
       Name: main.condStructDirect
-      OutOfLinePCRanges: [0xcbeb0..0xcbf50]
+      OutOfLinePCRanges: [0xcc2e0..0xcc380]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 126 StructureType main.condFields
           Locations:
-            - Range: 0xcbeb0..0xcbf50
+            - Range: 0xcc2e0..0xcc380
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcbeb0..0xcbee4
+            - Range: 0xcc2e0..0xcc314
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xcbee4..0xcbee8
+            - Range: 0xcc314..0xcc318
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 88}
                 - Size: 8
                   Op: {CfaOffset: 96}
-            - Range: 0xcbee8..0xcbf50
+            - Range: 0xcc318..0xcc380
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 88}
@@ -6419,140 +6833,36 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 32
+    - ID: 34
       Name: main.condNullPtr
-      OutOfLinePCRanges: [0xcbf50..0xcc030]
+      OutOfLinePCRanges: [0xcc380..0xcc460]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 105 PointerType *int
           Locations:
-            - Range: 0xcbf50..0xcbf9c
+            - Range: 0xcc380..0xcc3cc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcbf9c..0xcc030
+            - Range: 0xcc3cc..0xcc460
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcbf50..0xcbfa0
+            - Range: 0xcc380..0xcc3d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcbfa0..0xcbfa4
+            - Range: 0xcc3d0..0xcc3d4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xcbfa4..0xcc030
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 16}
-                - Size: 8
-                  Op: {CfaOffset: 24}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 33
-      Name: main.condNullSlice
-      OutOfLinePCRanges: [0xcc030..0xcc130]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 112 GoSliceHeaderType []int
-          Locations:
-            - Range: 0xcc030..0xcc090
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcc090..0xcc094
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-                - Size: 8
-                  Op: {CfaOffset: 24}
-            - Range: 0xcc094..0xcc098
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-                - Size: 8
-                  Op: {CfaOffset: 24}
-            - Range: 0xcc098..0xcc130
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 8}
-                - Size: 8
-                  Op: {CfaOffset: 16}
-                - Size: 8
-                  Op: {CfaOffset: 24}
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xcc030..0xcc084
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-            - Range: 0xcc084..0xcc088
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 32}
-                - Size: 8
-                  Op: {CfaOffset: 40}
-            - Range: 0xcc088..0xcc130
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 32}
-                - Size: 8
-                  Op: {CfaOffset: 40}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 34
-      Name: main.condNullMap
-      OutOfLinePCRanges: [0xcc130..0xcc210]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 116 GoMapType map[string]int
-          Locations:
-            - Range: 0xcc130..0xcc17c
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcc17c..0xcc210
-              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xcc130..0xcc180
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcc180..0xcc184
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 16}
-                - Size: 8
-                  Op: {CfaOffset: 24}
-            - Range: 0xcc184..0xcc210
+            - Range: 0xcc3d4..0xcc460
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -6562,87 +6872,101 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 35
-      Name: main.condNullIface
-      OutOfLinePCRanges: [0xcc210..0xcc310]
+      Name: main.condNullSlice
+      OutOfLinePCRanges: [0xcc460..0xcc560]
       InlinePCRanges: []
       Variables:
-        - Name: i
-          Type: 15 GoInterfaceType error
+        - Name: s
+          Type: 112 GoSliceHeaderType []int
           Locations:
-            - Range: 0xcc210..0xcc27c
+            - Range: 0xcc460..0xcc4c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xcc27c..0xcc280
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xcc4c0..0xcc4c4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0xcc280..0xcc310
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0xcc4c4..0xcc4c8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0xcc4c8..0xcc560
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcc210..0xcc270
+            - Range: 0xcc460..0xcc4b4
               Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcc270..0xcc284
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+            - Range: 0xcc4b4..0xcc4b8
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 24}
-                - Size: 8
                   Op: {CfaOffset: 32}
-            - Range: 0xcc284..0xcc310
+                - Size: 8
+                  Op: {CfaOffset: 40}
+            - Range: 0xcc4b8..0xcc560
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 24}
-                - Size: 8
                   Op: {CfaOffset: 32}
+                - Size: 8
+                  Op: {CfaOffset: 40}
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 36
-      Name: main.condNullUnsafePtr
-      OutOfLinePCRanges: [0xcc310..0xcc3f0]
+      Name: main.condNullMap
+      OutOfLinePCRanges: [0xcc560..0xcc640]
       InlinePCRanges: []
       Variables:
-        - Name: p
-          Type: 16 VoidPointerType unsafe.Pointer
+        - Name: m
+          Type: 116 GoMapType map[string]int
           Locations:
-            - Range: 0xcc310..0xcc35c
+            - Range: 0xcc560..0xcc5ac
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcc35c..0xcc3f0
+            - Range: 0xcc5ac..0xcc640
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcc310..0xcc360
+            - Range: 0xcc560..0xcc5b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcc360..0xcc364
+            - Range: 0xcc5b0..0xcc5b4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xcc364..0xcc3f0
+            - Range: 0xcc5b4..0xcc640
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -6652,41 +6976,49 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 37
-      Name: main.lenString
-      OutOfLinePCRanges: [0xcc400..0xcc4e0]
+      Name: main.condNullIface
+      OutOfLinePCRanges: [0xcc640..0xcc740]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 9 GoStringHeaderType string
+        - Name: i
+          Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0xcc400..0xcc450
+            - Range: 0xcc640..0xcc6ac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xcc450..0xcc454
-              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0xcc454..0xcc4e0
-              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
+            - Range: 0xcc6ac..0xcc6b0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0xcc6b0..0xcc740
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcc400..0xcc448
+            - Range: 0xcc640..0xcc6a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcc448..0xcc458
+            - Range: 0xcc6a0..0xcc6b4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: {CfaOffset: 32}
-            - Range: 0xcc458..0xcc4e0
+            - Range: 0xcc6b4..0xcc740
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
@@ -6696,14 +7028,96 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 38
+      Name: main.condNullUnsafePtr
+      OutOfLinePCRanges: [0xcc740..0xcc820]
+      InlinePCRanges: []
+      Variables:
+        - Name: p
+          Type: 16 VoidPointerType unsafe.Pointer
+          Locations:
+            - Range: 0xcc740..0xcc78c
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcc78c..0xcc820
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcc740..0xcc790
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xcc790..0xcc794
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0xcc794..0xcc820
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 39
+      Name: main.lenString
+      OutOfLinePCRanges: [0xcc830..0xcc910]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcc830..0xcc880
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0xcc880..0xcc884
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
+            - Range: 0xcc884..0xcc910
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcc830..0xcc878
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcc878..0xcc888
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 24}
+                - Size: 8
+                  Op: {CfaOffset: 32}
+            - Range: 0xcc888..0xcc910
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 24}
+                - Size: 8
+                  Op: {CfaOffset: 32}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 40
       Name: main.lenSlice
-      OutOfLinePCRanges: [0xcc4e0..0xcc5d0]
+      OutOfLinePCRanges: [0xcc910..0xcca00]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 112 GoSliceHeaderType []int
           Locations:
-            - Range: 0xcc4e0..0xcc53c
+            - Range: 0xcc910..0xcc96c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6711,7 +7125,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcc53c..0xcc540
+            - Range: 0xcc96c..0xcc970
               Pieces:
                 - Size: 8
                   Op: null
@@ -6719,7 +7133,7 @@ Subprograms:
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcc540..0xcc544
+            - Range: 0xcc970..0xcc974
               Pieces:
                 - Size: 8
                   Op: null
@@ -6727,7 +7141,7 @@ Subprograms:
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcc544..0xcc5d0
+            - Range: 0xcc974..0xcca00
               Pieces:
                 - Size: 8
                   Op: null
@@ -6740,19 +7154,19 @@ Subprograms:
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcc4e0..0xcc530
+            - Range: 0xcc910..0xcc960
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
-            - Range: 0xcc530..0xcc534
+            - Range: 0xcc960..0xcc964
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
                 - Size: 8
                   Op: {CfaOffset: 40}
-            - Range: 0xcc534..0xcc5d0
+            - Range: 0xcc964..0xcca00
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
@@ -6761,36 +7175,36 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 39
+    - ID: 41
       Name: main.lenMap
-      OutOfLinePCRanges: [0xcc5d0..0xcc6c0]
+      OutOfLinePCRanges: [0xcca00..0xccaf0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 116 GoMapType map[string]int
           Locations:
-            - Range: 0xcc5d0..0xcc61c
+            - Range: 0xcca00..0xcca4c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcc61c..0xcc6c0
+            - Range: 0xcca4c..0xccaf0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcc5d0..0xcc620
+            - Range: 0xcca00..0xcca50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcc620..0xcc624
+            - Range: 0xcca50..0xcca54
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xcc624..0xcc6c0
+            - Range: 0xcca54..0xccaf0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -6799,110 +7213,36 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 40
+    - ID: 42
       Name: main.lenPtrString
-      OutOfLinePCRanges: [0xcc6c0..0xcc7a0]
+      OutOfLinePCRanges: [0xccaf0..0xccbd0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 101 PointerType *string
           Locations:
-            - Range: 0xcc6c0..0xcc70c
+            - Range: 0xccaf0..0xccb3c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcc70c..0xcc7a0
+            - Range: 0xccb3c..0xccbd0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcc6c0..0xcc710
+            - Range: 0xccaf0..0xccb40
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcc710..0xcc714
+            - Range: 0xccb40..0xccb44
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xcc714..0xcc7a0
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 16}
-                - Size: 8
-                  Op: {CfaOffset: 24}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 41
-      Name: main.lenStructFields
-      OutOfLinePCRanges: [0xcc7a0..0xcc8d0]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 129 StructureType main.lenFields
-          Locations:
-            - Range: 0xcc7a0..0xcc8d0
-              Pieces: [{Size: 72, Op: {CfaOffset: 8}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xcc7a0..0xcc814
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0xcc814..0xcc818
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 80}
-                - Size: 8
-                  Op: {CfaOffset: 88}
-            - Range: 0xcc818..0xcc8d0
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 80}
-                - Size: 8
-                  Op: {CfaOffset: 88}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 42
-      Name: main.lenPtrStructFields
-      OutOfLinePCRanges: [0xcc8d0..0xcc9f0]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 131 PointerType *main.lenFields
-          Locations:
-            - Range: 0xcc8d0..0xcc91c
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcc91c..0xcc9f0
-              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xcc8d0..0xcc920
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcc920..0xcc924
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 16}
-                - Size: 8
-                  Op: {CfaOffset: 24}
-            - Range: 0xcc924..0xcc9f0
+            - Range: 0xccb44..0xccbd0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -6912,35 +7252,71 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 43
-      Name: main.lenErrInt
-      OutOfLinePCRanges: [0xcc9f0..0xccad0]
+      Name: main.lenStructFields
+      OutOfLinePCRanges: [0xccbd0..0xccd00]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 7 BaseType int
+          Type: 129 StructureType main.lenFields
           Locations:
-            - Range: 0xcc9f0..0xcca44
+            - Range: 0xccbd0..0xccd00
+              Pieces: [{Size: 72, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xccbd0..0xccc44
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0xccc44..0xccc48
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 80}
+                - Size: 8
+                  Op: {CfaOffset: 88}
+            - Range: 0xccc48..0xccd00
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 80}
+                - Size: 8
+                  Op: {CfaOffset: 88}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 44
+      Name: main.lenPtrStructFields
+      OutOfLinePCRanges: [0xccd00..0xcce20]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 131 PointerType *main.lenFields
+          Locations:
+            - Range: 0xccd00..0xccd4c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcca44..0xccad0
+            - Range: 0xccd4c..0xcce20
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcc9f0..0xcca48
+            - Range: 0xccd00..0xccd50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcca48..0xcca4c
+            - Range: 0xccd50..0xccd54
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xcca4c..0xccad0
+            - Range: 0xccd54..0xcce20
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -6949,34 +7325,72 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 44
+    - ID: 45
+      Name: main.lenErrInt
+      OutOfLinePCRanges: [0xcce20..0xccf00]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcce20..0xcce74
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcce74..0xccf00
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcce20..0xcce78
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xcce78..0xcce7c
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0xcce7c..0xccf00
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 46
       Name: main.lenErrStruct
-      OutOfLinePCRanges: [0xccad0..0xccbd0]
+      OutOfLinePCRanges: [0xccf00..0xcd000]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 126 StructureType main.condFields
           Locations:
-            - Range: 0xccad0..0xccbd0
+            - Range: 0xccf00..0xcd000
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xccad0..0xccb44
+            - Range: 0xccf00..0xccf74
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xccb44..0xccb48
+            - Range: 0xccf74..0xccf78
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 88}
                 - Size: 8
                   Op: {CfaOffset: 96}
-            - Range: 0xccb48..0xccbd0
+            - Range: 0xccf78..0xcd000
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 88}
@@ -6985,28 +7399,28 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 45
+    - ID: 47
       Name: main.indexNilPtrSlice
-      OutOfLinePCRanges: [0xccbd0..0xccc80]
+      OutOfLinePCRanges: [0xcd000..0xcd0b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 131 PointerType *main.lenFields
           Locations:
-            - Range: 0xccbd0..0xccc20
+            - Range: 0xcd000..0xcd050
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xccbd0..0xccc24
+            - Range: 0xcd000..0xcd054
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xccc24..0xccc28
+            - Range: 0xcd054..0xcd058
               Pieces:
                 - Size: 8
                   Op: null
@@ -7015,60 +7429,60 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 46
+    - ID: 48
       Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
-      OutOfLinePCRanges: [0xccc80..0xcce40]
+      OutOfLinePCRanges: [0xcd0b0..0xcd270]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 132 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
           Locations:
-            - Range: 0xccc80..0xcce1c
+            - Range: 0xcd0b0..0xcd24c
               Pieces: []
-            - Range: 0xcce1c..0xcce1d
+            - Range: 0xcd24c..0xcd24d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcce1d..0xcce40
+            - Range: 0xcd24d..0xcd270
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 47
+    - ID: 49
       Name: main.bigArrayArg
-      OutOfLinePCRanges: [0xcce40..0xcced0]
+      OutOfLinePCRanges: [0xcd270..0xcd300]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 137 ArrayType [131072]int64
           Locations:
-            - Range: 0xcce40..0xcced0
+            - Range: 0xcd270..0xcd300
               Pieces: [{Size: 1048576, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 48
+    - ID: 50
       Name: main.bigArrayStructArg
-      OutOfLinePCRanges: [0xcced0..0xccf70]
+      OutOfLinePCRanges: [0xcd300..0xcd3a0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 138 PointerType *main.bigArrayStruct
           Locations:
-            - Range: 0xcced0..0xccefc
+            - Range: 0xcd300..0xcd32c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xccefc..0xccf70
+            - Range: 0xcd32c..0xcd3a0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 49
+    - ID: 51
       Name: main.structSliceArg
-      OutOfLinePCRanges: [0xccf70..0xcd030]
+      OutOfLinePCRanges: [0xcd3a0..0xcd460]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 140 GoSliceHeaderType []main.indexMemberStruct
           Locations:
-            - Range: 0xccf70..0xccf94
+            - Range: 0xcd3a0..0xcd3c4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7076,7 +7490,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xccf94..0xccfac
+            - Range: 0xcd3c4..0xcd3dc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7084,7 +7498,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0xccfac..0xccfb0
+            - Range: 0xcd3dc..0xcd3e0
               Pieces:
                 - Size: 8
                   Op: null
@@ -7097,113 +7511,19 @@ Subprograms:
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xccf70..0xccfb0
+            - Range: 0xcd3a0..0xcd3e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
-            - Range: 0xccfb0..0xcd000
+            - Range: 0xcd3e0..0xcd430
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
                 - Size: 8
                   Op: {CfaOffset: 40}
-            - Range: 0xcd000..0xcd030
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 50
-      Name: main.structArrayArg
-      OutOfLinePCRanges: [0xcd030..0xcd0d0]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 143 ArrayType [2]main.indexMemberStruct
-          Locations:
-            - Range: 0xcd030..0xcd0d0
-              Pieces: [{Size: 64, Op: {CfaOffset: 8}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xcd030..0xcd054
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0xcd054..0xcd060
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 72}
-                - Size: 8
-                  Op: {CfaOffset: 80}
-            - Range: 0xcd060..0xcd0d0
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 72}
-                - Size: 8
-                  Op: {CfaOffset: 80}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 51
-      Name: main.ptrStructSliceArg
-      OutOfLinePCRanges: [0xcd0d0..0xcd190]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 144 GoSliceHeaderType []*main.indexMemberStruct
-          Locations:
-            - Range: 0xcd0d0..0xcd0f4
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcd0f4..0xcd10c
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: null
-            - Range: 0xcd10c..0xcd110
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: null
-          Role: Parameter
-          DictIndex: -1
-        - Name: tag
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xcd0d0..0xcd114
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-            - Range: 0xcd114..0xcd164
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 32}
-                - Size: 8
-                  Op: {CfaOffset: 40}
-            - Range: 0xcd164..0xcd190
+            - Range: 0xcd430..0xcd460
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -7213,33 +7533,127 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 52
+      Name: main.structArrayArg
+      OutOfLinePCRanges: [0xcd460..0xcd500]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 143 ArrayType [2]main.indexMemberStruct
+          Locations:
+            - Range: 0xcd460..0xcd500
+              Pieces: [{Size: 64, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcd460..0xcd484
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0xcd484..0xcd490
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 72}
+                - Size: 8
+                  Op: {CfaOffset: 80}
+            - Range: 0xcd490..0xcd500
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 72}
+                - Size: 8
+                  Op: {CfaOffset: 80}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 53
+      Name: main.ptrStructSliceArg
+      OutOfLinePCRanges: [0xcd500..0xcd5c0]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 144 GoSliceHeaderType []*main.indexMemberStruct
+          Locations:
+            - Range: 0xcd500..0xcd524
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xcd524..0xcd53c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: null
+            - Range: 0xcd53c..0xcd540
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: null
+          Role: Parameter
+          DictIndex: -1
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcd500..0xcd544
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+            - Range: 0xcd544..0xcd594
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 32}
+                - Size: 8
+                  Op: {CfaOffset: 40}
+            - Range: 0xcd594..0xcd5c0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 54
       Name: main.ptrStructArrayArg
-      OutOfLinePCRanges: [0xcd190..0xcd230]
+      OutOfLinePCRanges: [0xcd5c0..0xcd660]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 146 ArrayType [2]*main.indexMemberStruct
           Locations:
-            - Range: 0xcd190..0xcd230
+            - Range: 0xcd5c0..0xcd660
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd190..0xcd1b4
+            - Range: 0xcd5c0..0xcd5e4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xcd1b4..0xcd1c4
+            - Range: 0xcd5e4..0xcd5f4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: {CfaOffset: 32}
-            - Range: 0xcd1c4..0xcd230
+            - Range: 0xcd5f4..0xcd660
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
@@ -7248,36 +7662,36 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 53
+    - ID: 55
       Name: main.indexMemberWrapperArg
-      OutOfLinePCRanges: [0xcd230..0xcd300]
+      OutOfLinePCRanges: [0xcd660..0xcd730]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 147 PointerType *main.indexMemberWrapper
           Locations:
-            - Range: 0xcd230..0xcd26c
+            - Range: 0xcd660..0xcd69c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd26c..0xcd300
+            - Range: 0xcd69c..0xcd730
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd230..0xcd258
+            - Range: 0xcd660..0xcd688
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcd258..0xcd270
+            - Range: 0xcd688..0xcd6a0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xcd270..0xcd300
+            - Range: 0xcd6a0..0xcd730
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -7286,164 +7700,60 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 54
+    - ID: 56
       Name: main.mapIndexIntKey
-      OutOfLinePCRanges: [0xcd300..0xcd370]
+      OutOfLinePCRanges: [0xcd730..0xcd7a0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 149 GoMapType map[int]string
           Locations:
-            - Range: 0xcd300..0xcd334
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 55
-      Name: main.mapIndexStringKey
-      OutOfLinePCRanges: [0xcd370..0xcd3e0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 116 GoMapType map[string]int
-          Locations:
-            - Range: 0xcd370..0xcd3a4
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 56
-      Name: main.mapIndexLargeMap
-      OutOfLinePCRanges: [0xcd3e0..0xcd460]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 116 GoMapType map[string]int
-          Locations:
-            - Range: 0xcd3e0..0xcd410
+            - Range: 0xcd730..0xcd764
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 57
-      Name: main.mapIndexMissing
-      OutOfLinePCRanges: [0xcd460..0xcd4d0]
+      Name: main.mapIndexStringKey
+      OutOfLinePCRanges: [0xcd7a0..0xcd810]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 116 GoMapType map[string]int
           Locations:
-            - Range: 0xcd460..0xcd494
+            - Range: 0xcd7a0..0xcd7d4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 58
-      Name: main.mapIndexKeyLen8
-      OutOfLinePCRanges: [0xcd5d0..0xcd650]
+      Name: main.mapIndexLargeMap
+      OutOfLinePCRanges: [0xcd810..0xcd890]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 116 GoMapType map[string]int
           Locations:
-            - Range: 0xcd5d0..0xcd600
+            - Range: 0xcd810..0xcd840
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 59
-      Name: main.mapIndexKeyLen24
-      OutOfLinePCRanges: [0xcd650..0xcd6d0]
+      Name: main.mapIndexMissing
+      OutOfLinePCRanges: [0xcd890..0xcd900]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 116 GoMapType map[string]int
           Locations:
-            - Range: 0xcd650..0xcd680
+            - Range: 0xcd890..0xcd8c4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 60
-      Name: main.mapIndexKeyLen48
-      OutOfLinePCRanges: [0xcd6d0..0xcd750]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 116 GoMapType map[string]int
-          Locations:
-            - Range: 0xcd6d0..0xcd700
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 61
-      Name: main.mapIndexKeyLen96
-      OutOfLinePCRanges: [0xcd750..0xcd7d0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 116 GoMapType map[string]int
-          Locations:
-            - Range: 0xcd750..0xcd780
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 62
-      Name: main.mapIndexKeyLen200
-      OutOfLinePCRanges: [0xcd7d0..0xcd850]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 116 GoMapType map[string]int
-          Locations:
-            - Range: 0xcd7d0..0xcd800
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 63
-      Name: main.mapIndexStructVal
-      OutOfLinePCRanges: [0xcd850..0xcd8e0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 154 GoMapType map[string]main.indexMemberStruct
-          Locations:
-            - Range: 0xcd850..0xcd884
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 64
-      Name: main.mapIndexPtrStructVal
-      OutOfLinePCRanges: [0xcd8e0..0xcd970]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 159 GoMapType map[string]*main.indexMemberStruct
-          Locations:
-            - Range: 0xcd8e0..0xcd914
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 65
-      Name: main.mapIndexEmptyKey
-      OutOfLinePCRanges: [0xcd970..0xcda00]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 116 GoMapType map[string]int
-          Locations:
-            - Range: 0xcd970..0xcd9a0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 66
-      Name: main.mapIndexKeyLen16
+      Name: main.mapIndexKeyLen8
       OutOfLinePCRanges: [0xcda00..0xcda80]
       InlinePCRanges: []
       Variables:
@@ -7455,8 +7765,8 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 67
-      Name: main.mapIndexKeyLen17
+    - ID: 61
+      Name: main.mapIndexKeyLen24
       OutOfLinePCRanges: [0xcda80..0xcdb00]
       InlinePCRanges: []
       Variables:
@@ -7468,79 +7778,183 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 68
-      Name: main.mapIndexBoolKey
-      OutOfLinePCRanges: [0xcdb00..0xcdb70]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 164 GoMapType map[bool]int
-          Locations:
-            - Range: 0xcdb00..0xcdb34
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 69
-      Name: main.mapIndexZeroValue
-      OutOfLinePCRanges: [0xcdb70..0xcdbe0]
+    - ID: 62
+      Name: main.mapIndexKeyLen48
+      OutOfLinePCRanges: [0xcdb00..0xcdb80]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 116 GoMapType map[string]int
           Locations:
-            - Range: 0xcdb70..0xcdba4
+            - Range: 0xcdb00..0xcdb30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 70
-      Name: main.mapIndexNilPtrVal
-      OutOfLinePCRanges: [0xcdbe0..0xcdc50]
+    - ID: 63
+      Name: main.mapIndexKeyLen96
+      OutOfLinePCRanges: [0xcdb80..0xcdc00]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 116 GoMapType map[string]int
+          Locations:
+            - Range: 0xcdb80..0xcdbb0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 64
+      Name: main.mapIndexKeyLen200
+      OutOfLinePCRanges: [0xcdc00..0xcdc80]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 116 GoMapType map[string]int
+          Locations:
+            - Range: 0xcdc00..0xcdc30
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 65
+      Name: main.mapIndexStructVal
+      OutOfLinePCRanges: [0xcdc80..0xcdd10]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 154 GoMapType map[string]main.indexMemberStruct
+          Locations:
+            - Range: 0xcdc80..0xcdcb4
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 66
+      Name: main.mapIndexPtrStructVal
+      OutOfLinePCRanges: [0xcdd10..0xcdda0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 159 GoMapType map[string]*main.indexMemberStruct
           Locations:
-            - Range: 0xcdbe0..0xcdc14
+            - Range: 0xcdd10..0xcdd44
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 67
+      Name: main.mapIndexEmptyKey
+      OutOfLinePCRanges: [0xcdda0..0xcde30]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 116 GoMapType map[string]int
+          Locations:
+            - Range: 0xcdda0..0xcddd0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 68
+      Name: main.mapIndexKeyLen16
+      OutOfLinePCRanges: [0xcde30..0xcdeb0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 116 GoMapType map[string]int
+          Locations:
+            - Range: 0xcde30..0xcde60
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 69
+      Name: main.mapIndexKeyLen17
+      OutOfLinePCRanges: [0xcdeb0..0xcdf30]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 116 GoMapType map[string]int
+          Locations:
+            - Range: 0xcdeb0..0xcdee0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 70
+      Name: main.mapIndexBoolKey
+      OutOfLinePCRanges: [0xcdf30..0xcdfa0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 164 GoMapType map[bool]int
+          Locations:
+            - Range: 0xcdf30..0xcdf64
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 71
-      Name: main.mapIndexLargeValue
-      OutOfLinePCRanges: [0xcdc50..0xcdce0]
+      Name: main.mapIndexZeroValue
+      OutOfLinePCRanges: [0xcdfa0..0xce010]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 169 GoMapType map[string]main.largeValueStruct
+          Type: 116 GoMapType map[string]int
           Locations:
-            - Range: 0xcdc50..0xcdc80
+            - Range: 0xcdfa0..0xcdfd4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 72
+      Name: main.mapIndexNilPtrVal
+      OutOfLinePCRanges: [0xce010..0xce080]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 159 GoMapType map[string]*main.indexMemberStruct
+          Locations:
+            - Range: 0xce010..0xce044
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 73
+      Name: main.mapIndexLargeValue
+      OutOfLinePCRanges: [0xce080..0xce110]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 169 GoMapType map[string]main.largeValueStruct
+          Locations:
+            - Range: 0xce080..0xce0b0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 74
       Name: main.condMultiReturn
-      OutOfLinePCRanges: [0xcdd60..0xcde20]
+      OutOfLinePCRanges: [0xce190..0xce250]
       InlinePCRanges: []
       Variables:
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdd60..0xcdda8
+            - Range: 0xce190..0xce1d8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xcdda8..0xcddac
+            - Range: 0xce1d8..0xce1dc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0xcddac..0xcde20
+            - Range: 0xce1dc..0xce250
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -7551,51 +7965,51 @@ Subprograms:
         - Name: r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdd60..0xcddfc
+            - Range: 0xce190..0xce22c
               Pieces: []
-            - Range: 0xcddfc..0xcddfd
+            - Range: 0xce22c..0xce22d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcddfd..0xcde20
+            - Range: 0xce22d..0xce250
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: r1
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdd60..0xcddfc
+            - Range: 0xce190..0xce22c
               Pieces: []
-            - Range: 0xcddfc..0xcddfd
+            - Range: 0xce22c..0xce22d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcddfd..0xcde20
+            - Range: 0xce22d..0xce250
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 73
+    - ID: 75
       Name: main.genericIdentity[go.shape.string]
-      OutOfLinePCRanges: [0xcde20..0xcdeb0]
+      OutOfLinePCRanges: [0xce250..0xce2e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 174 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcde20..0xcde50
+            - Range: 0xce250..0xce280
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcde50..0xcde54
+            - Range: 0xce280..0xce284
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xcde54..0xcdeb0
+            - Range: 0xce284..0xce2e0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -7606,68 +8020,68 @@ Subprograms:
         - Name: ~r0
           Type: 174 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcde20..0xcde88
+            - Range: 0xce250..0xce2b8
               Pieces: []
-            - Range: 0xcde88..0xcde89
+            - Range: 0xce2b8..0xce2b9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xcde89..0xcdeb0
+            - Range: 0xce2b9..0xce2e0
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 74
+    - ID: 76
       Name: main.genericIdentity[go.shape.int]
-      OutOfLinePCRanges: [0xcdeb0..0xcdf30]
+      OutOfLinePCRanges: [0xce2e0..0xce360]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 175 BaseType go.shape.int
           Locations:
-            - Range: 0xcdeb0..0xcdedc
+            - Range: 0xce2e0..0xce30c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0xcdedc..0xcdf30
+            - Range: 0xce30c..0xce360
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 175 BaseType go.shape.int
           Locations:
-            - Range: 0xcdeb0..0xcdf0c
+            - Range: 0xce2e0..0xce33c
               Pieces: []
-            - Range: 0xcdf0c..0xcdf0d
+            - Range: 0xce33c..0xce33d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdf0d..0xcdf30
+            - Range: 0xce33d..0xce360
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 75
+    - ID: 77
       Name: main.inlined
-      OutOfLinePCRanges: [0xcaed0..0xcaf40]
+      OutOfLinePCRanges: [0xcb110..0xcb180]
       InlinePCRanges:
         - Ranges: [0xc8b1c..0xc8b5c]
-          RootRanges: [0xc8960..0xcac00]
+          RootRanges: [0xc8960..0xcae40]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
             - Range: 0xc8b1c..0xc8b5c
               Pieces: []
-            - Range: 0xcaed0..0xcaef0
+            - Range: 0xcb110..0xcb130
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 76
+    - ID: 78
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xc8da4..0xc8ddc]
-          RootRanges: [0xc8960..0xcac00]
+          RootRanges: [0xc8960..0xcae40]
       Variables:
         - Name: ptr
           Type: 176 PointerType *****int
@@ -7677,12 +8091,12 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 77
+    - ID: 79
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xc8de8..0xc8e20]
-          RootRanges: [0xc8960..0xcac00]
+          RootRanges: [0xc8960..0xcae40]
       Variables:
         - Name: ptr
           Type: 178 PointerType **int
@@ -7692,17 +8106,17 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 78
+    - ID: 80
       Name: main.(*methodValueReceiver).inlinedMethod
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcdf34..0xcdf38]
-          RootRanges: [0xcdf30..0xcdf40]
+        - Ranges: [0xce364..0xce368]
+          RootRanges: [0xce360..0xce370]
       Variables:
         - Name: m
           Type: 179 PointerType *main.methodValueReceiver
           Locations:
-            - Range: 0xcdf34..0xcdf40
+            - Range: 0xce364..0xce370
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7712,28 +8126,28 @@ Types:
       ID: 176
       Name: '*****int'
       ByteSize: 8
-      GoRuntimeType: 40352
+      GoRuntimeType: 40384
       GoKind: 22
       Pointee: 177 PointerType ****int
     - __kind: PointerType
       ID: 177
       Name: '****int'
       ByteSize: 8
-      GoRuntimeType: 40288
+      GoRuntimeType: 40320
       GoKind: 22
       Pointee: 337 PointerType ***int
     - __kind: PointerType
       ID: 337
       Name: '***int'
       ByteSize: 8
-      GoRuntimeType: 40224
+      GoRuntimeType: 40256
       GoKind: 22
       Pointee: 178 PointerType **int
     - __kind: PointerType
       ID: 178
       Name: '**int'
       ByteSize: 8
-      GoRuntimeType: 40160
+      GoRuntimeType: 40192
       GoKind: 22
       Pointee: 105 PointerType *int
     - __kind: PointerType
@@ -7818,7 +8232,7 @@ Types:
       ID: 130
       Name: '*[]int'
       ByteSize: 8
-      GoRuntimeType: 40096
+      GoRuntimeType: 40128
       GoKind: 22
       Pointee: 112 GoSliceHeaderType []int
     - __kind: PointerType
@@ -7835,7 +8249,7 @@ Types:
       ID: 40
       Name: '*[]runtime.ancestorInfo'
       ByteSize: 8
-      GoRuntimeType: 44640
+      GoRuntimeType: 44672
       GoKind: 22
       Pointee: 41 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
@@ -7857,35 +8271,35 @@ Types:
       ID: 10
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 33920
+      GoRuntimeType: 33952
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
       ID: 108
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 32832
+      GoRuntimeType: 32864
       GoKind: 22
       Pointee: 15 GoInterfaceType error
     - __kind: PointerType
       ID: 289
       Name: '*errors.errorString'
       ByteSize: 8
-      GoRuntimeType: 66592
+      GoRuntimeType: 66720
       GoKind: 22
       Pointee: 290 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
       ID: 109
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 33792
+      GoRuntimeType: 33824
       GoKind: 22
       Pointee: 17 BaseType float32
     - __kind: PointerType
       ID: 104
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 33856
+      GoRuntimeType: 33888
       GoKind: 22
       Pointee: 14 BaseType float64
     - __kind: PointerType
@@ -7897,63 +8311,63 @@ Types:
       ID: 105
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 33472
+      GoRuntimeType: 33504
       GoKind: 22
       Pointee: 7 BaseType int
     - __kind: PointerType
       ID: 21
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 33216
+      GoRuntimeType: 33248
       GoKind: 22
       Pointee: 12 BaseType int32
     - __kind: PointerType
       ID: 107
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 33344
+      GoRuntimeType: 33376
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
       ID: 330
       Name: '*internal/abi.Type'
       ByteSize: 8
-      GoRuntimeType: 149536
+      GoRuntimeType: 149664
       GoKind: 22
       Pointee: 331 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
       ID: 298
       Name: '*internal/bisect.parseError'
       ByteSize: 8
-      GoRuntimeType: 70144
+      GoRuntimeType: 70272
       GoKind: 22
       Pointee: 299 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
       ID: 326
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 85184
+      GoRuntimeType: 85312
       GoKind: 22
       Pointee: 327 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 324
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
-      GoRuntimeType: 85056
+      GoRuntimeType: 85184
       GoKind: 22
       Pointee: 325 StructureType internal/poll.errNetClosing
     - __kind: PointerType
       ID: 99
       Name: '*internal/runtime/atomic.Pointer[runtime.m]'
       ByteSize: 8
-      GoRuntimeType: 109696
+      GoRuntimeType: 109824
       GoKind: 22
       Pointee: 100 UnresolvedPointeeType internal/runtime/atomic.Pointer[runtime.m]
     - __kind: PointerType
       ID: 297
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
-      GoRuntimeType: 69952
+      GoRuntimeType: 70080
       GoKind: 22
       Pointee: 286 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
@@ -7965,49 +8379,49 @@ Types:
       ID: 316
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
-      GoRuntimeType: 77376
+      GoRuntimeType: 77504
       GoKind: 22
       Pointee: 317 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
       ID: 296
       Name: '*internal/strconv.Error'
       ByteSize: 8
-      GoRuntimeType: 69664
+      GoRuntimeType: 69792
       GoKind: 22
       Pointee: 285 BaseType internal/strconv.Error
     - __kind: PointerType
       ID: 322
       Name: '*io/fs.PathError'
       ByteSize: 8
-      GoRuntimeType: 84928
+      GoRuntimeType: 85056
       GoKind: 22
       Pointee: 323 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
       ID: 138
       Name: '*main.bigArrayStruct'
       ByteSize: 8
-      GoRuntimeType: 31232
+      GoRuntimeType: 31264
       GoKind: 22
       Pointee: 139 StructureType main.bigArrayStruct
     - __kind: PointerType
       ID: 208
       Name: '*main.bigStruct'
       ByteSize: 8
-      GoRuntimeType: 31104
+      GoRuntimeType: 31136
       GoKind: 22
       Pointee: 209 StructureType main.bigStruct
     - __kind: PointerType
       ID: 128
       Name: '*main.condFields'
       ByteSize: 8
-      GoRuntimeType: 30848
+      GoRuntimeType: 30880
       GoKind: 22
       Pointee: 126 StructureType main.condFields
     - __kind: PointerType
       ID: 141
       Name: '*main.indexMemberStruct'
       ByteSize: 8
-      GoRuntimeType: 31040
+      GoRuntimeType: 31072
       GoKind: 22
       Pointee: 142 StructureType main.indexMemberStruct
     - __kind: PointerType
@@ -8020,14 +8434,14 @@ Types:
       ID: 267
       Name: '*main.largeValueStruct'
       ByteSize: 8
-      GoRuntimeType: 31168
+      GoRuntimeType: 31200
       GoKind: 22
       Pointee: 268 StructureType main.largeValueStruct
     - __kind: PointerType
       ID: 131
       Name: '*main.lenFields'
       ByteSize: 8
-      GoRuntimeType: 30912
+      GoRuntimeType: 30944
       GoKind: 22
       Pointee: 129 StructureType main.lenFields
     - __kind: PointerType
@@ -8130,77 +8544,77 @@ Types:
       ID: 318
       Name: '*os.SyscallError'
       ByteSize: 8
-      GoRuntimeType: 81600
+      GoRuntimeType: 81728
       GoKind: 22
       Pointee: 319 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 291
       Name: '*reflect.ValueError'
       ByteSize: 8
-      GoRuntimeType: 67456
+      GoRuntimeType: 67584
       GoKind: 22
       Pointee: 292 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
       ID: 310
       Name: '*runtime.PanicNilError'
       ByteSize: 8
-      GoRuntimeType: 75840
+      GoRuntimeType: 75968
       GoKind: 22
       Pointee: 311 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
       ID: 314
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
-      GoRuntimeType: 76480
+      GoRuntimeType: 76608
       GoKind: 22
       Pointee: 315 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 27
       Name: '*runtime._defer'
       ByteSize: 8
-      GoRuntimeType: 34112
+      GoRuntimeType: 34144
       GoKind: 22
       Pointee: 28 UnresolvedPointeeType runtime._defer
     - __kind: PointerType
       ID: 25
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 93568
+      GoRuntimeType: 93696
       GoKind: 22
       Pointee: 26 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 312
       Name: '*runtime.boundsError'
       ByteSize: 8
-      GoRuntimeType: 75968
+      GoRuntimeType: 76096
       GoKind: 22
       Pointee: 313 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 69
       Name: '*runtime.cgoCallers'
       ByteSize: 8
-      GoRuntimeType: 36224
+      GoRuntimeType: 36256
       GoKind: 22
       Pointee: 70 UnresolvedPointeeType runtime.cgoCallers
     - __kind: PointerType
       ID: 48
       Name: '*runtime.coro'
       ByteSize: 8
-      GoRuntimeType: 34944
+      GoRuntimeType: 34976
       GoKind: 22
       Pointee: 49 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
       ID: 320
       Name: '*runtime.errorAddressString'
       ByteSize: 8
-      GoRuntimeType: 84416
+      GoRuntimeType: 84544
       GoKind: 22
       Pointee: 321 StructureType runtime.errorAddressString
     - __kind: PointerType
       ID: 308
       Name: '*runtime.errorString'
       ByteSize: 8
-      GoRuntimeType: 74176
+      GoRuntimeType: 74304
       GoKind: 22
       Pointee: 300 GoStringHeaderType runtime.errorString
     - __kind: PointerType
@@ -8212,28 +8626,28 @@ Types:
       ID: 59
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 83136
+      GoRuntimeType: 83264
       GoKind: 22
       Pointee: 23 StructureType runtime.g
     - __kind: PointerType
       ID: 29
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 94208
+      GoRuntimeType: 94336
       GoKind: 22
       Pointee: 30 StructureType runtime.m
     - __kind: PointerType
       ID: 68
       Name: '*runtime.p'
       ByteSize: 8
-      GoRuntimeType: 75584
+      GoRuntimeType: 75712
       GoKind: 22
       Pointee: 187 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 309
       Name: '*runtime.plainError'
       ByteSize: 8
-      GoRuntimeType: 74304
+      GoRuntimeType: 74432
       GoKind: 22
       Pointee: 303 GoStringHeaderType runtime.plainError
     - __kind: PointerType
@@ -8245,56 +8659,56 @@ Types:
       ID: 42
       Name: '*runtime.sudog'
       ByteSize: 8
-      GoRuntimeType: 34880
+      GoRuntimeType: 34912
       GoKind: 22
       Pointee: 43 UnresolvedPointeeType runtime.sudog
     - __kind: PointerType
       ID: 50
       Name: '*runtime.synctestBubble'
       ByteSize: 8
-      GoRuntimeType: 107456
+      GoRuntimeType: 107584
       GoKind: 22
       Pointee: 51 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
       ID: 293
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
-      GoRuntimeType: 69184
+      GoRuntimeType: 69312
       GoKind: 22
       Pointee: 294 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 45
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 142080
+      GoRuntimeType: 142208
       GoKind: 22
       Pointee: 46 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 83
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 115072
+      GoRuntimeType: 115200
       GoKind: 22
       Pointee: 84 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 53
       Name: '*runtime.xRegState'
       ByteSize: 8
-      GoRuntimeType: 35136
+      GoRuntimeType: 35168
       GoKind: 22
       Pointee: 54 UnresolvedPointeeType runtime.xRegState
     - __kind: PointerType
       ID: 306
       Name: '*strconv.NumError'
       ByteSize: 8
-      GoRuntimeType: 73280
+      GoRuntimeType: 73408
       GoKind: 22
       Pointee: 307 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 101
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 32896
+      GoRuntimeType: 32928
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
@@ -8306,7 +8720,7 @@ Types:
       ID: 329
       Name: '*syscall.Errno'
       ByteSize: 8
-      GoRuntimeType: 95168
+      GoRuntimeType: 95296
       GoKind: 22
       Pointee: 328 BaseType syscall.Errno
     - __kind: PointerType
@@ -8358,7 +8772,7 @@ Types:
       ID: 295
       Name: '*time.fileSizeError'
       ByteSize: 8
-      GoRuntimeType: 69376
+      GoRuntimeType: 69504
       GoKind: 22
       Pointee: 282 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
@@ -8370,46 +8784,46 @@ Types:
       ID: 110
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 33536
+      GoRuntimeType: 33568
       GoKind: 22
       Pointee: 11 BaseType uint
     - __kind: PointerType
       ID: 111
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 33152
+      GoRuntimeType: 33184
       GoKind: 22
       Pointee: 6 BaseType uint16
     - __kind: PointerType
       ID: 22
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 33280
+      GoRuntimeType: 33312
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 106
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 33408
+      GoRuntimeType: 33440
       GoKind: 22
       Pointee: 8 BaseType uint64
     - __kind: PointerType
       ID: 5
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 33024
+      GoRuntimeType: 33056
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 20
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 33600
+      GoRuntimeType: 33632
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 684
+      ID: 693
       Name: Probe[main.(*methodValueReceiver).inlinedMethod]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8421,12 +8835,12 @@ Types:
             Type: 179 PointerType *main.methodValueReceiver
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: m}
+                  Variable: {subprogram: 80, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 682
+      ID: 691
       Name: Probe[main.PointerChainArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -8438,7 +8852,7 @@ Types:
             Type: 176 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: ptr}
+                  Variable: {subprogram: 78, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -8449,12 +8863,12 @@ Types:
             Type: 176 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: ptr}
+                  Variable: {subprogram: 78, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 683
+      ID: 692
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8466,12 +8880,12 @@ Types:
             Type: 178 PointerType **int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: ptr}
+                  Variable: {subprogram: 79, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 594
+      ID: 603
       Name: Probe[main.bigArrayArg]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8483,12 +8897,12 @@ Types:
             Type: 13 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: s}
+                  Variable: {subprogram: 49, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 596
+      ID: 605
       Name: Probe[main.bigArrayArg]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8500,18 +8914,18 @@ Types:
             Type: 13 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: s}
+                  Variable: {subprogram: 49, index: 0, name: s}
                   Offset: 1048568
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 595
+      ID: 604
       Name: Probe[main.bigArrayArg]Return
     - __kind: EventRootType
-      ID: 597
+      ID: 606
       Name: Probe[main.bigArrayArg]Return
     - __kind: EventRootType
-      ID: 598
+      ID: 607
       Name: Probe[main.bigArrayStructArg]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -8523,7 +8937,7 @@ Types:
             Type: 13 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: s}
+                  Variable: {subprogram: 50, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -8531,7 +8945,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 599
+      ID: 608
       Name: Probe[main.bigArrayStructArg]Return
     - __kind: EventRootType
       ID: 381
@@ -8962,6 +9376,85 @@ Types:
       ID: 388
       Name: Probe[main.condInt8]Return
     - __kind: EventRootType
+      ID: 492
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 493
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 494
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 495
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 496
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 497
+      Name: Probe[main.condLineMixed]Line
+    - __kind: EventRootType
+      ID: 498
+      Name: Probe[main.condLineMixed]Line
+      ByteSize: 131
+      ExprStatusArraySize: 2
+      Expressions:
+        - Name: s
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: b
+          Offset: 18
+          Kind: local
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 1
+          DictIndex: -1
+        - Name: x
+          Offset: 19
+          Kind: local
+          Expression:
+            Type: 126 StructureType main.condFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 80
+          DictIndex: -1
+        - Name: p
+          Offset: 99
+          Kind: local
+          Expression:
+            Type: 128 PointerType *main.condFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 3, name: p}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: ss
+          Offset: 107
+          Kind: local
+          Expression:
+            Type: 112 GoSliceHeaderType []int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 4, name: ss}
+                  Offset: 0
+                  ByteSize: 24
+          DictIndex: -1
+    - __kind: EventRootType
       ID: 487
       Name: Probe[main.condLine]Line
       ByteSize: 25
@@ -9009,6 +9502,62 @@ Types:
     - __kind: EventRootType
       ID: 489
       Name: Probe[main.condLine]Line
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 490
+      Name: Probe[main.condLine]Line
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: "n"
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 0, name: "n"}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: tag
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: result
+          Offset: 25
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 2, name: result}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 491
+      Name: Probe[main.condLine]Line
       ByteSize: 25
       ExprStatusArraySize: 1
       Expressions:
@@ -9035,10 +9584,10 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 674
+      ID: 683
       Name: Probe[main.condMultiReturn]
     - __kind: EventRootType
-      ID: 675
+      ID: 684
       Name: Probe[main.condMultiReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -9050,7 +9599,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 1, name: r0}
+                  Variable: {subprogram: 74, index: 1, name: r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -9061,7 +9610,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 2, name: r1}
+                  Variable: {subprogram: 74, index: 2, name: r1}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -9157,7 +9706,7 @@ Types:
       ID: 476
       Name: Probe[main.condNilPtrStruct]Return
     - __kind: EventRootType
-      ID: 496
+      ID: 505
       Name: Probe[main.condNullIface]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -9169,76 +9718,16 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 35, index: 1, name: tag}
+                  Variable: {subprogram: 37, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 497
+      ID: 506
       Name: Probe[main.condNullIface]Return
     - __kind: EventRootType
-      ID: 494
+      ID: 503
       Name: Probe[main.condNullMap]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 34, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 495
-      Name: Probe[main.condNullMap]Return
-    - __kind: EventRootType
-      ID: 490
-      Name: Probe[main.condNullPtr]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 32, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 491
-      Name: Probe[main.condNullPtr]Return
-    - __kind: EventRootType
-      ID: 492
-      Name: Probe[main.condNullSlice]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 33, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 493
-      Name: Probe[main.condNullSlice]Return
-    - __kind: EventRootType
-      ID: 498
-      Name: Probe[main.condNullUnsafePtr]
       ByteSize: 17
       ExprStatusArraySize: 1
       Expressions:
@@ -9254,7 +9743,67 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
+      ID: 504
+      Name: Probe[main.condNullMap]Return
+    - __kind: EventRootType
       ID: 499
+      Name: Probe[main.condNullPtr]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 500
+      Name: Probe[main.condNullPtr]Return
+    - __kind: EventRootType
+      ID: 501
+      Name: Probe[main.condNullSlice]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 502
+      Name: Probe[main.condNullSlice]Return
+    - __kind: EventRootType
+      ID: 507
+      Name: Probe[main.condNullUnsafePtr]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 508
       Name: Probe[main.condNullUnsafePtr]Return
     - __kind: EventRootType
       ID: 483
@@ -10066,7 +10615,7 @@ Types:
       ID: 410
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 678
+      ID: 687
       Name: Probe[main.genericIdentity[go.shape.int]]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10079,12 +10628,12 @@ Types:
             Type: 175 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: x}
+                  Variable: {subprogram: 76, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 679
+      ID: 688
       Name: Probe[main.genericIdentity[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10097,12 +10646,12 @@ Types:
             Type: 175 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 1, name: ~r0}
+                  Variable: {subprogram: 76, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 676
+      ID: 685
       Name: Probe[main.genericIdentity[go.shape.string]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -10115,12 +10664,12 @@ Types:
             Type: 174 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: x}
+                  Variable: {subprogram: 75, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 677
+      ID: 686
       Name: Probe[main.genericIdentity[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -10133,12 +10682,12 @@ Types:
             Type: 174 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 1, name: ~r0}
+                  Variable: {subprogram: 75, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 620
+      ID: 629
       Name: Probe[main.indexMemberWrapperArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -10150,7 +10699,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
+                  Variable: {subprogram: 55, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10161,7 +10710,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 622
+      ID: 631
       Name: Probe[main.indexMemberWrapperArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10173,7 +10722,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
+                  Variable: {subprogram: 55, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10184,7 +10733,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 624
+      ID: 633
       Name: Probe[main.indexMemberWrapperArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -10196,7 +10745,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
+                  Variable: {subprogram: 55, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10210,7 +10759,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 626
+      ID: 635
       Name: Probe[main.indexMemberWrapperArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10222,7 +10771,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
+                  Variable: {subprogram: 55, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10236,19 +10785,19 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 621
+      ID: 630
       Name: Probe[main.indexMemberWrapperArg]Return
     - __kind: EventRootType
-      ID: 623
+      ID: 632
       Name: Probe[main.indexMemberWrapperArg]Return
     - __kind: EventRootType
-      ID: 625
+      ID: 634
       Name: Probe[main.indexMemberWrapperArg]Return
     - __kind: EventRootType
-      ID: 627
+      ID: 636
       Name: Probe[main.indexMemberWrapperArg]Return
     - __kind: EventRootType
-      ID: 586
+      ID: 595
       Name: Probe[main.indexNilPtrSlice]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10260,7 +10809,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: x}
+                  Variable: {subprogram: 47, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10273,7 +10822,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 588
+      ID: 597
       Name: Probe[main.indexNilPtrSlice]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10285,12 +10834,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 1, name: tag}
+                  Variable: {subprogram: 47, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 590
+      ID: 599
       Name: Probe[main.indexNilPtrSlice]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10302,7 +10851,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: x}
+                  Variable: {subprogram: 47, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10315,16 +10864,16 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 587
+      ID: 596
       Name: Probe[main.indexNilPtrSlice]Return
     - __kind: EventRootType
-      ID: 589
+      ID: 598
       Name: Probe[main.indexNilPtrSlice]Return
     - __kind: EventRootType
-      ID: 591
+      ID: 600
       Name: Probe[main.indexNilPtrSlice]Return
     - __kind: EventRootType
-      ID: 680
+      ID: 689
       Name: Probe[main.inlined]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10336,12 +10885,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: x}
+                  Variable: {subprogram: 77, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 681
+      ID: 690
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
       ID: 338
@@ -10554,7 +11103,7 @@ Types:
       ID: 359
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 578
+      ID: 587
       Name: Probe[main.lenErrInt]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -10566,7 +11115,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: x}
+                  Variable: {subprogram: 45, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -10577,21 +11126,21 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 1, name: tag}
+                  Variable: {subprogram: 45, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 580
+      ID: 589
       Name: Probe[main.lenErrInt]
     - __kind: EventRootType
-      ID: 579
+      ID: 588
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 581
+      ID: 590
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 582
+      ID: 591
       Name: Probe[main.lenErrStruct]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -10603,7 +11152,7 @@ Types:
             Type: 126 StructureType main.condFields
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: x}
+                  Variable: {subprogram: 46, index: 0, name: x}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -10614,21 +11163,21 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 1, name: tag}
+                  Variable: {subprogram: 46, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 584
+      ID: 593
       Name: Probe[main.lenErrStruct]
     - __kind: EventRootType
-      ID: 583
+      ID: 592
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 585
+      ID: 594
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 532
+      ID: 541
       Name: Probe[main.lenMap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -10640,12 +11189,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Variable: {subprogram: 41, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 534
+      ID: 543
       Name: Probe[main.lenMap]
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -10657,7 +11206,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: m}
+                  Variable: {subprogram: 41, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -10671,7 +11220,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 536
+      ID: 545
       Name: Probe[main.lenMap]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -10683,845 +11232,16 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: m}
+                  Variable: {subprogram: 41, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
                   Bias: 0
                   ByteSize: 8
           DictIndex: -1
-    - __kind: EventRootType
-      ID: 538
-      Name: Probe[main.lenMap]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 540
-      Name: Probe[main.lenMap]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(m)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 8 BaseType uint64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 0
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 542
-      Name: Probe[main.lenMap]
-      ByteSize: 25
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 116 GoMapType map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-          DictIndex: -1
-        - Name: tag
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 533
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 535
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 537
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 539
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 541
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 543
-      Name: Probe[main.lenMap]Return
-    - __kind: EventRootType
-      ID: 544
-      Name: Probe[main.lenPtrString]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(s)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 546
-      Name: Probe[main.lenPtrString]
-      ByteSize: 25
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 101 PointerType *string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 8
-          DictIndex: -1
-        - Name: tag
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 545
-      Name: Probe[main.lenPtrString]Return
     - __kind: EventRootType
       ID: 547
-      Name: Probe[main.lenPtrString]Return
-    - __kind: EventRootType
-      ID: 568
-      Name: Probe[main.lenPtrStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: items_0
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 16
-                  ByteSize: 16
-                - __kind: SliceBoundsCheckOp
-                  Index: 0
-                - __kind: DereferenceOp
-                  Bias: 0
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 570
-      Name: Probe[main.lenPtrStructFields]
-      ByteSize: 25
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 131 PointerType *main.lenFields
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-          DictIndex: -1
-        - Name: tag
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 572
-      Name: Probe[main.lenPtrStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.Dict)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 8 BaseType uint64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 40
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 0
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 574
-      Name: Probe[main.lenPtrStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.Items)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 24
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 576
-      Name: Probe[main.lenPtrStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.S)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 569
-      Name: Probe[main.lenPtrStructFields]Return
-    - __kind: EventRootType
-      ID: 571
-      Name: Probe[main.lenPtrStructFields]Return
-    - __kind: EventRootType
-      ID: 573
-      Name: Probe[main.lenPtrStructFields]Return
-    - __kind: EventRootType
-      ID: 575
-      Name: Probe[main.lenPtrStructFields]Return
-    - __kind: EventRootType
-      ID: 577
-      Name: Probe[main.lenPtrStructFields]Return
-    - __kind: EventRootType
-      ID: 520
-      Name: Probe[main.lenSlice]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 522
-      Name: Probe[main.lenSlice]
-      ByteSize: 2
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: isEmpty(s)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-                - __kind: ExprPushOffsetOp
-                  ByteSize: 8
-                - __kind: ExprLoadLiteralOp
-                  Data: AAAAAAAAAAA=
-                - __kind: ExprCmpEqBaseOp
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 524
-      Name: Probe[main.lenSlice]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s_len
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 526
-      Name: Probe[main.lenSlice]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 528
-      Name: Probe[main.lenSlice]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(s)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 530
-      Name: Probe[main.lenSlice]
-      ByteSize: 41
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 112 GoSliceHeaderType []int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 24
-          DictIndex: -1
-        - Name: tag
-          Offset: 25
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 521
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 523
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 525
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 527
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 529
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 531
-      Name: Probe[main.lenSlice]Return
-    - __kind: EventRootType
-      ID: 500
-      Name: Probe[main.lenString]
-      ByteSize: 33
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-        - Name: tag
-          Offset: 17
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 502
-      Name: Probe[main.lenString]
-      ByteSize: 2
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s_len_eq_5
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-                - __kind: ExprPushOffsetOp
-                  ByteSize: 8
-                - __kind: ExprLoadLiteralOp
-                  Data: BQAAAAAAAAA=
-                - __kind: ExprCmpEqBaseOp
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 504
-      Name: Probe[main.lenString]
-      ByteSize: 2
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(s) == 5
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-                - __kind: ExprPushOffsetOp
-                  ByteSize: 8
-                - __kind: ExprLoadLiteralOp
-                  Data: BQAAAAAAAAA=
-                - __kind: ExprCmpEqBaseOp
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 506
-      Name: Probe[main.lenString]
-      ByteSize: 2
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s_isEmpty
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-                - __kind: ExprPushOffsetOp
-                  ByteSize: 8
-                - __kind: ExprLoadLiteralOp
-                  Data: AAAAAAAAAAA=
-                - __kind: ExprCmpEqBaseOp
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 508
-      Name: Probe[main.lenString]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 510
-      Name: Probe[main.lenString]
-      ByteSize: 2
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: isEmpty(s)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-                - __kind: ExprPushOffsetOp
-                  ByteSize: 8
-                - __kind: ExprLoadLiteralOp
-                  Data: AAAAAAAAAAA=
-                - __kind: ExprCmpEqBaseOp
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 512
-      Name: Probe[main.lenString]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s_len
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 514
-      Name: Probe[main.lenString]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 516
-      Name: Probe[main.lenString]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(s)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 518
-      Name: Probe[main.lenString]
-      ByteSize: 33
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-        - Name: tag
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 501
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 503
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 505
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 507
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 509
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 511
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 513
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 515
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 517
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 519
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 548
-      Name: Probe[main.lenStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: items_2
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 16
-                  ByteSize: 16
-                - __kind: SliceBoundsCheckOp
-                  Index: 2
-                - __kind: DereferenceOp
-                  Bias: 16
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 550
-      Name: Probe[main.lenStructFields]
-      ByteSize: 89
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 129 StructureType main.lenFields
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 72
-          DictIndex: -1
-        - Name: tag
-          Offset: 73
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 552
-      Name: Probe[main.lenStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.Dict)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 8 BaseType uint64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 40
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 0
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 554
-      Name: Probe[main.lenStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.PtrSlice)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 56
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 556
-      Name: Probe[main.lenStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.PtrStr)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 48
-                  ByteSize: 8
-                - __kind: DereferenceOp
-                  Bias: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 558
-      Name: Probe[main.lenStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.Items)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 24
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 560
-      Name: Probe[main.lenStructFields]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: len(x.S)
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: x}
-                  Offset: 8
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 562
-      Name: Probe[main.lenStructFields]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 564
-      Name: Probe[main.lenStructFields]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 566
-      Name: Probe[main.lenStructFields]
+      Name: Probe[main.lenMap]
       ByteSize: 17
       ExprStatusArraySize: 1
       Expressions:
@@ -11538,33 +11258,862 @@ Types:
           DictIndex: -1
     - __kind: EventRootType
       ID: 549
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenMap]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(m)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 41, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+          DictIndex: -1
     - __kind: EventRootType
       ID: 551
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenMap]
+      ByteSize: 25
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 116 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 41, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 41, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 542
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 544
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 546
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 548
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 550
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 552
+      Name: Probe[main.lenMap]Return
     - __kind: EventRootType
       ID: 553
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenPtrString]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 42, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+          DictIndex: -1
     - __kind: EventRootType
       ID: 555
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenPtrString]
+      ByteSize: 25
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 101 PointerType *string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 42, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 42, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 554
+      Name: Probe[main.lenPtrString]Return
+    - __kind: EventRootType
+      ID: 556
+      Name: Probe[main.lenPtrString]Return
+    - __kind: EventRootType
+      ID: 577
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: items_0
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 16
+                  ByteSize: 16
+                - __kind: SliceBoundsCheckOp
+                  Index: 0
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 579
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 25
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 131 PointerType *main.lenFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 581
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.Dict)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 40
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 583
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.Items)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 24
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 585
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.S)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 578
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 580
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 582
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 584
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 586
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 529
+      Name: Probe[main.lenSlice]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 531
+      Name: Probe[main.lenSlice]
+      ByteSize: 2
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: isEmpty(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 533
+      Name: Probe[main.lenSlice]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s_len
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 535
+      Name: Probe[main.lenSlice]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 537
+      Name: Probe[main.lenSlice]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 539
+      Name: Probe[main.lenSlice]
+      ByteSize: 41
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 112 GoSliceHeaderType []int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+          DictIndex: -1
+        - Name: tag
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 530
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 532
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 534
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 536
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 538
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 540
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 509
+      Name: Probe[main.lenString]
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: tag
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 511
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s_len_eq_5
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 513
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(s) == 5
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 515
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s_isEmpty
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 517
+      Name: Probe[main.lenString]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 519
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: isEmpty(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 521
+      Name: Probe[main.lenString]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s_len
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 523
+      Name: Probe[main.lenString]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 525
+      Name: Probe[main.lenString]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 527
+      Name: Probe[main.lenString]
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: tag
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 510
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 512
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 514
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 516
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 518
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 520
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 522
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 524
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 526
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 528
+      Name: Probe[main.lenString]Return
     - __kind: EventRootType
       ID: 557
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: items_2
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 16
+                  ByteSize: 16
+                - __kind: SliceBoundsCheckOp
+                  Index: 2
+                - __kind: DereferenceOp
+                  Bias: 16
+                  ByteSize: 8
+          DictIndex: -1
     - __kind: EventRootType
       ID: 559
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenStructFields]
+      ByteSize: 89
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 129 StructureType main.lenFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 72
+          DictIndex: -1
+        - Name: tag
+          Offset: 73
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
     - __kind: EventRootType
       ID: 561
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.Dict)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 40
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+          DictIndex: -1
     - __kind: EventRootType
       ID: 563
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.PtrSlice)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 56
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+          DictIndex: -1
     - __kind: EventRootType
       ID: 565
-      Name: Probe[main.lenStructFields]Return
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.PtrStr)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 48
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+          DictIndex: -1
     - __kind: EventRootType
       ID: 567
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.Items)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 24
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 569
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: len(x.S)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: x}
+                  Offset: 8
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 571
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 573
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 575
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 558
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 560
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 562
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 564
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 566
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 568
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 570
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 572
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 574
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 576
       Name: Probe[main.lenStructFields]Return
     - __kind: EventRootType
       ID: 379
@@ -11598,7 +12147,7 @@ Types:
       ID: 380
       Name: Probe[main.mapArg]Return
     - __kind: EventRootType
-      ID: 664
+      ID: 673
       Name: Probe[main.mapIndexBoolKey]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11610,7 +12159,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11637,7 +12186,7 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 666
+      ID: 675
       Name: Probe[main.mapIndexBoolKey]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11649,7 +12198,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11676,13 +12225,13 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 665
+      ID: 674
+      Name: Probe[main.mapIndexBoolKey]Return
+    - __kind: EventRootType
+      ID: 676
       Name: Probe[main.mapIndexBoolKey]Return
     - __kind: EventRootType
       ID: 667
-      Name: Probe[main.mapIndexBoolKey]Return
-    - __kind: EventRootType
-      ID: 658
       Name: Probe[main.mapIndexEmptyKey]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11694,7 +12243,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11721,10 +12270,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 659
+      ID: 668
       Name: Probe[main.mapIndexEmptyKey]Return
     - __kind: EventRootType
-      ID: 628
+      ID: 637
       Name: Probe[main.mapIndexIntKey]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -11736,7 +12285,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: m}
+                  Variable: {subprogram: 56, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11763,10 +12312,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 629
+      ID: 638
       Name: Probe[main.mapIndexIntKey]Return
     - __kind: EventRootType
-      ID: 660
+      ID: 669
       Name: Probe[main.mapIndexKeyLen16]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11778,7 +12327,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11805,10 +12354,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 661
+      ID: 670
       Name: Probe[main.mapIndexKeyLen16]Return
     - __kind: EventRootType
-      ID: 662
+      ID: 671
       Name: Probe[main.mapIndexKeyLen17]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11820,7 +12369,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11847,10 +12396,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 663
+      ID: 672
       Name: Probe[main.mapIndexKeyLen17]Return
     - __kind: EventRootType
-      ID: 648
+      ID: 657
       Name: Probe[main.mapIndexKeyLen200]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11862,7 +12411,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
+                  Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11889,10 +12438,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 649
+      ID: 658
       Name: Probe[main.mapIndexKeyLen200]Return
     - __kind: EventRootType
-      ID: 642
+      ID: 651
       Name: Probe[main.mapIndexKeyLen24]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11904,7 +12453,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
+                  Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11931,10 +12480,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 643
+      ID: 652
       Name: Probe[main.mapIndexKeyLen24]Return
     - __kind: EventRootType
-      ID: 644
+      ID: 653
       Name: Probe[main.mapIndexKeyLen48]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11946,7 +12495,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
+                  Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -11973,10 +12522,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 645
+      ID: 654
       Name: Probe[main.mapIndexKeyLen48]Return
     - __kind: EventRootType
-      ID: 640
+      ID: 649
       Name: Probe[main.mapIndexKeyLen8]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -11988,7 +12537,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
+                  Variable: {subprogram: 60, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12015,10 +12564,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 641
+      ID: 650
       Name: Probe[main.mapIndexKeyLen8]Return
     - __kind: EventRootType
-      ID: 646
+      ID: 655
       Name: Probe[main.mapIndexKeyLen96]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12030,7 +12579,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12057,10 +12606,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 647
+      ID: 656
       Name: Probe[main.mapIndexKeyLen96]Return
     - __kind: EventRootType
-      ID: 636
+      ID: 645
       Name: Probe[main.mapIndexLargeMap]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12072,7 +12621,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: m}
+                  Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12099,10 +12648,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 637
+      ID: 646
       Name: Probe[main.mapIndexLargeMap]Return
     - __kind: EventRootType
-      ID: 672
+      ID: 681
       Name: Probe[main.mapIndexLargeValue]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12114,7 +12663,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12144,10 +12693,10 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 673
+      ID: 682
       Name: Probe[main.mapIndexLargeValue]Return
     - __kind: EventRootType
-      ID: 638
+      ID: 647
       Name: Probe[main.mapIndexMissing]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12159,7 +12708,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
+                  Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12186,10 +12735,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 639
+      ID: 648
       Name: Probe[main.mapIndexMissing]Return
     - __kind: EventRootType
-      ID: 670
+      ID: 679
       Name: Probe[main.mapIndexNilPtrVal]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12201,7 +12750,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 72, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12231,10 +12780,10 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 671
+      ID: 680
       Name: Probe[main.mapIndexNilPtrVal]Return
     - __kind: EventRootType
-      ID: 654
+      ID: 663
       Name: Probe[main.mapIndexPtrStructVal]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12246,7 +12795,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12276,7 +12825,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 656
+      ID: 665
       Name: Probe[main.mapIndexPtrStructVal]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12288,7 +12837,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12318,13 +12867,13 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 655
+      ID: 664
       Name: Probe[main.mapIndexPtrStructVal]Return
     - __kind: EventRootType
-      ID: 657
+      ID: 666
       Name: Probe[main.mapIndexPtrStructVal]Return
     - __kind: EventRootType
-      ID: 630
+      ID: 639
       Name: Probe[main.mapIndexStringKey]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12336,7 +12885,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12363,10 +12912,10 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 632
+      ID: 641
       Name: Probe[main.mapIndexStringKey]
     - __kind: EventRootType
-      ID: 634
+      ID: 643
       Name: Probe[main.mapIndexStringKey]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12378,7 +12927,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12405,16 +12954,16 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 631
+      ID: 640
       Name: Probe[main.mapIndexStringKey]Return
     - __kind: EventRootType
-      ID: 633
+      ID: 642
       Name: Probe[main.mapIndexStringKey]Return
     - __kind: EventRootType
-      ID: 635
+      ID: 644
       Name: Probe[main.mapIndexStringKey]Return
     - __kind: EventRootType
-      ID: 650
+      ID: 659
       Name: Probe[main.mapIndexStructVal]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12426,7 +12975,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12453,7 +13002,7 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 652
+      ID: 661
       Name: Probe[main.mapIndexStructVal]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12465,7 +13014,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12492,13 +13041,13 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 651
+      ID: 660
       Name: Probe[main.mapIndexStructVal]Return
     - __kind: EventRootType
-      ID: 653
+      ID: 662
       Name: Probe[main.mapIndexStructVal]Return
     - __kind: EventRootType
-      ID: 668
+      ID: 677
       Name: Probe[main.mapIndexZeroValue]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12510,7 +13059,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12537,7 +13086,7 @@ Types:
                   HeaderByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 669
+      ID: 678
       Name: Probe[main.mapIndexZeroValue]Return
     - __kind: EventRootType
       ID: 383
@@ -12546,7 +13095,7 @@ Types:
       ID: 384
       Name: Probe[main.noArgs]Return
     - __kind: EventRootType
-      ID: 616
+      ID: 625
       Name: Probe[main.ptrStructArrayArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12558,7 +13107,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: s}
+                  Variable: {subprogram: 54, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12566,7 +13115,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 618
+      ID: 627
       Name: Probe[main.ptrStructArrayArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12578,7 +13127,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: s}
+                  Variable: {subprogram: 54, index: 0, name: s}
                   Offset: 8
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -12586,13 +13135,13 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 617
+      ID: 626
       Name: Probe[main.ptrStructArrayArg]Return
     - __kind: EventRootType
-      ID: 619
+      ID: 628
       Name: Probe[main.ptrStructArrayArg]Return
     - __kind: EventRootType
-      ID: 612
+      ID: 621
       Name: Probe[main.ptrStructSliceArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12604,7 +13153,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: s}
+                  Variable: {subprogram: 53, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -12617,7 +13166,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 614
+      ID: 623
       Name: Probe[main.ptrStructSliceArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12629,7 +13178,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: s}
+                  Variable: {subprogram: 53, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -12642,10 +13191,10 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 613
+      ID: 622
       Name: Probe[main.ptrStructSliceArg]Return
     - __kind: EventRootType
-      ID: 615
+      ID: 624
       Name: Probe[main.ptrStructSliceArg]Return
     - __kind: EventRootType
       ID: 340
@@ -12807,7 +13356,7 @@ Types:
       ID: 373
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 608
+      ID: 617
       Name: Probe[main.structArrayArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12819,12 +13368,12 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: s}
+                  Variable: {subprogram: 52, index: 0, name: s}
                   Offset: 0
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 610
+      ID: 619
       Name: Probe[main.structArrayArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12836,18 +13385,18 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: s}
+                  Variable: {subprogram: 52, index: 0, name: s}
                   Offset: 40
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
+      ID: 618
+      Name: Probe[main.structArrayArg]Return
+    - __kind: EventRootType
+      ID: 620
+      Name: Probe[main.structArrayArg]Return
+    - __kind: EventRootType
       ID: 609
-      Name: Probe[main.structArrayArg]Return
-    - __kind: EventRootType
-      ID: 611
-      Name: Probe[main.structArrayArg]Return
-    - __kind: EventRootType
-      ID: 600
       Name: Probe[main.structSliceArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12859,7 +13408,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: s}
+                  Variable: {subprogram: 51, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -12869,7 +13418,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 602
+      ID: 611
       Name: Probe[main.structSliceArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12881,7 +13430,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: s}
+                  Variable: {subprogram: 51, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -12891,7 +13440,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 604
+      ID: 613
       Name: Probe[main.structSliceArg]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -12903,12 +13452,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 1, name: tag}
+                  Variable: {subprogram: 51, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 606
+      ID: 615
       Name: Probe[main.structSliceArg]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -12920,7 +13469,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: s}
+                  Variable: {subprogram: 51, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
                 - __kind: SliceBoundsCheckOp
@@ -12930,22 +13479,22 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
+      ID: 610
+      Name: Probe[main.structSliceArg]Return
+    - __kind: EventRootType
+      ID: 612
+      Name: Probe[main.structSliceArg]Return
+    - __kind: EventRootType
+      ID: 614
+      Name: Probe[main.structSliceArg]Return
+    - __kind: EventRootType
+      ID: 616
+      Name: Probe[main.structSliceArg]Return
+    - __kind: EventRootType
       ID: 601
-      Name: Probe[main.structSliceArg]Return
-    - __kind: EventRootType
-      ID: 603
-      Name: Probe[main.structSliceArg]Return
-    - __kind: EventRootType
-      ID: 605
-      Name: Probe[main.structSliceArg]Return
-    - __kind: EventRootType
-      ID: 607
-      Name: Probe[main.structSliceArg]Return
-    - __kind: EventRootType
-      ID: 592
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 593
+      ID: 602
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -12957,7 +13506,7 @@ Types:
             Type: 132 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: ~r0}
+                  Variable: {subprogram: 48, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -12965,7 +13514,7 @@ Types:
       ID: 95
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 57920
+      GoRuntimeType: 58048
       GoKind: 17
       Count: 10
       HasCount: true
@@ -12974,7 +13523,7 @@ Types:
       ID: 335
       Name: '[128]uint8'
       ByteSize: 128
-      GoRuntimeType: 54080
+      GoRuntimeType: 54112
       GoKind: 17
       Count: 128
       HasCount: true
@@ -12983,7 +13532,7 @@ Types:
       ID: 137
       Name: '[131072]int64'
       ByteSize: 1048576
-      GoRuntimeType: 54752
+      GoRuntimeType: 54784
       GoKind: 17
       Count: 131072
       HasCount: true
@@ -12992,7 +13541,7 @@ Types:
       ID: 336
       Name: '[256]uint8'
       ByteSize: 256
-      GoRuntimeType: 54368
+      GoRuntimeType: 54400
       GoKind: 17
       Count: 256
       HasCount: true
@@ -13009,7 +13558,7 @@ Types:
       ID: 82
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 60800
+      GoRuntimeType: 60928
       GoKind: 17
       Count: 2
       HasCount: true
@@ -13018,7 +13567,7 @@ Types:
       ID: 81
       Name: '[2][2]*runtime.traceBuf'
       ByteSize: 32
-      GoRuntimeType: 60896
+      GoRuntimeType: 61024
       GoKind: 17
       Count: 2
       HasCount: true
@@ -13027,7 +13576,7 @@ Types:
       ID: 87
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 61088
+      GoRuntimeType: 61216
       GoKind: 17
       Count: 2
       HasCount: true
@@ -13044,7 +13593,7 @@ Types:
       ID: 58
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 59168
+      GoRuntimeType: 59296
       GoKind: 17
       Count: 2
       HasCount: true
@@ -13053,7 +13602,7 @@ Types:
       ID: 93
       Name: '[32]uint64'
       ByteSize: 256
-      GoRuntimeType: 63392
+      GoRuntimeType: 63520
       GoKind: 17
       Count: 32
       HasCount: true
@@ -13062,7 +13611,7 @@ Types:
       ID: 73
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 57824
+      GoRuntimeType: 57952
       GoKind: 17
       Count: 32
       HasCount: true
@@ -13071,7 +13620,7 @@ Types:
       ID: 113
       Name: '[3]int'
       ByteSize: 24
-      GoRuntimeType: 53504
+      GoRuntimeType: 53536
       GoKind: 17
       Count: 3
       HasCount: true
@@ -13080,7 +13629,7 @@ Types:
       ID: 127
       Name: '[3]int16'
       ByteSize: 6
-      GoRuntimeType: 53216
+      GoRuntimeType: 53248
       GoKind: 17
       Count: 3
       HasCount: true
@@ -13089,7 +13638,7 @@ Types:
       ID: 57
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 59072
+      GoRuntimeType: 59200
       GoKind: 17
       Count: 3
       HasCount: true
@@ -13098,7 +13647,7 @@ Types:
       ID: 115
       Name: '[3]string'
       ByteSize: 48
-      GoRuntimeType: 53600
+      GoRuntimeType: 53632
       GoKind: 17
       Count: 3
       HasCount: true
@@ -13107,7 +13656,7 @@ Types:
       ID: 94
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 62624
+      GoRuntimeType: 62752
       GoKind: 17
       Count: 4
       HasCount: true
@@ -13116,7 +13665,7 @@ Types:
       ID: 62
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 57728
+      GoRuntimeType: 57856
       GoKind: 17
       Count: 6
       HasCount: true
@@ -13125,7 +13674,7 @@ Types:
       ID: 88
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 60992
+      GoRuntimeType: 61120
       GoKind: 17
       Count: 8
       HasCount: true
@@ -13156,7 +13705,7 @@ Types:
       ID: 66
       Name: '[]*runtime.p'
       ByteSize: 24
-      GoRuntimeType: 41952
+      GoRuntimeType: 41984
       GoKind: 23
       RawFields:
         - Name: array
@@ -13233,7 +13782,7 @@ Types:
       ID: 112
       Name: '[]int'
       ByteSize: 24
-      GoRuntimeType: 43680
+      GoRuntimeType: 43712
       GoKind: 23
       RawFields:
         - Name: array
@@ -13336,7 +13885,7 @@ Types:
       ID: 114
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 43936
+      GoRuntimeType: 43968
       GoKind: 23
       RawFields:
         - Name: array
@@ -13359,7 +13908,7 @@ Types:
       ID: 39
       Name: '[]uint8'
       ByteSize: 24
-      GoRuntimeType: 43296
+      GoRuntimeType: 43328
       GoKind: 23
       RawFields:
         - Name: array
@@ -13382,7 +13931,7 @@ Types:
       ID: 44
       Name: '[]uintptr'
       ByteSize: 24
-      GoRuntimeType: 43808
+      GoRuntimeType: 43840
       GoKind: 23
       RawFields:
         - Name: array
@@ -13405,25 +13954,25 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 49088
+      GoRuntimeType: 49120
       GoKind: 1
     - __kind: BaseType
       ID: 18
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 48896
+      GoRuntimeType: 48928
       GoKind: 16
     - __kind: BaseType
       ID: 103
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 48832
+      GoRuntimeType: 48864
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 15
       Name: error
       ByteSize: 16
-      GoRuntimeType: 74048
+      GoRuntimeType: 74176
       GoKind: 20
       RawFields:
         - Name: tab
@@ -13440,25 +13989,25 @@ Types:
       ID: 17
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 48960
+      GoRuntimeType: 48992
       GoKind: 13
     - __kind: BaseType
       ID: 14
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 49024
+      GoRuntimeType: 49056
       GoKind: 14
     - __kind: GoSubroutineType
       ID: 63
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 41056
+      GoRuntimeType: 41088
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 78
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 65760
+      GoRuntimeType: 65888
       GoKind: 19
     - __kind: BaseType
       ID: 175
@@ -13613,37 +14162,37 @@ Types:
       ID: 7
       Name: int
       ByteSize: 8
-      GoRuntimeType: 48640
+      GoRuntimeType: 48672
       GoKind: 2
     - __kind: BaseType
       ID: 102
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 48256
+      GoRuntimeType: 48288
       GoKind: 4
     - __kind: BaseType
       ID: 12
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 48384
+      GoRuntimeType: 48416
       GoKind: 5
     - __kind: BaseType
       ID: 13
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 48512
+      GoRuntimeType: 48544
       GoKind: 6
     - __kind: BaseType
       ID: 19
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 48128
+      GoRuntimeType: 48160
       GoKind: 3
     - __kind: BaseType
       ID: 332
       Name: internal/abi.BoundsErrorCode
       ByteSize: 1
-      GoRuntimeType: 49792
+      GoRuntimeType: 49824
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 331
@@ -13657,7 +14206,7 @@ Types:
       ID: 92
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 131712
+      GoRuntimeType: 131840
       GoKind: 25
       RawFields:
         - Name: buf
@@ -13682,14 +14231,14 @@ Types:
     - __kind: StructureType
       ID: 325
       Name: internal/poll.errNetClosing
-      GoRuntimeType: 104928
+      GoRuntimeType: 105056
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 36
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 85696
+      GoRuntimeType: 85824
       GoKind: 25
       RawFields:
         - Name: u
@@ -13699,7 +14248,7 @@ Types:
       ID: 76
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 117760
+      GoRuntimeType: 117888
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -13719,7 +14268,7 @@ Types:
       ID: 33
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 105728
+      GoRuntimeType: 105856
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -13732,7 +14281,7 @@ Types:
       ID: 37
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 105568
+      GoRuntimeType: 105696
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -13744,20 +14293,20 @@ Types:
     - __kind: StructureType
       ID: 77
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 72352
+      GoRuntimeType: 72480
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 34
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 72256
+      GoRuntimeType: 72384
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
       ID: 286
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
-      GoRuntimeType: 64608
+      GoRuntimeType: 64736
       GoKind: 24
       RawFields:
         - Name: str
@@ -13776,7 +14325,7 @@ Types:
       ID: 317
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
-      GoRuntimeType: 108576
+      GoRuntimeType: 108704
       GoKind: 25
       RawFields:
         - Name: typ
@@ -13786,7 +14335,7 @@ Types:
       ID: 285
       Name: internal/strconv.Error
       ByteSize: 8
-      GoRuntimeType: 64512
+      GoRuntimeType: 64640
       GoKind: 2
     - __kind: UnresolvedPointeeType
       ID: 323
@@ -13796,14 +14345,14 @@ Types:
       ID: 279
       Name: main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 80960
+      GoRuntimeType: 81088
       GoKind: 25
       RawFields: [{Name: a, Offset: 0, Type: 7 BaseType int}]
     - __kind: StructureType
       ID: 139
       Name: main.bigArrayStruct
       ByteSize: 1048584
-      GoRuntimeType: 96928
+      GoRuntimeType: 97056
       GoKind: 25
       RawFields:
         - Name: tag
@@ -13816,7 +14365,7 @@ Types:
       ID: 209
       Name: main.bigStruct
       ByteSize: 184
-      GoRuntimeType: 140320
+      GoRuntimeType: 140448
       GoKind: 25
       RawFields:
         - Name: Field1
@@ -13847,7 +14396,7 @@ Types:
       ID: 126
       Name: main.condFields
       ByteSize: 80
-      GoRuntimeType: 147872
+      GoRuntimeType: 148000
       GoKind: 25
       RawFields:
         - Name: I8
@@ -13893,7 +14442,7 @@ Types:
       ID: 142
       Name: main.indexMemberStruct
       ByteSize: 32
-      GoRuntimeType: 110656
+      GoRuntimeType: 110784
       GoKind: 25
       RawFields:
         - Name: Val
@@ -13924,7 +14473,7 @@ Types:
       ID: 268
       Name: main.largeValueStruct
       ByteSize: 264
-      GoRuntimeType: 96768
+      GoRuntimeType: 96896
       GoKind: 25
       RawFields:
         - Name: Pad
@@ -13937,7 +14486,7 @@ Types:
       ID: 129
       Name: main.lenFields
       ByteSize: 72
-      GoRuntimeType: 133600
+      GoRuntimeType: 133728
       GoKind: 25
       RawFields:
         - Name: S
@@ -14283,70 +14832,70 @@ Types:
       ID: 164
       Name: map[bool]int
       ByteSize: 8
-      GoRuntimeType: 78528
+      GoRuntimeType: 78656
       GoKind: 21
       HeaderType: 166 GoSwissMapHeaderType map<bool,int>
     - __kind: GoMapType
       ID: 218
       Name: map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 78656
+      GoRuntimeType: 78784
       GoKind: 21
       HeaderType: 220 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 149
       Name: map[int]string
       ByteSize: 8
-      GoRuntimeType: 78784
+      GoRuntimeType: 78912
       GoKind: 21
       HeaderType: 151 GoSwissMapHeaderType map<int,string>
     - __kind: GoMapType
       ID: 159
       Name: map[string]*main.indexMemberStruct
       ByteSize: 8
-      GoRuntimeType: 78912
+      GoRuntimeType: 79040
       GoKind: 21
       HeaderType: 161 GoSwissMapHeaderType map<string,*main.indexMemberStruct>
     - __kind: GoMapType
       ID: 116
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 78400
+      GoRuntimeType: 78528
       GoKind: 21
       HeaderType: 118 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 121
       Name: map[string]main.bigStruct
       ByteSize: 8
-      GoRuntimeType: 79040
+      GoRuntimeType: 79168
       GoKind: 21
       HeaderType: 123 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: GoMapType
       ID: 154
       Name: map[string]main.indexMemberStruct
       ByteSize: 8
-      GoRuntimeType: 79168
+      GoRuntimeType: 79296
       GoKind: 21
       HeaderType: 156 GoSwissMapHeaderType map<string,main.indexMemberStruct>
     - __kind: GoMapType
       ID: 169
       Name: map[string]main.largeValueStruct
       ByteSize: 8
-      GoRuntimeType: 79296
+      GoRuntimeType: 79424
       GoKind: 21
       HeaderType: 171 GoSwissMapHeaderType map<string,main.largeValueStruct>
     - __kind: GoMapType
       ID: 132
       Name: map[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 79552
+      GoRuntimeType: 79680
       GoKind: 21
       HeaderType: 134 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: ArrayType
       ID: 257
       Name: noalg.[8]struct { key bool; elem int }
       ByteSize: 128
-      GoRuntimeType: 53696
+      GoRuntimeType: 53728
       GoKind: 17
       Count: 8
       HasCount: true
@@ -14355,7 +14904,7 @@ Types:
       ID: 277
       Name: noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
       ByteSize: 128
-      GoRuntimeType: 53792
+      GoRuntimeType: 53824
       GoKind: 17
       Count: 8
       HasCount: true
@@ -14364,7 +14913,7 @@ Types:
       ID: 233
       Name: noalg.[8]struct { key int; elem string }
       ByteSize: 192
-      GoRuntimeType: 53888
+      GoRuntimeType: 53920
       GoKind: 17
       Count: 8
       HasCount: true
@@ -14373,7 +14922,7 @@ Types:
       ID: 206
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
-      GoRuntimeType: 54176
+      GoRuntimeType: 54208
       GoKind: 17
       Count: 8
       HasCount: true
@@ -14382,7 +14931,7 @@ Types:
       ID: 249
       Name: noalg.[8]struct { key string; elem *main.indexMemberStruct }
       ByteSize: 192
-      GoRuntimeType: 53984
+      GoRuntimeType: 54016
       GoKind: 17
       Count: 8
       HasCount: true
@@ -14391,7 +14940,7 @@ Types:
       ID: 265
       Name: noalg.[8]struct { key string; elem *main.largeValueStruct }
       ByteSize: 192
-      GoRuntimeType: 54464
+      GoRuntimeType: 54496
       GoKind: 17
       Count: 8
       HasCount: true
@@ -14400,7 +14949,7 @@ Types:
       ID: 198
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 53312
+      GoRuntimeType: 53344
       GoKind: 17
       Count: 8
       HasCount: true
@@ -14409,7 +14958,7 @@ Types:
       ID: 241
       Name: noalg.[8]struct { key string; elem main.indexMemberStruct }
       ByteSize: 384
-      GoRuntimeType: 54272
+      GoRuntimeType: 54304
       GoKind: 17
       Count: 8
       HasCount: true
@@ -14418,7 +14967,7 @@ Types:
       ID: 216
       Name: noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
       ByteSize: 128
-      GoRuntimeType: 54656
+      GoRuntimeType: 54688
       GoKind: 17
       Count: 8
       HasCount: true
@@ -14427,7 +14976,7 @@ Types:
       ID: 256
       Name: noalg.map.group[bool]int
       ByteSize: 136
-      GoRuntimeType: 87360
+      GoRuntimeType: 87488
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14440,7 +14989,7 @@ Types:
       ID: 276
       Name: noalg.map.group[int]main.aStructNotUsedAsAnArgument
       ByteSize: 136
-      GoRuntimeType: 87616
+      GoRuntimeType: 87744
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14453,7 +15002,7 @@ Types:
       ID: 232
       Name: noalg.map.group[int]string
       ByteSize: 200
-      GoRuntimeType: 87872
+      GoRuntimeType: 88000
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14466,7 +15015,7 @@ Types:
       ID: 248
       Name: noalg.map.group[string]*main.indexMemberStruct
       ByteSize: 200
-      GoRuntimeType: 88128
+      GoRuntimeType: 88256
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14479,7 +15028,7 @@ Types:
       ID: 197
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 87104
+      GoRuntimeType: 87232
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14492,7 +15041,7 @@ Types:
       ID: 205
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
-      GoRuntimeType: 88384
+      GoRuntimeType: 88512
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14505,7 +15054,7 @@ Types:
       ID: 240
       Name: noalg.map.group[string]main.indexMemberStruct
       ByteSize: 392
-      GoRuntimeType: 88640
+      GoRuntimeType: 88768
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14518,7 +15067,7 @@ Types:
       ID: 264
       Name: noalg.map.group[string]main.largeValueStruct
       ByteSize: 200
-      GoRuntimeType: 88896
+      GoRuntimeType: 89024
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14531,7 +15080,7 @@ Types:
       ID: 215
       Name: noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 136
-      GoRuntimeType: 89408
+      GoRuntimeType: 89536
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -14544,7 +15093,7 @@ Types:
       ID: 258
       Name: noalg.struct { key bool; elem int }
       ByteSize: 16
-      GoRuntimeType: 87232
+      GoRuntimeType: 87360
       GoKind: 25
       RawFields:
         - Name: key
@@ -14557,7 +15106,7 @@ Types:
       ID: 278
       Name: noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
       ByteSize: 16
-      GoRuntimeType: 87488
+      GoRuntimeType: 87616
       GoKind: 25
       RawFields:
         - Name: key
@@ -14570,7 +15119,7 @@ Types:
       ID: 234
       Name: noalg.struct { key int; elem string }
       ByteSize: 24
-      GoRuntimeType: 87744
+      GoRuntimeType: 87872
       GoKind: 25
       RawFields:
         - Name: key
@@ -14583,7 +15132,7 @@ Types:
       ID: 207
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
-      GoRuntimeType: 88256
+      GoRuntimeType: 88384
       GoKind: 25
       RawFields:
         - Name: key
@@ -14596,7 +15145,7 @@ Types:
       ID: 250
       Name: noalg.struct { key string; elem *main.indexMemberStruct }
       ByteSize: 24
-      GoRuntimeType: 88000
+      GoRuntimeType: 88128
       GoKind: 25
       RawFields:
         - Name: key
@@ -14609,7 +15158,7 @@ Types:
       ID: 266
       Name: noalg.struct { key string; elem *main.largeValueStruct }
       ByteSize: 24
-      GoRuntimeType: 88768
+      GoRuntimeType: 88896
       GoKind: 25
       RawFields:
         - Name: key
@@ -14622,7 +15171,7 @@ Types:
       ID: 199
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 86976
+      GoRuntimeType: 87104
       GoKind: 25
       RawFields:
         - Name: key
@@ -14635,7 +15184,7 @@ Types:
       ID: 242
       Name: noalg.struct { key string; elem main.indexMemberStruct }
       ByteSize: 48
-      GoRuntimeType: 88512
+      GoRuntimeType: 88640
       GoKind: 25
       RawFields:
         - Name: key
@@ -14648,7 +15197,7 @@ Types:
       ID: 217
       Name: noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
       ByteSize: 16
-      GoRuntimeType: 89280
+      GoRuntimeType: 89408
       GoKind: 25
       RawFields:
         - Name: key
@@ -14685,7 +15234,7 @@ Types:
       ID: 313
       Name: runtime.boundsError
       ByteSize: 24
-      GoRuntimeType: 132608
+      GoRuntimeType: 132736
       GoKind: 25
       RawFields:
         - Name: x
@@ -14711,14 +15260,14 @@ Types:
     - __kind: StructureType
       ID: 90
       Name: runtime.dlogPerM
-      GoRuntimeType: 71488
+      GoRuntimeType: 71616
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 321
       Name: runtime.errorAddressString
       ByteSize: 24
-      GoRuntimeType: 124288
+      GoRuntimeType: 124416
       GoKind: 25
       RawFields:
         - Name: msg
@@ -14731,7 +15280,7 @@ Types:
       ID: 300
       Name: runtime.errorString
       ByteSize: 16
-      GoRuntimeType: 70912
+      GoRuntimeType: 71040
       GoKind: 24
       RawFields:
         - Name: str
@@ -14750,7 +15299,7 @@ Types:
       ID: 23
       Name: runtime.g
       ByteSize: 456
-      GoRuntimeType: 164384
+      GoRuntimeType: 164512
       GoKind: 25
       RawFields:
         - Name: stack
@@ -14952,7 +15501,7 @@ Types:
       ID: 55
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 83008
+      GoRuntimeType: 83136
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -14962,7 +15511,7 @@ Types:
       ID: 31
       Name: runtime.gobuf
       ByteSize: 48
-      GoRuntimeType: 135136
+      GoRuntimeType: 135264
       GoKind: 25
       RawFields:
         - Name: sp
@@ -14987,7 +15536,7 @@ Types:
       ID: 47
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 100448
+      GoRuntimeType: 100576
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -15000,7 +15549,7 @@ Types:
       ID: 60
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 123136
+      GoRuntimeType: 123264
       GoKind: 25
       RawFields:
         - Name: stack
@@ -15019,13 +15568,13 @@ Types:
       ID: 32
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 63840
+      GoRuntimeType: 63968
       GoKind: 12
     - __kind: StructureType
       ID: 96
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 102848
+      GoRuntimeType: 102976
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -15038,7 +15587,7 @@ Types:
       ID: 72
       Name: runtime.listNodeManual
       ByteSize: 16
-      GoRuntimeType: 102048
+      GoRuntimeType: 102176
       GoKind: 25
       RawFields:
         - Name: prev
@@ -15051,13 +15600,13 @@ Types:
       ID: 97
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 64224
+      GoRuntimeType: 64352
       GoKind: 2
     - __kind: StructureType
       ID: 30
       Name: runtime.m
       ByteSize: 1824
-      GoRuntimeType: 169664
+      GoRuntimeType: 169792
       GoKind: 25
       RawFields:
         - Name: g0
@@ -15286,7 +15835,7 @@ Types:
       ID: 75
       Name: runtime.mLockProfile
       ByteSize: 56
-      GoRuntimeType: 135648
+      GoRuntimeType: 135776
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -15311,7 +15860,7 @@ Types:
       ID: 91
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 131040
+      GoRuntimeType: 131168
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -15333,7 +15882,7 @@ Types:
       ID: 80
       Name: runtime.mTraceState
       ByteSize: 72
-      GoRuntimeType: 135904
+      GoRuntimeType: 136032
       GoKind: 25
       RawFields:
         - Name: writing
@@ -15358,7 +15907,7 @@ Types:
       ID: 74
       Name: runtime.mWaitList
       ByteSize: 16
-      GoRuntimeType: 102528
+      GoRuntimeType: 102656
       GoKind: 25
       RawFields:
         - Name: next
@@ -15371,7 +15920,7 @@ Types:
       ID: 98
       Name: runtime.mWeakPointer
       ByteSize: 8
-      GoRuntimeType: 107936
+      GoRuntimeType: 108064
       GoKind: 25
       RawFields:
         - Name: m
@@ -15381,13 +15930,13 @@ Types:
       ID: 38
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 63936
+      GoRuntimeType: 64064
       GoKind: 12
     - __kind: StructureType
       ID: 71
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 84032
+      GoRuntimeType: 84160
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
@@ -15398,7 +15947,7 @@ Types:
       ID: 86
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 102688
+      GoRuntimeType: 102816
       GoKind: 25
       RawFields:
         - Name: entries
@@ -15411,7 +15960,7 @@ Types:
       ID: 89
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 124096
+      GoRuntimeType: 124224
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -15430,7 +15979,7 @@ Types:
       ID: 303
       Name: runtime.plainError
       ByteSize: 16
-      GoRuntimeType: 71008
+      GoRuntimeType: 71136
       GoKind: 24
       RawFields:
         - Name: str
@@ -15449,13 +15998,13 @@ Types:
       ID: 64
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 64128
+      GoRuntimeType: 64256
       GoKind: 12
     - __kind: ArrayType
       ID: 61
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 67744
+      GoRuntimeType: 67872
       GoKind: 17
       Count: 2
       HasCount: true
@@ -15464,7 +16013,7 @@ Types:
       ID: 24
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 99168
+      GoRuntimeType: 99296
       GoKind: 25
       RawFields:
         - Name: lo
@@ -15485,7 +16034,7 @@ Types:
       ID: 294
       Name: runtime.synctestDeadlockError
       ByteSize: 24
-      GoRuntimeType: 110496
+      GoRuntimeType: 110624
       GoKind: 25
       RawFields:
         - Name: reason
@@ -15498,7 +16047,7 @@ Types:
       ID: 65
       Name: runtime.throwType
       ByteSize: 4
-      GoRuntimeType: 49280
+      GoRuntimeType: 49312
       GoKind: 10
     - __kind: UnresolvedPointeeType
       ID: 46
@@ -15508,7 +16057,7 @@ Types:
       ID: 79
       Name: runtime.traceBlockReason
       ByteSize: 1
-      GoRuntimeType: 49344
+      GoRuntimeType: 49376
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 84
@@ -15518,7 +16067,7 @@ Types:
       ID: 56
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 100768
+      GoRuntimeType: 100896
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -15531,19 +16080,19 @@ Types:
       ID: 35
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 110176
+      GoRuntimeType: 110304
       GoKind: 8
     - __kind: StructureType
       ID: 85
       Name: runtime.winlibcall
-      GoRuntimeType: 71392
+      GoRuntimeType: 71520
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 52
       Name: runtime.xRegPerG
       ByteSize: 8
-      GoRuntimeType: 82880
+      GoRuntimeType: 83008
       GoKind: 25
       RawFields:
         - Name: state
@@ -15561,7 +16110,7 @@ Types:
       ID: 9
       Name: string
       ByteSize: 16
-      GoRuntimeType: 48064
+      GoRuntimeType: 48096
       GoKind: 24
       RawFields:
         - Name: str
@@ -15580,7 +16129,7 @@ Types:
       ID: 328
       Name: syscall.Errno
       ByteSize: 8
-      GoRuntimeType: 86848
+      GoRuntimeType: 86976
       GoKind: 12
     - __kind: StructureType
       ID: 253
@@ -15802,7 +16351,7 @@ Types:
       ID: 282
       Name: time.fileSizeError
       ByteSize: 16
-      GoRuntimeType: 64320
+      GoRuntimeType: 64448
       GoKind: 24
       RawFields:
         - Name: str
@@ -15821,45 +16370,45 @@ Types:
       ID: 11
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 48704
+      GoRuntimeType: 48736
       GoKind: 7
     - __kind: BaseType
       ID: 6
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 48320
+      GoRuntimeType: 48352
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 48448
+      GoRuntimeType: 48480
       GoKind: 10
     - __kind: BaseType
       ID: 8
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 48576
+      GoRuntimeType: 48608
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 48192
+      GoRuntimeType: 48224
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 48768
+      GoRuntimeType: 48800
       GoKind: 12
     - __kind: VoidPointerType
       ID: 16
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 49152
+      GoRuntimeType: 49184
       GoKind: 26
-MaxTypeID: 684
+MaxTypeID: 693
 Issues:
     - probe_definition:
         id: condCompound_eq_of_eq
@@ -16167,6 +16716,26 @@ Issues:
       issue:
         Kind: 7
         Message: condition variable "x" not available at any event
+    - probe_definition:
+        id: condLineReturn_cond_return
+        version: 0
+        type: LOG_PROBE
+        where:
+            methodName: main.condLineReturn
+            sourceFile: main.go
+            lines: ["571"]
+        tags: ['issue:ConditionVariableUnavailable']
+        when:
+            dsl: '@return == 14'
+            json: {eq: [{ref: '@return'}, 14]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: matched
+        segments: [matched]
+        captureSnapshot: false
+      issue:
+        Kind: 7
+        Message: condition variable "@return" not found
     - probe_definition:
         id: condNull_int_vs_null
         version: 0

--- a/pkg/dyninst/testdata/decoded/simple/PointerChainArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/PointerChainArg.json
@@ -18,7 +18,7 @@
           {
             "function": "main.PointerChainArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 367
+            "lineNumber": 395
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/PointerSmallChainArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/PointerSmallChainArg.json
@@ -18,7 +18,7 @@
           {
             "function": "main.PointerSmallChainArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 371
+            "lineNumber": 399
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/bigMapArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/bigMapArg.json
@@ -18,7 +18,7 @@
           {
             "function": "main.bigMapArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 364
+            "lineNumber": 392
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condBool_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condBool_nocond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condBool",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 457
+            "lineNumber": 485
           },
           {
             "function": "main.main",
@@ -82,7 +82,7 @@
           {
             "function": "main.condBool",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 457
+            "lineNumber": 485
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condFloat32_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condFloat32_nocond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condFloat32",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 447
+            "lineNumber": 475
           },
           {
             "function": "main.main",
@@ -78,7 +78,7 @@
           {
             "function": "main.condFloat32",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 447
+            "lineNumber": 475
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condFloat64_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condFloat64_nocond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condFloat64",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 452
+            "lineNumber": 480
           },
           {
             "function": "main.main",
@@ -78,7 +78,7 @@
           {
             "function": "main.condFloat64",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 452
+            "lineNumber": 480
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condInt16_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condInt16_nocond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condInt16",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 412
+            "lineNumber": 440
           },
           {
             "function": "main.main",
@@ -82,7 +82,7 @@
           {
             "function": "main.condInt16",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 412
+            "lineNumber": 440
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condInt32_cond_with_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/condInt32_cond_with_capture.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condInt32",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 417
+            "lineNumber": 445
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condInt32_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condInt32_nocond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condInt32",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 417
+            "lineNumber": 445
           },
           {
             "function": "main.main",
@@ -82,7 +82,7 @@
           {
             "function": "main.condInt32",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 417
+            "lineNumber": 445
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condInt64_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condInt64_nocond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condInt64",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 422
+            "lineNumber": 450
           },
           {
             "function": "main.main",
@@ -82,7 +82,7 @@
           {
             "function": "main.condInt64",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 422
+            "lineNumber": 450
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condInt8_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condInt8_nocond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condInt8",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 407
+            "lineNumber": 435
           },
           {
             "function": "main.main",
@@ -82,7 +82,7 @@
           {
             "function": "main.condInt8",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 407
+            "lineNumber": 435
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condLineMixed_cond_bool.json
+++ b/pkg/dyninst/testdata/decoded/simple/condLineMixed_cond_bool.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.condLine",
+      "method": "main.condLineMixed",
       "version": 0,
       "thread_id": "[goid]",
       "thread_name": ""
@@ -15,18 +15,18 @@
         "timestamp": "[ts]",
         "language": "go",
         "probe": {
-          "id": "condCompound_line_and",
+          "id": "condLineMixed_cond_bool",
           "location": {
-            "method": "main.condLine",
+            "method": "main.condLineMixed",
             "file": "main.go",
-            "line": 547
+            "line": 561
           }
         }
       },
       "type": "snapshot"
     },
     "timestamp": "[ts]",
-    "message": "n == 7 && tag == \"match\" [n=7, tag=match]",
+    "message": "matched",
     "process_tags": "entrypoint.name:sample,svc.user:sample"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/condLineMixed_cond_isEmpty_slice.json
+++ b/pkg/dyninst/testdata/decoded/simple/condLineMixed_cond_isEmpty_slice.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.condLine",
+      "method": "main.condLineMixed",
       "version": 0,
       "thread_id": "[goid]",
       "thread_name": ""
@@ -15,18 +15,18 @@
         "timestamp": "[ts]",
         "language": "go",
         "probe": {
-          "id": "condCompound_line_and",
+          "id": "condLineMixed_cond_isEmpty_slice",
           "location": {
-            "method": "main.condLine",
+            "method": "main.condLineMixed",
             "file": "main.go",
-            "line": 547
+            "line": 561
           }
         }
       },
       "type": "snapshot"
     },
     "timestamp": "[ts]",
-    "message": "n == 7 && tag == \"match\" [n=7, tag=match]",
+    "message": "matched",
     "process_tags": "entrypoint.name:sample,svc.user:sample"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/condLineMixed_cond_len_string.json
+++ b/pkg/dyninst/testdata/decoded/simple/condLineMixed_cond_len_string.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.condLine",
+      "method": "main.condLineMixed",
       "version": 0,
       "thread_id": "[goid]",
       "thread_name": ""
@@ -15,18 +15,18 @@
         "timestamp": "[ts]",
         "language": "go",
         "probe": {
-          "id": "condCompound_line_and",
+          "id": "condLineMixed_cond_len_string",
           "location": {
-            "method": "main.condLine",
+            "method": "main.condLineMixed",
             "file": "main.go",
-            "line": 547
+            "line": 561
           }
         }
       },
       "type": "snapshot"
     },
     "timestamp": "[ts]",
-    "message": "n == 7 && tag == \"match\" [n=7, tag=match]",
+    "message": "matched",
     "process_tags": "entrypoint.name:sample,svc.user:sample"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/condLineMixed_cond_ptrstruct_field.json
+++ b/pkg/dyninst/testdata/decoded/simple/condLineMixed_cond_ptrstruct_field.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.condLine",
+      "method": "main.condLineMixed",
       "version": 0,
       "thread_id": "[goid]",
       "thread_name": ""
@@ -15,18 +15,18 @@
         "timestamp": "[ts]",
         "language": "go",
         "probe": {
-          "id": "condCompound_line_and",
+          "id": "condLineMixed_cond_ptrstruct_field",
           "location": {
-            "method": "main.condLine",
+            "method": "main.condLineMixed",
             "file": "main.go",
-            "line": 547
+            "line": 561
           }
         }
       },
       "type": "snapshot"
     },
     "timestamp": "[ts]",
-    "message": "n == 7 && tag == \"match\" [n=7, tag=match]",
+    "message": "matched",
     "process_tags": "entrypoint.name:sample,svc.user:sample"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/condLineMixed_cond_string.json
+++ b/pkg/dyninst/testdata/decoded/simple/condLineMixed_cond_string.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.condLine",
+      "method": "main.condLineMixed",
       "version": 0,
       "thread_id": "[goid]",
       "thread_name": ""
@@ -15,18 +15,18 @@
         "timestamp": "[ts]",
         "language": "go",
         "probe": {
-          "id": "condCompound_line_and",
+          "id": "condLineMixed_cond_string",
           "location": {
-            "method": "main.condLine",
+            "method": "main.condLineMixed",
             "file": "main.go",
-            "line": 547
+            "line": 561
           }
         }
       },
       "type": "snapshot"
     },
     "timestamp": "[ts]",
-    "message": "n == 7 && tag == \"match\" [n=7, tag=match]",
+    "message": "matched",
     "process_tags": "entrypoint.name:sample,svc.user:sample"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/condLineMixed_cond_struct_field.json
+++ b/pkg/dyninst/testdata/decoded/simple/condLineMixed_cond_struct_field.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.condLine",
+      "method": "main.condLineMixed",
       "version": 0,
       "thread_id": "[goid]",
       "thread_name": ""
@@ -15,18 +15,18 @@
         "timestamp": "[ts]",
         "language": "go",
         "probe": {
-          "id": "condCompound_line_and",
+          "id": "condLineMixed_cond_struct_field",
           "location": {
-            "method": "main.condLine",
+            "method": "main.condLineMixed",
             "file": "main.go",
-            "line": 547
+            "line": 561
           }
         }
       },
       "type": "snapshot"
     },
     "timestamp": "[ts]",
-    "message": "n == 7 && tag == \"match\" [n=7, tag=match]",
+    "message": "matched",
     "process_tags": "entrypoint.name:sample,svc.user:sample"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/condLineMixed_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condLineMixed_nocond.json
@@ -1,0 +1,453 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.condLineMixed",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.condLineMixed",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 561
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 122
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "condLineMixed_nocond",
+          "location": {
+            "method": "main.condLineMixed",
+            "file": "main.go",
+            "line": 561
+          }
+        },
+        "captures": {
+          "lines": {
+            "561": {
+              "locals": {
+                "s": {
+                  "type": "string",
+                  "value": "hello"
+                },
+                "b": {
+                  "type": "bool",
+                  "value": "true"
+                },
+                "x": {
+                  "type": "main.condFields",
+                  "fields": {
+                    "I8": {
+                      "type": "int8",
+                      "value": "10"
+                    },
+                    "I16": {
+                      "type": "int16",
+                      "value": "200"
+                    },
+                    "I32": {
+                      "type": "int32",
+                      "value": "300"
+                    },
+                    "I64": {
+                      "type": "int64",
+                      "value": "400"
+                    },
+                    "U8": {
+                      "type": "uint8",
+                      "value": "50"
+                    },
+                    "U16": {
+                      "type": "uint16",
+                      "value": "600"
+                    },
+                    "U32": {
+                      "type": "uint32",
+                      "value": "700"
+                    },
+                    "U64": {
+                      "type": "uint64",
+                      "value": "800"
+                    },
+                    "F32": {
+                      "type": "float32",
+                      "value": "1.5"
+                    },
+                    "F64": {
+                      "type": "float64",
+                      "value": "2.5"
+                    },
+                    "B": {
+                      "type": "bool",
+                      "value": "true"
+                    },
+                    "S": {
+                      "type": "string",
+                      "value": "world"
+                    },
+                    "arr": {
+                      "type": "[3]int16",
+                      "size": "3",
+                      "elements": [
+                        {
+                          "type": "int16",
+                          "value": "0"
+                        },
+                        {
+                          "type": "int16",
+                          "value": "0"
+                        },
+                        {
+                          "type": "int16",
+                          "value": "0"
+                        }
+                      ]
+                    }
+                  }
+                },
+                "p": {
+                  "type": "*main.condFields",
+                  "address": "[addr]",
+                  "fields": {
+                    "I8": {
+                      "type": "int8",
+                      "value": "10"
+                    },
+                    "I16": {
+                      "type": "int16",
+                      "value": "200"
+                    },
+                    "I32": {
+                      "type": "int32",
+                      "value": "300"
+                    },
+                    "I64": {
+                      "type": "int64",
+                      "value": "400"
+                    },
+                    "U8": {
+                      "type": "uint8",
+                      "value": "50"
+                    },
+                    "U16": {
+                      "type": "uint16",
+                      "value": "600"
+                    },
+                    "U32": {
+                      "type": "uint32",
+                      "value": "700"
+                    },
+                    "U64": {
+                      "type": "uint64",
+                      "value": "800"
+                    },
+                    "F32": {
+                      "type": "float32",
+                      "value": "1.5"
+                    },
+                    "F64": {
+                      "type": "float64",
+                      "value": "2.5"
+                    },
+                    "B": {
+                      "type": "bool",
+                      "value": "true"
+                    },
+                    "S": {
+                      "type": "string",
+                      "value": "world"
+                    },
+                    "arr": {
+                      "type": "[3]int16",
+                      "size": "3",
+                      "elements": [
+                        {
+                          "type": "int16",
+                          "value": "0"
+                        },
+                        {
+                          "type": "int16",
+                          "value": "0"
+                        },
+                        {
+                          "type": "int16",
+                          "value": "0"
+                        }
+                      ]
+                    }
+                  }
+                },
+                "ss": {
+                  "type": "[]int",
+                  "size": "5",
+                  "elements": [
+                    {
+                      "type": "int",
+                      "value": "1"
+                    },
+                    {
+                      "type": "int",
+                      "value": "2"
+                    },
+                    {
+                      "type": "int",
+                      "value": "3"
+                    },
+                    {
+                      "type": "int",
+                      "value": "4"
+                    },
+                    {
+                      "type": "int",
+                      "value": "5"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "process_tags": "entrypoint.name:sample,svc.user:sample"
+  },
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.condLineMixed",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.condLineMixed",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 561
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 131
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "condLineMixed_nocond",
+          "location": {
+            "method": "main.condLineMixed",
+            "file": "main.go",
+            "line": 561
+          }
+        },
+        "captures": {
+          "lines": {
+            "561": {
+              "locals": {
+                "s": {
+                  "type": "string",
+                  "value": "xy"
+                },
+                "b": {
+                  "type": "bool",
+                  "value": "false"
+                },
+                "x": {
+                  "type": "main.condFields",
+                  "fields": {
+                    "I8": {
+                      "type": "int8",
+                      "value": "1"
+                    },
+                    "I16": {
+                      "type": "int16",
+                      "value": "2"
+                    },
+                    "I32": {
+                      "type": "int32",
+                      "value": "3"
+                    },
+                    "I64": {
+                      "type": "int64",
+                      "value": "4"
+                    },
+                    "U8": {
+                      "type": "uint8",
+                      "value": "5"
+                    },
+                    "U16": {
+                      "type": "uint16",
+                      "value": "6"
+                    },
+                    "U32": {
+                      "type": "uint32",
+                      "value": "7"
+                    },
+                    "U64": {
+                      "type": "uint64",
+                      "value": "8"
+                    },
+                    "F32": {
+                      "type": "float32",
+                      "value": "0.10000000149011612"
+                    },
+                    "F64": {
+                      "type": "float64",
+                      "value": "0.2"
+                    },
+                    "B": {
+                      "type": "bool",
+                      "value": "false"
+                    },
+                    "S": {
+                      "type": "string",
+                      "value": "other"
+                    },
+                    "arr": {
+                      "type": "[3]int16",
+                      "size": "3",
+                      "elements": [
+                        {
+                          "type": "int16",
+                          "value": "0"
+                        },
+                        {
+                          "type": "int16",
+                          "value": "0"
+                        },
+                        {
+                          "type": "int16",
+                          "value": "0"
+                        }
+                      ]
+                    }
+                  }
+                },
+                "p": {
+                  "type": "*main.condFields",
+                  "address": "[addr]",
+                  "fields": {
+                    "I8": {
+                      "type": "int8",
+                      "value": "1"
+                    },
+                    "I16": {
+                      "type": "int16",
+                      "value": "2"
+                    },
+                    "I32": {
+                      "type": "int32",
+                      "value": "3"
+                    },
+                    "I64": {
+                      "type": "int64",
+                      "value": "4"
+                    },
+                    "U8": {
+                      "type": "uint8",
+                      "value": "5"
+                    },
+                    "U16": {
+                      "type": "uint16",
+                      "value": "6"
+                    },
+                    "U32": {
+                      "type": "uint32",
+                      "value": "7"
+                    },
+                    "U64": {
+                      "type": "uint64",
+                      "value": "8"
+                    },
+                    "F32": {
+                      "type": "float32",
+                      "value": "0.10000000149011612"
+                    },
+                    "F64": {
+                      "type": "float64",
+                      "value": "0.2"
+                    },
+                    "B": {
+                      "type": "bool",
+                      "value": "false"
+                    },
+                    "S": {
+                      "type": "string",
+                      "value": "other"
+                    },
+                    "arr": {
+                      "type": "[3]int16",
+                      "size": "3",
+                      "elements": [
+                        {
+                          "type": "int16",
+                          "value": "0"
+                        },
+                        {
+                          "type": "int16",
+                          "value": "0"
+                        },
+                        {
+                          "type": "int16",
+                          "value": "0"
+                        }
+                      ]
+                    }
+                  }
+                },
+                "ss": {
+                  "type": "[]int",
+                  "size": "0",
+                  "elements": []
+                }
+              }
+            }
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "process_tags": "entrypoint.name:sample,svc.user:sample"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/condLine_cond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condLine_cond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condLine",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 519
+            "lineNumber": 547
           },
           {
             "function": "main.main",
@@ -41,12 +41,12 @@
           "location": {
             "method": "main.condLine",
             "file": "main.go",
-            "line": 519
+            "line": 547
           }
         },
         "captures": {
           "lines": {
-            "519": {
+            "547": {
               "captureExpressions": {
                 "tag_val": {
                   "type": "string",

--- a/pkg/dyninst/testdata/decoded/simple/condLine_local_cond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condLine_local_cond.json
@@ -15,18 +15,18 @@
         "timestamp": "[ts]",
         "language": "go",
         "probe": {
-          "id": "condCompound_line_and",
+          "id": "condLine_local_cond",
           "location": {
             "method": "main.condLine",
             "file": "main.go",
-            "line": 547
+            "line": 548
           }
         }
       },
       "type": "snapshot"
     },
     "timestamp": "[ts]",
-    "message": "n == 7 && tag == \"match\" [n=7, tag=match]",
+    "message": "tag=match",
     "process_tags": "entrypoint.name:sample,svc.user:sample"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/condLine_local_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condLine_local_nocond.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.condUint8",
+      "method": "main.condLine",
       "version": 0,
       "thread_id": "[goid]",
       "thread_name": ""
@@ -16,14 +16,14 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.condUint8",
+            "function": "main.condLine",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 455
+            "lineNumber": 548
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 57
+            "lineNumber": 115
           },
           {
             "function": "runtime.main",
@@ -37,21 +37,29 @@
           }
         ],
         "probe": {
-          "id": "condUint8_nocond",
+          "id": "condLine_local_nocond",
           "location": {
-            "method": "main.condUint8"
+            "method": "main.condLine",
+            "file": "main.go",
+            "line": 548
           }
         },
         "captures": {
-          "entry": {
-            "arguments": {
-              "x": {
-                "type": "uint8",
-                "value": "42"
-              },
-              "tag": {
-                "type": "string",
-                "value": "match"
+          "lines": {
+            "548": {
+              "locals": {
+                "n": {
+                  "type": "int",
+                  "value": "7"
+                },
+                "tag": {
+                  "type": "string",
+                  "value": "match"
+                },
+                "result": {
+                  "type": "int",
+                  "value": "14"
+                }
               }
             }
           }
@@ -60,7 +68,6 @@
       "type": "snapshot"
     },
     "timestamp": "[ts]",
-    "duration": "[duration]",
     "process_tags": "entrypoint.name:sample,svc.user:sample"
   },
   {
@@ -68,7 +75,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.condUint8",
+      "method": "main.condLine",
       "version": 0,
       "thread_id": "[goid]",
       "thread_name": ""
@@ -80,14 +87,14 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.condUint8",
+            "function": "main.condLine",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 455
+            "lineNumber": 548
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 58
+            "lineNumber": 116
           },
           {
             "function": "runtime.main",
@@ -101,21 +108,29 @@
           }
         ],
         "probe": {
-          "id": "condUint8_nocond",
+          "id": "condLine_local_nocond",
           "location": {
-            "method": "main.condUint8"
+            "method": "main.condLine",
+            "file": "main.go",
+            "line": 548
           }
         },
         "captures": {
-          "entry": {
-            "arguments": {
-              "x": {
-                "type": "uint8",
-                "value": "7"
-              },
-              "tag": {
-                "type": "string",
-                "value": "miss"
+          "lines": {
+            "548": {
+              "locals": {
+                "n": {
+                  "type": "int",
+                  "value": "0"
+                },
+                "tag": {
+                  "type": "string",
+                  "value": "miss"
+                },
+                "result": {
+                  "type": "int",
+                  "value": "0"
+                }
               }
             }
           }
@@ -124,7 +139,6 @@
       "type": "snapshot"
     },
     "timestamp": "[ts]",
-    "duration": "[duration]",
     "process_tags": "entrypoint.name:sample,svc.user:sample"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/condLine_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condLine_nocond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condLine",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 519
+            "lineNumber": 547
           },
           {
             "function": "main.main",
@@ -41,12 +41,12 @@
           "location": {
             "method": "main.condLine",
             "file": "main.go",
-            "line": 519
+            "line": 547
           }
         },
         "captures": {
           "lines": {
-            "519": {
+            "547": {
               "locals": {
                 "n": {
                   "type": "int",
@@ -85,7 +85,7 @@
           {
             "function": "main.condLine",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 519
+            "lineNumber": 547
           },
           {
             "function": "main.main",
@@ -108,12 +108,12 @@
           "location": {
             "method": "main.condLine",
             "file": "main.go",
-            "line": 519
+            "line": 547
           }
         },
         "captures": {
           "lines": {
-            "519": {
+            "547": {
               "locals": {
                 "n": {
                   "type": "int",

--- a/pkg/dyninst/testdata/decoded/simple/condNilPtr_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condNilPtr_nocond.json
@@ -18,12 +18,12 @@
           {
             "function": "main.condNilPtrStruct",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 488
+            "lineNumber": 516
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 121
+            "lineNumber": 149
           },
           {
             "function": "runtime.main",
@@ -150,12 +150,12 @@
           {
             "function": "main.condNilPtrStruct",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 488
+            "lineNumber": 516
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 122
+            "lineNumber": 150
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/condOnly_cond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condOnly_cond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condOnly",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 509
+            "lineNumber": 537
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condOnly_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condOnly_nocond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condOnly",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 509
+            "lineNumber": 537
           },
           {
             "function": "main.main",
@@ -82,7 +82,7 @@
           {
             "function": "main.condOnly",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 509
+            "lineNumber": 537
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condPtrStruct_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condPtrStruct_nocond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condPtrStructArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 478
+            "lineNumber": 506
           },
           {
             "function": "main.main",
@@ -150,7 +150,7 @@
           {
             "function": "main.condPtrStructArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 478
+            "lineNumber": 506
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condReturnAndLocal_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condReturnAndLocal_nocond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condReturnAndLocal",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 498
+            "lineNumber": 526
           },
           {
             "function": "main.main",
@@ -90,7 +90,7 @@
           {
             "function": "main.condReturnAndLocal",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 498
+            "lineNumber": 526
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condString_eq_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/condString_eq_capture.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condString",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 462
+            "lineNumber": 490
           },
           {
             "function": "main.main",
@@ -77,7 +77,7 @@
           {
             "function": "main.condString",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 462
+            "lineNumber": 490
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condString_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condString_nocond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condString",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 462
+            "lineNumber": 490
           },
           {
             "function": "main.main",
@@ -82,7 +82,7 @@
           {
             "function": "main.condString",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 462
+            "lineNumber": 490
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condString_snapshot_with_cond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condString_snapshot_with_cond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condString",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 462
+            "lineNumber": 490
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condStruct_cond_i32_capture_tag.json
+++ b/pkg/dyninst/testdata/decoded/simple/condStruct_cond_i32_capture_tag.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condStructArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 470
+            "lineNumber": 498
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condStruct_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condStruct_nocond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condStructArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 470
+            "lineNumber": 498
           },
           {
             "function": "main.main",
@@ -149,7 +149,7 @@
           {
             "function": "main.condStructArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 470
+            "lineNumber": 498
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condUint16_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condUint16_nocond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condUint16",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 432
+            "lineNumber": 460
           },
           {
             "function": "main.main",
@@ -82,7 +82,7 @@
           {
             "function": "main.condUint16",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 432
+            "lineNumber": 460
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condUint32_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condUint32_nocond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condUint32",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 437
+            "lineNumber": 465
           },
           {
             "function": "main.main",
@@ -82,7 +82,7 @@
           {
             "function": "main.condUint32",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 437
+            "lineNumber": 465
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condUint64_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condUint64_nocond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condUint64",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 442
+            "lineNumber": 470
           },
           {
             "function": "main.main",
@@ -82,7 +82,7 @@
           {
             "function": "main.condUint64",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 442
+            "lineNumber": 470
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/genericIdentity.json
+++ b/pkg/dyninst/testdata/decoded/simple/genericIdentity.json
@@ -18,12 +18,12 @@
           {
             "function": "main.genericIdentity[go.shape.int]",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 931
+            "lineNumber": 984
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 286
+            "lineNumber": 314
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/indexBigArrayStruct_last.json
+++ b/pkg/dyninst/testdata/decoded/simple/indexBigArrayStruct_last.json
@@ -18,12 +18,12 @@
           {
             "function": "main.bigArrayStructArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 710
+            "lineNumber": 763
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 191
+            "lineNumber": 219
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/indexBigArray_first.json
+++ b/pkg/dyninst/testdata/decoded/simple/indexBigArray_first.json
@@ -18,12 +18,12 @@
           {
             "function": "main.bigArrayArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 703
+            "lineNumber": 756
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 190
+            "lineNumber": 218
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/indexBigArray_last.json
+++ b/pkg/dyninst/testdata/decoded/simple/indexBigArray_last.json
@@ -18,12 +18,12 @@
           {
             "function": "main.bigArrayArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 703
+            "lineNumber": 756
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 190
+            "lineNumber": 218
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/indexErr_array_oob_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/indexErr_array_oob_capture.json
@@ -18,7 +18,7 @@
           {
             "function": "main.intArrayArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 315
+            "lineNumber": 343
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/indexErr_slice_oob_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/indexErr_slice_oob_capture.json
@@ -18,7 +18,7 @@
           {
             "function": "main.intSliceArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 310
+            "lineNumber": 338
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/indexIntArray_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/indexIntArray_capture.json
@@ -18,7 +18,7 @@
           {
             "function": "main.intArrayArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 315
+            "lineNumber": 343
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/indexIntSlice_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/indexIntSlice_capture.json
@@ -18,7 +18,7 @@
           {
             "function": "main.intSliceArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 310
+            "lineNumber": 338
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/indexMember_arrayStruct_capture_int.json
+++ b/pkg/dyninst/testdata/decoded/simple/indexMember_arrayStruct_capture_int.json
@@ -18,12 +18,12 @@
           {
             "function": "main.structArrayArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 747
+            "lineNumber": 800
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 204
+            "lineNumber": 232
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/indexMember_arrayStruct_capture_string.json
+++ b/pkg/dyninst/testdata/decoded/simple/indexMember_arrayStruct_capture_string.json
@@ -18,12 +18,12 @@
           {
             "function": "main.structArrayArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 747
+            "lineNumber": 800
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 204
+            "lineNumber": 232
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/indexMember_ptrArrayStruct_capture_int.json
+++ b/pkg/dyninst/testdata/decoded/simple/indexMember_ptrArrayStruct_capture_int.json
@@ -18,12 +18,12 @@
           {
             "function": "main.ptrStructArrayArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 763
+            "lineNumber": 816
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 215
+            "lineNumber": 243
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/indexMember_ptrArrayStruct_capture_string.json
+++ b/pkg/dyninst/testdata/decoded/simple/indexMember_ptrArrayStruct_capture_string.json
@@ -18,12 +18,12 @@
           {
             "function": "main.ptrStructArrayArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 763
+            "lineNumber": 816
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 215
+            "lineNumber": 243
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/indexMember_ptrSliceStruct_capture_int.json
+++ b/pkg/dyninst/testdata/decoded/simple/indexMember_ptrSliceStruct_capture_int.json
@@ -18,12 +18,12 @@
           {
             "function": "main.ptrStructSliceArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 755
+            "lineNumber": 808
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 211
+            "lineNumber": 239
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/indexMember_ptrSliceStruct_capture_string.json
+++ b/pkg/dyninst/testdata/decoded/simple/indexMember_ptrSliceStruct_capture_string.json
@@ -18,12 +18,12 @@
           {
             "function": "main.ptrStructSliceArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 755
+            "lineNumber": 808
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 211
+            "lineNumber": 239
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/indexMember_sliceStruct_capture_int.json
+++ b/pkg/dyninst/testdata/decoded/simple/indexMember_sliceStruct_capture_int.json
@@ -18,12 +18,12 @@
           {
             "function": "main.structSliceArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 740
+            "lineNumber": 793
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 200
+            "lineNumber": 228
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/indexMember_sliceStruct_capture_string.json
+++ b/pkg/dyninst/testdata/decoded/simple/indexMember_sliceStruct_capture_string.json
@@ -18,12 +18,12 @@
           {
             "function": "main.structSliceArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 740
+            "lineNumber": 793
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 200
+            "lineNumber": 228
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/indexMember_wrapper_arr_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/indexMember_wrapper_arr_capture.json
@@ -18,12 +18,12 @@
           {
             "function": "main.indexMemberWrapperArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 771
+            "lineNumber": 824
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 224
+            "lineNumber": 252
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/indexMember_wrapper_arr_capture_1.json
+++ b/pkg/dyninst/testdata/decoded/simple/indexMember_wrapper_arr_capture_1.json
@@ -18,12 +18,12 @@
           {
             "function": "main.indexMemberWrapperArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 771
+            "lineNumber": 824
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 224
+            "lineNumber": 252
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/indexMember_wrapper_ptrArr_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/indexMember_wrapper_ptrArr_capture.json
@@ -18,12 +18,12 @@
           {
             "function": "main.indexMemberWrapperArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 771
+            "lineNumber": 824
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 224
+            "lineNumber": 252
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/indexMember_wrapper_ptrArr_capture_1.json
+++ b/pkg/dyninst/testdata/decoded/simple/indexMember_wrapper_ptrArr_capture_1.json
@@ -18,12 +18,12 @@
           {
             "function": "main.indexMemberWrapperArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 771
+            "lineNumber": 824
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 224
+            "lineNumber": 252
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/indexNilPtr_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/indexNilPtr_capture.json
@@ -18,12 +18,12 @@
           {
             "function": "main.indexNilPtrSlice",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 665
+            "lineNumber": 718
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 196
+            "lineNumber": 224
           },
           {
             "function": "runtime.main",
@@ -77,12 +77,12 @@
           {
             "function": "main.indexNilPtrSlice",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 665
+            "lineNumber": 718
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 197
+            "lineNumber": 225
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/indexPtrStructSliceField_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/indexPtrStructSliceField_capture.json
@@ -18,12 +18,12 @@
           {
             "function": "main.lenPtrStructFields",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 639
+            "lineNumber": 692
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 171
+            "lineNumber": 199
           },
           {
             "function": "runtime.main",
@@ -77,12 +77,12 @@
           {
             "function": "main.lenPtrStructFields",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 639
+            "lineNumber": 692
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 175
+            "lineNumber": 203
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/indexStringArray_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/indexStringArray_capture.json
@@ -18,7 +18,7 @@
           {
             "function": "main.stringArrayArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 325
+            "lineNumber": 353
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/indexStringSlice_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/indexStringSlice_capture.json
@@ -18,7 +18,7 @@
           {
             "function": "main.stringSliceArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 320
+            "lineNumber": 348
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/indexStructSliceField_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/indexStructSliceField_capture.json
@@ -18,12 +18,12 @@
           {
             "function": "main.lenStructFields",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 633
+            "lineNumber": 686
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 161
+            "lineNumber": 189
           },
           {
             "function": "runtime.main",
@@ -77,12 +77,12 @@
           {
             "function": "main.lenStructFields",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 630
+            "lineNumber": 683
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 165
+            "lineNumber": 193
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/inlined.json
+++ b/pkg/dyninst/testdata/decoded/simple/inlined.json
@@ -18,7 +18,7 @@
           {
             "function": "main.inlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 332
+            "lineNumber": 360
           },
           {
             "function": "main.main",
@@ -83,12 +83,12 @@
           {
             "function": "main.inlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 333
+            "lineNumber": 361
           },
           {
             "function": "main.funcArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 337
+            "lineNumber": 365
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/inlinedMethod.json
+++ b/pkg/dyninst/testdata/decoded/simple/inlinedMethod.json
@@ -18,17 +18,17 @@
           {
             "function": "main.(*methodValueReceiver).inlinedMethod",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 946
+            "lineNumber": 999
           },
           {
             "function": "main.methodValueSink",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 951
+            "lineNumber": 1004
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 294
+            "lineNumber": 322
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/intArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/intArg.json
@@ -18,7 +18,7 @@
           {
             "function": "main.intArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 300
+            "lineNumber": 328
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/intArrayArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/intArrayArg.json
@@ -18,7 +18,7 @@
           {
             "function": "main.intArrayArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 315
+            "lineNumber": 343
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/intArrayArgFrameless.json
+++ b/pkg/dyninst/testdata/decoded/simple/intArrayArgFrameless.json
@@ -18,7 +18,7 @@
           {
             "function": "main.stringArrayArgFrameless",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 329
+            "lineNumber": 357
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/intSliceArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/intSliceArg.json
@@ -18,7 +18,7 @@
           {
             "function": "main.intSliceArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 310
+            "lineNumber": 338
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/lenErrInt_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenErrInt_nocond.json
@@ -18,12 +18,12 @@
           {
             "function": "main.lenErrInt",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 647
+            "lineNumber": 700
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 181
+            "lineNumber": 209
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/lenErrStruct_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenErrStruct_nocond.json
@@ -18,12 +18,12 @@
           {
             "function": "main.lenErrStruct",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 655
+            "lineNumber": 708
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 182
+            "lineNumber": 210
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/lenMap_len_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenMap_len_capture.json
@@ -18,12 +18,12 @@
           {
             "function": "main.lenMap",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 609
+            "lineNumber": 662
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 151
+            "lineNumber": 179
           },
           {
             "function": "runtime.main",
@@ -77,12 +77,12 @@
           {
             "function": "main.lenMap",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 609
+            "lineNumber": 662
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 152
+            "lineNumber": 180
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/lenMap_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenMap_nocond.json
@@ -18,12 +18,12 @@
           {
             "function": "main.lenMap",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 609
+            "lineNumber": 662
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 151
+            "lineNumber": 179
           },
           {
             "function": "runtime.main",
@@ -114,12 +114,12 @@
           {
             "function": "main.lenMap",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 609
+            "lineNumber": 662
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 152
+            "lineNumber": 180
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/lenPtrString_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenPtrString_nocond.json
@@ -18,12 +18,12 @@
           {
             "function": "main.lenPtrString",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 615
+            "lineNumber": 668
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 154
+            "lineNumber": 182
           },
           {
             "function": "runtime.main",
@@ -83,12 +83,12 @@
           {
             "function": "main.lenPtrString",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 615
+            "lineNumber": 668
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 156
+            "lineNumber": 184
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/lenPtrStructFields_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenPtrStructFields_nocond.json
@@ -18,12 +18,12 @@
           {
             "function": "main.lenPtrStructFields",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 639
+            "lineNumber": 692
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 171
+            "lineNumber": 199
           },
           {
             "function": "runtime.main",
@@ -174,12 +174,12 @@
           {
             "function": "main.lenPtrStructFields",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 639
+            "lineNumber": 692
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 175
+            "lineNumber": 203
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/lenSlice_len_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenSlice_len_capture.json
@@ -18,12 +18,12 @@
           {
             "function": "main.lenSlice",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 603
+            "lineNumber": 656
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 149
+            "lineNumber": 177
           },
           {
             "function": "runtime.main",
@@ -77,12 +77,12 @@
           {
             "function": "main.lenSlice",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 603
+            "lineNumber": 656
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 150
+            "lineNumber": 178
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/lenSlice_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenSlice_nocond.json
@@ -18,12 +18,12 @@
           {
             "function": "main.lenSlice",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 603
+            "lineNumber": 656
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 149
+            "lineNumber": 177
           },
           {
             "function": "runtime.main",
@@ -104,12 +104,12 @@
           {
             "function": "main.lenSlice",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 603
+            "lineNumber": 656
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 150
+            "lineNumber": 178
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/lenString_eq_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenString_eq_capture.json
@@ -18,12 +18,12 @@
           {
             "function": "main.lenString",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 597
+            "lineNumber": 650
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 147
+            "lineNumber": 175
           },
           {
             "function": "runtime.main",
@@ -77,12 +77,12 @@
           {
             "function": "main.lenString",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 597
+            "lineNumber": 650
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 148
+            "lineNumber": 176
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/lenString_isEmpty_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenString_isEmpty_capture.json
@@ -18,12 +18,12 @@
           {
             "function": "main.lenString",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 597
+            "lineNumber": 650
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 147
+            "lineNumber": 175
           },
           {
             "function": "runtime.main",
@@ -77,12 +77,12 @@
           {
             "function": "main.lenString",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 597
+            "lineNumber": 650
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 148
+            "lineNumber": 176
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/lenString_len_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenString_len_capture.json
@@ -18,12 +18,12 @@
           {
             "function": "main.lenString",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 597
+            "lineNumber": 650
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 147
+            "lineNumber": 175
           },
           {
             "function": "runtime.main",
@@ -77,12 +77,12 @@
           {
             "function": "main.lenString",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 597
+            "lineNumber": 650
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 148
+            "lineNumber": 176
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/lenString_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenString_nocond.json
@@ -18,12 +18,12 @@
           {
             "function": "main.lenString",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 597
+            "lineNumber": 650
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 147
+            "lineNumber": 175
           },
           {
             "function": "runtime.main",
@@ -82,12 +82,12 @@
           {
             "function": "main.lenString",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 597
+            "lineNumber": 650
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 148
+            "lineNumber": 176
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/lenStructFields_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenStructFields_nocond.json
@@ -18,12 +18,12 @@
           {
             "function": "main.lenStructFields",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 633
+            "lineNumber": 686
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 161
+            "lineNumber": 189
           },
           {
             "function": "runtime.main",
@@ -173,12 +173,12 @@
           {
             "function": "main.lenStructFields",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 630
+            "lineNumber": 683
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 165
+            "lineNumber": 193
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/mapArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/mapArg.json
@@ -18,7 +18,7 @@
           {
             "function": "main.mapArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 343
+            "lineNumber": 371
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/mapIndex_boolKey_false.json
+++ b/pkg/dyninst/testdata/decoded/simple/mapIndex_boolKey_false.json
@@ -18,12 +18,12 @@
           {
             "function": "main.mapIndexBoolKey",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 899
+            "lineNumber": 952
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 265
+            "lineNumber": 293
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/mapIndex_boolKey_true.json
+++ b/pkg/dyninst/testdata/decoded/simple/mapIndex_boolKey_true.json
@@ -18,12 +18,12 @@
           {
             "function": "main.mapIndexBoolKey",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 899
+            "lineNumber": 952
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 265
+            "lineNumber": 293
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/mapIndex_emptyKey_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/mapIndex_emptyKey_capture.json
@@ -18,12 +18,12 @@
           {
             "function": "main.mapIndexEmptyKey",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 878
+            "lineNumber": 931
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 258
+            "lineNumber": 286
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/mapIndex_intKey_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/mapIndex_intKey_capture.json
@@ -18,12 +18,12 @@
           {
             "function": "main.mapIndexIntKey",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 778
+            "lineNumber": 831
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 231
+            "lineNumber": 259
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/mapIndex_keyLen16.json
+++ b/pkg/dyninst/testdata/decoded/simple/mapIndex_keyLen16.json
@@ -18,12 +18,12 @@
           {
             "function": "main.mapIndexKeyLen16",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 885
+            "lineNumber": 938
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 261
+            "lineNumber": 289
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/mapIndex_keyLen17.json
+++ b/pkg/dyninst/testdata/decoded/simple/mapIndex_keyLen17.json
@@ -18,12 +18,12 @@
           {
             "function": "main.mapIndexKeyLen17",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 892
+            "lineNumber": 945
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 262
+            "lineNumber": 290
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/mapIndex_keyLen200.json
+++ b/pkg/dyninst/testdata/decoded/simple/mapIndex_keyLen200.json
@@ -18,12 +18,12 @@
           {
             "function": "main.mapIndexKeyLen200",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 855
+            "lineNumber": 908
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 247
+            "lineNumber": 275
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/mapIndex_keyLen24.json
+++ b/pkg/dyninst/testdata/decoded/simple/mapIndex_keyLen24.json
@@ -18,12 +18,12 @@
           {
             "function": "main.mapIndexKeyLen24",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 834
+            "lineNumber": 887
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 244
+            "lineNumber": 272
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/mapIndex_keyLen48.json
+++ b/pkg/dyninst/testdata/decoded/simple/mapIndex_keyLen48.json
@@ -18,12 +18,12 @@
           {
             "function": "main.mapIndexKeyLen48",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 841
+            "lineNumber": 894
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 245
+            "lineNumber": 273
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/mapIndex_keyLen8.json
+++ b/pkg/dyninst/testdata/decoded/simple/mapIndex_keyLen8.json
@@ -18,12 +18,12 @@
           {
             "function": "main.mapIndexKeyLen8",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 827
+            "lineNumber": 880
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 243
+            "lineNumber": 271
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/mapIndex_keyLen96.json
+++ b/pkg/dyninst/testdata/decoded/simple/mapIndex_keyLen96.json
@@ -18,12 +18,12 @@
           {
             "function": "main.mapIndexKeyLen96",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 848
+            "lineNumber": 901
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 246
+            "lineNumber": 274
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/mapIndex_largeMap_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/mapIndex_largeMap_capture.json
@@ -18,12 +18,12 @@
           {
             "function": "main.mapIndexLargeMap",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 793
+            "lineNumber": 846
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 237
+            "lineNumber": 265
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/mapIndex_largeValue_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/mapIndex_largeValue_capture.json
@@ -18,12 +18,12 @@
           {
             "function": "main.mapIndexLargeValue",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 922
+            "lineNumber": 975
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 277
+            "lineNumber": 305
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/mapIndex_missing_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/mapIndex_missing_capture.json
@@ -18,12 +18,12 @@
           {
             "function": "main.mapIndexMissing",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 800
+            "lineNumber": 853
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 238
+            "lineNumber": 266
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/mapIndex_nilPtrVal_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/mapIndex_nilPtrVal_capture.json
@@ -18,12 +18,12 @@
           {
             "function": "main.mapIndexNilPtrVal",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 914
+            "lineNumber": 967
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 271
+            "lineNumber": 299
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/mapIndex_ptrStructVal_capture_int.json
+++ b/pkg/dyninst/testdata/decoded/simple/mapIndex_ptrStructVal_capture_int.json
@@ -18,12 +18,12 @@
           {
             "function": "main.mapIndexPtrStructVal",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 871
+            "lineNumber": 924
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 254
+            "lineNumber": 282
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/mapIndex_ptrStructVal_capture_string.json
+++ b/pkg/dyninst/testdata/decoded/simple/mapIndex_ptrStructVal_capture_string.json
@@ -18,12 +18,12 @@
           {
             "function": "main.mapIndexPtrStructVal",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 871
+            "lineNumber": 924
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 254
+            "lineNumber": 282
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/mapIndex_stringKey_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/mapIndex_stringKey_capture.json
@@ -18,12 +18,12 @@
           {
             "function": "main.mapIndexStringKey",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 785
+            "lineNumber": 838
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 232
+            "lineNumber": 260
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/mapIndex_structVal_capture_int.json
+++ b/pkg/dyninst/testdata/decoded/simple/mapIndex_structVal_capture_int.json
@@ -18,12 +18,12 @@
           {
             "function": "main.mapIndexStructVal",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 863
+            "lineNumber": 916
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 250
+            "lineNumber": 278
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/mapIndex_structVal_capture_string.json
+++ b/pkg/dyninst/testdata/decoded/simple/mapIndex_structVal_capture_string.json
@@ -18,12 +18,12 @@
           {
             "function": "main.mapIndexStructVal",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 863
+            "lineNumber": 916
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 250
+            "lineNumber": 278
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/mapIndex_zeroValue_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/mapIndex_zeroValue_capture.json
@@ -18,12 +18,12 @@
           {
             "function": "main.mapIndexZeroValue",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 906
+            "lineNumber": 959
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 268
+            "lineNumber": 296
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/simple/noArgs.json
+++ b/pkg/dyninst/testdata/decoded/simple/noArgs.json
@@ -18,7 +18,7 @@
           {
             "function": "main.noArgs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 377
+            "lineNumber": 405
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/stringArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/stringArg.json
@@ -18,7 +18,7 @@
           {
             "function": "main.stringArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 305
+            "lineNumber": 333
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/stringArrayArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/stringArrayArg.json
@@ -18,7 +18,7 @@
           {
             "function": "main.stringArrayArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 325
+            "lineNumber": 353
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/stringSliceArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/stringSliceArg.json
@@ -18,7 +18,7 @@
           {
             "function": "main.stringSliceArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 320
+            "lineNumber": 348
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/usesMapsOfMapsThatDoNotAppearAsArguments.json
+++ b/pkg/dyninst/testdata/decoded/simple/usesMapsOfMapsThatDoNotAppearAsArguments.json
@@ -18,7 +18,7 @@
           {
             "function": "main.usesMapsOfMapsThatDoNotAppearAsArguments",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 685
+            "lineNumber": 738
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testprogs/progs/simple/main.go
+++ b/pkg/dyninst/testprogs/progs/simple/main.go
@@ -115,6 +115,34 @@ func main() {
 	condLine(7, "match")
 	condLine(0, "miss")
 
+	// Line probe target with mixed types live at one line. Called twice — once
+	// with values that match the conditional probes, once with values that
+	// don't. Each conditional probe on this function should fire only on the
+	// matching call.
+	condLineMixed("hello", true, condFields{
+		I8: 10, I16: 200, I32: 300, I64: 400,
+		U8: 50, U16: 600, U32: 700, U64: 800,
+		F32: 1.5, F64: 2.5, B: true, S: "world",
+	}, &condFields{
+		I8: 10, I16: 200, I32: 300, I64: 400,
+		U8: 50, U16: 600, U32: 700, U64: 800,
+		F32: 1.5, F64: 2.5, B: true, S: "world",
+	}, []int{1, 2, 3, 4, 5})
+	condLineMixed("xy", false, condFields{
+		I8: 1, I16: 2, I32: 3, I64: 4,
+		U8: 5, U16: 6, U32: 7, U64: 8,
+		F32: 0.1, F64: 0.2, B: false, S: "other",
+	}, &condFields{
+		I8: 1, I16: 2, I32: 3, I64: 4,
+		U8: 5, U16: 6, U32: 7, U64: 8,
+		F32: 0.1, F64: 0.2, B: false, S: "other",
+	}, []int{})
+
+	// Line probe target with a return value: used to verify that @return is
+	// rejected inside a line-probe condition (the return slot does not exist
+	// at a mid-function PC).
+	condLineReturn(7)
+
 	// Nil pointer in condition dereference chain: called twice.
 	// First call: non-nil pointer matching condition → normal snapshot, no eval error.
 	// Second call: nil pointer → condition eval error, snapshot still emitted.
@@ -518,6 +546,31 @@ func condLine(n int, tag string) {
 	// keep them in registers/stack at the probe site.
 	result := n * 2 // target for line probe conditions on n
 	fmt.Println(result, n, tag)
+}
+
+// condLineMixed is a target for line-probe conditions on the full type
+// matrix at a single line PC. It mirrors the entry-probe condition matrix
+// (condString / condBool / condStructArg / condPtrStructArg / lenString /
+// lenSlice) but exercises each at a line probe location rather than at
+// function entry. All parameters and the local are read after the target
+// line so the compiler keeps them live at the probe site.
+//
+//go:noinline
+func condLineMixed(s string, b bool, x condFields, p *condFields, ss []int) {
+	local := len(s) // target for line probe conditions on local
+	fmt.Println(local, s, b, x.I32, x.S, p.I32, p.S, ss)
+}
+
+// condLineReturn is a target for `@return` references inside line-probe
+// conditions. At a line PC inside the function the return slot is not
+// populated yet, so any `@return` reference in a line-probe condition must
+// be rejected.
+//
+//go:noinline
+func condLineReturn(n int) int {
+	doubled := n * 2 // target for line probe with @return condition
+	fmt.Println(doubled)
+	return doubled
 }
 
 // condSliceArg is a target for unsupported-type condition errors (slice).

--- a/pkg/dyninst/testprogs/testdata/probes/simple.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/simple.yaml
@@ -743,7 +743,7 @@ probes:
     methodName: main.condLine
     sourceFile: main.go
     lines:
-      - "519"
+      - "547"
   when:
     dsl: "n == 7"
     json: {eq: [{ref: "n"}, 7]}
@@ -768,9 +768,234 @@ probes:
     methodName: main.condLine
     sourceFile: main.go
     lines:
-      - "519"
+      - "547"
   sampling:
     snapshotsPerSecond: 10
+
+# Line probe with condition on a local variable computed before the line.
+# Verifies the probe resolves `result`'s location at the line PC (line 548,
+# after `result := n * 2` on line 547), not at function entry where the
+# local does not exist. result == 14 fires only for condLine(7, "match").
+#
+# On go1.23 the local's location list is missing at this line PC, so the
+# probe fails to install with ConditionVariableUnavailable.
+- id: condLine_local_cond
+  tags:
+    - "skip_integration:arch=arm64,toolchain=go1.23.11"
+    - "skip_integration:arch=amd64,toolchain=go1.23.11"
+    - "issue:ConditionVariableUnavailable@arch=arm64,toolchain=go1.23.11"
+    - "issue:ConditionVariableUnavailable@arch=amd64,toolchain=go1.23.11"
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.condLine
+    sourceFile: main.go
+    lines:
+      - "548"
+  when:
+    dsl: "result == 14"
+    json: {eq: [{ref: "result"}, 14]}
+  template: "tag={tag}"
+  segments:
+    - str: "tag="
+    - json: {ref: "tag"}
+      dsl: "tag"
+  sampling:
+    snapshotsPerSecond: 10
+
+# Line probe at the same line WITHOUT condition (control for condLine_local_cond).
+- id: condLine_local_nocond
+  tags:
+    - "skip_integration:arch=arm64,toolchain=go1.23.11"
+    - "skip_integration:arch=amd64,toolchain=go1.23.11"
+  type: LOG_PROBE
+  captureSnapshot: true
+  where:
+    methodName: main.condLine
+    sourceFile: main.go
+    lines:
+      - "548"
+  sampling:
+    snapshotsPerSecond: 10
+
+# ==========================================================================
+# Condition tests: line probes — full type matrix at a single line PC
+#
+# Mirrors the entry-probe condition matrix (string, bool, struct field,
+# pointer-to-struct field, len, isEmpty) but at a line PC rather than at
+# function entry. condLineMixed(s, b, x, p, ss) is called twice — once with
+# the matching values, once with non-matching — so each conditional probe
+# fires exactly once.
+# ==========================================================================
+
+# Condition on string parameter at a line.
+- id: condLineMixed_cond_string
+  tags:
+    - "skip_integration:arch=arm64,toolchain=go1.23.11"
+    - "skip_integration:arch=amd64,toolchain=go1.23.11"
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.condLineMixed
+    sourceFile: main.go
+    lines:
+      - "561"
+  when:
+    dsl: "s == \"hello\""
+    json: {eq: [{ref: "s"}, "hello"]}
+  template: "matched"
+  segments:
+    - str: "matched"
+  sampling:
+    snapshotsPerSecond: 10
+
+# Condition on bool parameter at a line.
+- id: condLineMixed_cond_bool
+  tags:
+    - "skip_integration:arch=arm64,toolchain=go1.23.11"
+    - "skip_integration:arch=amd64,toolchain=go1.23.11"
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.condLineMixed
+    sourceFile: main.go
+    lines:
+      - "561"
+  when:
+    dsl: "b == true"
+    json: {eq: [{ref: "b"}, true]}
+  template: "matched"
+  segments:
+    - str: "matched"
+  sampling:
+    snapshotsPerSecond: 10
+
+# Condition on struct field at a line.
+- id: condLineMixed_cond_struct_field
+  tags:
+    - "skip_integration:arch=arm64,toolchain=go1.23.11"
+    - "skip_integration:arch=amd64,toolchain=go1.23.11"
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.condLineMixed
+    sourceFile: main.go
+    lines:
+      - "561"
+  when:
+    dsl: "x.I32 == 300"
+    json: {eq: [{getmember: [{ref: "x"}, "I32"]}, 300]}
+  template: "matched"
+  segments:
+    - str: "matched"
+  sampling:
+    snapshotsPerSecond: 10
+
+# Condition on pointer-to-struct field at a line.
+- id: condLineMixed_cond_ptrstruct_field
+  tags:
+    - "skip_integration:arch=arm64,toolchain=go1.23.11"
+    - "skip_integration:arch=amd64,toolchain=go1.23.11"
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.condLineMixed
+    sourceFile: main.go
+    lines:
+      - "561"
+  when:
+    dsl: "p.S == \"world\""
+    json: {eq: [{getmember: [{ref: "p"}, "S"]}, "world"]}
+  template: "matched"
+  segments:
+    - str: "matched"
+  sampling:
+    snapshotsPerSecond: 10
+
+# Condition using len() on a string parameter at a line.
+- id: condLineMixed_cond_len_string
+  tags:
+    - "skip_integration:arch=arm64,toolchain=go1.23.11"
+    - "skip_integration:arch=amd64,toolchain=go1.23.11"
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.condLineMixed
+    sourceFile: main.go
+    lines:
+      - "561"
+  when:
+    dsl: "len(s) == 5"
+    json: {eq: [{len: {ref: "s"}}, 5]}
+  template: "matched"
+  segments:
+    - str: "matched"
+  sampling:
+    snapshotsPerSecond: 10
+
+# Condition using isEmpty() on a slice parameter at a line. The slice is
+# empty on the second call (ss = []int{}), so this probe fires once.
+- id: condLineMixed_cond_isEmpty_slice
+  tags:
+    - "skip_integration:arch=arm64,toolchain=go1.23.11"
+    - "skip_integration:arch=amd64,toolchain=go1.23.11"
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.condLineMixed
+    sourceFile: main.go
+    lines:
+      - "561"
+  when:
+    dsl: "isEmpty(ss)"
+    json: {isEmpty: {ref: "ss"}}
+  template: "matched"
+  segments:
+    - str: "matched"
+  sampling:
+    snapshotsPerSecond: 10
+
+# Line probe at the same line WITHOUT condition (control: fires on both calls).
+- id: condLineMixed_nocond
+  tags:
+    - "skip_integration:arch=arm64,toolchain=go1.23.11"
+    - "skip_integration:arch=amd64,toolchain=go1.23.11"
+  type: LOG_PROBE
+  captureSnapshot: true
+  where:
+    methodName: main.condLineMixed
+    sourceFile: main.go
+    lines:
+      - "561"
+  sampling:
+    snapshotsPerSecond: 10
+
+# ==========================================================================
+# Condition tests: line probes — @return is invalid at a mid-function PC
+#
+# The return slot is not populated until the function returns. A line probe
+# inside the function body should reject any @return reference in its
+# condition. condLineReturn(n int) int is called once.
+# ==========================================================================
+
+- id: condLineReturn_cond_return
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.condLineReturn
+    sourceFile: main.go
+    lines:
+      - "571"
+  when:
+    dsl: "@return == 14"
+    json: {eq: [{ref: "@return"}, 14]}
+  template: "matched"
+  segments:
+    - str: "matched"
+  sampling:
+    snapshotsPerSecond: 10
+  tags:
+    - "issue:ConditionVariableUnavailable"
 
 # ==========================================================================
 # Condition tests: condition + capture expressions on the same probe
@@ -2964,7 +3189,7 @@ probes:
     methodName: main.condLine
     sourceFile: main.go
     lines:
-      - "519"
+      - "547"
   when:
     dsl: "n == 7 && tag == \"match\""
     json:


### PR DESCRIPTION
### What does this PR do?

Adds line-probe variants of the existing entry-probe condition matrix in testprogs/simple. The existing condLine probes only test a parameter at a single line; the new probes exercise:

  - condition on a local computed before the line (condLine_local_cond)
  - condition on string / bool / struct field / pointer-struct field / len(string) / isEmpty(slice) at a line (condLineMixed_*)
  - rejection of @return inside a line-probe condition with ConditionVariableUnavailable (condLineReturn_cond_return)

Adds two new target functions (condLineMixed, condLineReturn) and bumps the existing condLine probes' line reference from 519 to 547 to account for the new call sites in main(). Regenerates the irgen snapshot YAMLs and decoded JSON snapshots.

### Motivation

More tests, yay!

### Describe how you validated your changes

It's testing.

### Additional Notes

Just noticed we don't have all that many line probes. Now a downside of this is the more you add, the more line probes need to be adjusted.