### PR TITLE
[CONS-8164] Use `net.JoinHostPort` for IPv6-safe cluster agent internal URLs

### DIFF
--- a/pkg/clusteragent/api/leader_forwarder.go
+++ b/pkg/clusteragent/api/leader_forwarder.go
@@ -121,7 +121,7 @@ func (lf *LeaderForwarder) SetLeaderIP(leaderIP string) {
 	lf.proxy = &httputil.ReverseProxy{
 		Director: func(req *http.Request) {
 			req.URL.Scheme = "https"
-			req.URL.Host = leaderIP + ":" + lf.apiPort
+			req.URL.Host = net.JoinHostPort(leaderIP, lf.apiPort)
 			req.Header.Add(forwardHeader, "true")
 		},
 		Transport: lf.transport,

--- a/pkg/util/clusteragent/clcrunner.go
+++ b/pkg/util/clusteragent/clcrunner.go
@@ -9,7 +9,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
@@ -87,12 +89,19 @@ func (c *CLCRunnerClient) init() {
 	c.clcRunnerPort = pkgconfigsetup.Datadog().GetInt("cluster_checks.clc_runners_port")
 }
 
+// runnerURL builds the URL of a CLC Runner endpoint, properly bracketing
+// IPv6 hosts.
+func (c *CLCRunnerClient) runnerURL(IP, subPath string) string {
+	addr := net.JoinHostPort(IP, strconv.Itoa(c.clcRunnerPort))
+	return fmt.Sprintf("https://%s/%s/%s", addr, clcRunnerPath, subPath)
+}
+
 // GetVersion fetches the version of the CLC Runner
 func (c *CLCRunnerClient) GetVersion(IP string) (version.Version, error) {
 	var version version.Version
 	var err error
 
-	rawURL := fmt.Sprintf("https://%s:%d/%s/%s", IP, c.clcRunnerPort, clcRunnerPath, clcRunnerVersionPath)
+	rawURL := c.runnerURL(IP, clcRunnerVersionPath)
 
 	req, err := http.NewRequest("GET", rawURL, nil)
 	if err != nil {
@@ -125,7 +134,7 @@ func (c *CLCRunnerClient) GetRunnerStats(IP string) (types.CLCRunnersStats, erro
 	var stats types.CLCRunnersStats
 	var err error
 
-	rawURL := fmt.Sprintf("https://%s:%d/%s/%s", IP, c.clcRunnerPort, clcRunnerPath, clcRunnerStatsPath)
+	rawURL := c.runnerURL(IP, clcRunnerStatsPath)
 
 	req, err := http.NewRequest("GET", rawURL, nil)
 	if err != nil {
@@ -160,7 +169,7 @@ func (c *CLCRunnerClient) GetRunnerStats(IP string) (types.CLCRunnersStats, erro
 func (c *CLCRunnerClient) GetRunnerWorkers(IP string) (types.Workers, error) {
 	var workers types.Workers
 
-	rawURL := fmt.Sprintf("https://%s:%d/%s/%s", IP, c.clcRunnerPort, clcRunnerPath, clcRunnerWorkersPath)
+	rawURL := c.runnerURL(IP, clcRunnerWorkersPath)
 
 	req, err := http.NewRequest("GET", rawURL, nil)
 	if err != nil {

--- a/releasenotes/notes/fix-ipv6-cluster-agent-internal-urls-39bb2425e167b3fa.yaml
+++ b/releasenotes/notes/fix-ipv6-cluster-agent-internal-urls-39bb2425e167b3fa.yaml
@@ -1,0 +1,17 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix IPv6 address formatting in URLs built between the Cluster Agent
+    and Cluster Level Check Runner pods, and in the Cluster Agent
+    leader-forwarder. When the source pod IPs are IPv6, the address is
+    now properly wrapped in brackets (e.g. ``https://[fd38::1]:5005/...``)
+    so that the ``GetVersion``, ``GetRunnerStats`` and ``GetRunnerWorkers``
+    HTTP calls — and the leader-forwarding reverse proxy — succeed on
+    IPv6-only clusters.


### PR DESCRIPTION
### What does this PR do?

Replaces naive ``IP+":"+port`` / ``fmt.Sprintf("%s:%d", IP, port)`` with
``net.JoinHostPort`` so that IPv6 pod IPs are properly bracketed in the URLs
the Cluster Agent builds for its internal callouts.

Fixed locations (all owned by ``@DataDog/container-platform``):

- ``pkg/clusteragent/api/leader_forwarder.go`` — the ``LeaderForwarder``
  reverse-proxy ``Director`` setting ``req.URL.Host = leaderIP+":"+apiPort``.
- ``pkg/util/clusteragent/clcrunner.go`` — the three CLC Runner client
  methods ``GetVersion``, ``GetRunnerStats`` and ``GetRunnerWorkers``. A small
  file-local helper ``runnerURL(IP, subPath)`` centralizes the URL build.

### Motivation

**Jira:** [CONS-8164](https://datadoghq.atlassian.net/browse/CONS-8164)

In IPv6-only Kubernetes clusters, pod IPs are IPv6 literals. Without
bracketing, ``fd38::1:5005`` is ambiguous (too many colons) and ``net.Dial``
rejects it.

This PR is the ``container-platform`` slice of a per-team cleanup of the
remaining naive concatenations after PR #48345. Sister PRs (one per
code-owning team) will land alongside this one.

### Describe how you validated your changes

- The change is mechanical: each call site keeps the same scheme, port and
  path; only the host:port formatting switches to ``net.JoinHostPort``. This
  mirrors the established pattern from PR #48345.
- IPv6 behavior is exercised end-to-end on IPv6-only Kubernetes clusters
  (the reproduction scenario from CONS-8164).

### Additional Notes

The companion DCA flare provider URLs (also reaching the cluster agent over
the same IPC port) are fixed in the sibling ``agent-configuration`` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CONS-8164]: https://datadoghq.atlassian.net/browse/CONS-8164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ