### PR TITLE
[CONS-8164] Use `net.JoinHostPort` for IPv6-safe ECS metadata detection URLs

### DIFF
--- a/pkg/util/ecs/metadata/detection.go
+++ b/pkg/util/ecs/metadata/detection.go
@@ -12,9 +12,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"runtime"
+	"strconv"
 	"time"
 
 	"github.com/hashicorp/go-version"
@@ -59,7 +61,7 @@ func detectAgentV1URL() (string, error) {
 			log.Debugf("Could not get docker default gateway: %s", err)
 		}
 		if gw != nil {
-			urls = append(urls, fmt.Sprintf("http://%s:%d/", gw.String(), v1.DefaultAgentPort))
+			urls = append(urls, fmt.Sprintf("http://%s/", net.JoinHostPort(gw.String(), strconv.Itoa(v1.DefaultAgentPort))))
 		}
 
 		// Try the default IP for awsvpc mode
@@ -96,7 +98,7 @@ func getAgentV1ContainerURLs(ctx context.Context) ([]string, error) {
 	for _, network := range ecsConfig.NetworkSettings.Networks {
 		ip := network.IPAddress
 		if ip.IsValid() {
-			urls = append(urls, fmt.Sprintf("http://%s:%d/", ip, v1.DefaultAgentPort))
+			urls = append(urls, fmt.Sprintf("http://%s/", net.JoinHostPort(ip.String(), strconv.Itoa(v1.DefaultAgentPort))))
 		}
 	}
 
@@ -104,7 +106,7 @@ func getAgentV1ContainerURLs(ctx context.Context) ([]string, error) {
 	// runs in the (default) host network mode. This allows us to connect back to it
 	// from an agent container running in awsvpc mode.
 	if ecsConfig.Config != nil && ecsConfig.Config.Hostname != "" {
-		urls = append(urls, fmt.Sprintf("http://%s:%d/", ecsConfig.Config.Hostname, v1.DefaultAgentPort))
+		urls = append(urls, fmt.Sprintf("http://%s/", net.JoinHostPort(ecsConfig.Config.Hostname, strconv.Itoa(v1.DefaultAgentPort))))
 	}
 
 	return urls, nil

--- a/releasenotes/notes/fix-ipv6-ecs-metadata-detection-afd1bd0f04a29e73.yaml
+++ b/releasenotes/notes/fix-ipv6-ecs-metadata-detection-afd1bd0f04a29e73.yaml
@@ -1,0 +1,16 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix IPv6 address formatting in the candidate URLs the ECS metadata
+    autodetection probes for the local ECS agent (default gateway,
+    container network IPs, container hostname). The host:port portion is
+    now built with ``net.JoinHostPort`` so an IPv6 gateway / container IP
+    yields a parseable URL like ``http://[fd38::1]:51678/`` instead of
+    ``http://fd38::1:51678/``.


### PR DESCRIPTION
### What does this PR do?

Replaces three naive ``fmt.Sprintf("%s:%d", host, port)`` host:port
concatenations in ``pkg/util/ecs/metadata/detection.go`` with
``net.JoinHostPort``, so the candidate URLs the ECS metadata
autodetection probes for the local ECS agent (default gateway, container
network IPs, container hostname) handle IPv6 hosts correctly.

### Motivation

**Jira:** [CONS-8164](https://datadoghq.atlassian.net/browse/CONS-8164)

In dual-stack ECS / Docker setups, the default gateway IP and container
IPs may be IPv6. The unbracketed form yielded URLs that fail with
``too many colons in address``.

This PR is the ``ecs-experiences`` slice of a per-team cleanup of the
remaining naive concatenations after PR #48345. Sister PRs (one per
code-owning team) will land alongside this one.

### Describe how you validated your changes

Mechanical replacement; existing IPv4 / hostname cases keep their exact
string form (``net.JoinHostPort`` only brackets IPv6 literals). The
hardcoded ``http://localhost:%d/`` and ``http://169.254.172.1:%d/``
fallbacks are intentionally left as-is — neither is an IPv6 literal.

### Additional Notes

The ``ip`` variable is a ``netip.Addr``; ``ip.String()`` is now passed to
``net.JoinHostPort`` (previously the ``%s`` verb already produced the
same string output, so no behavior change for IPv4 callers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CONS-8164]: https://datadoghq.atlassian.net/browse/CONS-8164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ