### PR TITLE
Strict Error Checking in SNMP Profiles CLI

### DIFF
--- a/pkg/networkdevice/profile/profiledefinition/BUILD.bazel
+++ b/pkg/networkdevice/profile/profiledefinition/BUILD.bazel
@@ -16,7 +16,10 @@ go_library(
     ],
     importpath = "github.com/DataDog/datadog-agent/pkg/networkdevice/profile/profiledefinition",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_invopop_jsonschema//:jsonschema"],
+    deps = [
+        "@com_github_invopop_jsonschema//:jsonschema",
+        "@in_yaml_go_yaml_v2//:yaml",
+    ],
 )
 
 go_test(

--- a/pkg/networkdevice/profile/profiledefinition/normalize_cmd/cmd/root.go
+++ b/pkg/networkdevice/profile/profiledefinition/normalize_cmd/cmd/root.go
@@ -9,6 +9,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -42,9 +43,14 @@ var rootCmd = &cobra.Command{
 			fmt.Printf("parse failure %v, unable to generate output\n", err)
 		}
 		for _, filePath := range args {
-			filename := filepath.Base(filePath)
-			name := filename[:len(filename)-len(filepath.Ext(filename))] // remove extension
-			def, errors := GetProfile(filePath)
+			var name string
+			if filePath == "-" {
+				name = "stdin"
+			} else {
+				filename := filepath.Base(filePath)
+				name = filename[:len(filename)-len(filepath.Ext(filename))] // remove extension
+			}
+			def, errors := GetProfile(filePath, strict)
 			if len(errors) > 0 {
 				fmt.Printf("*** %d error(s) in profile %q ***\n", len(errors), filePath)
 				for _, e := range errors {
@@ -62,14 +68,23 @@ var rootCmd = &cobra.Command{
 
 // GetProfile parses a profile from a file path and validates it.
 func GetProfile(filePath string, strict bool) (*profiledefinition.ProfileDefinition, []string) {
-	file, err := os.Open(filePath)
-	if err != nil {
-		return nil, []string{fmt.Sprintf("unable to read file: %v", err)}
+	var inFile io.Reader
+	if filePath == "-" {
+		inFile = os.Stdin
+	} else {
+		f, err := os.Open(filePath)
+		if err != nil {
+			return nil, []string{fmt.Sprintf("unable to read file: %v", err)}
+		}
+		defer func() {
+			_ = f.Close()
+		}()
+		inFile = f
 	}
 	def := profiledefinition.NewProfileDefinition()
-	dec := yaml.NewDecoder(file)
+	dec := yaml.NewDecoder(inFile)
 	dec.SetStrict(strict)
-	err = dec.Decode(&def)
+	err := dec.Decode(&def)
 	if err != nil {
 		return nil, []string{fmt.Sprintf("unable to parse profile: %v", err)}
 	}
@@ -85,11 +100,11 @@ func WriteProfile(def *profiledefinition.ProfileDefinition, name string, outdir 
 	if outdir == "" {
 		return nil
 	}
-	var filename string
+	var outPath string
 	var data []byte
 	if useJSON {
 		var err error
-		filename = name + ".json"
+		outPath = filepath.Join(outdir, name+".json")
 		data, err = json.Marshal(def)
 		if err != nil {
 			return fmt.Errorf("unable to marshal profile %s: %w", name, err)
@@ -97,22 +112,28 @@ func WriteProfile(def *profiledefinition.ProfileDefinition, name string, outdir 
 	} else {
 		var err error
 		data, err = yaml.Marshal(def)
-		filename = name + ".yaml"
+		outPath = filepath.Join(outdir, name+".yaml")
 		if err != nil {
 			return fmt.Errorf("unable to marshal profile %s: %w", name, err)
 		}
 	}
-	outfile := filepath.Join(outdir, filename)
-	f, err := os.Create(outfile)
-	if err != nil {
-		return fmt.Errorf("unable to create file %s: %w", outfile, err)
+	var writer io.Writer
+	if outdir == "-" {
+		writer = os.Stdout
+		outPath = "stdout"
+	} else {
+		f, err := os.Create(outPath)
+		if err != nil {
+			return fmt.Errorf("unable to create file %s: %w", outPath, err)
+		}
+		defer func() {
+			_ = f.Close()
+		}()
+		writer = f
 	}
-	defer func() {
-		_ = f.Close()
-	}()
-	_, err = f.Write(data)
+	_, err := writer.Write(data)
 	if err != nil {
-		return fmt.Errorf("unable to write to file %s: %w", outfile, err)
+		return fmt.Errorf("unable to write to %s: %w", outPath, err)
 	}
 	return nil
 }

--- a/pkg/networkdevice/profile/profiledefinition/yaml_utils.go
+++ b/pkg/networkdevice/profile/profiledefinition/yaml_utils.go
@@ -5,7 +5,43 @@
 
 package profiledefinition
 
-import "errors"
+import (
+	"errors"
+
+	"go.yaml.in/yaml/v2"
+)
+
+// unmarshalWithFirstError calls unmarshal(arg), but if the result is a
+// yaml.TypeError it replaces the errors in it with the errors from the original
+// error.
+//
+// This is needed because if you call `unmarshal` twice in the same method, and
+// it generates an error both times, the returned errors are actually the same
+// object, so the second call will modify the previously-returned error value,
+// overwriting whatever the original errors were. Usually this is not what we
+// want when we have the pattern "try to parse the input as the expected type,
+// and if that fails try parsing it as a legacy format" - if both fail, we want
+// the error for the expected type.
+//
+// For example, if the main type is a struct but you also support a legacy type
+// where it was just a string, using this method ensures that a malformed struct
+// will get you an error message like "field X not found in type Y" instead of
+// "cannot unmarshal !!map into string".
+func unmarshalWithFirstError(err error, unmarshal func(any) error, arg any) error {
+	var typeErrors []string
+	if typeErr, ok := err.(*yaml.TypeError); ok {
+		typeErrors = append(typeErrors, typeErr.Errors...)
+	}
+	newErr := unmarshal(arg)
+	if newErr != nil {
+		if typeErr, ok := newErr.(*yaml.TypeError); len(typeErrors) > 0 && ok {
+			typeErr.Errors = typeErrors
+			return typeErr
+		}
+		return newErr
+	}
+	return nil
+}
 
 // StringArray is list of string with a yaml un-marshaller that support both array and string.
 // See test file for example usage.
@@ -18,8 +54,7 @@ func (a *StringArray) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	err := unmarshal(&multi)
 	if err != nil {
 		var single string
-		err := unmarshal(&single)
-		if err != nil {
+		if err := unmarshalWithFirstError(err, unmarshal, &single); err != nil {
 			return err
 		}
 		*a = []string{single}
@@ -35,8 +70,7 @@ func (a *SymbolConfigCompat) UnmarshalYAML(unmarshal func(interface{}) error) er
 	err := unmarshal(&symbol)
 	if err != nil {
 		var str string
-		err := unmarshal(&str)
-		if err != nil {
+		if err := unmarshalWithFirstError(err, unmarshal, &str); err != nil {
 			return err
 		}
 		*a = SymbolConfigCompat(SymbolConfig{Name: str})
@@ -52,8 +86,7 @@ func (mtcl *MetricTagConfigList) UnmarshalYAML(unmarshal func(interface{}) error
 	err := unmarshal(&multi)
 	if err != nil {
 		var tags []string
-		err := unmarshal(&tags)
-		if err != nil {
+		if err := unmarshalWithFirstError(err, unmarshal, &tags); err != nil {
 			return err
 		}
 		multi = []MetricTagConfig{}
@@ -71,8 +104,7 @@ func (mc *MetricsConfig) UnmarshalYAML(unmarshal func(interface{}) error) error 
 	err := unmarshal((*metricsConfig)(mc))
 
 	var rawData map[string]interface{}
-	rawErr := unmarshal(&rawData)
-	if rawErr != nil {
+	if err := unmarshalWithFirstError(err, unmarshal, &rawData); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
### What does this PR do?
These are some changes I made locally to the profile-checking CLI tool; I made them a long time ago but only recently discovered I had never put them in a PR.

It allows the CLI tool to read a profile from stdin instead of requiring that it be from a file, and it prints more complete and useful error messages on invalid profiles. This tool is generally only used internally when debugging profiles.

### Motivation

The CLI tool is helpful for checking the correctness of an SNMP profile, but at present it doesn't use strict parsing (so e.g. extra fields will be silently ignored, when in practice they usually indicate a mistake) and in the case of certain legacy types it prints unhelpful error messages. The legacy issue comes up with types like `SymbolConfigCompat`, which unmarshals into a SymbolConfig struct but can also unmarshal a single string. The UnmarshalYAML method will try to parse the input as a struct, and if that fails, will try parsing it as a string instead. If both fail, the current behavior returns the error from string parsing, which is confusing and unhelpful - for example, if you have an extra key in your struct, you would expect an error like `field X not found in type Y` but would get `cannot unmarshal !!map into string`.

### Describe how you validated your changes

Local testing; this shouldn't affect any existing user experience except in the very specific case where they are currently using a malformed profile.

### Additional Notes
