### PR TITLE
[CONS-8164] Use `net.JoinHostPort` for IPv6-safe goroutines pprof URL

### DIFF
--- a/pkg/util/goroutinesdump/goroutinedump.go
+++ b/pkg/util/goroutinesdump/goroutinedump.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"time"
 
@@ -23,8 +24,8 @@ func Get() (string, error) {
 		return "", err
 	}
 
-	pprofURL := fmt.Sprintf("http://%v:%s/debug/pprof/goroutine?debug=2",
-		ipcAddress, pkgconfigsetup.Datadog().GetString("expvar_port"))
+	addr := net.JoinHostPort(ipcAddress, pkgconfigsetup.Datadog().GetString("expvar_port"))
+	pprofURL := fmt.Sprintf("http://%s/debug/pprof/goroutine?debug=2", addr)
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	client := http.Client{}

--- a/releasenotes/notes/fix-ipv6-goroutines-pprof-url-160d771e134cf4c5.yaml
+++ b/releasenotes/notes/fix-ipv6-goroutines-pprof-url-160d771e134cf4c5.yaml
@@ -1,0 +1,16 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix IPv6 address formatting in the URL used by the agent's goroutine
+    dump helper to reach the local expvar / pprof endpoint. The host:port
+    is now properly bracketed (e.g.
+    ``http://[::1]:5000/debug/pprof/goroutine?debug=2``) so the goroutine
+    dump succeeds when ``cmd_host`` (or the deprecated ``ipc_address``)
+    is set to an IPv6 literal.


### PR DESCRIPTION
### What does this PR do?

Replaces the naive ``fmt.Sprintf("%s:%s", host, port)`` host:port
concatenation in ``pkg/util/goroutinesdump/goroutinedump.go`` with
``net.JoinHostPort`` so the goroutine-dump helper builds a properly
bracketed pprof URL when the agent's IPC address is an IPv6 literal.

### Motivation

**Jira:** [CONS-8164](https://datadoghq.atlassian.net/browse/CONS-8164)

When ``cmd_host`` (or the deprecated ``ipc_address``) is set to an IPv6
literal, the unbracketed form yielded a URL that fails with ``dial tcp:
too many colons in address``.

This PR is the ``agent-runtimes`` slice of a per-team cleanup of the
remaining naive concatenations after PR #48345. Sister PRs (one per
code-owning team) will land alongside this one.

### Describe how you validated your changes

Mechanical replacement; existing IPv4 / hostname cases keep their exact
string form (``net.JoinHostPort`` only brackets IPv6 literals).

### Additional Notes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CONS-8164]: https://datadoghq.atlassian.net/browse/CONS-8164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ