### PR TITLE
[CONS-8164] Use `net.JoinHostPort` for IPv6-safe process-agent IPC URLs

### DIFF
--- a/cmd/process-agent/subcommands/config/config.go
+++ b/cmd/process-agent/subcommands/config/config.go
@@ -9,6 +9,8 @@ package config
 import (
 	"errors"
 	"fmt"
+	"net"
+	"strconv"
 
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
@@ -195,7 +197,7 @@ func getClient(deps dependencies) (settings.Client, error) {
 		return nil, fmt.Errorf("invalid process_config.cmd_port -- %d", port)
 	}
 
-	ipcAddressWithPort := fmt.Sprintf("https://%s:%d/config", ipcAddress, port)
+	ipcAddressWithPort := fmt.Sprintf("https://%s/config", net.JoinHostPort(ipcAddress, strconv.Itoa(port)))
 	if err != nil {
 		return nil, err
 	}

--- a/comp/process/agent/impl/status.go
+++ b/comp/process/agent/impl/status.go
@@ -11,6 +11,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
+	"strconv"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
@@ -74,7 +76,7 @@ func (s StatusProvider) populateStatus() map[string]interface{} {
 
 		// Using the core agent's expvar server
 		port := s.config.GetInt("expvar_port")
-		url = fmt.Sprintf("http://%s:%d/debug/vars", ipcAddr, port)
+		url = fmt.Sprintf("http://%s/debug/vars", net.JoinHostPort(ipcAddr, strconv.Itoa(port)))
 	}
 
 	agentStatus, err := processStatus.GetStatus(s.config, url, s.hostname)

--- a/comp/process/status/impl/status.go
+++ b/comp/process/status/impl/status.go
@@ -11,6 +11,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
+	"strconv"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
@@ -95,7 +97,8 @@ func (s statusProvider) populateStatus() map[string]interface{} {
 			return status
 		}
 
-		url = fmt.Sprintf("http://%s:%d/debug/vars", ipcAddr, s.config.GetInt("process_config.expvar_port"))
+		addr := net.JoinHostPort(ipcAddr, strconv.Itoa(s.config.GetInt("process_config.expvar_port")))
+		url = fmt.Sprintf("http://%s/debug/vars", addr)
 	}
 
 	agentStatus, err := processStatus.GetStatus(s.config, url, s.hostname)

--- a/releasenotes/notes/fix-ipv6-process-agent-ipc-urls-201611382f6ed2eb.yaml
+++ b/releasenotes/notes/fix-ipv6-process-agent-ipc-urls-201611382f6ed2eb.yaml
@@ -1,0 +1,17 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix IPv6 address formatting in URLs the process-agent uses to reach the
+    core agent's expvar server and the process-agent's own config endpoint.
+    When ``cmd_host`` (or the deprecated ``ipc_address``) is set to an IPv6
+    literal, the address is now properly wrapped in brackets
+    (e.g. ``http://[::1]:6062/debug/vars``) so that the process status
+    component and the ``process-agent config`` subcommand succeed on
+    IPv6-only setups.


### PR DESCRIPTION
### What does this PR do?

Replaces naive ``fmt.Sprintf("%s:%d", host, port)`` with ``net.JoinHostPort``
so that IPv6 IPC addresses are properly bracketed.

Fixed locations (all owned by ``@DataDog/container-experiences``):

- ``comp/process/agent/impl/status.go`` — process status provider's call
  to the core agent expvar server.
- ``comp/process/status/impl/status.go`` — process status provider's call
  to the process-agent expvar server.
- ``cmd/process-agent/subcommands/config/config.go`` — ``process-agent
  config`` subcommand's call to the process-agent config endpoint.

### Motivation

**Jira:** [CONS-8164](https://datadoghq.atlassian.net/browse/CONS-8164)

When ``cmd_host`` (or the deprecated ``ipc_address``) is set to an IPv6
literal, the unbracketed form yielded URLs that fail with
``dial tcp: too many colons in address``.

This PR is the ``container-experiences`` slice of a per-team cleanup of the
remaining naive concatenations after PR #48345. Sister PRs (one per
code-owning team) will land alongside this one.

### Describe how you validated your changes

- The change is mechanical: each call site keeps the same scheme, port and
  path; only the host:port formatting switches to ``net.JoinHostPort``. This
  mirrors the established pattern from PR #48345.
- IPv6 behavior is exercised end-to-end on IPv6-only Kubernetes clusters
  (the reproduction scenario from CONS-8164).

### Additional Notes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CONS-8164]: https://datadoghq.atlassian.net/browse/CONS-8164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ