### PR TITLE
[CONS-8164] Use `net.JoinHostPort` for IPv6-safe autoscaler-list URLs

### DIFF
--- a/pkg/cli/subcommands/autoscalerlist/command.go
+++ b/pkg/cli/subcommands/autoscalerlist/command.go
@@ -11,6 +11,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
+	"strconv"
 
 	"go.uber.org/fx"
 
@@ -101,7 +103,8 @@ func getAutoscalerURL(config config.Component) (string, error) {
 
 	var urlstr string
 	if flavor.GetFlavor() == flavor.ClusterAgent {
-		urlstr = fmt.Sprintf("https://%v:%v/autoscaler-list", ipcAddress, config.GetInt("cluster_agent.cmd_port"))
+		addr := net.JoinHostPort(ipcAddress, strconv.Itoa(config.GetInt("cluster_agent.cmd_port")))
+		urlstr = fmt.Sprintf("https://%s/autoscaler-list", addr)
 	} else {
 		return "", errors.New("running autoscaler-list is only supported on the cluster agent")
 	}
@@ -137,7 +140,8 @@ func getLocalAutoscalingWorkloadCheck(w io.Writer, config config.Component, c ip
 	if err != nil {
 		return err
 	}
-	urlstr := fmt.Sprintf("https://%v:%v/local-autoscaling-check", ipcAddress, config.GetInt("cluster_agent.cmd_port"))
+	addr := net.JoinHostPort(ipcAddress, strconv.Itoa(config.GetInt("cluster_agent.cmd_port")))
+	urlstr := fmt.Sprintf("https://%s/local-autoscaling-check", addr)
 
 	r, err := c.Get(urlstr, ipchttp.WithLeaveConnectionOpen)
 	if err != nil {

--- a/releasenotes/notes/fix-ipv6-autoscaler-list-url-b3bd608f059bbe57.yaml
+++ b/releasenotes/notes/fix-ipv6-autoscaler-list-url-b3bd608f059bbe57.yaml
@@ -1,0 +1,16 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix IPv6 address formatting in the URLs built by the cluster-agent
+    ``autoscaler-list`` subcommand to reach the local cluster-agent IPC
+    endpoint. The host:port is now properly bracketed
+    (e.g. ``https://[::1]:5005/autoscaler-list``) so the subcommand
+    succeeds when ``cmd_host`` (or the deprecated ``ipc_address``) is set
+    to an IPv6 literal.


### PR DESCRIPTION
### What does this PR do?

Replaces two naive ``fmt.Sprintf("%s:%d", host, port)`` host:port
concatenations in ``pkg/cli/subcommands/autoscalerlist/command.go`` with
``net.JoinHostPort`` so IPv6 IPC addresses are properly bracketed.

Co-owned by ``@DataDog/container-autoscaling`` and
``@DataDog/container-integrations``.

### Motivation

**Jira:** [CONS-8164](https://datadoghq.atlassian.net/browse/CONS-8164)

When ``cmd_host`` (or the deprecated ``ipc_address``) is set to an IPv6
literal, the unbracketed form yielded URLs that fail with
``dial tcp: too many colons in address``.

This PR is the ``container-autoscaling`` / ``container-integrations``
slice of a per-team cleanup of the remaining naive concatenations after
PR #48345. Sister PRs (one per code-owning team) will land alongside
this one.

### Describe how you validated your changes

Mechanical replacement; existing IPv4 / hostname cases keep their exact
string form (``net.JoinHostPort`` only brackets IPv6 literals).

### Additional Notes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CONS-8164]: https://datadoghq.atlassian.net/browse/CONS-8164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ