### PR TITLE
skip download kernel headers test on ubuntu

### DIFF
--- a/pkg/util/kernel/headers/find_headers_test.go
+++ b/pkg/util/kernel/headers/find_headers_test.go
@@ -9,6 +9,8 @@ package headers
 
 import (
 	"bytes"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,6 +21,9 @@ import (
 )
 
 func TestDownloadKernelHeaders(t *testing.T) {
+	if strings.Contains(os.Getenv("CI_JOB_NAME"), "ubuntu") {
+		t.SkipNow()
+	}
 	flake.Mark(t) // flaky because it reaches out to real package repos
 	ebpftest.LogLevel(t, "debug")
 	t.Cleanup(func() { HeaderProvider = nil })


### PR DESCRIPTION
### What does this PR do?

Skips kernel header download tests on Ubuntu

### Motivation

Ubuntu infra is having a hard time

### Describe how you validated your changes

### Additional Notes
