### PR TITLE
[CONS-8164] Use `net.JoinHostPort` for IPv6-safe SNMP traps listener

### DIFF
--- a/comp/snmptraps/config/def/config.go
+++ b/comp/snmptraps/config/def/config.go
@@ -8,6 +8,8 @@ package config
 import (
 	"fmt"
 	"hash/fnv"
+	"net"
+	"strconv"
 
 	"github.com/gosnmp/gosnmp"
 
@@ -103,7 +105,7 @@ func (c *TrapsConfig) SetDefaults(host string, namespace string) error {
 
 // Addr returns the host:port address to listen on.
 func (c *TrapsConfig) Addr() string {
-	return fmt.Sprintf("%s:%d", c.BindHost, c.Port)
+	return net.JoinHostPort(c.BindHost, strconv.Itoa(int(c.Port)))
 }
 
 // BuildSNMPParams returns a valid GoSNMP params structure from configuration.

--- a/releasenotes/notes/fix-ipv6-snmptraps-listener-63e9210f33c1eced.yaml
+++ b/releasenotes/notes/fix-ipv6-snmptraps-listener-63e9210f33c1eced.yaml
@@ -1,0 +1,15 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix IPv6 address formatting in the SNMP traps listener bind address
+    (``TrapsConfig.Addr``). The host:port is now built with
+    ``net.JoinHostPort`` so binding to an IPv6
+    ``network_devices.snmp_traps.bind_host`` no longer fails with ``too
+    many colons in address``.


### PR DESCRIPTION
### What does this PR do?

Replaces the naive ``fmt.Sprintf("%s:%d", host, port)`` host:port
concatenation in ``TrapsConfig.Addr`` with ``net.JoinHostPort``, so the
SNMP traps listener can bind to an IPv6 host.

### Motivation

**Jira:** [CONS-8164](https://datadoghq.atlassian.net/browse/CONS-8164)

When ``network_devices.snmp_traps.bind_host`` is an IPv6 literal, the
unbracketed form yielded a listener address that ``net.ListenUDP``
rejects with ``too many colons in address``.

### Describe how you validated your changes

Mechanical replacement; existing IPv4 / hostname cases keep their exact
string form (``net.JoinHostPort`` only brackets IPv6 literals). Existing
SNMP traps config tests continue to pass.

### Additional Notes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CONS-8164]: https://datadoghq.atlassian.net/browse/CONS-8164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ