### PR TITLE
[CONS-8164] Use `net.JoinHostPort` for IPv6-safe agent IPC URLs

### DIFF
--- a/cmd/agent/common/common.go
+++ b/cmd/agent/common/common.go
@@ -9,7 +9,9 @@ package common
 
 import (
 	"fmt"
+	"net"
 	"path/filepath"
+	"strconv"
 
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	ipchttp "github.com/DataDog/datadog-agent/comp/core/ipc/httphelpers"
@@ -37,5 +39,6 @@ func NewSettingsClient(client ipc.HTTPClient) (settings.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	return settingshttp.NewSecureClient(client, fmt.Sprintf("https://%v:%v/agent/config", ipcAddress, pkgconfigsetup.Datadog().GetInt("cmd_port")), "agent", ipchttp.WithLeaveConnectionOpen), nil
+	addr := net.JoinHostPort(ipcAddress, strconv.Itoa(pkgconfigsetup.Datadog().GetInt("cmd_port")))
+	return settingshttp.NewSecureClient(client, fmt.Sprintf("https://%s/agent/config", addr), "agent", ipchttp.WithLeaveConnectionOpen), nil
 }

--- a/cmd/agent/subcommands/diagnose/command.go
+++ b/cmd/agent/subcommands/diagnose/command.go
@@ -11,8 +11,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 
 	"go.uber.org/fx"
@@ -464,8 +466,8 @@ func printPayload(name payloadName, _ log.Component, config config.Component, cl
 	if err != nil {
 		return err
 	}
-	apiConfigURL := fmt.Sprintf("https://%v:%d%s%s",
-		ipcAddress, config.GetInt("cmd_port"), metadataEndpoint, name)
+	addr := net.JoinHostPort(ipcAddress, strconv.Itoa(config.GetInt("cmd_port")))
+	apiConfigURL := fmt.Sprintf("https://%s%s%s", addr, metadataEndpoint, name)
 
 	r, err := client.Get(apiConfigURL, ipchttp.WithCloseConnection)
 	if err != nil {
@@ -481,8 +483,8 @@ func printHealthPlatformIssues(_ log.Component, config config.Component, client 
 	if err != nil {
 		return err
 	}
-	apiConfigURL := fmt.Sprintf("https://%v:%d/health-platform/issues",
-		ipcAddress, config.GetInt("cmd_port"))
+	addr := net.JoinHostPort(ipcAddress, strconv.Itoa(config.GetInt("cmd_port")))
+	apiConfigURL := fmt.Sprintf("https://%s/health-platform/issues", addr)
 
 	r, err := client.Get(apiConfigURL, ipchttp.WithCloseConnection)
 	if err != nil {
@@ -502,7 +504,8 @@ func requestDiagnosesFromAgentProcess(diagCfg diagnose.Config, client ipc.HTTPCl
 
 	// Form call end-point
 	//nolint:revive // TODO(CINT) Fix revive linter
-	diagnoseURL := fmt.Sprintf("https://%v:%v/agent/diagnose", ipcAddress, pkgconfigsetup.Datadog().GetInt("cmd_port"))
+	addr := net.JoinHostPort(ipcAddress, strconv.Itoa(pkgconfigsetup.Datadog().GetInt("cmd_port")))
+	diagnoseURL := fmt.Sprintf("https://%s/agent/diagnose", addr)
 
 	// Serialized diag config to pass it to Agent execution context
 	var cfgSer []byte
@@ -536,7 +539,8 @@ func printAgentFullTelemetry(config config.Component, client ipc.HTTPClient) err
 	if err != nil {
 		return err
 	}
-	r, err := client.Get(fmt.Sprintf("http://%s:%s/telemetry", ipcAddress, config.GetString("expvar_port")))
+	addr := net.JoinHostPort(ipcAddress, config.GetString("expvar_port"))
+	r, err := client.Get(fmt.Sprintf("http://%s/telemetry", addr))
 	if err != nil {
 		return fmt.Errorf("error getting full telemetry payload: %w", err)
 	}

--- a/cmd/agent/subcommands/stop/command.go
+++ b/cmd/agent/subcommands/stop/command.go
@@ -11,6 +11,8 @@ package stop
 import (
 	"bytes"
 	"fmt"
+	"net"
+	"strconv"
 
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
@@ -57,7 +59,8 @@ func stop(config config.Component, _ *cliParams, _ log.Component, client ipc.HTT
 	if err != nil {
 		return err
 	}
-	urlstr := fmt.Sprintf("https://%v:%v/agent/stop", ipcAddress, config.GetInt("cmd_port"))
+	addr := net.JoinHostPort(ipcAddress, strconv.Itoa(config.GetInt("cmd_port")))
+	urlstr := fmt.Sprintf("https://%s/agent/stop", addr)
 
 	_, e := client.Post(urlstr, "application/json", bytes.NewBuffer([]byte{}))
 	if e != nil {

--- a/pkg/cli/subcommands/health/command.go
+++ b/pkg/cli/subcommands/health/command.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"sort"
 	"strconv"
 	"strings"
@@ -85,9 +86,11 @@ func requestHealth(_ log.Component, config config.Component, cliParams *cliParam
 
 	var urlstr string
 	if flavor.GetFlavor() == flavor.ClusterAgent {
-		urlstr = fmt.Sprintf("https://%v:%v/status/health", ipcAddress, config.GetInt("cluster_agent.cmd_port"))
+		addr := net.JoinHostPort(ipcAddress, strconv.Itoa(config.GetInt("cluster_agent.cmd_port")))
+		urlstr = fmt.Sprintf("https://%s/status/health", addr)
 	} else {
-		urlstr = fmt.Sprintf("https://%v:%v/agent/status/health", ipcAddress, config.GetInt("cmd_port"))
+		addr := net.JoinHostPort(ipcAddress, strconv.Itoa(config.GetInt("cmd_port")))
+		urlstr = fmt.Sprintf("https://%s/agent/status/health", addr)
 	}
 
 	timeout := time.Duration(cliParams.timeout) * time.Second

--- a/pkg/cli/subcommands/taggerlist/command.go
+++ b/pkg/cli/subcommands/taggerlist/command.go
@@ -9,6 +9,8 @@ package taggerlist
 import (
 	"errors"
 	"fmt"
+	"net"
+	"strconv"
 
 	"go.uber.org/fx"
 
@@ -107,9 +109,11 @@ func getTaggerURL(config config.Component) (string, error) {
 
 	var urlstr string
 	if flavor.GetFlavor() == flavor.ClusterAgent {
-		urlstr = fmt.Sprintf("https://%v:%v/tagger-list", ipcAddress, config.GetInt("cluster_agent.cmd_port"))
+		addr := net.JoinHostPort(ipcAddress, strconv.Itoa(config.GetInt("cluster_agent.cmd_port")))
+		urlstr = fmt.Sprintf("https://%s/tagger-list", addr)
 	} else {
-		urlstr = fmt.Sprintf("https://%v:%v/agent/tagger-list", ipcAddress, config.GetInt("cmd_port"))
+		addr := net.JoinHostPort(ipcAddress, strconv.Itoa(config.GetInt("cmd_port")))
+		urlstr = fmt.Sprintf("https://%s/agent/tagger-list", addr)
 	}
 
 	return urlstr, nil

--- a/pkg/cli/subcommands/workloadlist/command.go
+++ b/pkg/cli/subcommands/workloadlist/command.go
@@ -10,7 +10,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
+	"strconv"
 
 	"go.uber.org/fx"
 
@@ -139,9 +141,11 @@ func workloadURL(verbose bool, search string, jsonFormat bool) (string, error) {
 
 	var prefix string
 	if flavor.GetFlavor() == flavor.ClusterAgent {
-		prefix = fmt.Sprintf("https://%v:%v/workload-list", ipcAddress, pkgconfigsetup.Datadog().GetInt("cluster_agent.cmd_port"))
+		addr := net.JoinHostPort(ipcAddress, strconv.Itoa(pkgconfigsetup.Datadog().GetInt("cluster_agent.cmd_port")))
+		prefix = fmt.Sprintf("https://%s/workload-list", addr)
 	} else {
-		prefix = fmt.Sprintf("https://%v:%v/agent/workload-list", ipcAddress, pkgconfigsetup.Datadog().GetInt("cmd_port"))
+		addr := net.JoinHostPort(ipcAddress, strconv.Itoa(pkgconfigsetup.Datadog().GetInt("cmd_port")))
+		prefix = fmt.Sprintf("https://%s/agent/workload-list", addr)
 	}
 
 	// Build query parameters - backend will process format

--- a/pkg/config/fetcher/from_processes.go
+++ b/pkg/config/fetcher/from_processes.go
@@ -8,6 +8,8 @@ package fetcher
 
 import (
 	"fmt"
+	"net"
+	"strconv"
 	"time"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
@@ -74,7 +76,7 @@ func ProcessAgentConfig(config config.Reader, client ipc.HTTPClient, getEntireCo
 		return "", fmt.Errorf("invalid process_config.cmd_port -- %d", port)
 	}
 
-	ipcAddressWithPort := fmt.Sprintf("https://%s:%d/config", ipcAddress, port)
+	ipcAddressWithPort := fmt.Sprintf("https://%s/config", net.JoinHostPort(ipcAddress, strconv.Itoa(port)))
 	if getEntireConfig {
 		ipcAddressWithPort += "/all"
 	}

--- a/pkg/flare/clusteragent/archive_dca.go
+++ b/pkg/flare/clusteragent/archive_dca.go
@@ -13,9 +13,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"path/filepath"
+	"strconv"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	diagnose "github.com/DataDog/datadog-agent/comp/core/diagnose/def"
@@ -254,13 +256,23 @@ func getLocalClusterAgentDiagnose(fb flaretypes.FlareBuilder, diagnose diagnose.
 	return fb.AddFile("diagnose.log", bytes)
 }
 
-func getDCAAutoscalerList(remote *flare.RemoteFlareProvider) ([]byte, error) {
+// dcaIPCHostPort returns `host:port` for the local cluster agent IPC
+// endpoint, with IPv6 hosts properly bracketed.
+func dcaIPCHostPort() (string, error) {
 	ipcAddress, err := pkgconfigsetup.GetIPCAddress(pkgconfigsetup.Datadog())
+	if err != nil {
+		return "", err
+	}
+	return net.JoinHostPort(ipcAddress, strconv.Itoa(pkgconfigsetup.Datadog().GetInt("cluster_agent.cmd_port"))), nil
+}
+
+func getDCAAutoscalerList(remote *flare.RemoteFlareProvider) ([]byte, error) {
+	addr, err := dcaIPCHostPort()
 	if err != nil {
 		return nil, err
 	}
 
-	autoscalerListURL := fmt.Sprintf("https://%v:%v/autoscaler-list", ipcAddress, pkgconfigsetup.Datadog().GetInt("cluster_agent.cmd_port"))
+	autoscalerListURL := fmt.Sprintf("https://%s/autoscaler-list", addr)
 
 	r, err := remote.IPC.GetClient().Get(autoscalerListURL, ipchttp.WithCloseConnection)
 	if err != nil {
@@ -279,11 +291,11 @@ func getDCAAutoscalerList(remote *flare.RemoteFlareProvider) ([]byte, error) {
 }
 
 func getDCALocalAutoscalingWorkloadList(remote *flare.RemoteFlareProvider) ([]byte, error) {
-	ipcAddress, err := pkgconfigsetup.GetIPCAddress(pkgconfigsetup.Datadog())
+	addr, err := dcaIPCHostPort()
 	if err != nil {
 		return nil, err
 	}
-	localAutoscalingWorkloadListURL := fmt.Sprintf("https://%v:%v/local-autoscaling-check", ipcAddress, pkgconfigsetup.Datadog().GetInt("cluster_agent.cmd_port"))
+	localAutoscalingWorkloadListURL := fmt.Sprintf("https://%s/local-autoscaling-check", addr)
 	r, err := remote.IPC.GetClient().Get(localAutoscalingWorkloadListURL, ipchttp.WithCloseConnection)
 	if err != nil {
 		return nil, err
@@ -301,23 +313,23 @@ func getDCALocalAutoscalingWorkloadList(remote *flare.RemoteFlareProvider) ([]by
 }
 
 func getDCATaggerList(remote *flare.RemoteFlareProvider) ([]byte, error) {
-	ipcAddress, err := pkgconfigsetup.GetIPCAddress(pkgconfigsetup.Datadog())
+	addr, err := dcaIPCHostPort()
 	if err != nil {
 		return nil, err
 	}
 
-	taggerListURL := fmt.Sprintf("https://%v:%v/tagger-list", ipcAddress, pkgconfigsetup.Datadog().GetInt("cluster_agent.cmd_port"))
+	taggerListURL := fmt.Sprintf("https://%s/tagger-list", addr)
 
 	return remote.GetTaggerList(taggerListURL)
 }
 
 func getDCAWorkloadList(remote *flare.RemoteFlareProvider) ([]byte, error) {
-	ipcAddress, err := pkgconfigsetup.GetIPCAddress(pkgconfigsetup.Datadog())
+	addr, err := dcaIPCHostPort()
 	if err != nil {
 		return nil, err
 	}
 
-	return remote.GetWorkloadList(fmt.Sprintf("https://%v:%v/workload-list?verbose=true", ipcAddress, pkgconfigsetup.Datadog().GetInt("cluster_agent.cmd_port")))
+	return remote.GetWorkloadList(fmt.Sprintf("https://%s/workload-list?verbose=true", addr))
 }
 
 func getClusterAgentMetadataPayload(client ipc.HTTPClient) ([]byte, error) {

--- a/releasenotes/notes/fix-ipv6-agent-ipc-url-construction-1a3e7bb39bc9296b.yaml
+++ b/releasenotes/notes/fix-ipv6-agent-ipc-url-construction-1a3e7bb39bc9296b.yaml
@@ -1,0 +1,17 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix IPv6 address formatting in URLs built to reach the Agent's IPC
+    endpoint. When ``cmd_host`` (or the deprecated ``ipc_address``) is set to
+    an IPv6 literal, the address is now properly wrapped in brackets
+    (e.g. ``https://[::1]:5001/agent/config``) so that calls from
+    ``agent stop``, ``agent diagnose``, ``agent health``, ``agent workload-list``,
+    ``agent tagger-list``, the cluster-agent flare provider and the
+    process-agent config fetcher succeed on IPv6-only setups.


### PR DESCRIPTION
### What does this PR do?

Replaces naive `fmt.Sprintf("%s:%d", host, port)` host:port concatenation in
URLs built to reach the local agent IPC endpoint with `net.JoinHostPort`,
which properly wraps IPv6 hosts in brackets.

Fixed locations (all owned by `@DataDog/agent-configuration`):

- `cmd/agent/common/common.go` — `NewSettingsClient`
- `cmd/agent/subcommands/diagnose/command.go` — `printPayload`,
  `printHealthPlatformIssues`, `requestDiagnosesFromAgentProcess`,
  `printAgentFullTelemetry`
- `cmd/agent/subcommands/stop/command.go` — `agent stop`
- `pkg/cli/subcommands/health/command.go` — `agent health`
- `pkg/cli/subcommands/taggerlist/command.go` — `agent tagger-list`
- `pkg/cli/subcommands/workloadlist/command.go` — `agent workload-list`
- `pkg/config/fetcher/from_processes.go` — `ProcessAgentConfig`
- `pkg/flare/clusteragent/archive_dca.go` — DCA flare providers (introduces
  a small file-local helper `dcaIPCHostPort()` to deduplicate the four
  identical lookups)

### Motivation

**Jira:** [CONS-8164](https://datadoghq.atlassian.net/browse/CONS-8164)

When `cmd_host` (or the deprecated `ipc_address`) is set to an IPv6 literal,
the unbracketed form yielded broken URLs like `https://::1:5001/agent/...`
that fail with `dial tcp: too many colons in address`. The original ticket
fix (PR #48345) only covered the cluster-agent endpoint construction;
several other CLI commands and the cluster-agent flare providers had the
same bug.

This PR is the `agent-configuration` slice of a per-team cleanup of the
remaining naive concatenations. Sister PRs (one per code-owning team) will
land alongside this one.

### Describe how you validated your changes

- The change is mechanical: each call site retains the same scheme, port
  config key and path; only the host:port formatting switches to
  `net.JoinHostPort`. This mirrors the established pattern from PR #48345.
- IPv6 behavior is exercised end-to-end on IPv6-only Kubernetes clusters,
  which was the reproduction setup in CONS-8164.
- No existing unit tests had to change.

### Additional Notes

- A few `localhost` / `127.0.0.1` literal hosts in the same files (e.g.
  `pkg/config/fetcher/from_processes.go` `SecurityAgentConfig` /
  `TraceAgentConfig`, `pkg/flare/clusteragent/archive_dca.go`
  `getClusterAgentMetadataPayload`) are intentionally untouched — IPv4 /
  hostname literals are not affected by the IPv6 colon-ambiguity bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CONS-8164]: https://datadoghq.atlassian.net/browse/CONS-8164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ