### PR TITLE
[CONS-8164] Use `net.JoinHostPort` for IPv6-safe AppSec processor address

### DIFF
--- a/pkg/clusteragent/appsec/config/config.go
+++ b/pkg/clusteragent/appsec/config/config.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"net"
 	"slices"
 	"strconv"
 	"strings"
@@ -113,7 +114,7 @@ func (p Processor) String() string {
 	if address == "" {
 		address = p.ServiceName + "." + p.Namespace + ".svc"
 	}
-	return address + ":" + strconv.Itoa(p.Port)
+	return net.JoinHostPort(address, strconv.Itoa(p.Port))
 }
 
 // Product represents the configuration of the AppSec Injection Proxy agent feature

--- a/releasenotes/notes/fix-ipv6-appsec-processor-address-33ae25bbe651e4ce.yaml
+++ b/releasenotes/notes/fix-ipv6-appsec-processor-address-33ae25bbe651e4ce.yaml
@@ -1,0 +1,14 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix IPv6 address formatting in the AppSec injection-proxy
+    ``Processor.String()``. When the configured processor ``Address`` is
+    an IPv6 literal, the resulting string is now properly bracketed
+    (e.g. ``[fd38::1]:8126``) so that downstream consumers can parse it.


### PR DESCRIPTION
### What does this PR do?

Replaces the naive ``address + ":" + strconv.Itoa(p.Port)`` host:port
concatenation in ``Processor.String()`` with ``net.JoinHostPort`` so that
IPv6 processor addresses are properly bracketed.

Fixed location (co-owned by ``@DataDog/asm-go`` and
``@DataDog/container-platform``):

- ``pkg/clusteragent/appsec/config/config.go``

### Motivation

**Jira:** [CONS-8164](https://datadoghq.atlassian.net/browse/CONS-8164)

When the configured processor ``Address`` is an IPv6 literal, the
unbracketed form yielded a string with multiple colons that downstream
consumers can't parse.

This PR is the ``asm-go`` / ``container-platform`` slice of a per-team
cleanup of the remaining naive concatenations after PR #48345. Sister PRs
(one per code-owning team) will land alongside this one.

### Describe how you validated your changes

Mechanical replacement; existing IPv4 / hostname / k8s-DNS-name cases
keep their exact string form (``net.JoinHostPort`` only brackets IPv6
literals).

### Additional Notes

The default fallback ``ServiceName.Namespace.svc`` form does not contain
colons, so it is unaffected by ``net.JoinHostPort``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CONS-8164]: https://datadoghq.atlassian.net/browse/CONS-8164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ