### PR TITLE
[CONS-8164] Use `net.JoinHostPort` for IPv6-safe stream-event-platform URL

### DIFF
--- a/cmd/agent/subcommands/streamep/command.go
+++ b/cmd/agent/subcommands/streamep/command.go
@@ -11,6 +11,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
+	"strconv"
 
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
@@ -69,7 +71,7 @@ func streamEventPlatform(_ log.Component, config config.Component, client ipc.HT
 		return err
 	}
 
-	urlstr := fmt.Sprintf("https://%v:%v/agent/stream-event-platform", ipcAddress, config.GetInt("cmd_port"))
+	urlstr := fmt.Sprintf("https://%s/agent/stream-event-platform", net.JoinHostPort(ipcAddress, strconv.Itoa(config.GetInt("cmd_port"))))
 	return streamRequest(client, urlstr, body, func(chunk []byte) {
 		fmt.Print(string(chunk))
 	})

--- a/releasenotes/notes/fix-ipv6-streamep-url-33f820d2f413f47e.yaml
+++ b/releasenotes/notes/fix-ipv6-streamep-url-33f820d2f413f47e.yaml
@@ -1,0 +1,16 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix IPv6 address formatting in the URL built by the ``agent
+    stream-event-platform`` subcommand to reach the local agent IPC
+    endpoint. The address is now properly bracketed
+    (e.g. ``https://[::1]:5001/agent/stream-event-platform``) so the
+    subcommand succeeds when ``cmd_host`` (or the deprecated
+    ``ipc_address``) is set to an IPv6 literal.


### PR DESCRIPTION
### What does this PR do?

Replaces the naive ``fmt.Sprintf("%s:%d", host, port)`` host:port
concatenation in ``cmd/agent/subcommands/streamep/command.go`` (used by
``agent stream-event-platform``) with ``net.JoinHostPort``, so IPv6 IPC
addresses are properly bracketed.

### Motivation

**Jira:** [CONS-8164](https://datadoghq.atlassian.net/browse/CONS-8164)

When ``cmd_host`` (or the deprecated ``ipc_address``) is set to an IPv6
literal, the unbracketed form yielded a URL that fails with ``dial tcp:
too many colons in address``.

This PR is the ``container-integrations`` slice of a per-team cleanup of
the remaining naive concatenations after PR #48345. Sister PRs (one per
code-owning team) will land alongside this one.

### Describe how you validated your changes

Mechanical replacement; existing IPv4 / hostname cases keep their exact
string form (``net.JoinHostPort`` only brackets IPv6 literals).

### Additional Notes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CONS-8164]: https://datadoghq.atlassian.net/browse/CONS-8164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ