### PR TITLE
[CONS-8164] Use `net.JoinHostPort` for IPv6-safe OTLP bind address

### DIFF
--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"encoding/hex"
 	"errors"
-	"fmt"
 	"math"
 	"net"
 	"net/http"
@@ -125,7 +124,7 @@ func (o *OTLPReceiver) Start() {
 		}
 		if ln == nil {
 			// if the fd was not provided, or we failed to get a listener from it, listen on the given address
-			ln, err = loader.GetTCPListener(fmt.Sprintf("%s:%d", cfg.BindHost, cfg.GRPCPort))
+			ln, err = loader.GetTCPListener(net.JoinHostPort(cfg.BindHost, strconv.Itoa(cfg.GRPCPort)))
 		}
 
 		if err != nil {

--- a/releasenotes/notes/fix-ipv6-otlp-bind-address-fc89391a4e9a211f.yaml
+++ b/releasenotes/notes/fix-ipv6-otlp-bind-address-fc89391a4e9a211f.yaml
@@ -1,0 +1,15 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix IPv6 address formatting in the trace-agent's OTLP gRPC listener
+    bind address. When ``apm_config.receiver_socket`` / ``bind_host`` is
+    set to an IPv6 literal, the address is now properly bracketed
+    (e.g. ``[fd38::1]:4317``) so the listener can be opened on IPv6-only
+    hosts.


### PR DESCRIPTION
### What does this PR do?

Replaces the naive ``fmt.Sprintf("%s:%d", host, port)`` host:port
concatenation in ``pkg/trace/api/otlp.go`` with ``net.JoinHostPort`` so
the OTLP gRPC listener uses a properly bracketed ``host:port`` for IPv6
bind hosts. Removes the now-unused ``fmt`` import.

### Motivation

**Jira:** [CONS-8164](https://datadoghq.atlassian.net/browse/CONS-8164)

When ``apm_config.receiver_socket`` / ``bind_host`` is set to an IPv6
literal, the unbracketed form yielded a listener address that
``net.Listen("tcp", ...)`` rejects with ``too many colons in address``.

This PR is the ``opentelemetry`` slice of a per-team cleanup of the
remaining naive concatenations after PR #48345. Sister PRs (one per
code-owning team) will land alongside this one.

### Describe how you validated your changes

Mechanical replacement; existing IPv4 / hostname cases keep their exact
string form (``net.JoinHostPort`` only brackets IPv6 literals).

### Additional Notes

The earlier listener creation site (line 314) already used
``net.JoinHostPort`` — only line 360 was missing the same treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CONS-8164]: https://datadoghq.atlassian.net/browse/CONS-8164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ