### PR TITLE
[CONS-8164] Use `net.JoinHostPort` for IPv6-safe NDM host:port

### DIFF
--- a/comp/netflow/config/def/config.go
+++ b/comp/netflow/config/def/config.go
@@ -7,6 +7,8 @@ package config
 
 import (
 	"fmt"
+	"net"
+	"strconv"
 
 	coreconfig "github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
@@ -141,5 +143,5 @@ func (mainConfig *NetflowConfig) SetDefaults(namespace string, logger log.Compon
 
 // Addr returns the host:port address to listen on.
 func (c *ListenerConfig) Addr() string {
-	return fmt.Sprintf("%s:%d", c.BindHost, c.Port)
+	return net.JoinHostPort(c.BindHost, strconv.Itoa(int(c.Port)))
 }

--- a/comp/networkdeviceconfig/impl/networkdeviceconfig.go
+++ b/comp/networkdeviceconfig/impl/networkdeviceconfig.go
@@ -7,13 +7,14 @@
 package networkdeviceconfigimpl
 
 import (
-	"fmt"
+	"net"
+	"strings"
+
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	compdef "github.com/DataDog/datadog-agent/comp/def"
 	networkdeviceconfig "github.com/DataDog/datadog-agent/comp/networkdeviceconfig/def"
 	"golang.org/x/crypto/ssh"
-	"strings"
 )
 
 // Requires defines the dependencies for the networkdeviceconfig component
@@ -108,7 +109,7 @@ func connectToHost(ipAddress string, ac AuthCredentials) (*ssh.Client, error) {
 	// ⚠️TODO: Use a proper host key callback in production code (pull in known hosts file from user, etc.)
 	sshConfig.HostKeyCallback = ssh.InsecureIgnoreHostKey()
 
-	host := fmt.Sprintf("%s:%s", ipAddress, ac.Port)
+	host := net.JoinHostPort(ipAddress, ac.Port)
 	client, err := ssh.Dial(ac.Protocol, host, sshConfig)
 	if err != nil {
 		return nil, err

--- a/pkg/collector/corechecks/network-devices/versa/client/client.go
+++ b/pkg/collector/corechecks/network-devices/versa/client/client.go
@@ -11,16 +11,32 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
+
+// bracketIPv6Host wraps a bare IPv6 literal (e.g. `fd38::1`) in brackets so it
+// is safe to assign to `url.URL.Host`. Inputs that are not bare IPv6 literals
+// (IPv4, hostnames, host:port forms, full URLs, or already-bracketed IPv6) are
+// returned unchanged.
+func bracketIPv6Host(host string) string {
+	if strings.HasPrefix(host, "[") {
+		return host
+	}
+	if ip := net.ParseIP(host); ip != nil && ip.To4() == nil {
+		return "[" + host + "]"
+	}
+	return host
+}
 
 const (
 	defaultBasicPort   = 9182
@@ -102,12 +118,12 @@ func NewClient(directorEndpoint string, directorPort int, analyticsEndpoint stri
 
 	directorEndpointURL := url.URL{
 		Scheme: scheme,
-		Host:   directorEndpoint,
+		Host:   bracketIPv6Host(directorEndpoint),
 	}
 
 	analyticsEndpointURL := url.URL{
 		Scheme: scheme,
-		Host:   analyticsEndpoint,
+		Host:   bracketIPv6Host(analyticsEndpoint),
 	}
 
 	client := &Client{

--- a/pkg/collector/corechecks/network-devices/versa/client/request.go
+++ b/pkg/collector/corechecks/network-devices/versa/client/request.go
@@ -10,7 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
 	"strconv"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -23,8 +25,14 @@ func (client *Client) newRequest(method, uri string, body io.Reader, useSessionA
 	if useSessionAuth {
 		return http.NewRequestWithContext(context.Background(), method, client.directorEndpoint+uri, body)
 	}
-	log.Tracef("Endpoint: %s:%d%s", client.directorEndpoint, client.directorAPIPort, uri)
-	return http.NewRequestWithContext(context.Background(), method, fmt.Sprintf("%s:%d%s", client.directorEndpoint, client.directorAPIPort, uri), body)
+	parsedURL, err := url.Parse(client.directorEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("invalid director endpoint %q: %w", client.directorEndpoint, err)
+	}
+	parsedURL.Host = net.JoinHostPort(parsedURL.Hostname(), strconv.Itoa(client.directorAPIPort))
+	endpointWithPort := parsedURL.String()
+	log.Tracef("Endpoint: %s%s", endpointWithPort, uri)
+	return http.NewRequestWithContext(context.Background(), method, endpointWithPort+uri, body)
 }
 
 // TODO: can we move this to a common package? Cisco SD-WAN and Versa use this

--- a/pkg/networkconfigmanagement/remote/ssh.go
+++ b/pkg/networkconfigmanagement/remote/ssh.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"slices"
 	"strings"
@@ -299,7 +300,7 @@ func connectToHost(ipAddress string, auth ncmconfig.AuthCredentials, config *ncm
 		HostKeyAlgorithms: config.HostKeyAlgorithms,
 	}
 
-	host := fmt.Sprintf("%s:%s", ipAddress, auth.Port)
+	host := net.JoinHostPort(ipAddress, auth.Port)
 	client, err := ssh.Dial(auth.Protocol, host, sshConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to %s: %w", host, err)

--- a/releasenotes/notes/fix-ipv6-ndm-host-port-98e3cd61730bab14.yaml
+++ b/releasenotes/notes/fix-ipv6-ndm-host-port-98e3cd61730bab14.yaml
@@ -1,0 +1,18 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix IPv6 address formatting in several network-device monitoring code
+    paths: the NetFlow listener bind address, the SSH connection target
+    used by the network device configuration component and the network
+    config management remote SSH client, and the Versa director endpoint
+    URL. All now properly bracket IPv6 hosts (e.g. ``[fd38::1]:22``) so
+    listeners can bind and SSH dials succeed on IPv6-only networks. The
+    Versa client additionally re-parses the configured ``directorEndpoint``
+    URL to bracket the host before joining it with ``directorAPIPort``.


### PR DESCRIPTION
### What does this PR do?

Replaces naive ``fmt.Sprintf("%s:%d", host, port)`` host:port
concatenations with ``net.JoinHostPort`` in several network-device
monitoring code paths, so IPv6 hosts are properly bracketed.

Fixed locations (all owned by ``@DataDog/ndm-integrations``):

- ``comp/netflow/config/def/config.go`` — ``ListenerConfig.Addr()``
  NetFlow listener bind address.
- ``comp/networkdeviceconfig/impl/networkdeviceconfig.go`` — SSH dial
  target for the network device configuration component.
- ``pkg/networkconfigmanagement/remote/ssh.go`` — NCM SSH dial target.
- ``pkg/collector/corechecks/network-devices/versa/client/request.go`` —
  Versa director endpoint URL. The director URL is now re-parsed via
  ``net/url`` so the host (which already includes the scheme) is
  bracketed before joining with ``directorAPIPort``.

### Motivation

**Jira:** [CONS-8164](https://datadoghq.atlassian.net/browse/CONS-8164)

When the configured host (NetFlow bind, network-device IP, Versa
director endpoint) is an IPv6 literal, the unbracketed form yielded
addresses / URLs that fail with ``too many colons in address``.

This PR is the ``ndm-integrations`` slice of a per-team cleanup of the
remaining naive concatenations after PR #48345. Sister PRs (one per
code-owning team) will land alongside this one.

### Describe how you validated your changes

Mechanical replacement; existing IPv4 / hostname cases keep their exact
string form (``net.JoinHostPort`` only brackets IPv6 literals). Existing
NetFlow ``TestListenerConfig_Addr`` and other unit tests in the affected
packages continue to pass.

### Additional Notes

The Versa client uses an additional ``url.Parse`` step because
``directorEndpoint`` already contains the scheme; re-emitting via
``url.URL.String()`` after a ``net.JoinHostPort`` host substitution keeps
the URL well-formed for both IPv4 and IPv6 hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CONS-8164]: https://datadoghq.atlassian.net/browse/CONS-8164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ