### PR TITLE
[CONS-8164] Use `net.JoinHostPort` for IPv6-safe MongoDB action URI

### DIFF
--- a/pkg/privateactionrunner/bundles/mongodb/BUILD.bazel
+++ b/pkg/privateactionrunner/bundles/mongodb/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/privateactionrunner/adapters/logging",
         "//pkg/privateactionrunner/libs/privateconnection",
         "//pkg/privateactionrunner/types",
+        "//pkg/util/hostport",
         "@org_mongodb_go_mongo_driver//bson/primitive",
         "@org_mongodb_go_mongo_driver//mongo",
         "@org_mongodb_go_mongo_driver//mongo/options",

--- a/pkg/privateactionrunner/bundles/mongodb/helpers.go
+++ b/pkg/privateactionrunner/bundles/mongodb/helpers.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"strings"
 
@@ -89,11 +90,10 @@ func buildSRVConnectionURI(username, password, srvHost, database, authSource str
 func buildStandardConnectionURI(username, password, host, port, database, authSource, authMechanism string) (string, error) {
 	escapedUsername := url.QueryEscape(username)
 	escapedPassword := url.QueryEscape(password)
-	escapedHost := url.QueryEscape(host)
-	escapedPort := url.QueryEscape(port)
+	hostPort := net.JoinHostPort(host, port)
 	escapedDatabase := url.QueryEscape(database)
 
-	connectionUri := fmt.Sprintf("mongodb://%v:%v@%v:%v", escapedUsername, escapedPassword, escapedHost, escapedPort)
+	connectionUri := fmt.Sprintf("mongodb://%v:%v@%s", escapedUsername, escapedPassword, hostPort)
 	params := []string{}
 	if database != "" {
 		connectionUri = fmt.Sprintf("%s/%s", connectionUri, escapedDatabase)

--- a/pkg/privateactionrunner/bundles/mongodb/helpers.go
+++ b/pkg/privateactionrunner/bundles/mongodb/helpers.go
@@ -9,12 +9,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
 	"net/url"
 	"strings"
 
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/connstring"
+
+	"github.com/DataDog/datadog-agent/pkg/util/hostport"
 )
 
 func createMongoClientOptions(ctx context.Context, credentialTokens map[string]string) (*options.ClientOptions, *connstring.ConnString, error) {
@@ -90,7 +91,7 @@ func buildSRVConnectionURI(username, password, srvHost, database, authSource str
 func buildStandardConnectionURI(username, password, host, port, database, authSource, authMechanism string) (string, error) {
 	escapedUsername := url.QueryEscape(username)
 	escapedPassword := url.QueryEscape(password)
-	hostPort := net.JoinHostPort(host, port)
+	hostPort := hostport.Join(host, port)
 	escapedDatabase := url.QueryEscape(database)
 
 	connectionUri := fmt.Sprintf("mongodb://%v:%v@%s", escapedUsername, escapedPassword, hostPort)

--- a/pkg/util/hostport/BUILD.bazel
+++ b/pkg/util/hostport/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "hostport",
+    srcs = ["hostport.go"],
+    importpath = "github.com/DataDog/datadog-agent/pkg/util/hostport",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "hostport_test",
+    srcs = ["hostport_test.go"],
+    embed = [":hostport"],
+    gotags = ["test"],
+)

--- a/pkg/util/hostport/hostport.go
+++ b/pkg/util/hostport/hostport.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// Package hostport provides IPv6-aware host:port helpers.
+package hostport
+
+import "net"
+
+// Join combines a host and port into the canonical "host:port" form, or
+// "[host]:port" for IPv6 literals. Unlike net.JoinHostPort, it accepts an
+// IPv6 host in either bare (`fd38::1`) or already-bracketed (`[fd38::1]`)
+// form: net.JoinHostPort would otherwise double-bracket the latter.
+func Join(host, port string) string {
+	if len(host) >= 2 && host[0] == '[' && host[len(host)-1] == ']' {
+		host = host[1 : len(host)-1]
+	}
+	return net.JoinHostPort(host, port)
+}

--- a/pkg/util/hostport/hostport_test.go
+++ b/pkg/util/hostport/hostport_test.go
@@ -1,0 +1,30 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package hostport
+
+import "testing"
+
+func TestJoin(t *testing.T) {
+	for _, tc := range []struct {
+		name, host, port, want string
+	}{
+		{"ipv4", "1.2.3.4", "443", "1.2.3.4:443"},
+		{"hostname", "example.com", "443", "example.com:443"},
+		{"ipv6 bare", "fd38::1", "443", "[fd38::1]:443"},
+		{"ipv6 bracketed", "[fd38::1]", "443", "[fd38::1]:443"},
+		{"ipv6 loopback bare", "::1", "443", "[::1]:443"},
+		{"ipv6 loopback bracketed", "[::1]", "443", "[::1]:443"},
+		{"ipv6 listen-all bare", "::", "443", "[::]:443"},
+		{"ipv6 listen-all bracketed", "[::]", "443", "[::]:443"},
+		{"empty host", "", "443", ":443"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Join(tc.host, tc.port); got != tc.want {
+				t.Errorf("Join(%q, %q) = %q, want %q", tc.host, tc.port, got, tc.want)
+			}
+		})
+	}
+}

--- a/releasenotes/notes/fix-ipv6-mongodb-action-uri-9af8936dd698f5c0.yaml
+++ b/releasenotes/notes/fix-ipv6-mongodb-action-uri-9af8936dd698f5c0.yaml
@@ -1,0 +1,16 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix IPv6 host handling in the MongoDB action's standard connection
+    URI builder. The host:port portion now uses ``net.JoinHostPort`` so
+    IPv6 hosts are properly bracketed (e.g.
+    ``mongodb://user:pass@[fd38::1]:27017``); previously the host was
+    URL-escaped, which percent-encoded any IPv6 brackets and produced an
+    invalid MongoDB connection string.


### PR DESCRIPTION
### What does this PR do?

Fixes the host:port portion of the MongoDB action's standard connection
URI builder so that IPv6 hosts work.

Fixed location (owned by ``@DataDog/action-platform``):

- ``pkg/privateactionrunner/bundles/mongodb/helpers.go`` —
  ``buildStandardConnectionURI`` now uses ``hostport.Join(host, port)``
  instead of ``url.QueryEscape(host) + ":" + url.QueryEscape(port)``.

### Motivation

**Jira:** [CONS-8164](https://datadoghq.atlassian.net/browse/CONS-8164)

The previous code had two IPv6 issues for MongoDB connection strings:

1. ``url.QueryEscape(host)`` percent-encodes ``[`` / ``]``, so a user
   providing a bracketed IPv6 host (``[fd38::1]``) ended up with
   ``%5Bfd38%3A%3A1%5D`` in the URI — which the MongoDB driver rejects.
2. A user providing a bare IPv6 (``fd38::1``) would yield
   ``mongodb://...@fd38::1:27017``, which has too many colons and is
   ambiguous.

``hostport.Join`` handles both cases by emitting the canonical form
(``[fd38::1]:27017`` for IPv6, ``host:27017`` unchanged for hostnames /
IPv4).

This PR is the ``action-platform`` slice of a per-team cleanup of the
remaining naive concatenations after PR #48345. Sister PRs (one per
code-owning team) will land alongside this one.

### Why the `hostport.Join` helper?

The MongoDB connection-string spec
([RFC 3986 §3.2.2](https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.2)
URI authority, on which the MongoDB driver's parser is built) makes
bracketed IPv6 the *canonical* form for hosts in URIs. Users wiring up a
MongoDB action that talks to an IPv6 backend will naturally configure
the host the way the driver itself documents it — i.e. with brackets.

The previous ``url.QueryEscape(host) + ":" + ...`` code happened to never
double-bracket (because it never bracketed itself), but it
percent-encoded the user-supplied brackets and broke the URI. A bare
``net.JoinHostPort`` would swing the other way and emit
``[[fd38::1]]:27017``. ``hostport.Join`` strips one pair of surrounding
brackets first, so both ``fd38::1`` and ``[fd38::1]`` produce the
canonical ``[fd38::1]:27017``.

### Describe how you validated your changes

- ``hostport.Join`` produces the correct output for IPv4
  (``1.2.3.4:27017``), hostname (``mongo.example.com:27017``), bare IPv6
  (``fd38::1`` → ``[fd38::1]:27017``), and bracketed IPv6
  (``[fd38::1]`` → ``[fd38::1]:27017``) inputs.
- The username / password URL-escaping is preserved so user-supplied
  ``@`` / ``:`` / ``/`` characters in credentials still encode safely.

### Additional Notes

- The ``buildSRVConnectionURI`` variant uses an SRV hostname (DNS name
  only, no port, no IPv6 literals) and is intentionally left unchanged.
- The ``database`` argument keeps its ``url.QueryEscape`` because it can
  contain ``/`` (and is appended after the path separator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CONS-8164]: https://datadoghq.atlassian.net/browse/CONS-8164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
