### PR TITLE
[CONS-8164] Use `net.JoinHostPort` for IPv6-safe agent telemetry URL

### DIFF
--- a/comp/core/agenttelemetry/impl/sender.go
+++ b/comp/core/agenttelemetry/impl/sender.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -174,7 +175,7 @@ func newSenderClientImpl(agentCfg config.Component) client {
 func buildURL(endpoint logconfig.Endpoint) string {
 	var address string
 	if endpoint.Port != 0 {
-		address = fmt.Sprintf("%v:%v", endpoint.Host, endpoint.Port)
+		address = net.JoinHostPort(endpoint.Host, strconv.Itoa(endpoint.Port))
 	} else {
 		address = endpoint.Host
 	}

--- a/releasenotes/notes/fix-ipv6-agent-telemetry-url-ad27ecd88131c5da.yaml
+++ b/releasenotes/notes/fix-ipv6-agent-telemetry-url-ad27ecd88131c5da.yaml
@@ -1,0 +1,14 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix IPv6 address formatting in the agent telemetry sender's URL build.
+    When the configured telemetry endpoint host is an IPv6 literal, the
+    address is now properly bracketed (e.g. ``https://[fd38::1]:443/...``)
+    so the underlying ``net/url`` and HTTP clients can parse the URL.


### PR DESCRIPTION
### What does this PR do?

Replaces the naive ``fmt.Sprintf("%s:%d", host, port)`` host:port
concatenation in ``comp/core/agenttelemetry/impl/sender.go`` (``buildURL``)
with ``net.JoinHostPort`` so IPv6 telemetry endpoint hosts are properly
bracketed.

### Motivation

**Jira:** [CONS-8164](https://datadoghq.atlassian.net/browse/CONS-8164)

When the configured telemetry endpoint host is an IPv6 literal, the
unbracketed form yielded a URL that fails with ``dial tcp: too many
colons in address``.

This PR is the ``agent-health`` slice of a per-team cleanup of the
remaining naive concatenations after PR #48345. Sister PRs (one per
code-owning team) will land alongside this one.

### Describe how you validated your changes

Mechanical replacement; existing IPv4 / hostname cases keep their exact
string form (``net.JoinHostPort`` only brackets IPv6 literals).

### Additional Notes

The ``endpoint.Port == 0`` branch in ``buildURL`` is intentionally left
unchanged — it passes the bare host through, mirroring the pre-existing
behavior when no port is configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CONS-8164]: https://datadoghq.atlassian.net/browse/CONS-8164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ