### PR TITLE
[CONS-8164] Use `net.JoinHostPort` for IPv6-safe trace-loader OTLP listener

### DIFF
--- a/cmd/loader/main_nix.go
+++ b/cmd/loader/main_nix.go
@@ -362,7 +362,7 @@ func getListeners(cfg model.Reader) (tcpFD int, listeners map[string]uintptr, er
 	if configcheck.IsConfigEnabled(cfg) {
 		grpcPort := cfg.GetInt(pkgconfigsetup.OTLPTracePort)
 		log.Infof("Listening to otlp port %d", grpcPort)
-		ln, err := loader.GetTCPListener(fmt.Sprintf("%s:%d", traceCfgReceiverHost, grpcPort))
+		ln, err := loader.GetTCPListener(net.JoinHostPort(traceCfgReceiverHost, strconv.Itoa(grpcPort)))
 		if err != nil {
 			return tcpFD, listeners, fmt.Errorf("error listening to otlp receiver: %v", err)
 		}

--- a/releasenotes/notes/fix-ipv6-trace-loader-otlp-listener-d047b861fcfba4ad.yaml
+++ b/releasenotes/notes/fix-ipv6-trace-loader-otlp-listener-d047b861fcfba4ad.yaml
@@ -1,0 +1,15 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix IPv6 address formatting in the trace-loader's OTLP TCP listener
+    bind address. The host:port is now built with ``net.JoinHostPort``,
+    matching the existing trace-receiver listener path, so binding to an
+    IPv6 ``traceCfgReceiverHost`` no longer fails with ``too many colons
+    in address``.


### PR DESCRIPTION
### What does this PR do?

Replaces the one remaining naive ``fmt.Sprintf("%s:%d", host, port)``
host:port concatenation in ``cmd/loader/main_nix.go`` with
``net.JoinHostPort``, so the trace-loader's OTLP TCP listener can bind
to an IPv6 host. The earlier trace-receiver listener at line 319 was
already using ``net.JoinHostPort``.

Co-owned by ``@DataDog/agent-runtimes`` and ``@DataDog/agent-apm``.

### Motivation

**Jira:** [CONS-8164](https://datadoghq.atlassian.net/browse/CONS-8164)

When ``traceCfgReceiverHost`` is an IPv6 literal, the unbracketed form
yielded a listener address that ``net.Listen("tcp", ...)`` rejects with
``too many colons in address``.

This change was originally part of PR #48351 (which bundled fixes
across multiple teams' files); it's carried into the per-team cleanup
series for CONS-8164. Sister PRs (one per code-owning team) will land
alongside this one.

### Describe how you validated your changes

Mechanical replacement; existing IPv4 / hostname cases keep their exact
string form (``net.JoinHostPort`` only brackets IPv6 literals).

### Additional Notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CONS-8164]: https://datadoghq.atlassian.net/browse/CONS-8164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ