### PR TITLE
[CONS-8164] Use `net.JoinHostPort` for IPv6-safe Windows systray flare URL

### DIFF
--- a/comp/systray/systray/impl/doflare.go
+++ b/comp/systray/systray/impl/doflare.go
@@ -10,6 +10,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"net"
 	"regexp"
 	"strconv"
 	"sync"
@@ -180,7 +181,8 @@ func requestFlare(s *systrayImpl, caseID, customerEmail string) (response string
 	if err != nil {
 		return "", err
 	}
-	urlstr := fmt.Sprintf("https://%v:%v/agent/flare", ipcAddress, pkgconfigsetup.Datadog().GetInt("cmd_port"))
+	addr := net.JoinHostPort(ipcAddress, strconv.Itoa(pkgconfigsetup.Datadog().GetInt("cmd_port")))
+	urlstr := fmt.Sprintf("https://%s/agent/flare", addr)
 
 	r, e := s.client.Post(urlstr, "application/json", bytes.NewBuffer([]byte{}))
 	var filePath string

--- a/releasenotes/notes/fix-ipv6-windows-systray-flare-url-959cc130c1c84775.yaml
+++ b/releasenotes/notes/fix-ipv6-windows-systray-flare-url-959cc130c1c84775.yaml
@@ -1,0 +1,15 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix IPv6 address formatting in the URL the Windows systray builds to
+    request a flare from the local agent. The host:port is now properly
+    bracketed (e.g. ``https://[::1]:5001/agent/flare``) so the flare
+    request succeeds when ``cmd_host`` (or the deprecated
+    ``ipc_address``) is set to an IPv6 literal.


### PR DESCRIPTION
### What does this PR do?

Replaces the naive ``fmt.Sprintf("%s:%d", host, port)`` host:port
concatenation in ``comp/systray/systray/impl/doflare.go`` with
``net.JoinHostPort`` so IPv6 IPC addresses are properly bracketed.

### Motivation

**Jira:** [CONS-8164](https://datadoghq.atlassian.net/browse/CONS-8164)

When ``cmd_host`` (or the deprecated ``ipc_address``) is set to an IPv6
literal, the unbracketed form yielded a URL that fails with ``dial tcp:
too many colons in address``.

This PR is the ``windows-products`` slice of a per-team cleanup of the
remaining naive concatenations after PR #48345. Sister PRs (one per
code-owning team) will land alongside this one.

### Describe how you validated your changes

Mechanical replacement; existing IPv4 / hostname cases keep their exact
string form (``net.JoinHostPort`` only brackets IPv6 literals).

### Additional Notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CONS-8164]: https://datadoghq.atlassian.net/browse/CONS-8164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ