### PR TITLE
[CONS-8164] Use `net.JoinHostPort` for IPv6-safe dogstatsd subcommand URLs

### DIFF
--- a/cmd/agent/subcommands/dogstatsd/command.go
+++ b/cmd/agent/subcommands/dogstatsd/command.go
@@ -11,8 +11,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/DataDog/zstd"
@@ -91,7 +93,7 @@ func triggerDump(config cconfig.Component, client ipc.HTTPClient) (string, error
 	}
 
 	port := config.GetInt("cmd_port")
-	url := fmt.Sprintf("https://%v:%v/agent/dogstatsd-contexts-dump", addr, port)
+	url := fmt.Sprintf("https://%s/agent/dogstatsd-contexts-dump", net.JoinHostPort(addr, strconv.Itoa(port)))
 
 	body, err := client.Post(url, "", nil)
 	if err != nil {

--- a/cmd/agent/subcommands/dogstatsdstats/command.go
+++ b/cmd/agent/subcommands/dogstatsdstats/command.go
@@ -11,7 +11,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"os"
+	"strconv"
 
 	"go.uber.org/fx"
 
@@ -77,7 +79,7 @@ func requestDogstatsdStats(_ log.Component, config config.Component, cliParams *
 	if err != nil {
 		return err
 	}
-	urlstr := fmt.Sprintf("https://%v:%v/agent/dogstatsd-stats", ipcAddress, pkgconfigsetup.Datadog().GetInt("cmd_port"))
+	urlstr := fmt.Sprintf("https://%s/agent/dogstatsd-stats", net.JoinHostPort(ipcAddress, strconv.Itoa(pkgconfigsetup.Datadog().GetInt("cmd_port"))))
 
 	r, e := client.Get(urlstr, ipchttp.WithLeaveConnectionOpen)
 	if e != nil {

--- a/releasenotes/notes/fix-ipv6-dogstatsd-subcommand-urls-ecba0e79791c4d1b.yaml
+++ b/releasenotes/notes/fix-ipv6-dogstatsd-subcommand-urls-ecba0e79791c4d1b.yaml
@@ -1,0 +1,16 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix IPv6 address formatting in URLs built by the ``agent dogstatsd-stats``
+    and ``agent dogstatsd dump-contexts`` / ``agent dogstatsd top``
+    subcommands when reaching the local agent IPC endpoint. The address is
+    now properly bracketed (e.g. ``https://[::1]:5001/agent/dogstatsd-stats``)
+    so the calls succeed when ``cmd_host`` (or the deprecated
+    ``ipc_address``) is set to an IPv6 literal.


### PR DESCRIPTION
### What does this PR do?

Replaces naive ``fmt.Sprintf("%s:%d", host, port)`` with ``net.JoinHostPort``
so that IPv6 IPC addresses are properly bracketed.

Fixed locations (all owned by ``@DataDog/agent-metric-pipelines``):

- ``cmd/agent/subcommands/dogstatsdstats/command.go`` — ``agent
  dogstatsd-stats``.
- ``cmd/agent/subcommands/dogstatsd/command.go`` — ``triggerDump`` (used
  by ``agent dogstatsd dump-contexts`` and ``agent dogstatsd top``).

### Motivation

**Jira:** [CONS-8164](https://datadoghq.atlassian.net/browse/CONS-8164)

When ``cmd_host`` (or the deprecated ``ipc_address``) is an IPv6 literal,
the unbracketed form yielded URLs that fail with ``dial tcp: too many
colons in address``.

This PR is the ``agent-metric-pipelines`` slice of a per-team cleanup of
the remaining naive concatenations after PR #48345. Sister PRs (one per
code-owning team) will land alongside this one.

### Describe how you validated your changes

- Mechanical replacement; existing IPv4 / hostname cases keep their exact
  string form (``net.JoinHostPort`` only brackets IPv6 literals).

### Additional Notes

An additional naive concatenation in ``pkg/jmxfetch/jmxfetch.go:525``
emits a JMXfetch-specific ``statsd:host:port`` URI consumed by the
JMXfetch Java side. We deliberately do **not** change it in this PR
because we cannot confirm from the agent repo that the JMXfetch parser
accepts ``statsd:[::1]:8125``. A follow-up issue tracking the
JMXfetch-side change should be opened separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CONS-8164]: https://datadoghq.atlassian.net/browse/CONS-8164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ