### PR TITLE
[noisy_neighbor] Add Per-cgroup PMU + more tracepoint signals (default off)

### DIFF
--- a/cmd/system-probe/modules/noisy_neighbor.go
+++ b/cmd/system-probe/modules/noisy_neighbor.go
@@ -25,16 +25,19 @@ import (
 
 func init() { registerModule(NoisyNeighbor) }
 
-// NoisyNeighbor is the system-probe module Factory for the noisy neighbor probe.
+// NoisyNeighbor Factory
 var NoisyNeighbor = &module.Factory{
 	Name: config.NoisyNeighborModule,
 	Fn: func(_ *sysconfigtypes.Config, _ module.FactoryDependencies) (module.Module, error) {
 		log.Infof("Starting the noisy neighbor module")
 		p, err := noisyneighbor.NewProbe(ebpf.NewConfig())
 		if err != nil {
-			return nil, fmt.Errorf("noisy_neighbor: probe construction failed: %w", err)
+			return nil, fmt.Errorf("unable to start the noisy neighbor probe: %w", err)
 		}
-		return &noisyNeighborModule{probe: p}, nil
+		return &noisyNeighborModule{
+			Probe:     p,
+			lastCheck: &atomic.Int64{},
+		}, nil
 	},
 	NeedsEBPF: func() bool {
 		return true
@@ -44,73 +47,49 @@ var NoisyNeighbor = &module.Factory{
 var _ module.Module = &noisyNeighborModule{}
 
 type noisyNeighborModule struct {
-	probe     *noisyneighbor.Probe
-	lastCheck atomic.Int64
-
-	// mu serializes (closed flag write, inflight.Add) against (closed flag
-	// read in Close, inflight.Wait). Without it, Close could observe
-	// inflight==0 while a request is about to call Add.
-	mu       sync.Mutex
-	closed   bool
-	inflight sync.WaitGroup
+	*noisyneighbor.Probe
+	lastCheck *atomic.Int64
+	inflight  sync.WaitGroup
+	closed    atomic.Bool
 }
 
-// enter marks the start of an in-flight /check request. Returns false if the
-// module is closing, in which case the caller must not proceed.
-func (n *noisyNeighborModule) enter() bool {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-	if n.closed {
-		return false
-	}
-	n.inflight.Add(1)
-	return true
-}
-
-// GetStats implements module.Module.GetStats.
-func (n *noisyNeighborModule) GetStats() map[string]any {
-	return map[string]any{
+// GetStats implements module.Module.GetStats
+func (n *noisyNeighborModule) GetStats() map[string]interface{} {
+	return map[string]interface{}{
 		"last_check": n.lastCheck.Load(),
 	}
 }
 
-// Register implements module.Module.Register.
-func (n *noisyNeighborModule) Register(router *module.Router) error {
-	// Limit concurrency to one as the probe check is not thread safe (mainly
-	// in the entry count buffers).
-	router.HandleFunc("/check", utils.WithConcurrencyLimit(1, n.handleCheck))
+// Register implements module.Module.Register
+func (n *noisyNeighborModule) Register(httpMux *module.Router) error {
+	// Limit concurrency to one as the probe check is not thread safe (mainly in the entry count buffers)
+	httpMux.HandleFunc("/check", utils.WithConcurrencyLimit(1, func(w http.ResponseWriter, req *http.Request) {
+		if n.closed.Load() {
+			http.Error(w, "module closing", http.StatusServiceUnavailable)
+			return
+		}
+		n.inflight.Add(1)
+		defer n.inflight.Done()
+		// Re-check after Add to close the race where Close() observed inflight==0
+		// before our Add but set closed afterwards.
+		if n.closed.Load() {
+			http.Error(w, "module closing", http.StatusServiceUnavailable)
+			return
+		}
+		n.lastCheck.Store(time.Now().Unix())
+		stats := n.Probe.GetAndFlush()
+		utils.WriteAsJSON(req, w, stats, utils.GetPrettyPrintFromQueryParams(req))
+	}))
+
 	return nil
 }
 
-// handleCheck serves the /check endpoint: flushes the BPF map and writes the
-// aggregated per-cgroup stats as JSON. enter() must be the first call so
-// nothing touches n.probe before the close handshake observes us.
-func (n *noisyNeighborModule) handleCheck(w http.ResponseWriter, r *http.Request) {
-	if !n.enter() {
-		http.Error(w, "module closing", http.StatusServiceUnavailable)
-		return
-	}
-	defer n.inflight.Done()
-
-	stats, err := n.probe.GetAndFlush(r.Context())
-	if err != nil {
-		log.Warnf("noisy_neighbor: GetAndFlush returned error, skipping emission: %v", err)
-		http.Error(w, fmt.Sprintf("noisy_neighbor flush error: %v", err), http.StatusInternalServerError)
-		return
-	}
-	n.lastCheck.Store(time.Now().Unix())
-	utils.WriteAsJSON(r, w, stats, utils.GetPrettyPrintFromQueryParams(r))
-}
-
-// Close marks the module as closing, waits for any in-flight /check handlers
-// to complete, and then tears down the underlying eBPF probe. The HTTP
-// server that hosts /check is expected to stop accepting new requests
-// concurrently with or before Close is invoked. Probe shutdown is idempotent
-// via sync.OnceFunc inside Probe.
+// Close marks the module as closing, waits for any in-flight /check
+// handlers to complete, and then tears down the underlying eBPF probe.
+// Without this, an in-flight GetAndFlush iterating the BPF map could race
+// with Probe.Close() unloading the manager.
 func (n *noisyNeighborModule) Close() {
-	n.mu.Lock()
-	n.closed = true
-	n.mu.Unlock()
+	n.closed.Store(true)
 	n.inflight.Wait()
-	n.probe.Close()
+	n.Probe.Close()
 }

--- a/cmd/system-probe/modules/noisy_neighbor.go
+++ b/cmd/system-probe/modules/noisy_neighbor.go
@@ -30,7 +30,7 @@ import (
 var pmuMetricConfigKeys = map[string]string{
 	"cycles_pmu":           "noisy_neighbor.pmu_metrics.cycles",
 	"instructions_pmu":     "noisy_neighbor.pmu_metrics.instructions",
-	"llc_misses_pmu":       "noisy_neighbor.pmu_metrics.llc_misses",
+	"cache_misses_pmu":     "noisy_neighbor.pmu_metrics.cache_misses",
 	"cache_references_pmu": "noisy_neighbor.pmu_metrics.cache_references",
 	"itlb_misses_pmu":      "noisy_neighbor.pmu_metrics.itlb_misses",
 	"branch_misses_pmu":    "noisy_neighbor.pmu_metrics.branch_misses",

--- a/cmd/system-probe/modules/noisy_neighbor.go
+++ b/cmd/system-probe/modules/noisy_neighbor.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe/noisyneighbor"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/system-probe/api/module"
 	"github.com/DataDog/datadog-agent/pkg/system-probe/config"
@@ -23,6 +24,28 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+// pmuMetricConfigKeys maps each BPF perf-event-array map name to its
+// noisy_neighbor.pmu_metrics.* config key. Kept in one place so adding a
+// new PMU event is a single edit.
+var pmuMetricConfigKeys = map[string]string{
+	"cycles_pmu":           "noisy_neighbor.pmu_metrics.cycles",
+	"instructions_pmu":     "noisy_neighbor.pmu_metrics.instructions",
+	"llc_misses_pmu":       "noisy_neighbor.pmu_metrics.llc_misses",
+	"cache_references_pmu": "noisy_neighbor.pmu_metrics.cache_references",
+	"itlb_misses_pmu":      "noisy_neighbor.pmu_metrics.itlb_misses",
+	"branch_misses_pmu":    "noisy_neighbor.pmu_metrics.branch_misses",
+	"cpu_migrations_pmu":   "noisy_neighbor.pmu_metrics.cpu_migrations",
+}
+
+func readPMUMetricsConfig() map[string]bool {
+	cfg := pkgconfigsetup.SystemProbe()
+	out := make(map[string]bool, len(pmuMetricConfigKeys))
+	for mapName, configKey := range pmuMetricConfigKeys {
+		out[mapName] = cfg.GetBool(configKey)
+	}
+	return out
+}
+
 func init() { registerModule(NoisyNeighbor) }
 
 // NoisyNeighbor Factory
@@ -30,13 +53,15 @@ var NoisyNeighbor = &module.Factory{
 	Name: config.NoisyNeighborModule,
 	Fn: func(_ *sysconfigtypes.Config, _ module.FactoryDependencies) (module.Module, error) {
 		log.Infof("Starting the noisy neighbor module")
-		p, err := noisyneighbor.NewProbe(ebpf.NewConfig())
+		pmuMetrics := readPMUMetricsConfig()
+		p, err := noisyneighbor.NewProbe(ebpf.NewConfig(), noisyneighbor.Config{PMUMetrics: pmuMetrics})
 		if err != nil {
 			return nil, fmt.Errorf("unable to start the noisy neighbor probe: %w", err)
 		}
 		return &noisyNeighborModule{
-			Probe:     p,
-			lastCheck: &atomic.Int64{},
+			Probe:      p,
+			lastCheck:  &atomic.Int64{},
+			pmuMetrics: pmuMetrics,
 		}, nil
 	},
 	NeedsEBPF: func() bool {
@@ -48,15 +73,17 @@ var _ module.Module = &noisyNeighborModule{}
 
 type noisyNeighborModule struct {
 	*noisyneighbor.Probe
-	lastCheck *atomic.Int64
-	inflight  sync.WaitGroup
-	closed    atomic.Bool
+	lastCheck  *atomic.Int64
+	pmuMetrics map[string]bool
+	inflight   sync.WaitGroup
+	closed     atomic.Bool
 }
 
 // GetStats implements module.Module.GetStats
 func (n *noisyNeighborModule) GetStats() map[string]interface{} {
 	return map[string]interface{}{
-		"last_check": n.lastCheck.Load(),
+		"last_check":  n.lastCheck.Load(),
+		"pmu_metrics": n.pmuMetrics,
 	}
 }
 

--- a/cmd/system-probe/modules/noisy_neighbor.go
+++ b/cmd/system-probe/modules/noisy_neighbor.go
@@ -10,6 +10,7 @@ package modules
 import (
 	"fmt"
 	"net/http"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -48,23 +49,47 @@ var _ module.Module = &noisyNeighborModule{}
 type noisyNeighborModule struct {
 	*noisyneighbor.Probe
 	lastCheck *atomic.Int64
+	inflight  sync.WaitGroup
+	closed    atomic.Bool
 }
 
 // GetStats implements module.Module.GetStats
-func (n noisyNeighborModule) GetStats() map[string]interface{} {
+func (n *noisyNeighborModule) GetStats() map[string]interface{} {
 	return map[string]interface{}{
 		"last_check": n.lastCheck.Load(),
 	}
 }
 
 // Register implements module.Module.Register
-func (n noisyNeighborModule) Register(httpMux *module.Router) error {
+func (n *noisyNeighborModule) Register(httpMux *module.Router) error {
 	// Limit concurrency to one as the probe check is not thread safe (mainly in the entry count buffers)
 	httpMux.HandleFunc("/check", utils.WithConcurrencyLimit(1, func(w http.ResponseWriter, req *http.Request) {
+		if n.closed.Load() {
+			http.Error(w, "module closing", http.StatusServiceUnavailable)
+			return
+		}
+		n.inflight.Add(1)
+		defer n.inflight.Done()
+		// Re-check after Add to close the race where Close() observed inflight==0
+		// before our Add but set closed afterwards.
+		if n.closed.Load() {
+			http.Error(w, "module closing", http.StatusServiceUnavailable)
+			return
+		}
 		n.lastCheck.Store(time.Now().Unix())
 		stats := n.Probe.GetAndFlush()
 		utils.WriteAsJSON(req, w, stats, utils.GetPrettyPrintFromQueryParams(req))
 	}))
 
 	return nil
+}
+
+// Close marks the module as closing, waits for any in-flight /check
+// handlers to complete, and then tears down the underlying eBPF probe.
+// Without this, an in-flight GetAndFlush iterating the BPF map could race
+// with Probe.Close() unloading the manager.
+func (n *noisyNeighborModule) Close() {
+	n.closed.Store(true)
+	n.inflight.Wait()
+	n.Probe.Close()
 }

--- a/cmd/system-probe/modules/noisy_neighbor.go
+++ b/cmd/system-probe/modules/noisy_neighbor.go
@@ -25,19 +25,16 @@ import (
 
 func init() { registerModule(NoisyNeighbor) }
 
-// NoisyNeighbor Factory
+// NoisyNeighbor is the system-probe module Factory for the noisy neighbor probe.
 var NoisyNeighbor = &module.Factory{
 	Name: config.NoisyNeighborModule,
 	Fn: func(_ *sysconfigtypes.Config, _ module.FactoryDependencies) (module.Module, error) {
 		log.Infof("Starting the noisy neighbor module")
 		p, err := noisyneighbor.NewProbe(ebpf.NewConfig())
 		if err != nil {
-			return nil, fmt.Errorf("unable to start the noisy neighbor probe: %w", err)
+			return nil, fmt.Errorf("noisy_neighbor: probe construction failed: %w", err)
 		}
-		return &noisyNeighborModule{
-			Probe:     p,
-			lastCheck: &atomic.Int64{},
-		}, nil
+		return &noisyNeighborModule{probe: p}, nil
 	},
 	NeedsEBPF: func() bool {
 		return true
@@ -47,49 +44,73 @@ var NoisyNeighbor = &module.Factory{
 var _ module.Module = &noisyNeighborModule{}
 
 type noisyNeighborModule struct {
-	*noisyneighbor.Probe
-	lastCheck *atomic.Int64
-	inflight  sync.WaitGroup
-	closed    atomic.Bool
+	probe     *noisyneighbor.Probe
+	lastCheck atomic.Int64
+
+	// mu serializes (closed flag write, inflight.Add) against (closed flag
+	// read in Close, inflight.Wait). Without it, Close could observe
+	// inflight==0 while a request is about to call Add.
+	mu       sync.Mutex
+	closed   bool
+	inflight sync.WaitGroup
 }
 
-// GetStats implements module.Module.GetStats
-func (n *noisyNeighborModule) GetStats() map[string]interface{} {
-	return map[string]interface{}{
+// enter marks the start of an in-flight /check request. Returns false if the
+// module is closing, in which case the caller must not proceed.
+func (n *noisyNeighborModule) enter() bool {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if n.closed {
+		return false
+	}
+	n.inflight.Add(1)
+	return true
+}
+
+// GetStats implements module.Module.GetStats.
+func (n *noisyNeighborModule) GetStats() map[string]any {
+	return map[string]any{
 		"last_check": n.lastCheck.Load(),
 	}
 }
 
-// Register implements module.Module.Register
-func (n *noisyNeighborModule) Register(httpMux *module.Router) error {
-	// Limit concurrency to one as the probe check is not thread safe (mainly in the entry count buffers)
-	httpMux.HandleFunc("/check", utils.WithConcurrencyLimit(1, func(w http.ResponseWriter, req *http.Request) {
-		if n.closed.Load() {
-			http.Error(w, "module closing", http.StatusServiceUnavailable)
-			return
-		}
-		n.inflight.Add(1)
-		defer n.inflight.Done()
-		// Re-check after Add to close the race where Close() observed inflight==0
-		// before our Add but set closed afterwards.
-		if n.closed.Load() {
-			http.Error(w, "module closing", http.StatusServiceUnavailable)
-			return
-		}
-		n.lastCheck.Store(time.Now().Unix())
-		stats := n.Probe.GetAndFlush()
-		utils.WriteAsJSON(req, w, stats, utils.GetPrettyPrintFromQueryParams(req))
-	}))
-
+// Register implements module.Module.Register.
+func (n *noisyNeighborModule) Register(router *module.Router) error {
+	// Limit concurrency to one as the probe check is not thread safe (mainly
+	// in the entry count buffers).
+	router.HandleFunc("/check", utils.WithConcurrencyLimit(1, n.handleCheck))
 	return nil
 }
 
-// Close marks the module as closing, waits for any in-flight /check
-// handlers to complete, and then tears down the underlying eBPF probe.
-// Without this, an in-flight GetAndFlush iterating the BPF map could race
-// with Probe.Close() unloading the manager.
+// handleCheck serves the /check endpoint: flushes the BPF map and writes the
+// aggregated per-cgroup stats as JSON. enter() must be the first call so
+// nothing touches n.probe before the close handshake observes us.
+func (n *noisyNeighborModule) handleCheck(w http.ResponseWriter, r *http.Request) {
+	if !n.enter() {
+		http.Error(w, "module closing", http.StatusServiceUnavailable)
+		return
+	}
+	defer n.inflight.Done()
+
+	stats, err := n.probe.GetAndFlush(r.Context())
+	if err != nil {
+		log.Warnf("noisy_neighbor: GetAndFlush returned error, skipping emission: %v", err)
+		http.Error(w, fmt.Sprintf("noisy_neighbor flush error: %v", err), http.StatusInternalServerError)
+		return
+	}
+	n.lastCheck.Store(time.Now().Unix())
+	utils.WriteAsJSON(r, w, stats, utils.GetPrettyPrintFromQueryParams(r))
+}
+
+// Close marks the module as closing, waits for any in-flight /check handlers
+// to complete, and then tears down the underlying eBPF probe. The HTTP
+// server that hosts /check is expected to stop accepting new requests
+// concurrently with or before Close is invoked. Probe shutdown is idempotent
+// via sync.OnceFunc inside Probe.
 func (n *noisyNeighborModule) Close() {
-	n.closed.Store(true)
+	n.mu.Lock()
+	n.closed = true
+	n.mu.Unlock()
 	n.inflight.Wait()
-	n.Probe.Close()
+	n.probe.Close()
 }

--- a/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern-user.h
+++ b/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern-user.h
@@ -17,6 +17,7 @@ typedef struct {
     __u64 sum_branch_misses;
     __u64 sum_cpu_migrations;
     __u64 wakeup_count;
+    __u64 sum_cache_references;
 } cgroup_agg_stats_t;
 
 // Per-PMU-event stamp: counter value plus enabled/running times.
@@ -39,6 +40,7 @@ typedef struct {
     pmu_event_stamp_t itlb_misses;
     pmu_event_stamp_t branch_misses;
     pmu_event_stamp_t cpu_migrations;
+    pmu_event_stamp_t cache_references;
 } task_pmu_stamp_t;
 
 #endif

--- a/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern-user.h
+++ b/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern-user.h
@@ -8,6 +8,13 @@ typedef struct {
     __u64 event_count;
     __u64 preemption_count;
     __u64 pid_count;
+    __u64 sum_cycles;
+    __u64 sum_instructions;
 } cgroup_agg_stats_t;
+
+typedef struct {
+    __u64 cycles;
+    __u64 instructions;
+} task_pmu_stamp_t;
 
 #endif

--- a/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern-user.h
+++ b/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern-user.h
@@ -14,13 +14,31 @@ typedef struct {
     __u64 sum_itlb_misses;
     __u64 sum_softirq_ns;
     __u64 block_io_requests;
+    __u64 sum_branch_misses;
+    __u64 sum_cpu_migrations;
+    __u64 wakeup_count;
 } cgroup_agg_stats_t;
 
+// Per-PMU-event stamp: counter value plus enabled/running times.
+// enabled and running are needed to scale counter deltas back up when the
+// kernel time-multiplexes a hardware counter onto fewer physical counters
+// than there are configured events. Without scaling, multiplexed events
+// under-report by a factor of running/enabled. See bpf_perf_event_read_value
+// docs and tools/perf/Documentation/perf-stat.txt for the standard formula
+// scaled = counter * enabled / running.
 typedef struct {
-    __u64 cycles;
-    __u64 instructions;
-    __u64 llc_misses;
-    __u64 itlb_misses;
+    __u64 counter;
+    __u64 enabled;
+    __u64 running;
+} pmu_event_stamp_t;
+
+typedef struct {
+    pmu_event_stamp_t cycles;
+    pmu_event_stamp_t instructions;
+    pmu_event_stamp_t llc_misses;
+    pmu_event_stamp_t itlb_misses;
+    pmu_event_stamp_t branch_misses;
+    pmu_event_stamp_t cpu_migrations;
 } task_pmu_stamp_t;
 
 #endif

--- a/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern-user.h
+++ b/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern-user.h
@@ -10,11 +10,17 @@ typedef struct {
     __u64 pid_count;
     __u64 sum_cycles;
     __u64 sum_instructions;
+    __u64 sum_llc_misses;
+    __u64 sum_itlb_misses;
+    __u64 sum_softirq_ns;
+    __u64 block_io_requests;
 } cgroup_agg_stats_t;
 
 typedef struct {
     __u64 cycles;
     __u64 instructions;
+    __u64 llc_misses;
+    __u64 itlb_misses;
 } task_pmu_stamp_t;
 
 #endif

--- a/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern-user.h
+++ b/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern-user.h
@@ -10,7 +10,7 @@ typedef struct {
     __u64 pid_count;
     __u64 sum_cycles;
     __u64 sum_instructions;
-    __u64 sum_llc_misses;
+    __u64 sum_cache_misses;
     __u64 sum_itlb_misses;
     __u64 sum_softirq_ns;
     __u64 block_io_requests;
@@ -36,7 +36,7 @@ typedef struct {
 typedef struct {
     pmu_event_stamp_t cycles;
     pmu_event_stamp_t instructions;
-    pmu_event_stamp_t llc_misses;
+    pmu_event_stamp_t cache_misses;
     pmu_event_stamp_t itlb_misses;
     pmu_event_stamp_t branch_misses;
     pmu_event_stamp_t cpu_migrations;

--- a/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern.c
+++ b/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern.c
@@ -12,7 +12,15 @@
 
 BPF_TASK_STORAGE_MAP(runq_enqueued, u64)
 
+BPF_TASK_STORAGE_MAP(task_oncpu_pmu, task_pmu_stamp_t)
+
 BPF_PERCPU_HASH_MAP(cgroup_agg_stats, __u64, cgroup_agg_stats_t, MAX_TASK_ENTRIES)
+
+// Per-CPU perf event arrays for cycles and instructions counters. Populated
+// from user space at probe init; if a CPU's slot is unset, the read helper
+// returns -ENOENT and the corresponding deltas are skipped.
+BPF_PERF_EVENT_ARRAY_MAP(cycles_pmu, u32)
+BPF_PERF_EVENT_ARRAY_MAP(instructions_pmu, u32)
 
 void bpf_rcu_read_lock(void) __ksym;
 void bpf_rcu_read_unlock(void) __ksym;
@@ -91,6 +99,28 @@ int tp_sched_switch(u64 *ctx) {
     u32 prev_pid = prev->pid;
     u32 next_pid = next->pid;
 
+    // Sample PMU counters once. Reads return -ENOENT (or other negative) when
+    // perf events haven't been attached for this CPU; in that case we skip
+    // both the prev close-out and the next stamp. The runqueue-wait path
+    // below is unaffected.
+    struct bpf_perf_event_value cyc_val = {};
+    struct bpf_perf_event_value ins_val = {};
+    long cyc_err = bpf_perf_event_read_value(&cycles_pmu, BPF_F_CURRENT_CPU, &cyc_val, sizeof(cyc_val));
+    long ins_err = bpf_perf_event_read_value(&instructions_pmu, BPF_F_CURRENT_CPU, &ins_val, sizeof(ins_val));
+    bool pmu_ok = (cyc_err == 0) && (ins_err == 0);
+
+    if (pmu_ok && prev_pid) {
+        task_pmu_stamp_t *stamp = bpf_task_storage_get(&task_oncpu_pmu, prev, NULL, 0);
+        if (stamp) {
+            u64 prev_cgroup_id = get_task_cgroup_id(prev);
+            cgroup_agg_stats_t *stats = get_or_create_cgroup_stats(prev_cgroup_id);
+            if (stats) {
+                stats->sum_cycles += cyc_val.counter - stamp->cycles;
+                stats->sum_instructions += ins_val.counter - stamp->instructions;
+            }
+        }
+    }
+
     if (prev->__state == TASK_RUNNING) {
         enqueue_timestamp(prev);
     }
@@ -105,6 +135,15 @@ int tp_sched_switch(u64 *ctx) {
 
     if (!next_pid) {
         return 0;
+    }
+
+    if (pmu_ok) {
+        task_pmu_stamp_t zero = {};
+        task_pmu_stamp_t *stamp = bpf_task_storage_get(&task_oncpu_pmu, next, &zero, BPF_LOCAL_STORAGE_GET_F_CREATE);
+        if (stamp) {
+            stamp->cycles = cyc_val.counter;
+            stamp->instructions = ins_val.counter;
+        }
     }
 
     u64 *tsp = bpf_task_storage_get(&runq_enqueued, next, NULL, 0);

--- a/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern.c
+++ b/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern.c
@@ -109,8 +109,11 @@ static __always_inline u64 scaled_pmu_delta(struct bpf_perf_event_value *val, pm
 // from being used as a stamp baseline (which would produce a huge bogus
 // delta on the next sched_switch) or as an accumulator input.
 //
-// cycles and instructions share a single ok flag because CPI requires
-// both; if either fails we skip the pair.
+// Every counter is gated independently: cycles can be on while instructions
+// is off, etc. (CPI, if needed, is computed dashboard-side from the raw
+// counters.) When a userspace toggle disables a perf event, that event's
+// perf-event-array map stays empty, the read returns -ENOENT, the ok flag
+// stays false, and accumulation skips that counter only.
 typedef struct {
     struct bpf_perf_event_value cycles;
     struct bpf_perf_event_value instructions;
@@ -119,27 +122,28 @@ typedef struct {
     struct bpf_perf_event_value branch_misses;
     struct bpf_perf_event_value cpu_migrations;
     struct bpf_perf_event_value cache_references;
-    bool ci_ok;
+    bool cycles_ok;
+    bool instructions_ok;
     bool llc_ok;
     bool itlb_ok;
-    bool bm_ok;
-    bool cm_ok;
-    bool cr_ok;
+    bool branch_misses_ok;
+    bool cpu_migrations_ok;
+    bool cache_references_ok;
 } pmu_sample_t;
 
 static __always_inline void pmu_sample_all(pmu_sample_t *s) {
-    long cyc_err = bpf_perf_event_read_value(&cycles_pmu, BPF_F_CURRENT_CPU, &s->cycles, sizeof(s->cycles));
-    long ins_err = bpf_perf_event_read_value(&instructions_pmu, BPF_F_CURRENT_CPU, &s->instructions, sizeof(s->instructions));
-    s->ci_ok = (cyc_err == 0) && (ins_err == 0);
+    s->cycles_ok = bpf_perf_event_read_value(&cycles_pmu, BPF_F_CURRENT_CPU, &s->cycles, sizeof(s->cycles)) == 0;
+    s->instructions_ok = bpf_perf_event_read_value(&instructions_pmu, BPF_F_CURRENT_CPU, &s->instructions, sizeof(s->instructions)) == 0;
     s->llc_ok = bpf_perf_event_read_value(&llc_misses_pmu, BPF_F_CURRENT_CPU, &s->llc_misses, sizeof(s->llc_misses)) == 0;
     s->itlb_ok = bpf_perf_event_read_value(&itlb_misses_pmu, BPF_F_CURRENT_CPU, &s->itlb_misses, sizeof(s->itlb_misses)) == 0;
-    s->bm_ok = bpf_perf_event_read_value(&branch_misses_pmu, BPF_F_CURRENT_CPU, &s->branch_misses, sizeof(s->branch_misses)) == 0;
-    s->cm_ok = bpf_perf_event_read_value(&cpu_migrations_pmu, BPF_F_CURRENT_CPU, &s->cpu_migrations, sizeof(s->cpu_migrations)) == 0;
-    s->cr_ok = bpf_perf_event_read_value(&cache_references_pmu, BPF_F_CURRENT_CPU, &s->cache_references, sizeof(s->cache_references)) == 0;
+    s->branch_misses_ok = bpf_perf_event_read_value(&branch_misses_pmu, BPF_F_CURRENT_CPU, &s->branch_misses, sizeof(s->branch_misses)) == 0;
+    s->cpu_migrations_ok = bpf_perf_event_read_value(&cpu_migrations_pmu, BPF_F_CURRENT_CPU, &s->cpu_migrations, sizeof(s->cpu_migrations)) == 0;
+    s->cache_references_ok = bpf_perf_event_read_value(&cache_references_pmu, BPF_F_CURRENT_CPU, &s->cache_references, sizeof(s->cache_references)) == 0;
 }
 
 static __always_inline bool pmu_any_ok(pmu_sample_t *s) {
-    return s->ci_ok || s->llc_ok || s->itlb_ok || s->bm_ok || s->cm_ok || s->cr_ok;
+    return s->cycles_ok || s->instructions_ok || s->llc_ok || s->itlb_ok ||
+           s->branch_misses_ok || s->cpu_migrations_ok || s->cache_references_ok;
 }
 
 static __always_inline void pmu_stamp_event(pmu_event_stamp_t *slot, struct bpf_perf_event_value *val) {
@@ -149,8 +153,10 @@ static __always_inline void pmu_stamp_event(pmu_event_stamp_t *slot, struct bpf_
 }
 
 static __always_inline void pmu_stamp_from_sample(task_pmu_stamp_t *stamp, pmu_sample_t *s) {
-    if (s->ci_ok) {
+    if (s->cycles_ok) {
         pmu_stamp_event(&stamp->cycles, &s->cycles);
+    }
+    if (s->instructions_ok) {
         pmu_stamp_event(&stamp->instructions, &s->instructions);
     }
     if (s->llc_ok) {
@@ -159,20 +165,22 @@ static __always_inline void pmu_stamp_from_sample(task_pmu_stamp_t *stamp, pmu_s
     if (s->itlb_ok) {
         pmu_stamp_event(&stamp->itlb_misses, &s->itlb_misses);
     }
-    if (s->bm_ok) {
+    if (s->branch_misses_ok) {
         pmu_stamp_event(&stamp->branch_misses, &s->branch_misses);
     }
-    if (s->cm_ok) {
+    if (s->cpu_migrations_ok) {
         pmu_stamp_event(&stamp->cpu_migrations, &s->cpu_migrations);
     }
-    if (s->cr_ok) {
+    if (s->cache_references_ok) {
         pmu_stamp_event(&stamp->cache_references, &s->cache_references);
     }
 }
 
 static __always_inline void pmu_accum_to_stats(cgroup_agg_stats_t *stats, task_pmu_stamp_t *stamp, pmu_sample_t *s) {
-    if (s->ci_ok) {
+    if (s->cycles_ok) {
         stats->sum_cycles += scaled_pmu_delta(&s->cycles, &stamp->cycles);
+    }
+    if (s->instructions_ok) {
         stats->sum_instructions += scaled_pmu_delta(&s->instructions, &stamp->instructions);
     }
     if (s->llc_ok) {
@@ -181,13 +189,13 @@ static __always_inline void pmu_accum_to_stats(cgroup_agg_stats_t *stats, task_p
     if (s->itlb_ok) {
         stats->sum_itlb_misses += scaled_pmu_delta(&s->itlb_misses, &stamp->itlb_misses);
     }
-    if (s->bm_ok) {
+    if (s->branch_misses_ok) {
         stats->sum_branch_misses += scaled_pmu_delta(&s->branch_misses, &stamp->branch_misses);
     }
-    if (s->cm_ok) {
+    if (s->cpu_migrations_ok) {
         stats->sum_cpu_migrations += scaled_pmu_delta(&s->cpu_migrations, &stamp->cpu_migrations);
     }
-    if (s->cr_ok) {
+    if (s->cache_references_ok) {
         stats->sum_cache_references += scaled_pmu_delta(&s->cache_references, &stamp->cache_references);
     }
 }

--- a/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern.c
+++ b/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern.c
@@ -103,6 +103,95 @@ static __always_inline u64 scaled_pmu_delta(struct bpf_perf_event_value *val, pm
     return raw + (raw * missing) / running_delta;
 }
 
+// pmu_sample_t holds one sample of every PMU event we track, along with
+// per-event ok flags marking which reads succeeded. A failed read leaves
+// the bpf_perf_event_value buffer at zero; the ok flag prevents that zero
+// from being used as a stamp baseline (which would produce a huge bogus
+// delta on the next sched_switch) or as an accumulator input.
+//
+// cycles and instructions share a single ok flag because CPI requires
+// both; if either fails we skip the pair.
+typedef struct {
+    struct bpf_perf_event_value cycles;
+    struct bpf_perf_event_value instructions;
+    struct bpf_perf_event_value llc_misses;
+    struct bpf_perf_event_value itlb_misses;
+    struct bpf_perf_event_value branch_misses;
+    struct bpf_perf_event_value cpu_migrations;
+    struct bpf_perf_event_value cache_references;
+    bool ci_ok;
+    bool llc_ok;
+    bool itlb_ok;
+    bool bm_ok;
+    bool cm_ok;
+    bool cr_ok;
+} pmu_sample_t;
+
+static __always_inline void pmu_sample_all(pmu_sample_t *s) {
+    long cyc_err = bpf_perf_event_read_value(&cycles_pmu, BPF_F_CURRENT_CPU, &s->cycles, sizeof(s->cycles));
+    long ins_err = bpf_perf_event_read_value(&instructions_pmu, BPF_F_CURRENT_CPU, &s->instructions, sizeof(s->instructions));
+    s->ci_ok = (cyc_err == 0) && (ins_err == 0);
+    s->llc_ok = bpf_perf_event_read_value(&llc_misses_pmu, BPF_F_CURRENT_CPU, &s->llc_misses, sizeof(s->llc_misses)) == 0;
+    s->itlb_ok = bpf_perf_event_read_value(&itlb_misses_pmu, BPF_F_CURRENT_CPU, &s->itlb_misses, sizeof(s->itlb_misses)) == 0;
+    s->bm_ok = bpf_perf_event_read_value(&branch_misses_pmu, BPF_F_CURRENT_CPU, &s->branch_misses, sizeof(s->branch_misses)) == 0;
+    s->cm_ok = bpf_perf_event_read_value(&cpu_migrations_pmu, BPF_F_CURRENT_CPU, &s->cpu_migrations, sizeof(s->cpu_migrations)) == 0;
+    s->cr_ok = bpf_perf_event_read_value(&cache_references_pmu, BPF_F_CURRENT_CPU, &s->cache_references, sizeof(s->cache_references)) == 0;
+}
+
+static __always_inline bool pmu_any_ok(pmu_sample_t *s) {
+    return s->ci_ok || s->llc_ok || s->itlb_ok || s->bm_ok || s->cm_ok || s->cr_ok;
+}
+
+static __always_inline void pmu_stamp_event(pmu_event_stamp_t *slot, struct bpf_perf_event_value *val) {
+    slot->counter = val->counter;
+    slot->enabled = val->enabled;
+    slot->running = val->running;
+}
+
+static __always_inline void pmu_stamp_from_sample(task_pmu_stamp_t *stamp, pmu_sample_t *s) {
+    if (s->ci_ok) {
+        pmu_stamp_event(&stamp->cycles, &s->cycles);
+        pmu_stamp_event(&stamp->instructions, &s->instructions);
+    }
+    if (s->llc_ok) {
+        pmu_stamp_event(&stamp->llc_misses, &s->llc_misses);
+    }
+    if (s->itlb_ok) {
+        pmu_stamp_event(&stamp->itlb_misses, &s->itlb_misses);
+    }
+    if (s->bm_ok) {
+        pmu_stamp_event(&stamp->branch_misses, &s->branch_misses);
+    }
+    if (s->cm_ok) {
+        pmu_stamp_event(&stamp->cpu_migrations, &s->cpu_migrations);
+    }
+    if (s->cr_ok) {
+        pmu_stamp_event(&stamp->cache_references, &s->cache_references);
+    }
+}
+
+static __always_inline void pmu_accum_to_stats(cgroup_agg_stats_t *stats, task_pmu_stamp_t *stamp, pmu_sample_t *s) {
+    if (s->ci_ok) {
+        stats->sum_cycles += scaled_pmu_delta(&s->cycles, &stamp->cycles);
+        stats->sum_instructions += scaled_pmu_delta(&s->instructions, &stamp->instructions);
+    }
+    if (s->llc_ok) {
+        stats->sum_llc_misses += scaled_pmu_delta(&s->llc_misses, &stamp->llc_misses);
+    }
+    if (s->itlb_ok) {
+        stats->sum_itlb_misses += scaled_pmu_delta(&s->itlb_misses, &stamp->itlb_misses);
+    }
+    if (s->bm_ok) {
+        stats->sum_branch_misses += scaled_pmu_delta(&s->branch_misses, &stamp->branch_misses);
+    }
+    if (s->cm_ok) {
+        stats->sum_cpu_migrations += scaled_pmu_delta(&s->cpu_migrations, &stamp->cpu_migrations);
+    }
+    if (s->cr_ok) {
+        stats->sum_cache_references += scaled_pmu_delta(&s->cache_references, &stamp->cache_references);
+    }
+}
+
 static __always_inline cgroup_agg_stats_t *get_or_create_cgroup_stats(u64 cgroup_id) {
     cgroup_agg_stats_t *stats = bpf_map_lookup_elem(&cgroup_agg_stats, &cgroup_id);
     if (!stats) {
@@ -113,29 +202,50 @@ static __always_inline cgroup_agg_stats_t *get_or_create_cgroup_stats(u64 cgroup
     return stats;
 }
 
+// task_cgroup_stats returns the cgroup aggregate stats entry for the given
+// task, creating it on first observation. Returns NULL if the map insert fails.
+static __always_inline cgroup_agg_stats_t *task_cgroup_stats(struct task_struct *task) {
+    u64 cgroup_id = get_task_cgroup_id(task);
+    return get_or_create_cgroup_stats(cgroup_id);
+}
+
+// current_cgroup_stats returns the cgroup aggregate stats entry for the
+// currently-running task. Returns NULL if the current task pointer can't be
+// resolved or if the map insert fails.
+static __always_inline cgroup_agg_stats_t *current_cgroup_stats(void) {
+    struct task_struct *task = bpf_get_current_task_btf();
+    if (!task) {
+        return NULL;
+    }
+    return task_cgroup_stats(task);
+}
+
 // count_wakeup increments the per-cgroup wakeup counter for the given task.
 // Called only from the genuine wakeup tracepoints — not from the sched_switch
 // re-enqueue path (which is a preemption-driven re-enqueue, not a wakeup).
 static __always_inline void count_wakeup(struct task_struct *task) {
-    u64 cgroup_id = get_task_cgroup_id(task);
-    cgroup_agg_stats_t *stats = get_or_create_cgroup_stats(cgroup_id);
+    cgroup_agg_stats_t *stats = task_cgroup_stats(task);
     if (stats) {
         stats->wakeup_count += 1;
     }
 }
 
-SEC("tp_btf/sched_wakeup")
-int tp_sched_wakeup(u64 *ctx) {
-    struct task_struct *task = (void *)ctx[0];
+// handle_wakeup is the shared body of tp_sched_wakeup and tp_sched_wakeup_new.
+// Both tracepoints carry the same (task) shape and need the same accounting:
+// count the wakeup, then stamp the enqueue timestamp.
+static __always_inline int handle_wakeup(struct task_struct *task) {
     count_wakeup(task);
     return enqueue_timestamp(task);
 }
 
+SEC("tp_btf/sched_wakeup")
+int tp_sched_wakeup(u64 *ctx) {
+    return handle_wakeup((struct task_struct *)ctx[0]);
+}
+
 SEC("tp_btf/sched_wakeup_new")
 int tp_sched_wakeup_new(u64 *ctx) {
-    struct task_struct *task = (void *)ctx[0];
-    count_wakeup(task);
-    return enqueue_timestamp(task);
+    return handle_wakeup((struct task_struct *)ctx[0]);
 }
 
 SEC("tp_btf/sched_switch")
@@ -146,58 +256,18 @@ int tp_sched_switch(u64 *ctx) {
     u32 prev_pid = prev->pid;
     u32 next_pid = next->pid;
 
-    // Sample PMU counters once. Reads return -ENOENT (or other negative) when
-    // perf events haven't been attached for this CPU; in that case we skip
-    // both the prev close-out and the next stamp. The runqueue-wait path
-    // below is unaffected. Each counter is independent — if iTLB events
+    // Sample PMU counters once. Each read is independent — if iTLB events
     // aren't supported but cycles are, only iTLB deltas are skipped.
-    struct bpf_perf_event_value cyc_val = {};
-    struct bpf_perf_event_value ins_val = {};
-    struct bpf_perf_event_value llc_val = {};
-    struct bpf_perf_event_value itlb_val = {};
-    struct bpf_perf_event_value bm_val = {};
-    struct bpf_perf_event_value cm_val = {};
-    struct bpf_perf_event_value cr_val = {};
-    long cyc_err = bpf_perf_event_read_value(&cycles_pmu, BPF_F_CURRENT_CPU, &cyc_val, sizeof(cyc_val));
-    long ins_err = bpf_perf_event_read_value(&instructions_pmu, BPF_F_CURRENT_CPU, &ins_val, sizeof(ins_val));
-    long llc_err = bpf_perf_event_read_value(&llc_misses_pmu, BPF_F_CURRENT_CPU, &llc_val, sizeof(llc_val));
-    long itlb_err = bpf_perf_event_read_value(&itlb_misses_pmu, BPF_F_CURRENT_CPU, &itlb_val, sizeof(itlb_val));
-    long bm_err = bpf_perf_event_read_value(&branch_misses_pmu, BPF_F_CURRENT_CPU, &bm_val, sizeof(bm_val));
-    long cm_err = bpf_perf_event_read_value(&cpu_migrations_pmu, BPF_F_CURRENT_CPU, &cm_val, sizeof(cm_val));
-    long cr_err = bpf_perf_event_read_value(&cache_references_pmu, BPF_F_CURRENT_CPU, &cr_val, sizeof(cr_val));
-    bool ci_ok = (cyc_err == 0) && (ins_err == 0);
-    bool llc_ok = (llc_err == 0);
-    bool itlb_ok = (itlb_err == 0);
-    bool bm_ok = (bm_err == 0);
-    bool cm_ok = (cm_err == 0);
-    bool cr_ok = (cr_err == 0);
-    bool pmu_ok = ci_ok || llc_ok || itlb_ok || bm_ok || cm_ok || cr_ok;
+    pmu_sample_t pmu = {};
+    pmu_sample_all(&pmu);
+    bool pmu_ok = pmu_any_ok(&pmu);
 
     if (pmu_ok && prev_pid) {
         task_pmu_stamp_t *stamp = bpf_task_storage_get(&task_oncpu_pmu, prev, NULL, 0);
         if (stamp) {
-            u64 prev_cgroup_id = get_task_cgroup_id(prev);
-            cgroup_agg_stats_t *stats = get_or_create_cgroup_stats(prev_cgroup_id);
+            cgroup_agg_stats_t *stats = task_cgroup_stats(prev);
             if (stats) {
-                if (ci_ok) {
-                    stats->sum_cycles += scaled_pmu_delta(&cyc_val, &stamp->cycles);
-                    stats->sum_instructions += scaled_pmu_delta(&ins_val, &stamp->instructions);
-                }
-                if (llc_ok) {
-                    stats->sum_llc_misses += scaled_pmu_delta(&llc_val, &stamp->llc_misses);
-                }
-                if (itlb_ok) {
-                    stats->sum_itlb_misses += scaled_pmu_delta(&itlb_val, &stamp->itlb_misses);
-                }
-                if (bm_ok) {
-                    stats->sum_branch_misses += scaled_pmu_delta(&bm_val, &stamp->branch_misses);
-                }
-                if (cm_ok) {
-                    stats->sum_cpu_migrations += scaled_pmu_delta(&cm_val, &stamp->cpu_migrations);
-                }
-                if (cr_ok) {
-                    stats->sum_cache_references += scaled_pmu_delta(&cr_val, &stamp->cache_references);
-                }
+                pmu_accum_to_stats(stats, stamp, &pmu);
             }
         }
     }
@@ -207,8 +277,7 @@ int tp_sched_switch(u64 *ctx) {
     }
 
     if (preempted && prev_pid) {
-        u64 prev_cgroup_id = get_task_cgroup_id(prev);
-        cgroup_agg_stats_t *stats = get_or_create_cgroup_stats(prev_cgroup_id);
+        cgroup_agg_stats_t *stats = task_cgroup_stats(prev);
         if (stats) {
             stats->preemption_count += 1;
         }
@@ -222,39 +291,7 @@ int tp_sched_switch(u64 *ctx) {
         task_pmu_stamp_t zero = {};
         task_pmu_stamp_t *stamp = bpf_task_storage_get(&task_oncpu_pmu, next, &zero, BPF_LOCAL_STORAGE_GET_F_CREATE);
         if (stamp) {
-            if (ci_ok) {
-                stamp->cycles.counter = cyc_val.counter;
-                stamp->cycles.enabled = cyc_val.enabled;
-                stamp->cycles.running = cyc_val.running;
-                stamp->instructions.counter = ins_val.counter;
-                stamp->instructions.enabled = ins_val.enabled;
-                stamp->instructions.running = ins_val.running;
-            }
-            if (llc_ok) {
-                stamp->llc_misses.counter = llc_val.counter;
-                stamp->llc_misses.enabled = llc_val.enabled;
-                stamp->llc_misses.running = llc_val.running;
-            }
-            if (itlb_ok) {
-                stamp->itlb_misses.counter = itlb_val.counter;
-                stamp->itlb_misses.enabled = itlb_val.enabled;
-                stamp->itlb_misses.running = itlb_val.running;
-            }
-            if (bm_ok) {
-                stamp->branch_misses.counter = bm_val.counter;
-                stamp->branch_misses.enabled = bm_val.enabled;
-                stamp->branch_misses.running = bm_val.running;
-            }
-            if (cm_ok) {
-                stamp->cpu_migrations.counter = cm_val.counter;
-                stamp->cpu_migrations.enabled = cm_val.enabled;
-                stamp->cpu_migrations.running = cm_val.running;
-            }
-            if (cr_ok) {
-                stamp->cache_references.counter = cr_val.counter;
-                stamp->cache_references.enabled = cr_val.enabled;
-                stamp->cache_references.running = cr_val.running;
-            }
+            pmu_stamp_from_sample(stamp, &pmu);
         }
     }
 
@@ -266,8 +303,7 @@ int tp_sched_switch(u64 *ctx) {
     u64 runq_lat = bpf_ktime_get_ns() - *tsp;
     bpf_task_storage_delete(&runq_enqueued, next);
 
-    u64 cgroup_id = get_task_cgroup_id(next);
-    cgroup_agg_stats_t *stats = get_or_create_cgroup_stats(cgroup_id);
+    cgroup_agg_stats_t *stats = task_cgroup_stats(next);
     if (stats) {
         stats->sum_latencies_ns += runq_lat;
         stats->event_count += 1;
@@ -303,12 +339,7 @@ int tp_softirq_exit(u64 *ctx) {
     u64 delta = bpf_ktime_get_ns() - *slot;
     *slot = 0;
 
-    struct task_struct *task = bpf_get_current_task_btf();
-    if (!task) {
-        return 0;
-    }
-    u64 cgroup_id = get_task_cgroup_id(task);
-    cgroup_agg_stats_t *stats = get_or_create_cgroup_stats(cgroup_id);
+    cgroup_agg_stats_t *stats = current_cgroup_stats();
     if (stats) {
         stats->sum_softirq_ns += delta;
     }
@@ -320,12 +351,7 @@ int tp_softirq_exit(u64 *ctx) {
 // simple and matches what cgroup CPU accounting attributes elsewhere.
 SEC("tp_btf/block_rq_issue")
 int tp_block_rq_issue(u64 *ctx) {
-    struct task_struct *task = bpf_get_current_task_btf();
-    if (!task) {
-        return 0;
-    }
-    u64 cgroup_id = get_task_cgroup_id(task);
-    cgroup_agg_stats_t *stats = get_or_create_cgroup_stats(cgroup_id);
+    cgroup_agg_stats_t *stats = current_cgroup_stats();
     if (stats) {
         stats->block_io_requests += 1;
     }

--- a/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern.c
+++ b/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern.c
@@ -25,6 +25,7 @@ BPF_PERF_EVENT_ARRAY_MAP(llc_misses_pmu, u32)
 BPF_PERF_EVENT_ARRAY_MAP(itlb_misses_pmu, u32)
 BPF_PERF_EVENT_ARRAY_MAP(branch_misses_pmu, u32)
 BPF_PERF_EVENT_ARRAY_MAP(cpu_migrations_pmu, u32)
+BPF_PERF_EVENT_ARRAY_MAP(cache_references_pmu, u32)
 
 // Per-CPU softirq entry timestamp. Single-slot percpu array; softirq runs in
 // non-preemptible context so per-CPU storage is sufficient.
@@ -156,18 +157,21 @@ int tp_sched_switch(u64 *ctx) {
     struct bpf_perf_event_value itlb_val = {};
     struct bpf_perf_event_value bm_val = {};
     struct bpf_perf_event_value cm_val = {};
+    struct bpf_perf_event_value cr_val = {};
     long cyc_err = bpf_perf_event_read_value(&cycles_pmu, BPF_F_CURRENT_CPU, &cyc_val, sizeof(cyc_val));
     long ins_err = bpf_perf_event_read_value(&instructions_pmu, BPF_F_CURRENT_CPU, &ins_val, sizeof(ins_val));
     long llc_err = bpf_perf_event_read_value(&llc_misses_pmu, BPF_F_CURRENT_CPU, &llc_val, sizeof(llc_val));
     long itlb_err = bpf_perf_event_read_value(&itlb_misses_pmu, BPF_F_CURRENT_CPU, &itlb_val, sizeof(itlb_val));
     long bm_err = bpf_perf_event_read_value(&branch_misses_pmu, BPF_F_CURRENT_CPU, &bm_val, sizeof(bm_val));
     long cm_err = bpf_perf_event_read_value(&cpu_migrations_pmu, BPF_F_CURRENT_CPU, &cm_val, sizeof(cm_val));
+    long cr_err = bpf_perf_event_read_value(&cache_references_pmu, BPF_F_CURRENT_CPU, &cr_val, sizeof(cr_val));
     bool ci_ok = (cyc_err == 0) && (ins_err == 0);
     bool llc_ok = (llc_err == 0);
     bool itlb_ok = (itlb_err == 0);
     bool bm_ok = (bm_err == 0);
     bool cm_ok = (cm_err == 0);
-    bool pmu_ok = ci_ok || llc_ok || itlb_ok || bm_ok || cm_ok;
+    bool cr_ok = (cr_err == 0);
+    bool pmu_ok = ci_ok || llc_ok || itlb_ok || bm_ok || cm_ok || cr_ok;
 
     if (pmu_ok && prev_pid) {
         task_pmu_stamp_t *stamp = bpf_task_storage_get(&task_oncpu_pmu, prev, NULL, 0);
@@ -190,6 +194,9 @@ int tp_sched_switch(u64 *ctx) {
                 }
                 if (cm_ok) {
                     stats->sum_cpu_migrations += scaled_pmu_delta(&cm_val, &stamp->cpu_migrations);
+                }
+                if (cr_ok) {
+                    stats->sum_cache_references += scaled_pmu_delta(&cr_val, &stamp->cache_references);
                 }
             }
         }
@@ -242,6 +249,11 @@ int tp_sched_switch(u64 *ctx) {
                 stamp->cpu_migrations.counter = cm_val.counter;
                 stamp->cpu_migrations.enabled = cm_val.enabled;
                 stamp->cpu_migrations.running = cm_val.running;
+            }
+            if (cr_ok) {
+                stamp->cache_references.counter = cr_val.counter;
+                stamp->cache_references.enabled = cr_val.enabled;
+                stamp->cache_references.running = cr_val.running;
             }
         }
     }

--- a/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern.c
+++ b/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern.c
@@ -21,7 +21,7 @@ BPF_PERCPU_HASH_MAP(cgroup_agg_stats, __u64, cgroup_agg_stats_t, MAX_TASK_ENTRIE
 // and the corresponding deltas are skipped.
 BPF_PERF_EVENT_ARRAY_MAP(cycles_pmu, u32)
 BPF_PERF_EVENT_ARRAY_MAP(instructions_pmu, u32)
-BPF_PERF_EVENT_ARRAY_MAP(llc_misses_pmu, u32)
+BPF_PERF_EVENT_ARRAY_MAP(cache_misses_pmu, u32)
 BPF_PERF_EVENT_ARRAY_MAP(itlb_misses_pmu, u32)
 BPF_PERF_EVENT_ARRAY_MAP(branch_misses_pmu, u32)
 BPF_PERF_EVENT_ARRAY_MAP(cpu_migrations_pmu, u32)
@@ -117,14 +117,14 @@ static __always_inline u64 scaled_pmu_delta(struct bpf_perf_event_value *val, pm
 typedef struct {
     struct bpf_perf_event_value cycles;
     struct bpf_perf_event_value instructions;
-    struct bpf_perf_event_value llc_misses;
+    struct bpf_perf_event_value cache_misses;
     struct bpf_perf_event_value itlb_misses;
     struct bpf_perf_event_value branch_misses;
     struct bpf_perf_event_value cpu_migrations;
     struct bpf_perf_event_value cache_references;
     bool cycles_ok;
     bool instructions_ok;
-    bool llc_ok;
+    bool cache_misses_ok;
     bool itlb_ok;
     bool branch_misses_ok;
     bool cpu_migrations_ok;
@@ -134,7 +134,7 @@ typedef struct {
 static __always_inline void pmu_sample_all(pmu_sample_t *s) {
     s->cycles_ok = bpf_perf_event_read_value(&cycles_pmu, BPF_F_CURRENT_CPU, &s->cycles, sizeof(s->cycles)) == 0;
     s->instructions_ok = bpf_perf_event_read_value(&instructions_pmu, BPF_F_CURRENT_CPU, &s->instructions, sizeof(s->instructions)) == 0;
-    s->llc_ok = bpf_perf_event_read_value(&llc_misses_pmu, BPF_F_CURRENT_CPU, &s->llc_misses, sizeof(s->llc_misses)) == 0;
+    s->cache_misses_ok = bpf_perf_event_read_value(&cache_misses_pmu, BPF_F_CURRENT_CPU, &s->cache_misses, sizeof(s->cache_misses)) == 0;
     s->itlb_ok = bpf_perf_event_read_value(&itlb_misses_pmu, BPF_F_CURRENT_CPU, &s->itlb_misses, sizeof(s->itlb_misses)) == 0;
     s->branch_misses_ok = bpf_perf_event_read_value(&branch_misses_pmu, BPF_F_CURRENT_CPU, &s->branch_misses, sizeof(s->branch_misses)) == 0;
     s->cpu_migrations_ok = bpf_perf_event_read_value(&cpu_migrations_pmu, BPF_F_CURRENT_CPU, &s->cpu_migrations, sizeof(s->cpu_migrations)) == 0;
@@ -142,7 +142,7 @@ static __always_inline void pmu_sample_all(pmu_sample_t *s) {
 }
 
 static __always_inline bool pmu_any_ok(pmu_sample_t *s) {
-    return s->cycles_ok || s->instructions_ok || s->llc_ok || s->itlb_ok ||
+    return s->cycles_ok || s->instructions_ok || s->cache_misses_ok || s->itlb_ok ||
            s->branch_misses_ok || s->cpu_migrations_ok || s->cache_references_ok;
 }
 
@@ -159,8 +159,8 @@ static __always_inline void pmu_stamp_from_sample(task_pmu_stamp_t *stamp, pmu_s
     if (s->instructions_ok) {
         pmu_stamp_event(&stamp->instructions, &s->instructions);
     }
-    if (s->llc_ok) {
-        pmu_stamp_event(&stamp->llc_misses, &s->llc_misses);
+    if (s->cache_misses_ok) {
+        pmu_stamp_event(&stamp->cache_misses, &s->cache_misses);
     }
     if (s->itlb_ok) {
         pmu_stamp_event(&stamp->itlb_misses, &s->itlb_misses);
@@ -183,8 +183,8 @@ static __always_inline void pmu_accum_to_stats(cgroup_agg_stats_t *stats, task_p
     if (s->instructions_ok) {
         stats->sum_instructions += scaled_pmu_delta(&s->instructions, &stamp->instructions);
     }
-    if (s->llc_ok) {
-        stats->sum_llc_misses += scaled_pmu_delta(&s->llc_misses, &stamp->llc_misses);
+    if (s->cache_misses_ok) {
+        stats->sum_cache_misses += scaled_pmu_delta(&s->cache_misses, &stamp->cache_misses);
     }
     if (s->itlb_ok) {
         stats->sum_itlb_misses += scaled_pmu_delta(&s->itlb_misses, &stamp->itlb_misses);

--- a/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern.c
+++ b/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern.c
@@ -16,11 +16,17 @@ BPF_TASK_STORAGE_MAP(task_oncpu_pmu, task_pmu_stamp_t)
 
 BPF_PERCPU_HASH_MAP(cgroup_agg_stats, __u64, cgroup_agg_stats_t, MAX_TASK_ENTRIES)
 
-// Per-CPU perf event arrays for cycles and instructions counters. Populated
-// from user space at probe init; if a CPU's slot is unset, the read helper
-// returns -ENOENT and the corresponding deltas are skipped.
+// Per-CPU perf event arrays for hardware counters. Populated from user space
+// at probe init; if a CPU's slot is unset, the read helper returns -ENOENT
+// and the corresponding deltas are skipped.
 BPF_PERF_EVENT_ARRAY_MAP(cycles_pmu, u32)
 BPF_PERF_EVENT_ARRAY_MAP(instructions_pmu, u32)
+BPF_PERF_EVENT_ARRAY_MAP(llc_misses_pmu, u32)
+BPF_PERF_EVENT_ARRAY_MAP(itlb_misses_pmu, u32)
+
+// Per-CPU softirq entry timestamp. Single-slot percpu array; softirq runs in
+// non-preemptible context so per-CPU storage is sufficient.
+BPF_PERCPU_ARRAY_MAP(softirq_start_ns, __u64, 1)
 
 void bpf_rcu_read_lock(void) __ksym;
 void bpf_rcu_read_unlock(void) __ksym;
@@ -102,12 +108,20 @@ int tp_sched_switch(u64 *ctx) {
     // Sample PMU counters once. Reads return -ENOENT (or other negative) when
     // perf events haven't been attached for this CPU; in that case we skip
     // both the prev close-out and the next stamp. The runqueue-wait path
-    // below is unaffected.
+    // below is unaffected. Each counter is independent — if iTLB events
+    // aren't supported but cycles are, only iTLB deltas are skipped.
     struct bpf_perf_event_value cyc_val = {};
     struct bpf_perf_event_value ins_val = {};
+    struct bpf_perf_event_value llc_val = {};
+    struct bpf_perf_event_value itlb_val = {};
     long cyc_err = bpf_perf_event_read_value(&cycles_pmu, BPF_F_CURRENT_CPU, &cyc_val, sizeof(cyc_val));
     long ins_err = bpf_perf_event_read_value(&instructions_pmu, BPF_F_CURRENT_CPU, &ins_val, sizeof(ins_val));
-    bool pmu_ok = (cyc_err == 0) && (ins_err == 0);
+    long llc_err = bpf_perf_event_read_value(&llc_misses_pmu, BPF_F_CURRENT_CPU, &llc_val, sizeof(llc_val));
+    long itlb_err = bpf_perf_event_read_value(&itlb_misses_pmu, BPF_F_CURRENT_CPU, &itlb_val, sizeof(itlb_val));
+    bool ci_ok = (cyc_err == 0) && (ins_err == 0);
+    bool llc_ok = (llc_err == 0);
+    bool itlb_ok = (itlb_err == 0);
+    bool pmu_ok = ci_ok || llc_ok || itlb_ok;
 
     if (pmu_ok && prev_pid) {
         task_pmu_stamp_t *stamp = bpf_task_storage_get(&task_oncpu_pmu, prev, NULL, 0);
@@ -115,8 +129,16 @@ int tp_sched_switch(u64 *ctx) {
             u64 prev_cgroup_id = get_task_cgroup_id(prev);
             cgroup_agg_stats_t *stats = get_or_create_cgroup_stats(prev_cgroup_id);
             if (stats) {
-                stats->sum_cycles += cyc_val.counter - stamp->cycles;
-                stats->sum_instructions += ins_val.counter - stamp->instructions;
+                if (ci_ok) {
+                    stats->sum_cycles += cyc_val.counter - stamp->cycles;
+                    stats->sum_instructions += ins_val.counter - stamp->instructions;
+                }
+                if (llc_ok) {
+                    stats->sum_llc_misses += llc_val.counter - stamp->llc_misses;
+                }
+                if (itlb_ok) {
+                    stats->sum_itlb_misses += itlb_val.counter - stamp->itlb_misses;
+                }
             }
         }
     }
@@ -141,8 +163,16 @@ int tp_sched_switch(u64 *ctx) {
         task_pmu_stamp_t zero = {};
         task_pmu_stamp_t *stamp = bpf_task_storage_get(&task_oncpu_pmu, next, &zero, BPF_LOCAL_STORAGE_GET_F_CREATE);
         if (stamp) {
-            stamp->cycles = cyc_val.counter;
-            stamp->instructions = ins_val.counter;
+            if (ci_ok) {
+                stamp->cycles = cyc_val.counter;
+                stamp->instructions = ins_val.counter;
+            }
+            if (llc_ok) {
+                stamp->llc_misses = llc_val.counter;
+            }
+            if (itlb_ok) {
+                stamp->itlb_misses = itlb_val.counter;
+            }
         }
     }
 
@@ -162,6 +192,61 @@ int tp_sched_switch(u64 *ctx) {
         stats->pid_count = get_cgroup_pids_count(next);
     }
 
+    return 0;
+}
+
+// Softirq accounting: stamp the entry timestamp per CPU; on exit, attribute
+// the elapsed nanoseconds to the cgroup of whatever task was running on this
+// CPU when the softirq fired. For irq-tail softirq processing, this charges
+// time back to the interrupted task's cgroup (the victim — exactly what we
+// want). For ksoftirqd-driven softirqs, it charges to the ksoftirqd cgroup
+// (typically root); a known limitation we accept for the prototype.
+SEC("tp_btf/softirq_entry")
+int tp_softirq_entry(u64 *ctx) {
+    u32 zero = 0;
+    u64 *slot = bpf_map_lookup_elem(&softirq_start_ns, &zero);
+    if (slot) {
+        *slot = bpf_ktime_get_ns();
+    }
+    return 0;
+}
+
+SEC("tp_btf/softirq_exit")
+int tp_softirq_exit(u64 *ctx) {
+    u32 zero = 0;
+    u64 *slot = bpf_map_lookup_elem(&softirq_start_ns, &zero);
+    if (!slot || *slot == 0) {
+        return 0;
+    }
+    u64 delta = bpf_ktime_get_ns() - *slot;
+    *slot = 0;
+
+    struct task_struct *task = bpf_get_current_task_btf();
+    if (!task) {
+        return 0;
+    }
+    u64 cgroup_id = get_task_cgroup_id(task);
+    cgroup_agg_stats_t *stats = get_or_create_cgroup_stats(cgroup_id);
+    if (stats) {
+        stats->sum_softirq_ns += delta;
+    }
+    return 0;
+}
+
+// Block I/O issue tracking: count requests issued from each cgroup. Uses the
+// task that issued the I/O (current task), not the bio's owning cgroup —
+// simple and matches what cgroup CPU accounting attributes elsewhere.
+SEC("tp_btf/block_rq_issue")
+int tp_block_rq_issue(u64 *ctx) {
+    struct task_struct *task = bpf_get_current_task_btf();
+    if (!task) {
+        return 0;
+    }
+    u64 cgroup_id = get_task_cgroup_id(task);
+    cgroup_agg_stats_t *stats = get_or_create_cgroup_stats(cgroup_id);
+    if (stats) {
+        stats->block_io_requests += 1;
+    }
     return 0;
 }
 

--- a/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern.c
+++ b/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern.c
@@ -23,6 +23,8 @@ BPF_PERF_EVENT_ARRAY_MAP(cycles_pmu, u32)
 BPF_PERF_EVENT_ARRAY_MAP(instructions_pmu, u32)
 BPF_PERF_EVENT_ARRAY_MAP(llc_misses_pmu, u32)
 BPF_PERF_EVENT_ARRAY_MAP(itlb_misses_pmu, u32)
+BPF_PERF_EVENT_ARRAY_MAP(branch_misses_pmu, u32)
+BPF_PERF_EVENT_ARRAY_MAP(cpu_migrations_pmu, u32)
 
 // Per-CPU softirq entry timestamp. Single-slot percpu array; softirq runs in
 // non-preemptible context so per-CPU storage is sufficient.
@@ -75,6 +77,31 @@ static __always_inline int enqueue_timestamp(struct task_struct *task) {
     return 0;
 }
 
+// scaled_pmu_delta computes (val.counter - stamp.counter) scaled by
+// enabled/running to undo any time-multiplexing the kernel applied to the
+// underlying hardware counter. When enabled == running (no multiplexing),
+// the result equals the raw delta. When the event was paused for the
+// entire window (running_delta == 0), returns 0 — the sample carries no
+// usable information.
+static __always_inline u64 scaled_pmu_delta(struct bpf_perf_event_value *val, pmu_event_stamp_t *stamp) {
+    u64 raw = val->counter - stamp->counter;
+    u64 enabled_delta = val->enabled - stamp->enabled;
+    u64 running_delta = val->running - stamp->running;
+    if (running_delta == 0) {
+        return 0;
+    }
+    if (enabled_delta == running_delta) {
+        return raw;
+    }
+    // Compute as raw + raw*(enabled-running)/running rather than
+    // raw*enabled/running to keep the multiplication operands small in
+    // the common multiplexing case (enabled-running << running). This
+    // reduces — but does not eliminate — u64 overflow risk on very long
+    // sched windows.
+    u64 missing = enabled_delta - running_delta;
+    return raw + (raw * missing) / running_delta;
+}
+
 static __always_inline cgroup_agg_stats_t *get_or_create_cgroup_stats(u64 cgroup_id) {
     cgroup_agg_stats_t *stats = bpf_map_lookup_elem(&cgroup_agg_stats, &cgroup_id);
     if (!stats) {
@@ -85,15 +112,28 @@ static __always_inline cgroup_agg_stats_t *get_or_create_cgroup_stats(u64 cgroup
     return stats;
 }
 
+// count_wakeup increments the per-cgroup wakeup counter for the given task.
+// Called only from the genuine wakeup tracepoints — not from the sched_switch
+// re-enqueue path (which is a preemption-driven re-enqueue, not a wakeup).
+static __always_inline void count_wakeup(struct task_struct *task) {
+    u64 cgroup_id = get_task_cgroup_id(task);
+    cgroup_agg_stats_t *stats = get_or_create_cgroup_stats(cgroup_id);
+    if (stats) {
+        stats->wakeup_count += 1;
+    }
+}
+
 SEC("tp_btf/sched_wakeup")
 int tp_sched_wakeup(u64 *ctx) {
     struct task_struct *task = (void *)ctx[0];
+    count_wakeup(task);
     return enqueue_timestamp(task);
 }
 
 SEC("tp_btf/sched_wakeup_new")
 int tp_sched_wakeup_new(u64 *ctx) {
     struct task_struct *task = (void *)ctx[0];
+    count_wakeup(task);
     return enqueue_timestamp(task);
 }
 
@@ -114,14 +154,20 @@ int tp_sched_switch(u64 *ctx) {
     struct bpf_perf_event_value ins_val = {};
     struct bpf_perf_event_value llc_val = {};
     struct bpf_perf_event_value itlb_val = {};
+    struct bpf_perf_event_value bm_val = {};
+    struct bpf_perf_event_value cm_val = {};
     long cyc_err = bpf_perf_event_read_value(&cycles_pmu, BPF_F_CURRENT_CPU, &cyc_val, sizeof(cyc_val));
     long ins_err = bpf_perf_event_read_value(&instructions_pmu, BPF_F_CURRENT_CPU, &ins_val, sizeof(ins_val));
     long llc_err = bpf_perf_event_read_value(&llc_misses_pmu, BPF_F_CURRENT_CPU, &llc_val, sizeof(llc_val));
     long itlb_err = bpf_perf_event_read_value(&itlb_misses_pmu, BPF_F_CURRENT_CPU, &itlb_val, sizeof(itlb_val));
+    long bm_err = bpf_perf_event_read_value(&branch_misses_pmu, BPF_F_CURRENT_CPU, &bm_val, sizeof(bm_val));
+    long cm_err = bpf_perf_event_read_value(&cpu_migrations_pmu, BPF_F_CURRENT_CPU, &cm_val, sizeof(cm_val));
     bool ci_ok = (cyc_err == 0) && (ins_err == 0);
     bool llc_ok = (llc_err == 0);
     bool itlb_ok = (itlb_err == 0);
-    bool pmu_ok = ci_ok || llc_ok || itlb_ok;
+    bool bm_ok = (bm_err == 0);
+    bool cm_ok = (cm_err == 0);
+    bool pmu_ok = ci_ok || llc_ok || itlb_ok || bm_ok || cm_ok;
 
     if (pmu_ok && prev_pid) {
         task_pmu_stamp_t *stamp = bpf_task_storage_get(&task_oncpu_pmu, prev, NULL, 0);
@@ -130,14 +176,20 @@ int tp_sched_switch(u64 *ctx) {
             cgroup_agg_stats_t *stats = get_or_create_cgroup_stats(prev_cgroup_id);
             if (stats) {
                 if (ci_ok) {
-                    stats->sum_cycles += cyc_val.counter - stamp->cycles;
-                    stats->sum_instructions += ins_val.counter - stamp->instructions;
+                    stats->sum_cycles += scaled_pmu_delta(&cyc_val, &stamp->cycles);
+                    stats->sum_instructions += scaled_pmu_delta(&ins_val, &stamp->instructions);
                 }
                 if (llc_ok) {
-                    stats->sum_llc_misses += llc_val.counter - stamp->llc_misses;
+                    stats->sum_llc_misses += scaled_pmu_delta(&llc_val, &stamp->llc_misses);
                 }
                 if (itlb_ok) {
-                    stats->sum_itlb_misses += itlb_val.counter - stamp->itlb_misses;
+                    stats->sum_itlb_misses += scaled_pmu_delta(&itlb_val, &stamp->itlb_misses);
+                }
+                if (bm_ok) {
+                    stats->sum_branch_misses += scaled_pmu_delta(&bm_val, &stamp->branch_misses);
+                }
+                if (cm_ok) {
+                    stats->sum_cpu_migrations += scaled_pmu_delta(&cm_val, &stamp->cpu_migrations);
                 }
             }
         }
@@ -164,14 +216,32 @@ int tp_sched_switch(u64 *ctx) {
         task_pmu_stamp_t *stamp = bpf_task_storage_get(&task_oncpu_pmu, next, &zero, BPF_LOCAL_STORAGE_GET_F_CREATE);
         if (stamp) {
             if (ci_ok) {
-                stamp->cycles = cyc_val.counter;
-                stamp->instructions = ins_val.counter;
+                stamp->cycles.counter = cyc_val.counter;
+                stamp->cycles.enabled = cyc_val.enabled;
+                stamp->cycles.running = cyc_val.running;
+                stamp->instructions.counter = ins_val.counter;
+                stamp->instructions.enabled = ins_val.enabled;
+                stamp->instructions.running = ins_val.running;
             }
             if (llc_ok) {
-                stamp->llc_misses = llc_val.counter;
+                stamp->llc_misses.counter = llc_val.counter;
+                stamp->llc_misses.enabled = llc_val.enabled;
+                stamp->llc_misses.running = llc_val.running;
             }
             if (itlb_ok) {
-                stamp->itlb_misses = itlb_val.counter;
+                stamp->itlb_misses.counter = itlb_val.counter;
+                stamp->itlb_misses.enabled = itlb_val.enabled;
+                stamp->itlb_misses.running = itlb_val.running;
+            }
+            if (bm_ok) {
+                stamp->branch_misses.counter = bm_val.counter;
+                stamp->branch_misses.enabled = bm_val.enabled;
+                stamp->branch_misses.running = bm_val.running;
+            }
+            if (cm_ok) {
+                stamp->cpu_migrations.counter = cm_val.counter;
+                stamp->cpu_migrations.enabled = cm_val.enabled;
+                stamp->cpu_migrations.running = cm_val.running;
             }
         }
     }

--- a/pkg/collector/corechecks/ebpf/noisyneighbor/common.go
+++ b/pkg/collector/corechecks/ebpf/noisyneighbor/common.go
@@ -3,7 +3,13 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-// Package noisyneighbor contains the Noisy Neighbor check
+// Package noisyneighbor contains the Noisy Neighbor check.
+//
+// EXPERIMENTAL — this module is unstable and under active development. Metric
+// names, configuration keys, BPF map layout, and on-CPU overhead may all
+// change without notice between releases, and the check may be removed
+// outright. Use at your own risk; do not build production dashboards,
+// monitors, or alerting on top of these metrics yet.
 package noisyneighbor
 
 const (

--- a/pkg/collector/corechecks/ebpf/noisyneighbor/common.go
+++ b/pkg/collector/corechecks/ebpf/noisyneighbor/common.go
@@ -3,10 +3,10 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-// Package noisyneighbor contains the Noisy Neighbor check.
+// Package noisyneighbor contains the Noisy Neighbor check
 package noisyneighbor
 
 const (
-	// CheckName is the name of the check.
+	// CheckName is the name of the check
 	CheckName = "noisy_neighbor"
 )

--- a/pkg/collector/corechecks/ebpf/noisyneighbor/common.go
+++ b/pkg/collector/corechecks/ebpf/noisyneighbor/common.go
@@ -3,10 +3,10 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-// Package noisyneighbor contains the Noisy Neighbor check
+// Package noisyneighbor contains the Noisy Neighbor check.
 package noisyneighbor
 
 const (
-	// CheckName is the name of the check
+	// CheckName is the name of the check.
 	CheckName = "noisy_neighbor"
 )

--- a/pkg/collector/corechecks/ebpf/noisyneighbor/noisy_neighbor.go
+++ b/pkg/collector/corechecks/ebpf/noisyneighbor/noisy_neighbor.go
@@ -108,7 +108,6 @@ func (n *NoisyNeighborCheck) Run() error {
 		tags := n.getContainerTags(stat)
 		n.submitPrimaryMetrics(sender, stat, tags)
 		n.submitRawCounters(sender, stat, tags)
-		n.submitPSIFullMetrics(sender, stat, tags)
 	}
 	sender.Gauge("noisy_neighbor.system.cgroups_tracked", float64(totalCgroups), "", nil)
 	sender.Commit()
@@ -160,35 +159,4 @@ func (n *NoisyNeighborCheck) submitRawCounters(sender sender.Sender, stat model.
 	sender.Count("noisy_neighbor.softirq_ns", float64(stat.SumSoftirqNs), "", tags)
 	sender.Count("noisy_neighbor.block_io_requests", float64(stat.BlockIORequests), "", tags)
 	sender.Count("noisy_neighbor.wakeups", float64(stat.WakeupCount), "", tags)
-}
-
-// submitPSIFullMetrics emits the cgroup-scoped PSI "full" stalls for memory
-// and io. The "some" variants are already emitted by the generic container
-// processor as container.{memory,io}.partial_stall — we deliberately do not
-// duplicate those here. CPU "full" PSI is not exposed at the cgroup level
-// by the kernel.
-//
-// Emitted as Gauge of the cumulative-since-cgroup-creation microsecond
-// counter. Backend or dashboard math can compute deltas; emitting Gauge
-// (rather than Rate or MonotonicCount) means single-shot `agent check`
-// invocations include the value, which Rate/MonotonicCount would drop for
-// lack of a prior sample.
-func (n *NoisyNeighborCheck) submitPSIFullMetrics(sender sender.Sender, stat model.NoisyNeighborStats, tags []string) {
-	cg := n.cgroupReader.GetCgroupByInode(stat.CgroupID)
-	if cg == nil {
-		log.Debugf("noisy_neighbor: cgroup not found for inode %d, skipping PSI metrics", stat.CgroupID)
-		return
-	}
-	memStats := &cgroups.MemoryStats{}
-	if err := cg.GetMemoryStats(memStats); err != nil {
-		log.Debugf("noisy_neighbor: GetMemoryStats failed for cgroup %d: %v", stat.CgroupID, err)
-	} else if memStats.PSIFull.Total != nil {
-		sender.Gauge("noisy_neighbor.memory.pressure.full.total_us", float64(*memStats.PSIFull.Total), "", tags)
-	}
-	ioStats := &cgroups.IOStats{}
-	if err := cg.GetIOStats(ioStats); err != nil {
-		log.Debugf("noisy_neighbor: GetIOStats failed for cgroup %d: %v", stat.CgroupID, err)
-	} else if ioStats.PSIFull.Total != nil {
-		sender.Gauge("noisy_neighbor.io.pressure.full.total_us", float64(*ioStats.PSIFull.Total), "", tags)
-	}
 }

--- a/pkg/collector/corechecks/ebpf/noisyneighbor/noisy_neighbor.go
+++ b/pkg/collector/corechecks/ebpf/noisyneighbor/noisy_neighbor.go
@@ -153,6 +153,7 @@ func (n *NoisyNeighborCheck) submitRawCounters(sender sender.Sender, stat model.
 	sender.Count("noisy_neighbor.cycles", float64(stat.SumCycles), "", tags)
 	sender.Count("noisy_neighbor.instructions", float64(stat.SumInstructions), "", tags)
 	sender.Count("noisy_neighbor.llc_misses", float64(stat.SumLLCMisses), "", tags)
+	sender.Count("noisy_neighbor.cache_references", float64(stat.SumCacheReferences), "", tags)
 	sender.Count("noisy_neighbor.itlb_misses", float64(stat.SumITLBMisses), "", tags)
 	sender.Count("noisy_neighbor.branch_misses", float64(stat.SumBranchMisses), "", tags)
 	sender.Count("noisy_neighbor.cpu_migrations", float64(stat.SumCPUMigrations), "", tags)

--- a/pkg/collector/corechecks/ebpf/noisyneighbor/noisy_neighbor.go
+++ b/pkg/collector/corechecks/ebpf/noisyneighbor/noisy_neighbor.go
@@ -138,4 +138,8 @@ func (n *NoisyNeighborCheck) submitRawCounters(sender sender.Sender, stat model.
 	sender.Gauge("noisy_neighbor.unique_processes", float64(stat.UniquePidCount), "", tags)
 	sender.Count("noisy_neighbor.cycles", float64(stat.SumCycles), "", tags)
 	sender.Count("noisy_neighbor.instructions", float64(stat.SumInstructions), "", tags)
+	sender.Count("noisy_neighbor.llc_misses", float64(stat.SumLLCMisses), "", tags)
+	sender.Count("noisy_neighbor.itlb_misses", float64(stat.SumITLBMisses), "", tags)
+	sender.Count("noisy_neighbor.softirq_ns", float64(stat.SumSoftirqNs), "", tags)
+	sender.Count("noisy_neighbor.block_io_requests", float64(stat.BlockIORequests), "", tags)
 }

--- a/pkg/collector/corechecks/ebpf/noisyneighbor/noisy_neighbor.go
+++ b/pkg/collector/corechecks/ebpf/noisyneighbor/noisy_neighbor.go
@@ -43,6 +43,16 @@ type NoisyNeighborCheck struct {
 	tagger         tagger.Component
 	sysProbeClient *sysprobeclient.CheckClient
 	cgroupReader   *cgroups.Reader
+	// pmuMetricsEnabled is captured once during Configure to avoid a config
+	// lookup per metric per Run tick. Keys are the agent-side metric short
+	// names ("cycles", "instructions", ...); a missing or false entry means
+	// the metric is not emitted.
+	pmuMetricsEnabled map[string]bool
+}
+
+var pmuMetricConfigKeys = []string{
+	"cycles", "instructions", "llc_misses", "cache_references",
+	"itlb_misses", "branch_misses", "cpu_migrations",
 }
 
 // Factory returns the check.Check constructor used by the collector to
@@ -75,12 +85,17 @@ func (n *NoisyNeighborCheck) Configure(senderManager sender.SenderManager, _ uin
 	if err := n.config.Parse(config); err != nil {
 		return fmt.Errorf("noisy_neighbor check config: %w", err)
 	}
-	n.sysProbeClient = sysprobeclient.GetCheckClient(sysprobeclient.WithSocketPath(pkgconfigsetup.SystemProbe().GetString("system_probe_config.sysprobe_socket")))
+	sysCfg := pkgconfigsetup.SystemProbe()
+	n.sysProbeClient = sysprobeclient.GetCheckClient(sysprobeclient.WithSocketPath(sysCfg.GetString("system_probe_config.sysprobe_socket")))
 	reader, err := cgroups.NewReader(cgroups.WithReaderFilter(cgroups.ContainerFilter))
 	if err != nil {
 		return fmt.Errorf("noisy_neighbor: cgroup reader init failed: %w", err)
 	}
 	n.cgroupReader = reader
+	n.pmuMetricsEnabled = make(map[string]bool, len(pmuMetricConfigKeys))
+	for _, name := range pmuMetricConfigKeys {
+		n.pmuMetricsEnabled[name] = sysCfg.GetBool("noisy_neighbor.pmu_metrics." + name)
+	}
 	return nil
 }
 
@@ -147,16 +162,35 @@ func (n *NoisyNeighborCheck) submitPrimaryMetrics(sender sender.Sender, stat mod
 }
 
 func (n *NoisyNeighborCheck) submitRawCounters(sender sender.Sender, stat model.NoisyNeighborStats, tags []string) {
+	// Always-on counters: scheduling and software accounting that don't
+	// consume PMU counter slots.
 	sender.Count("noisy_neighbor.events.total", float64(stat.EventCount), "", tags)
 	sender.Gauge("noisy_neighbor.unique_processes", float64(stat.UniquePidCount), "", tags)
-	sender.Count("noisy_neighbor.cycles", float64(stat.SumCycles), "", tags)
-	sender.Count("noisy_neighbor.instructions", float64(stat.SumInstructions), "", tags)
-	sender.Count("noisy_neighbor.llc_misses", float64(stat.SumLLCMisses), "", tags)
-	sender.Count("noisy_neighbor.cache_references", float64(stat.SumCacheReferences), "", tags)
-	sender.Count("noisy_neighbor.itlb_misses", float64(stat.SumITLBMisses), "", tags)
-	sender.Count("noisy_neighbor.branch_misses", float64(stat.SumBranchMisses), "", tags)
-	sender.Count("noisy_neighbor.cpu_migrations", float64(stat.SumCPUMigrations), "", tags)
 	sender.Count("noisy_neighbor.softirq_ns", float64(stat.SumSoftirqNs), "", tags)
 	sender.Count("noisy_neighbor.block_io_requests", float64(stat.BlockIORequests), "", tags)
 	sender.Count("noisy_neighbor.wakeups", float64(stat.WakeupCount), "", tags)
+
+	// PMU counters: each is independently gated by noisy_neighbor.pmu_metrics.X.
+	// Disabled events don't emit (no zero-valued noise on dashboards).
+	if n.pmuMetricsEnabled["cycles"] {
+		sender.Count("noisy_neighbor.cycles", float64(stat.SumCycles), "", tags)
+	}
+	if n.pmuMetricsEnabled["instructions"] {
+		sender.Count("noisy_neighbor.instructions", float64(stat.SumInstructions), "", tags)
+	}
+	if n.pmuMetricsEnabled["llc_misses"] {
+		sender.Count("noisy_neighbor.llc_misses", float64(stat.SumLLCMisses), "", tags)
+	}
+	if n.pmuMetricsEnabled["cache_references"] {
+		sender.Count("noisy_neighbor.cache_references", float64(stat.SumCacheReferences), "", tags)
+	}
+	if n.pmuMetricsEnabled["itlb_misses"] {
+		sender.Count("noisy_neighbor.itlb_misses", float64(stat.SumITLBMisses), "", tags)
+	}
+	if n.pmuMetricsEnabled["branch_misses"] {
+		sender.Count("noisy_neighbor.branch_misses", float64(stat.SumBranchMisses), "", tags)
+	}
+	if n.pmuMetricsEnabled["cpu_migrations"] {
+		sender.Count("noisy_neighbor.cpu_migrations", float64(stat.SumCPUMigrations), "", tags)
+	}
 }

--- a/pkg/collector/corechecks/ebpf/noisyneighbor/noisy_neighbor.go
+++ b/pkg/collector/corechecks/ebpf/noisyneighbor/noisy_neighbor.go
@@ -136,4 +136,6 @@ func (n *NoisyNeighborCheck) submitPrimaryMetrics(sender sender.Sender, stat mod
 func (n *NoisyNeighborCheck) submitRawCounters(sender sender.Sender, stat model.NoisyNeighborStats, tags []string) {
 	sender.Count("noisy_neighbor.events.total", float64(stat.EventCount), "", tags)
 	sender.Gauge("noisy_neighbor.unique_processes", float64(stat.UniquePidCount), "", tags)
+	sender.Count("noisy_neighbor.cycles", float64(stat.SumCycles), "", tags)
+	sender.Count("noisy_neighbor.instructions", float64(stat.SumInstructions), "", tags)
 }

--- a/pkg/collector/corechecks/ebpf/noisyneighbor/noisy_neighbor.go
+++ b/pkg/collector/corechecks/ebpf/noisyneighbor/noisy_neighbor.go
@@ -11,29 +11,35 @@ import (
 	"fmt"
 	"time"
 
+	"go.yaml.in/yaml/v2"
+
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
+	sysprobeclient "github.com/DataDog/datadog-agent/pkg/system-probe/api/client"
+	sysconfig "github.com/DataDog/datadog-agent/pkg/system-probe/config"
+
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe/noisyneighbor/model"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
-	sysprobeclient "github.com/DataDog/datadog-agent/pkg/system-probe/api/client"
-	sysconfig "github.com/DataDog/datadog-agent/pkg/system-probe/config"
 	"github.com/DataDog/datadog-agent/pkg/util/cgroups"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 )
 
-// Check is the agent-side core check that consumes per-cgroup scheduling and
-// PMU stats from the system-probe noisyneighbor module and emits Datadog
-// metrics tagged by container. Run is not safe for concurrent invocations;
-// the collector framework serializes Run per check instance. The tagger
-// field is set by Factory; sysProbeClient and cgroupReader are set lazily
-// by Configure.
-type Check struct {
+// NoisyNeighborConfig holds the YAML-parseable configuration for the
+// noisy_neighbor check. The check currently has no tunable knobs, but the
+// type is kept so the standard check Configure flow can call Parse.
+type NoisyNeighborConfig struct{}
+
+// NoisyNeighborCheck is the agent-side core check that consumes per-cgroup
+// scheduling and PMU stats from the system-probe noisyneighbor module and
+// emits Datadog metrics tagged by container.
+type NoisyNeighborCheck struct {
 	core.CheckBase
+	config         *NoisyNeighborConfig
 	tagger         tagger.Component
 	sysProbeClient *sysprobeclient.CheckClient
 	cgroupReader   *cgroups.Reader
@@ -41,114 +47,119 @@ type Check struct {
 
 // Factory returns the check.Check constructor used by the collector to
 // instantiate the noisy_neighbor check.
-func Factory(t tagger.Component) option.Option[func() check.Check] {
+func Factory(tagger tagger.Component) option.Option[func() check.Check] {
 	return option.New(func() check.Check {
-		return &Check{
-			CheckBase: core.NewCheckBaseWithInterval(CheckName, 10*time.Second),
-			tagger:    t,
-		}
+		return newCheck(tagger)
 	})
+}
+
+func newCheck(tagger tagger.Component) check.Check {
+	return &NoisyNeighborCheck{
+		CheckBase: core.NewCheckBaseWithInterval(CheckName, 10*time.Second),
+		config:    &NoisyNeighborConfig{},
+		tagger:    tagger,
+	}
+}
+
+// Parse unmarshals the check's YAML configuration into c.
+func (c *NoisyNeighborConfig) Parse(data []byte) error {
+	return yaml.Unmarshal(data, c)
 }
 
 // Configure sets up the check by parsing its configuration, building a
 // system-probe client, and initializing the cgroup reader used for tagging.
-func (c *Check) Configure(senderManager sender.SenderManager, _ uint64, config, initConfig integration.Data, source, provider string) error {
-	if err := c.CommonConfigure(senderManager, initConfig, config, source, provider); err != nil {
-		return fmt.Errorf("noisy_neighbor: common configure: %w", err)
+func (n *NoisyNeighborCheck) Configure(senderManager sender.SenderManager, _ uint64, config, initConfig integration.Data, source string, provider string) error {
+	if err := n.CommonConfigure(senderManager, initConfig, config, source, provider); err != nil {
+		return err
 	}
-	socketPath := pkgconfigsetup.SystemProbe().GetString("system_probe_config.sysprobe_socket")
-	c.sysProbeClient = sysprobeclient.GetCheckClient(sysprobeclient.WithSocketPath(socketPath))
+	if err := n.config.Parse(config); err != nil {
+		return fmt.Errorf("noisy_neighbor check config: %w", err)
+	}
+	n.sysProbeClient = sysprobeclient.GetCheckClient(sysprobeclient.WithSocketPath(pkgconfigsetup.SystemProbe().GetString("system_probe_config.sysprobe_socket")))
 	reader, err := cgroups.NewReader(cgroups.WithReaderFilter(cgroups.ContainerFilter))
 	if err != nil {
 		return fmt.Errorf("noisy_neighbor: cgroup reader init failed: %w", err)
 	}
-	c.cgroupReader = reader
+	n.cgroupReader = reader
 	return nil
 }
 
 // Run fetches the latest per-cgroup stats from system-probe, refreshes the
 // cgroup reader, and emits Datadog metrics for each tracked container.
-func (c *Check) Run() error {
-	stats, err := sysprobeclient.GetCheck[[]model.Stats](c.sysProbeClient, sysconfig.NoisyNeighborModule)
+func (n *NoisyNeighborCheck) Run() error {
+	stats, err := sysprobeclient.GetCheck[[]model.NoisyNeighborStats](n.sysProbeClient, sysconfig.NoisyNeighborModule)
 	if err != nil {
-		return fmt.Errorf("noisy_neighbor: get check from system-probe: %w", err)
+		return fmt.Errorf("get noisy neighbor check: %w", err)
 	}
 
-	s, err := c.GetSender()
+	sender, err := n.GetSender()
 	if err != nil {
-		return fmt.Errorf("noisy_neighbor: get metric sender: %w", err)
+		return fmt.Errorf("get metric sender: %w", err)
 	}
 
-	if err := c.cgroupReader.RefreshCgroups(0); err != nil {
-		return fmt.Errorf("noisy_neighbor: refresh cgroups: %w", err)
+	err = n.cgroupReader.RefreshCgroups(0)
+	if err != nil {
+		return fmt.Errorf("unable to refresh cgroups: %w", err)
 	}
 
-	for i := range stats {
-		stat := &stats[i]
-		cg := c.cgroupReader.GetCgroupByInode(stat.CgroupID)
-		tags := containerTags(c.tagger, cg)
-		submitPrimaryMetrics(s, stat, tags)
-		submitRawCounters(s, stat, tags)
-		submitPSIFullMetrics(s, cg, stat, tags)
+	var totalCgroups uint64
+	for _, stat := range stats {
+		totalCgroups++
+		tags := n.getContainerTags(stat)
+		n.submitPrimaryMetrics(sender, stat, tags)
+		n.submitRawCounters(sender, stat, tags)
+		n.submitPSIFullMetrics(sender, stat, tags)
 	}
-	s.Gauge("noisy_neighbor.system.cgroups_tracked", float64(len(stats)), "", nil)
-	s.Commit()
+	sender.Gauge("noisy_neighbor.system.cgroups_tracked", float64(totalCgroups), "", nil)
+	sender.Commit()
 	return nil
 }
 
-// containerTags returns high-cardinality container tags for the given
-// cgroup, or nil if the cgroup is not a container or the tagger has no
-// entry for it.
-func containerTags(t tagger.Component, cg cgroups.Cgroup) []string {
-	if cg == nil {
-		return nil
+func (n *NoisyNeighborCheck) getContainerTags(stat model.NoisyNeighborStats) []string {
+	if cg := n.cgroupReader.GetCgroupByInode(stat.CgroupID); cg != nil {
+		containerID := cg.Identifier()
+		if containerID != "" {
+			entityID := types.NewEntityID(types.ContainerID, containerID)
+			if !entityID.Empty() {
+				taggerTags, err := n.tagger.Tag(entityID, types.HighCardinality)
+				if err != nil {
+					log.Warnf("noisy_neighbor: tagger error for container %s: %v", containerID, err)
+				} else {
+					return taggerTags
+				}
+			}
+		}
 	}
-	containerID := cg.Identifier()
-	if containerID == "" {
-		return nil
-	}
-	entityID := types.NewEntityID(types.ContainerID, containerID)
-	if entityID.Empty() {
-		return nil
-	}
-	tags, err := t.Tag(entityID, types.HighCardinality)
-	if err != nil {
-		log.Warnf("noisy_neighbor: tagger error for container %s: %v", containerID, err)
-		return nil
-	}
-	return tags
+	return []string{}
 }
 
-// submitPrimaryMetrics sends the main PSL (per-process scheduling latency)
-// and PSP (per-process preemption) metrics. Note: "process" in metric names
-// follows kernel convention, but these are thread-level measurements.
-func submitPrimaryMetrics(s sender.Sender, stat *model.Stats, tags []string) {
+// submitPrimaryMetrics sends the main PSL and PSP metrics
+// Note: "process" in metric names follows kernel convention, but these are thread-level measurements
+func (n *NoisyNeighborCheck) submitPrimaryMetrics(sender sender.Sender, stat model.NoisyNeighborStats, tags []string) {
 	if stat.UniquePidCount == 0 {
 		return
 	}
 
 	psl := float64(stat.SumLatenciesNs) / float64(stat.UniquePidCount)
-	s.Gauge("noisy_neighbor.process_scheduling_latency.per_process", psl, "", tags)
+	sender.Gauge("noisy_neighbor.process_scheduling_latency.per_process", psl, "", tags)
 
 	psp := float64(stat.PreemptionCount) / float64(stat.UniquePidCount)
-	s.Gauge("noisy_neighbor.process_scheduler_preemptions.per_process", psp, "", tags)
+	sender.Gauge("noisy_neighbor.process_scheduler_preemptions.per_process", psp, "", tags)
 }
 
-// submitRawCounters emits cumulative scheduling and PMU counters as Counts
-// and the unique-PID cardinality as a Gauge.
-func submitRawCounters(s sender.Sender, stat *model.Stats, tags []string) {
-	s.Count("noisy_neighbor.events.total", float64(stat.EventCount), "", tags)
-	s.Gauge("noisy_neighbor.unique_processes", float64(stat.UniquePidCount), "", tags)
-	s.Count("noisy_neighbor.cycles", float64(stat.SumCycles), "", tags)
-	s.Count("noisy_neighbor.instructions", float64(stat.SumInstructions), "", tags)
-	s.Count("noisy_neighbor.llc_misses", float64(stat.SumLLCMisses), "", tags)
-	s.Count("noisy_neighbor.cache_references", float64(stat.SumCacheReferences), "", tags)
-	s.Count("noisy_neighbor.itlb_misses", float64(stat.SumITLBMisses), "", tags)
-	s.Count("noisy_neighbor.branch_misses", float64(stat.SumBranchMisses), "", tags)
-	s.Count("noisy_neighbor.cpu_migrations", float64(stat.SumCPUMigrations), "", tags)
-	s.Count("noisy_neighbor.softirq_ns", float64(stat.SumSoftirqNs), "", tags)
-	s.Count("noisy_neighbor.block_io_requests", float64(stat.BlockIORequests), "", tags)
-	s.Count("noisy_neighbor.wakeups", float64(stat.WakeupCount), "", tags)
+func (n *NoisyNeighborCheck) submitRawCounters(sender sender.Sender, stat model.NoisyNeighborStats, tags []string) {
+	sender.Count("noisy_neighbor.events.total", float64(stat.EventCount), "", tags)
+	sender.Gauge("noisy_neighbor.unique_processes", float64(stat.UniquePidCount), "", tags)
+	sender.Count("noisy_neighbor.cycles", float64(stat.SumCycles), "", tags)
+	sender.Count("noisy_neighbor.instructions", float64(stat.SumInstructions), "", tags)
+	sender.Count("noisy_neighbor.llc_misses", float64(stat.SumLLCMisses), "", tags)
+	sender.Count("noisy_neighbor.cache_references", float64(stat.SumCacheReferences), "", tags)
+	sender.Count("noisy_neighbor.itlb_misses", float64(stat.SumITLBMisses), "", tags)
+	sender.Count("noisy_neighbor.branch_misses", float64(stat.SumBranchMisses), "", tags)
+	sender.Count("noisy_neighbor.cpu_migrations", float64(stat.SumCPUMigrations), "", tags)
+	sender.Count("noisy_neighbor.softirq_ns", float64(stat.SumSoftirqNs), "", tags)
+	sender.Count("noisy_neighbor.block_io_requests", float64(stat.BlockIORequests), "", tags)
+	sender.Count("noisy_neighbor.wakeups", float64(stat.WakeupCount), "", tags)
 }
 
 // submitPSIFullMetrics emits the cgroup-scoped PSI "full" stalls for memory
@@ -162,7 +173,8 @@ func submitRawCounters(s sender.Sender, stat *model.Stats, tags []string) {
 // (rather than Rate or MonotonicCount) means single-shot `agent check`
 // invocations include the value, which Rate/MonotonicCount would drop for
 // lack of a prior sample.
-func submitPSIFullMetrics(s sender.Sender, cg cgroups.Cgroup, stat *model.Stats, tags []string) {
+func (n *NoisyNeighborCheck) submitPSIFullMetrics(sender sender.Sender, stat model.NoisyNeighborStats, tags []string) {
+	cg := n.cgroupReader.GetCgroupByInode(stat.CgroupID)
 	if cg == nil {
 		log.Debugf("noisy_neighbor: cgroup not found for inode %d, skipping PSI metrics", stat.CgroupID)
 		return
@@ -171,12 +183,12 @@ func submitPSIFullMetrics(s sender.Sender, cg cgroups.Cgroup, stat *model.Stats,
 	if err := cg.GetMemoryStats(memStats); err != nil {
 		log.Debugf("noisy_neighbor: GetMemoryStats failed for cgroup %d: %v", stat.CgroupID, err)
 	} else if memStats.PSIFull.Total != nil {
-		s.Gauge("noisy_neighbor.memory.pressure.full.total_us", float64(*memStats.PSIFull.Total), "", tags)
+		sender.Gauge("noisy_neighbor.memory.pressure.full.total_us", float64(*memStats.PSIFull.Total), "", tags)
 	}
 	ioStats := &cgroups.IOStats{}
 	if err := cg.GetIOStats(ioStats); err != nil {
 		log.Debugf("noisy_neighbor: GetIOStats failed for cgroup %d: %v", stat.CgroupID, err)
 	} else if ioStats.PSIFull.Total != nil {
-		s.Gauge("noisy_neighbor.io.pressure.full.total_us", float64(*ioStats.PSIFull.Total), "", tags)
+		sender.Gauge("noisy_neighbor.io.pressure.full.total_us", float64(*ioStats.PSIFull.Total), "", tags)
 	}
 }

--- a/pkg/collector/corechecks/ebpf/noisyneighbor/noisy_neighbor.go
+++ b/pkg/collector/corechecks/ebpf/noisyneighbor/noisy_neighbor.go
@@ -29,8 +29,14 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 )
 
+// NoisyNeighborConfig holds the YAML-parseable configuration for the
+// noisy_neighbor check. The check currently has no tunable knobs, but the
+// type is kept so the standard check Configure flow can call Parse.
 type NoisyNeighborConfig struct{}
 
+// NoisyNeighborCheck is the agent-side core check that consumes per-cgroup
+// scheduling and PMU stats from the system-probe noisyneighbor module and
+// emits Datadog metrics tagged by container.
 type NoisyNeighborCheck struct {
 	core.CheckBase
 	config         *NoisyNeighborConfig
@@ -39,6 +45,8 @@ type NoisyNeighborCheck struct {
 	cgroupReader   *cgroups.Reader
 }
 
+// Factory returns the check.Check constructor used by the collector to
+// instantiate the noisy_neighbor check.
 func Factory(tagger tagger.Component) option.Option[func() check.Check] {
 	return option.New(func() check.Check {
 		return newCheck(tagger)
@@ -53,40 +61,45 @@ func newCheck(tagger tagger.Component) check.Check {
 	}
 }
 
+// Parse unmarshals the check's YAML configuration into c.
 func (c *NoisyNeighborConfig) Parse(data []byte) error {
 	return yaml.Unmarshal(data, c)
 }
 
+// Configure sets up the check by parsing its configuration, building a
+// system-probe client, and initializing the cgroup reader used for tagging.
 func (n *NoisyNeighborCheck) Configure(senderManager sender.SenderManager, _ uint64, config, initConfig integration.Data, source string, provider string) error {
 	if err := n.CommonConfigure(senderManager, initConfig, config, source, provider); err != nil {
 		return err
 	}
 	if err := n.config.Parse(config); err != nil {
-		return fmt.Errorf("noisy_neighbor check config: %s", err)
+		return fmt.Errorf("noisy_neighbor check config: %w", err)
 	}
 	n.sysProbeClient = sysprobeclient.GetCheckClient(sysprobeclient.WithSocketPath(pkgconfigsetup.SystemProbe().GetString("system_probe_config.sysprobe_socket")))
 	reader, err := cgroups.NewReader(cgroups.WithReaderFilter(cgroups.ContainerFilter))
 	if err != nil {
-		return fmt.Errorf("noisy_neighbor: cgroup reader init failed: %s", err)
+		return fmt.Errorf("noisy_neighbor: cgroup reader init failed: %w", err)
 	}
 	n.cgroupReader = reader
 	return nil
 }
 
+// Run fetches the latest per-cgroup stats from system-probe, refreshes the
+// cgroup reader, and emits Datadog metrics for each tracked container.
 func (n *NoisyNeighborCheck) Run() error {
 	stats, err := sysprobeclient.GetCheck[[]model.NoisyNeighborStats](n.sysProbeClient, sysconfig.NoisyNeighborModule)
 	if err != nil {
-		return fmt.Errorf("get noisy neighbor check: %s", err)
+		return fmt.Errorf("get noisy neighbor check: %w", err)
 	}
 
 	sender, err := n.GetSender()
 	if err != nil {
-		return fmt.Errorf("get metric sender: %s", err)
+		return fmt.Errorf("get metric sender: %w", err)
 	}
 
 	err = n.cgroupReader.RefreshCgroups(0)
 	if err != nil {
-		return fmt.Errorf("unable to refresh cgroups: %s", err)
+		return fmt.Errorf("unable to refresh cgroups: %w", err)
 	}
 
 	var totalCgroups uint64
@@ -95,6 +108,7 @@ func (n *NoisyNeighborCheck) Run() error {
 		tags := n.getContainerTags(stat)
 		n.submitPrimaryMetrics(sender, stat, tags)
 		n.submitRawCounters(sender, stat, tags)
+		n.submitPSIFullMetrics(sender, stat, tags)
 	}
 	sender.Gauge("noisy_neighbor.system.cgroups_tracked", float64(totalCgroups), "", nil)
 	sender.Commit()
@@ -140,6 +154,40 @@ func (n *NoisyNeighborCheck) submitRawCounters(sender sender.Sender, stat model.
 	sender.Count("noisy_neighbor.instructions", float64(stat.SumInstructions), "", tags)
 	sender.Count("noisy_neighbor.llc_misses", float64(stat.SumLLCMisses), "", tags)
 	sender.Count("noisy_neighbor.itlb_misses", float64(stat.SumITLBMisses), "", tags)
+	sender.Count("noisy_neighbor.branch_misses", float64(stat.SumBranchMisses), "", tags)
+	sender.Count("noisy_neighbor.cpu_migrations", float64(stat.SumCPUMigrations), "", tags)
 	sender.Count("noisy_neighbor.softirq_ns", float64(stat.SumSoftirqNs), "", tags)
 	sender.Count("noisy_neighbor.block_io_requests", float64(stat.BlockIORequests), "", tags)
+	sender.Count("noisy_neighbor.wakeups", float64(stat.WakeupCount), "", tags)
+}
+
+// submitPSIFullMetrics emits the cgroup-scoped PSI "full" stalls for memory
+// and io. The "some" variants are already emitted by the generic container
+// processor as container.{memory,io}.partial_stall — we deliberately do not
+// duplicate those here. CPU "full" PSI is not exposed at the cgroup level
+// by the kernel.
+//
+// Emitted as Gauge of the cumulative-since-cgroup-creation microsecond
+// counter. Backend or dashboard math can compute deltas; emitting Gauge
+// (rather than Rate or MonotonicCount) means single-shot `agent check`
+// invocations include the value, which Rate/MonotonicCount would drop for
+// lack of a prior sample.
+func (n *NoisyNeighborCheck) submitPSIFullMetrics(sender sender.Sender, stat model.NoisyNeighborStats, tags []string) {
+	cg := n.cgroupReader.GetCgroupByInode(stat.CgroupID)
+	if cg == nil {
+		log.Debugf("noisy_neighbor: cgroup not found for inode %d, skipping PSI metrics", stat.CgroupID)
+		return
+	}
+	memStats := &cgroups.MemoryStats{}
+	if err := cg.GetMemoryStats(memStats); err != nil {
+		log.Debugf("noisy_neighbor: GetMemoryStats failed for cgroup %d: %v", stat.CgroupID, err)
+	} else if memStats.PSIFull.Total != nil {
+		sender.Gauge("noisy_neighbor.memory.pressure.full.total_us", float64(*memStats.PSIFull.Total), "", tags)
+	}
+	ioStats := &cgroups.IOStats{}
+	if err := cg.GetIOStats(ioStats); err != nil {
+		log.Debugf("noisy_neighbor: GetIOStats failed for cgroup %d: %v", stat.CgroupID, err)
+	} else if ioStats.PSIFull.Total != nil {
+		sender.Gauge("noisy_neighbor.io.pressure.full.total_us", float64(*ioStats.PSIFull.Total), "", tags)
+	}
 }

--- a/pkg/collector/corechecks/ebpf/noisyneighbor/noisy_neighbor.go
+++ b/pkg/collector/corechecks/ebpf/noisyneighbor/noisy_neighbor.go
@@ -51,7 +51,7 @@ type NoisyNeighborCheck struct {
 }
 
 var pmuMetricConfigKeys = []string{
-	"cycles", "instructions", "llc_misses", "cache_references",
+	"cycles", "instructions", "cache_misses", "cache_references",
 	"itlb_misses", "branch_misses", "cpu_migrations",
 }
 
@@ -178,8 +178,8 @@ func (n *NoisyNeighborCheck) submitRawCounters(sender sender.Sender, stat model.
 	if n.pmuMetricsEnabled["instructions"] {
 		sender.Count("noisy_neighbor.instructions", float64(stat.SumInstructions), "", tags)
 	}
-	if n.pmuMetricsEnabled["llc_misses"] {
-		sender.Count("noisy_neighbor.llc_misses", float64(stat.SumLLCMisses), "", tags)
+	if n.pmuMetricsEnabled["cache_misses"] {
+		sender.Count("noisy_neighbor.cache_misses", float64(stat.SumCacheMisses), "", tags)
 	}
 	if n.pmuMetricsEnabled["cache_references"] {
 		sender.Count("noisy_neighbor.cache_references", float64(stat.SumCacheReferences), "", tags)

--- a/pkg/collector/corechecks/ebpf/noisyneighbor/noisy_neighbor.go
+++ b/pkg/collector/corechecks/ebpf/noisyneighbor/noisy_neighbor.go
@@ -11,35 +11,29 @@ import (
 	"fmt"
 	"time"
 
-	"go.yaml.in/yaml/v2"
-
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
-	sysprobeclient "github.com/DataDog/datadog-agent/pkg/system-probe/api/client"
-	sysconfig "github.com/DataDog/datadog-agent/pkg/system-probe/config"
-
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe/noisyneighbor/model"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	sysprobeclient "github.com/DataDog/datadog-agent/pkg/system-probe/api/client"
+	sysconfig "github.com/DataDog/datadog-agent/pkg/system-probe/config"
 	"github.com/DataDog/datadog-agent/pkg/util/cgroups"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 )
 
-// NoisyNeighborConfig holds the YAML-parseable configuration for the
-// noisy_neighbor check. The check currently has no tunable knobs, but the
-// type is kept so the standard check Configure flow can call Parse.
-type NoisyNeighborConfig struct{}
-
-// NoisyNeighborCheck is the agent-side core check that consumes per-cgroup
-// scheduling and PMU stats from the system-probe noisyneighbor module and
-// emits Datadog metrics tagged by container.
-type NoisyNeighborCheck struct {
+// Check is the agent-side core check that consumes per-cgroup scheduling and
+// PMU stats from the system-probe noisyneighbor module and emits Datadog
+// metrics tagged by container. Run is not safe for concurrent invocations;
+// the collector framework serializes Run per check instance. The tagger
+// field is set by Factory; sysProbeClient and cgroupReader are set lazily
+// by Configure.
+type Check struct {
 	core.CheckBase
-	config         *NoisyNeighborConfig
 	tagger         tagger.Component
 	sysProbeClient *sysprobeclient.CheckClient
 	cgroupReader   *cgroups.Reader
@@ -47,119 +41,114 @@ type NoisyNeighborCheck struct {
 
 // Factory returns the check.Check constructor used by the collector to
 // instantiate the noisy_neighbor check.
-func Factory(tagger tagger.Component) option.Option[func() check.Check] {
+func Factory(t tagger.Component) option.Option[func() check.Check] {
 	return option.New(func() check.Check {
-		return newCheck(tagger)
+		return &Check{
+			CheckBase: core.NewCheckBaseWithInterval(CheckName, 10*time.Second),
+			tagger:    t,
+		}
 	})
-}
-
-func newCheck(tagger tagger.Component) check.Check {
-	return &NoisyNeighborCheck{
-		CheckBase: core.NewCheckBaseWithInterval(CheckName, 10*time.Second),
-		config:    &NoisyNeighborConfig{},
-		tagger:    tagger,
-	}
-}
-
-// Parse unmarshals the check's YAML configuration into c.
-func (c *NoisyNeighborConfig) Parse(data []byte) error {
-	return yaml.Unmarshal(data, c)
 }
 
 // Configure sets up the check by parsing its configuration, building a
 // system-probe client, and initializing the cgroup reader used for tagging.
-func (n *NoisyNeighborCheck) Configure(senderManager sender.SenderManager, _ uint64, config, initConfig integration.Data, source string, provider string) error {
-	if err := n.CommonConfigure(senderManager, initConfig, config, source, provider); err != nil {
-		return err
+func (c *Check) Configure(senderManager sender.SenderManager, _ uint64, config, initConfig integration.Data, source, provider string) error {
+	if err := c.CommonConfigure(senderManager, initConfig, config, source, provider); err != nil {
+		return fmt.Errorf("noisy_neighbor: common configure: %w", err)
 	}
-	if err := n.config.Parse(config); err != nil {
-		return fmt.Errorf("noisy_neighbor check config: %w", err)
-	}
-	n.sysProbeClient = sysprobeclient.GetCheckClient(sysprobeclient.WithSocketPath(pkgconfigsetup.SystemProbe().GetString("system_probe_config.sysprobe_socket")))
+	socketPath := pkgconfigsetup.SystemProbe().GetString("system_probe_config.sysprobe_socket")
+	c.sysProbeClient = sysprobeclient.GetCheckClient(sysprobeclient.WithSocketPath(socketPath))
 	reader, err := cgroups.NewReader(cgroups.WithReaderFilter(cgroups.ContainerFilter))
 	if err != nil {
 		return fmt.Errorf("noisy_neighbor: cgroup reader init failed: %w", err)
 	}
-	n.cgroupReader = reader
+	c.cgroupReader = reader
 	return nil
 }
 
 // Run fetches the latest per-cgroup stats from system-probe, refreshes the
 // cgroup reader, and emits Datadog metrics for each tracked container.
-func (n *NoisyNeighborCheck) Run() error {
-	stats, err := sysprobeclient.GetCheck[[]model.NoisyNeighborStats](n.sysProbeClient, sysconfig.NoisyNeighborModule)
+func (c *Check) Run() error {
+	stats, err := sysprobeclient.GetCheck[[]model.Stats](c.sysProbeClient, sysconfig.NoisyNeighborModule)
 	if err != nil {
-		return fmt.Errorf("get noisy neighbor check: %w", err)
+		return fmt.Errorf("noisy_neighbor: get check from system-probe: %w", err)
 	}
 
-	sender, err := n.GetSender()
+	s, err := c.GetSender()
 	if err != nil {
-		return fmt.Errorf("get metric sender: %w", err)
+		return fmt.Errorf("noisy_neighbor: get metric sender: %w", err)
 	}
 
-	err = n.cgroupReader.RefreshCgroups(0)
-	if err != nil {
-		return fmt.Errorf("unable to refresh cgroups: %w", err)
+	if err := c.cgroupReader.RefreshCgroups(0); err != nil {
+		return fmt.Errorf("noisy_neighbor: refresh cgroups: %w", err)
 	}
 
-	var totalCgroups uint64
-	for _, stat := range stats {
-		totalCgroups++
-		tags := n.getContainerTags(stat)
-		n.submitPrimaryMetrics(sender, stat, tags)
-		n.submitRawCounters(sender, stat, tags)
-		n.submitPSIFullMetrics(sender, stat, tags)
+	for i := range stats {
+		stat := &stats[i]
+		cg := c.cgroupReader.GetCgroupByInode(stat.CgroupID)
+		tags := containerTags(c.tagger, cg)
+		submitPrimaryMetrics(s, stat, tags)
+		submitRawCounters(s, stat, tags)
+		submitPSIFullMetrics(s, cg, stat, tags)
 	}
-	sender.Gauge("noisy_neighbor.system.cgroups_tracked", float64(totalCgroups), "", nil)
-	sender.Commit()
+	s.Gauge("noisy_neighbor.system.cgroups_tracked", float64(len(stats)), "", nil)
+	s.Commit()
 	return nil
 }
 
-func (n *NoisyNeighborCheck) getContainerTags(stat model.NoisyNeighborStats) []string {
-	if cg := n.cgroupReader.GetCgroupByInode(stat.CgroupID); cg != nil {
-		containerID := cg.Identifier()
-		if containerID != "" {
-			entityID := types.NewEntityID(types.ContainerID, containerID)
-			if !entityID.Empty() {
-				taggerTags, err := n.tagger.Tag(entityID, types.HighCardinality)
-				if err != nil {
-					log.Warnf("noisy_neighbor: tagger error for container %s: %v", containerID, err)
-				} else {
-					return taggerTags
-				}
-			}
-		}
+// containerTags returns high-cardinality container tags for the given
+// cgroup, or nil if the cgroup is not a container or the tagger has no
+// entry for it.
+func containerTags(t tagger.Component, cg cgroups.Cgroup) []string {
+	if cg == nil {
+		return nil
 	}
-	return []string{}
+	containerID := cg.Identifier()
+	if containerID == "" {
+		return nil
+	}
+	entityID := types.NewEntityID(types.ContainerID, containerID)
+	if entityID.Empty() {
+		return nil
+	}
+	tags, err := t.Tag(entityID, types.HighCardinality)
+	if err != nil {
+		log.Warnf("noisy_neighbor: tagger error for container %s: %v", containerID, err)
+		return nil
+	}
+	return tags
 }
 
-// submitPrimaryMetrics sends the main PSL and PSP metrics
-// Note: "process" in metric names follows kernel convention, but these are thread-level measurements
-func (n *NoisyNeighborCheck) submitPrimaryMetrics(sender sender.Sender, stat model.NoisyNeighborStats, tags []string) {
+// submitPrimaryMetrics sends the main PSL (per-process scheduling latency)
+// and PSP (per-process preemption) metrics. Note: "process" in metric names
+// follows kernel convention, but these are thread-level measurements.
+func submitPrimaryMetrics(s sender.Sender, stat *model.Stats, tags []string) {
 	if stat.UniquePidCount == 0 {
 		return
 	}
 
 	psl := float64(stat.SumLatenciesNs) / float64(stat.UniquePidCount)
-	sender.Gauge("noisy_neighbor.process_scheduling_latency.per_process", psl, "", tags)
+	s.Gauge("noisy_neighbor.process_scheduling_latency.per_process", psl, "", tags)
 
 	psp := float64(stat.PreemptionCount) / float64(stat.UniquePidCount)
-	sender.Gauge("noisy_neighbor.process_scheduler_preemptions.per_process", psp, "", tags)
+	s.Gauge("noisy_neighbor.process_scheduler_preemptions.per_process", psp, "", tags)
 }
 
-func (n *NoisyNeighborCheck) submitRawCounters(sender sender.Sender, stat model.NoisyNeighborStats, tags []string) {
-	sender.Count("noisy_neighbor.events.total", float64(stat.EventCount), "", tags)
-	sender.Gauge("noisy_neighbor.unique_processes", float64(stat.UniquePidCount), "", tags)
-	sender.Count("noisy_neighbor.cycles", float64(stat.SumCycles), "", tags)
-	sender.Count("noisy_neighbor.instructions", float64(stat.SumInstructions), "", tags)
-	sender.Count("noisy_neighbor.llc_misses", float64(stat.SumLLCMisses), "", tags)
-	sender.Count("noisy_neighbor.cache_references", float64(stat.SumCacheReferences), "", tags)
-	sender.Count("noisy_neighbor.itlb_misses", float64(stat.SumITLBMisses), "", tags)
-	sender.Count("noisy_neighbor.branch_misses", float64(stat.SumBranchMisses), "", tags)
-	sender.Count("noisy_neighbor.cpu_migrations", float64(stat.SumCPUMigrations), "", tags)
-	sender.Count("noisy_neighbor.softirq_ns", float64(stat.SumSoftirqNs), "", tags)
-	sender.Count("noisy_neighbor.block_io_requests", float64(stat.BlockIORequests), "", tags)
-	sender.Count("noisy_neighbor.wakeups", float64(stat.WakeupCount), "", tags)
+// submitRawCounters emits cumulative scheduling and PMU counters as Counts
+// and the unique-PID cardinality as a Gauge.
+func submitRawCounters(s sender.Sender, stat *model.Stats, tags []string) {
+	s.Count("noisy_neighbor.events.total", float64(stat.EventCount), "", tags)
+	s.Gauge("noisy_neighbor.unique_processes", float64(stat.UniquePidCount), "", tags)
+	s.Count("noisy_neighbor.cycles", float64(stat.SumCycles), "", tags)
+	s.Count("noisy_neighbor.instructions", float64(stat.SumInstructions), "", tags)
+	s.Count("noisy_neighbor.llc_misses", float64(stat.SumLLCMisses), "", tags)
+	s.Count("noisy_neighbor.cache_references", float64(stat.SumCacheReferences), "", tags)
+	s.Count("noisy_neighbor.itlb_misses", float64(stat.SumITLBMisses), "", tags)
+	s.Count("noisy_neighbor.branch_misses", float64(stat.SumBranchMisses), "", tags)
+	s.Count("noisy_neighbor.cpu_migrations", float64(stat.SumCPUMigrations), "", tags)
+	s.Count("noisy_neighbor.softirq_ns", float64(stat.SumSoftirqNs), "", tags)
+	s.Count("noisy_neighbor.block_io_requests", float64(stat.BlockIORequests), "", tags)
+	s.Count("noisy_neighbor.wakeups", float64(stat.WakeupCount), "", tags)
 }
 
 // submitPSIFullMetrics emits the cgroup-scoped PSI "full" stalls for memory
@@ -173,8 +162,7 @@ func (n *NoisyNeighborCheck) submitRawCounters(sender sender.Sender, stat model.
 // (rather than Rate or MonotonicCount) means single-shot `agent check`
 // invocations include the value, which Rate/MonotonicCount would drop for
 // lack of a prior sample.
-func (n *NoisyNeighborCheck) submitPSIFullMetrics(sender sender.Sender, stat model.NoisyNeighborStats, tags []string) {
-	cg := n.cgroupReader.GetCgroupByInode(stat.CgroupID)
+func submitPSIFullMetrics(s sender.Sender, cg cgroups.Cgroup, stat *model.Stats, tags []string) {
 	if cg == nil {
 		log.Debugf("noisy_neighbor: cgroup not found for inode %d, skipping PSI metrics", stat.CgroupID)
 		return
@@ -183,12 +171,12 @@ func (n *NoisyNeighborCheck) submitPSIFullMetrics(sender sender.Sender, stat mod
 	if err := cg.GetMemoryStats(memStats); err != nil {
 		log.Debugf("noisy_neighbor: GetMemoryStats failed for cgroup %d: %v", stat.CgroupID, err)
 	} else if memStats.PSIFull.Total != nil {
-		sender.Gauge("noisy_neighbor.memory.pressure.full.total_us", float64(*memStats.PSIFull.Total), "", tags)
+		s.Gauge("noisy_neighbor.memory.pressure.full.total_us", float64(*memStats.PSIFull.Total), "", tags)
 	}
 	ioStats := &cgroups.IOStats{}
 	if err := cg.GetIOStats(ioStats); err != nil {
 		log.Debugf("noisy_neighbor: GetIOStats failed for cgroup %d: %v", stat.CgroupID, err)
 	} else if ioStats.PSIFull.Total != nil {
-		sender.Gauge("noisy_neighbor.io.pressure.full.total_us", float64(*ioStats.PSIFull.Total), "", tags)
+		s.Gauge("noisy_neighbor.io.pressure.full.total_us", float64(*ioStats.PSIFull.Total), "", tags)
 	}
 }

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/ebpf_types_linux.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/ebpf_types_linux.go
@@ -10,7 +10,7 @@ type ebpfCgroupAggStats struct {
 	Pid_count            uint64
 	Sum_cycles           uint64
 	Sum_instructions     uint64
-	Sum_llc_misses       uint64
+	Sum_cache_misses     uint64
 	Sum_itlb_misses      uint64
 	Sum_softirq_ns       uint64
 	Block_io_requests    uint64

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/ebpf_types_linux.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/ebpf_types_linux.go
@@ -4,17 +4,18 @@
 package noisyneighbor
 
 type ebpfCgroupAggStats struct {
-	Sum_latencies_ns   uint64
-	Event_count        uint64
-	Preemption_count   uint64
-	Pid_count          uint64
-	Sum_cycles         uint64
-	Sum_instructions   uint64
-	Sum_llc_misses     uint64
-	Sum_itlb_misses    uint64
-	Sum_softirq_ns     uint64
-	Block_io_requests  uint64
-	Sum_branch_misses  uint64
-	Sum_cpu_migrations uint64
-	Wakeup_count       uint64
+	Sum_latencies_ns     uint64
+	Event_count          uint64
+	Preemption_count     uint64
+	Pid_count            uint64
+	Sum_cycles           uint64
+	Sum_instructions     uint64
+	Sum_llc_misses       uint64
+	Sum_itlb_misses      uint64
+	Sum_softirq_ns       uint64
+	Block_io_requests    uint64
+	Sum_branch_misses    uint64
+	Sum_cpu_migrations   uint64
+	Wakeup_count         uint64
+	Sum_cache_references uint64
 }

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/ebpf_types_linux.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/ebpf_types_linux.go
@@ -8,4 +8,6 @@ type ebpfCgroupAggStats struct {
 	Event_count      uint64
 	Preemption_count uint64
 	Pid_count        uint64
+	Sum_cycles       uint64
+	Sum_instructions uint64
 }

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/ebpf_types_linux.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/ebpf_types_linux.go
@@ -4,10 +4,14 @@
 package noisyneighbor
 
 type ebpfCgroupAggStats struct {
-	Sum_latencies_ns uint64
-	Event_count      uint64
-	Preemption_count uint64
-	Pid_count        uint64
-	Sum_cycles       uint64
-	Sum_instructions uint64
+	Sum_latencies_ns  uint64
+	Event_count       uint64
+	Preemption_count  uint64
+	Pid_count         uint64
+	Sum_cycles        uint64
+	Sum_instructions  uint64
+	Sum_llc_misses    uint64
+	Sum_itlb_misses   uint64
+	Sum_softirq_ns    uint64
+	Block_io_requests uint64
 }

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/ebpf_types_linux.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/ebpf_types_linux.go
@@ -4,14 +4,17 @@
 package noisyneighbor
 
 type ebpfCgroupAggStats struct {
-	Sum_latencies_ns  uint64
-	Event_count       uint64
-	Preemption_count  uint64
-	Pid_count         uint64
-	Sum_cycles        uint64
-	Sum_instructions  uint64
-	Sum_llc_misses    uint64
-	Sum_itlb_misses   uint64
-	Sum_softirq_ns    uint64
-	Block_io_requests uint64
+	Sum_latencies_ns   uint64
+	Event_count        uint64
+	Preemption_count   uint64
+	Pid_count          uint64
+	Sum_cycles         uint64
+	Sum_instructions   uint64
+	Sum_llc_misses     uint64
+	Sum_itlb_misses    uint64
+	Sum_softirq_ns     uint64
+	Block_io_requests  uint64
+	Sum_branch_misses  uint64
+	Sum_cpu_migrations uint64
+	Wakeup_count       uint64
 }

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/model/types.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/model/types.go
@@ -3,16 +3,20 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-// Package model contains the model for the noisy neighbor check
+// Package model contains the platform-neutral payload types shared between
+// the noisy_neighbor system-probe probe and the agent-side core check.
 package model
 
-// NoisyNeighborStats contains the statistics from the noisy neighbor check
-type NoisyNeighborStats struct {
-	CgroupID           uint64
-	SumLatenciesNs     uint64
-	EventCount         uint64
-	PreemptionCount    uint64
-	UniquePidCount     uint64 // kernel task_struct->pid (TID) count
+// Stats holds the aggregated per-cgroup scheduling and PMU counters emitted
+// by the noisy_neighbor probe for one collection window.
+type Stats struct {
+	CgroupID        uint64
+	SumLatenciesNs  uint64
+	EventCount      uint64
+	PreemptionCount uint64
+	// UniquePidCount is the number of distinct kernel task_struct->pid values
+	// observed (Linux TIDs, not POSIX PIDs).
+	UniquePidCount     uint64
 	SumCycles          uint64
 	SumInstructions    uint64
 	SumLLCMisses       uint64

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/model/types.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/model/types.go
@@ -8,18 +8,19 @@ package model
 
 // NoisyNeighborStats contains the statistics from the noisy neighbor check
 type NoisyNeighborStats struct {
-	CgroupID         uint64
-	SumLatenciesNs   uint64
-	EventCount       uint64
-	PreemptionCount  uint64
-	UniquePidCount   uint64 // kernel task_struct->pid (TID) count
-	SumCycles        uint64
-	SumInstructions  uint64
-	SumLLCMisses     uint64
-	SumITLBMisses    uint64
-	SumSoftirqNs     uint64
-	BlockIORequests  uint64
-	SumBranchMisses  uint64
-	SumCPUMigrations uint64
-	WakeupCount      uint64
+	CgroupID           uint64
+	SumLatenciesNs     uint64
+	EventCount         uint64
+	PreemptionCount    uint64
+	UniquePidCount     uint64 // kernel task_struct->pid (TID) count
+	SumCycles          uint64
+	SumInstructions    uint64
+	SumLLCMisses       uint64
+	SumITLBMisses      uint64
+	SumSoftirqNs       uint64
+	BlockIORequests    uint64
+	SumBranchMisses    uint64
+	SumCPUMigrations   uint64
+	WakeupCount        uint64
+	SumCacheReferences uint64
 }

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/model/types.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/model/types.go
@@ -13,4 +13,6 @@ type NoisyNeighborStats struct {
 	EventCount      uint64
 	PreemptionCount uint64
 	UniquePidCount  uint64 // kernel task_struct->pid (TID) count
+	SumCycles       uint64
+	SumInstructions uint64
 }

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/model/types.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/model/types.go
@@ -8,15 +8,18 @@ package model
 
 // NoisyNeighborStats contains the statistics from the noisy neighbor check
 type NoisyNeighborStats struct {
-	CgroupID        uint64
-	SumLatenciesNs  uint64
-	EventCount      uint64
-	PreemptionCount uint64
-	UniquePidCount  uint64 // kernel task_struct->pid (TID) count
-	SumCycles       uint64
-	SumInstructions uint64
-	SumLLCMisses    uint64
-	SumITLBMisses   uint64
-	SumSoftirqNs    uint64
-	BlockIORequests uint64
+	CgroupID         uint64
+	SumLatenciesNs   uint64
+	EventCount       uint64
+	PreemptionCount  uint64
+	UniquePidCount   uint64 // kernel task_struct->pid (TID) count
+	SumCycles        uint64
+	SumInstructions  uint64
+	SumLLCMisses     uint64
+	SumITLBMisses    uint64
+	SumSoftirqNs     uint64
+	BlockIORequests  uint64
+	SumBranchMisses  uint64
+	SumCPUMigrations uint64
+	WakeupCount      uint64
 }

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/model/types.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/model/types.go
@@ -15,7 +15,7 @@ type NoisyNeighborStats struct {
 	UniquePidCount     uint64 // kernel task_struct->pid (TID) count
 	SumCycles          uint64
 	SumInstructions    uint64
-	SumLLCMisses       uint64
+	SumCacheMisses     uint64
 	SumITLBMisses      uint64
 	SumSoftirqNs       uint64
 	BlockIORequests    uint64

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/model/types.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/model/types.go
@@ -15,4 +15,8 @@ type NoisyNeighborStats struct {
 	UniquePidCount  uint64 // kernel task_struct->pid (TID) count
 	SumCycles       uint64
 	SumInstructions uint64
+	SumLLCMisses    uint64
+	SumITLBMisses   uint64
+	SumSoftirqNs    uint64
+	BlockIORequests uint64
 }

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/model/types.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/model/types.go
@@ -3,20 +3,16 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-// Package model contains the platform-neutral payload types shared between
-// the noisy_neighbor system-probe probe and the agent-side core check.
+// Package model contains the model for the noisy neighbor check
 package model
 
-// Stats holds the aggregated per-cgroup scheduling and PMU counters emitted
-// by the noisy_neighbor probe for one collection window.
-type Stats struct {
-	CgroupID        uint64
-	SumLatenciesNs  uint64
-	EventCount      uint64
-	PreemptionCount uint64
-	// UniquePidCount is the number of distinct kernel task_struct->pid values
-	// observed (Linux TIDs, not POSIX PIDs).
-	UniquePidCount     uint64
+// NoisyNeighborStats contains the statistics from the noisy neighbor check
+type NoisyNeighborStats struct {
+	CgroupID           uint64
+	SumLatenciesNs     uint64
+	EventCount         uint64
+	PreemptionCount    uint64
+	UniquePidCount     uint64 // kernel task_struct->pid (TID) count
 	SumCycles          uint64
 	SumInstructions    uint64
 	SumLLCMisses       uint64

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
@@ -9,11 +9,8 @@
 package noisyneighbor
 
 import (
-	"context"
-	"errors"
 	"fmt"
 	"runtime"
-	"sync"
 	"unsafe"
 
 	manager "github.com/DataDog/ebpf-manager"
@@ -27,80 +24,32 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// minimumKernelVersion is 6.2.0, the first kernel with bpf_rcu_read_lock,
-// which the probe uses to walk task_struct pointers safely.
+// 5.13 for kfuncs, 6.2 for bpf_rcu_read_lock kfunc
 var minimumKernelVersion = kernel.VersionCode(6, 2, 0)
 
-// ErrKernelTooOld is returned by NewProbe when the host kernel is below
-// minimumKernelVersion. Callers can use errors.Is to skip the module silently
-// on unsupported hosts.
-var ErrKernelTooOld = errors.New("kernel version below minimum")
-
-// Probe is the eBPF side of the noisy neighbor check. Construct only via
-// NewProbe — the zero value is not usable.
+// Probe is the eBPF side of the noisy neighbor check
 type Probe struct {
-	// mgr and closeFn are set once during NewProbe (before *Probe is
-	// published to other goroutines) and never reassigned afterward; safe
-	// to read without holding mu.
-	mgr     *ddebpf.Manager
-	closeFn func()
-
-	// mu serializes GetAndFlush against doClose and guards pmuFds against
-	// concurrent shutdown. pmuFds is written by attachPMU (pre-publication,
-	// no lock required) and read/cleared in doClose under mu.
-	mu     sync.Mutex
-	pmuFds []int
+	mgr    *ddebpf.Manager
+	pmuFDs []int
 }
 
-// NewProbe loads the noisy_neighbor eBPF asset, attaches its tracepoints,
-// and opens per-CPU PMU counters. Returns an error wrapping ErrKernelTooOld
-// on unsupported hosts (callers can use errors.Is). PMU events that fail to
-// open are logged and skipped — the returned Probe is still usable, but the
-// affected counters report zero. On any error after manager initialization,
-// resources are released before the error is returned. The caller must
-// invoke Close to release the probe on the success path.
+// NewProbe creates a [Probe]
 func NewProbe(cfg *ddebpf.Config) (*Probe, error) {
-	if err := checkKernelVersion(); err != nil {
-		return nil, err
+	kv, err := kernel.HostVersion()
+	if err != nil {
+		return nil, fmt.Errorf("kernel version: %w", err)
+	}
+	if kv < minimumKernelVersion {
+		return nil, fmt.Errorf("minimum kernel version %s not met, read %s", minimumKernelVersion, kv)
 	}
 
 	p := &Probe{}
-	// Wire close before any resource-acquiring step so cleanup paths can
-	// rely on p.closeFn() to release everything.
-	p.closeFn = sync.OnceFunc(p.doClose)
 
-	if err := p.loadManager(cfg); err != nil {
-		return nil, err
-	}
-	if err := p.attachProbes(); err != nil {
-		p.closeFn()
-		return nil, err
-	}
-	ddebpf.AddNameMappings(p.mgr.Manager, "noisy_neighbor")
-	p.attachPMU()
-	return p, nil
-}
-
-func checkKernelVersion() error {
-	kv, err := kernel.HostVersion()
-	if err != nil {
-		return fmt.Errorf("kernel version: %w", err)
-	}
-	if kv < minimumKernelVersion {
-		return fmt.Errorf("%w: minimum %s, got %s", ErrKernelTooOld, minimumKernelVersion, kv)
-	}
-	return nil
-}
-
-// loadManager selects the noisy-neighbor BPF asset (debug or release) and
-// initializes the ebpf-manager with the tracepoints and maps the kernel
-// program expects.
-func (p *Probe) loadManager(cfg *ddebpf.Config) error {
 	filename := "noisy-neighbor.o"
 	if cfg.BPFDebug {
 		filename = "noisy-neighbor-debug.o"
 	}
-	err := ddebpf.LoadCOREAsset(filename, func(r bytecode.AssetReader, opts manager.Options) error {
+	err = ddebpf.LoadCOREAsset(filename, func(buf bytecode.AssetReader, opts manager.Options) error {
 		p.mgr = ddebpf.NewManagerWithDefault(&manager.Manager{}, "noisy_neighbor", &ebpftelemetry.ErrorsTelemetryModifier{})
 		const uid = "noisy"
 		p.mgr.Probes = []*manager.Probe{
@@ -124,35 +73,29 @@ func (p *Probe) loadManager(cfg *ddebpf.Config) error {
 			{Name: "cache_references_pmu"},
 			{Name: "softirq_start_ns"},
 		}
-		if err := p.mgr.InitWithOptions(r, &opts); err != nil {
-			return fmt.Errorf("init ebpf manager: %w", err)
+		if err := p.mgr.InitWithOptions(buf, &opts); err != nil {
+			return fmt.Errorf("failed to init ebpf manager: %w", err)
 		}
 		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("load CO-RE asset %s: %w", filename, err)
+		return nil, err
 	}
-	return nil
-}
 
-// attachProbes attaches each manager probe sequentially. On failure the
-// caller (NewProbe) is expected to invoke p.closeFn() so the partially-
-// loaded manager and any prior attachments are torn down by doClose.
-//
-// We skip mgr.Start() and attach probes manually: Start() runs
-// cleanupTraceFS which tries to remove ALL orphaned kprobe events on the
-// host and fails fatally if any are pinned (common on dev machines where
-// a previous agent left tail-called kprobes behind). This module only
-// uses tracepoints, so we don't need the perf/ring reader startup that
-// Start() also handles. Stop() requires state >= initialized, which
-// InitWithOptions already set.
-func (p *Probe) attachProbes() error {
+	// Skip mgr.Start() and attach probes manually. Start() runs cleanupTraceFS
+	// which tries to remove ALL orphaned kprobe events on the host and fails
+	// fatally if any are pinned (common on dev machines where a previous agent
+	// left tail-called kprobes behind). This module only uses tracepoints, so
+	// we don't need the perf/ring reader startup that Start() also handles.
+	// Stop() requires state >= initialized, which InitWithOptions already set.
 	for _, probe := range p.mgr.Probes {
 		if err := probe.Attach(); err != nil {
-			return fmt.Errorf("attach probe %s: %w", probe.EBPFFuncName, err)
+			return nil, fmt.Errorf("failed to attach probe %s: %w", probe.EBPFFuncName, err)
 		}
 	}
-	return nil
+	ddebpf.AddNameMappings(p.mgr.Manager, "noisy_neighbor")
+	p.attachPMU()
+	return p, nil
 }
 
 // pmuEvent describes one perf event (hardware or software counter) that we
@@ -170,27 +113,24 @@ const itlbLoadMissesConfig = uint64(unix.PERF_COUNT_HW_CACHE_ITLB) |
 	(uint64(unix.PERF_COUNT_HW_CACHE_RESULT_MISS) << 16)
 
 // attachPMU opens per-CPU perf events for every counter we track and
-// populates the corresponding BPF perf-event-array maps. Called only from
-// NewProbe before the Probe is published to other goroutines, so writes to
-// p.pmuFds need no synchronization. See attachPMUEvent for per-event
-// semantics and failure modes.
+// populates the corresponding BPF perf-event-array maps. See attachPMUEvent
+// for per-event semantics and failure modes.
 func (p *Probe) attachPMU() {
 	events := []pmuEvent{
-		{mapName: "cycles_pmu", humanLabel: "cycles", perfType: unix.PERF_TYPE_HARDWARE, perfConfig: unix.PERF_COUNT_HW_CPU_CYCLES},
-		{mapName: "instructions_pmu", humanLabel: "instructions", perfType: unix.PERF_TYPE_HARDWARE, perfConfig: unix.PERF_COUNT_HW_INSTRUCTIONS},
-		{mapName: "llc_misses_pmu", humanLabel: "LLC misses", perfType: unix.PERF_TYPE_HARDWARE, perfConfig: unix.PERF_COUNT_HW_CACHE_MISSES},
-		{mapName: "itlb_misses_pmu", humanLabel: "iTLB misses", perfType: unix.PERF_TYPE_HW_CACHE, perfConfig: itlbLoadMissesConfig},
-		{mapName: "branch_misses_pmu", humanLabel: "branch misses", perfType: unix.PERF_TYPE_HARDWARE, perfConfig: unix.PERF_COUNT_HW_BRANCH_MISSES},
+		{"cycles_pmu", "cycles", unix.PERF_TYPE_HARDWARE, unix.PERF_COUNT_HW_CPU_CYCLES},
+		{"instructions_pmu", "instructions", unix.PERF_TYPE_HARDWARE, unix.PERF_COUNT_HW_INSTRUCTIONS},
+		{"llc_misses_pmu", "LLC misses", unix.PERF_TYPE_HARDWARE, unix.PERF_COUNT_HW_CACHE_MISSES},
+		{"itlb_misses_pmu", "iTLB misses", unix.PERF_TYPE_HW_CACHE, itlbLoadMissesConfig},
+		{"branch_misses_pmu", "branch misses", unix.PERF_TYPE_HARDWARE, unix.PERF_COUNT_HW_BRANCH_MISSES},
 		// CPU migrations is a software counter — doesn't compete for hardware
 		// PMU counters and is always available regardless of µarch.
-		{mapName: "cpu_migrations_pmu", humanLabel: "CPU migrations", perfType: unix.PERF_TYPE_SOFTWARE, perfConfig: unix.PERF_COUNT_SW_CPU_MIGRATIONS},
+		{"cpu_migrations_pmu", "CPU migrations", unix.PERF_TYPE_SOFTWARE, unix.PERF_COUNT_SW_CPU_MIGRATIONS},
 		// Cache references pairs with llc_misses to give LLC hit-rate: under
 		// cache thrashing the rate moves even when absolute miss count stays
 		// flat for memory-bound workloads already at floor miss rate.
-		{mapName: "cache_references_pmu", humanLabel: "cache references", perfType: unix.PERF_TYPE_HARDWARE, perfConfig: unix.PERF_COUNT_HW_CACHE_REFERENCES},
+		{"cache_references_pmu", "cache references", unix.PERF_TYPE_HARDWARE, unix.PERF_COUNT_HW_CACHE_REFERENCES},
 	}
 	numCPU := runtime.NumCPU()
-	p.pmuFds = make([]int, 0, len(events)*numCPU)
 	for _, ev := range events {
 		p.attachPMUEvent(ev, numCPU)
 	}
@@ -204,17 +144,13 @@ func (p *Probe) attachPMU() {
 // checks each read-value return code and skips just that counter's deltas.
 func (p *Probe) attachPMUEvent(ev pmuEvent, numCPU int) {
 	m, _, err := p.mgr.GetMap(ev.mapName)
-	if err != nil {
-		log.Warnf("noisy_neighbor: %s map (%s) lookup failed: %v", ev.humanLabel, ev.mapName, err)
-		return
-	}
-	if m == nil {
-		log.Warnf("noisy_neighbor: %s map (%s) not registered in manager", ev.humanLabel, ev.mapName)
+	if err != nil || m == nil {
+		log.Warnf("noisy_neighbor: %s map (%s) missing: %v", ev.humanLabel, ev.mapName, err)
 		return
 	}
 	var logged bool
-	for cpu := range numCPU {
-		fd, err := openPerfEvent(ev.perfType, ev.perfConfig, cpu)
+	for cpu := 0; cpu < numCPU; cpu++ {
+		fd, err := openHardwarePerfEvent(ev.perfType, ev.perfConfig, cpu)
 		if err != nil {
 			if !logged {
 				log.Warnf("noisy_neighbor: %s PMU event unavailable, metric will be zero: %v", ev.humanLabel, err)
@@ -224,64 +160,43 @@ func (p *Probe) attachPMUEvent(ev pmuEvent, numCPU int) {
 		}
 		if err := m.Put(uint32(cpu), uint32(fd)); err != nil {
 			log.Warnf("noisy_neighbor: failed to register %s fd on cpu %d: %v", ev.humanLabel, cpu, err)
-			if cerr := unix.Close(fd); cerr != nil {
-				log.Warnf("noisy_neighbor: failed to close orphaned %s fd on cpu %d: %v", ev.humanLabel, cpu, cerr)
-			}
+			_ = unix.Close(fd)
 			continue
 		}
-		p.pmuFds = append(p.pmuFds, fd)
+		p.pmuFDs = append(p.pmuFDs, fd)
 	}
 }
 
-// openPerfEvent opens a single perf event of any type (hardware, software,
-// or hw_cache) on the given CPU and returns the fd. unsafe.Sizeof is
-// required by the kernel ABI for perf_event_attr.size.
-func openPerfEvent(typ uint32, config uint64, cpu int) (int, error) {
+func openHardwarePerfEvent(perfType uint32, config uint64, cpu int) (int, error) {
 	attr := &unix.PerfEventAttr{
-		Type:   typ,
+		Type:   perfType,
 		Config: config,
 		Size:   uint32(unsafe.Sizeof(unix.PerfEventAttr{})),
 	}
 	fd, err := unix.PerfEventOpen(attr, -1, cpu, -1, unix.PERF_FLAG_FD_CLOEXEC)
 	if err != nil {
-		return -1, fmt.Errorf("perf_event_open(type=%d, config=%#x, cpu=%d): %w", typ, config, cpu, err)
+		return -1, err
 	}
 	if err := unix.IoctlSetInt(fd, unix.PERF_EVENT_IOC_ENABLE, 0); err != nil {
-		if cerr := unix.Close(fd); cerr != nil {
-			return -1, fmt.Errorf("enable perf event: %w (also close failed: %v)", err, cerr)
-		}
+		_ = unix.Close(fd)
 		return -1, fmt.Errorf("enable perf event: %w", err)
 	}
 	return fd, nil
 }
 
-// Close releases all associated resources. Safe to call multiple times.
+// Close releases all associated resources
 func (p *Probe) Close() {
-	p.closeFn()
-}
-
-// doClose is the unguarded shutdown path. It runs exactly once, gated by
-// p.closeFn = sync.OnceFunc(p.doClose).
-func (p *Probe) doClose() {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	var errs []error
-	for _, fd := range p.pmuFds {
+	for _, fd := range p.pmuFDs {
 		if err := unix.Close(fd); err != nil {
-			errs = append(errs, fmt.Errorf("close PMU fd %d: %w", fd, err))
+			log.Warnf("noisy_neighbor: failed to close PMU fd %d: %v", fd, err)
 		}
 	}
-	p.pmuFds = nil
+	p.pmuFDs = nil
 	if p.mgr != nil {
 		ddebpf.RemoveNameMappings(p.mgr.Manager)
 		if err := p.mgr.Stop(manager.CleanAll); err != nil {
-			// Manager stop failure is operationally critical: orphan kprobes
-			// can pin the next startup.
-			errs = append(errs, fmt.Errorf("stop ebpf manager: %w", err))
+			log.Warnf("error stopping ebpf manager: %s", err)
 		}
-	}
-	if err := errors.Join(errs...); err != nil {
-		log.Errorf("noisy_neighbor: shutdown errors: %v", err)
 	}
 }
 
@@ -289,100 +204,86 @@ func (p *Probe) doClose() {
 // and atomically deletes each returned cgroup's entry from the BPF map.
 // Cgroups with zero observable activity (no events, softirq, block-IO,
 // or wakeups) are filtered out of the return slice but still flushed.
-//
-// A non-nil error means the returned slice is nil and callers must not
-// emit metrics — the next cycle will double-count any cgroups whose Delete
-// failed. ctx cancellation aborts iteration between map operations.
-//
-// GetAndFlush holds p.mu for the entire iteration; Close blocks for the
-// same duration. Callers serialize at a higher layer (the system-probe
-// HTTP handler uses WithConcurrencyLimit(1)).
-func (p *Probe) GetAndFlush(ctx context.Context) ([]model.Stats, error) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
+func (p *Probe) GetAndFlush() []model.NoisyNeighborStats {
+	var nnstats []model.NoisyNeighborStats
 
 	aggMap, found, err := p.mgr.GetMap("cgroup_agg_stats")
 	if err != nil {
-		return nil, fmt.Errorf("get cgroup_agg_stats map: %w", err)
+		log.Errorf("failed to get cgroup_agg_stats map: %v", err)
+		return nnstats
 	}
 	if !found {
-		return nil, errors.New("cgroup_agg_stats map not found")
+		log.Warn("cgroup_agg_stats map not found")
+		return nnstats
 	}
-
-	// No capacity hint: the BPF map is sized for worst case (4096) but
-	// typical hosts carry tens to low hundreds of active cgroups, so
-	// pre-allocating would waste hundreds of KB per call.
-	var stats []model.Stats
-	var cgroupsToDelete []uint64
 
 	iter := aggMap.Iterate()
 	var cgroupID uint64
-	perCPUStats := make([]ebpfCgroupAggStats, runtime.NumCPU())
+	var perCPUStats []ebpfCgroupAggStats
+	var cgroupsToDelete []uint64
 
 	for iter.Next(&cgroupID, &perCPUStats) {
-		if err := ctx.Err(); err != nil {
-			return nil, err
+		var cgroupLatencies, cgroupEvents, cgroupPreemptions, pidCount uint64
+		var cgroupCycles, cgroupInstructions uint64
+		var cgroupLLCMisses, cgroupITLBMisses uint64
+		var cgroupSoftirqNs, cgroupBlockIO uint64
+		var cgroupBranchMisses, cgroupCPUMigrations, cgroupWakeups, cgroupCacheReferences uint64
+		for _, cpuStat := range perCPUStats {
+			cgroupLatencies += cpuStat.Sum_latencies_ns
+			cgroupEvents += cpuStat.Event_count
+			cgroupPreemptions += cpuStat.Preemption_count
+			cgroupCycles += cpuStat.Sum_cycles
+			cgroupInstructions += cpuStat.Sum_instructions
+			cgroupLLCMisses += cpuStat.Sum_llc_misses
+			cgroupITLBMisses += cpuStat.Sum_itlb_misses
+			cgroupSoftirqNs += cpuStat.Sum_softirq_ns
+			cgroupBlockIO += cpuStat.Block_io_requests
+			cgroupBranchMisses += cpuStat.Sum_branch_misses
+			cgroupCPUMigrations += cpuStat.Sum_cpu_migrations
+			cgroupWakeups += cpuStat.Wakeup_count
+			cgroupCacheReferences += cpuStat.Sum_cache_references
+			// pid_count is a global cgroup value (not per-CPU), so take the max rather than summing
+			if cpuStat.Pid_count > pidCount {
+				pidCount = cpuStat.Pid_count
+			}
 		}
+
 		cgroupsToDelete = append(cgroupsToDelete, cgroupID)
-		var agg model.Stats
-		aggregatePerCPU(&agg, cgroupID, perCPUStats)
-		if !hasActivity(&agg) {
+
+		if cgroupEvents == 0 && cgroupSoftirqNs == 0 && cgroupBlockIO == 0 && cgroupWakeups == 0 {
 			continue
 		}
-		stats = append(stats, agg)
+
+		stat := model.NoisyNeighborStats{
+			CgroupID:           cgroupID,
+			SumLatenciesNs:     cgroupLatencies,
+			EventCount:         cgroupEvents,
+			PreemptionCount:    cgroupPreemptions,
+			UniquePidCount:     pidCount,
+			SumCycles:          cgroupCycles,
+			SumInstructions:    cgroupInstructions,
+			SumLLCMisses:       cgroupLLCMisses,
+			SumITLBMisses:      cgroupITLBMisses,
+			SumSoftirqNs:       cgroupSoftirqNs,
+			BlockIORequests:    cgroupBlockIO,
+			SumBranchMisses:    cgroupBranchMisses,
+			SumCPUMigrations:   cgroupCPUMigrations,
+			WakeupCount:        cgroupWakeups,
+			SumCacheReferences: cgroupCacheReferences,
+		}
+
+		nnstats = append(nnstats, stat)
 	}
 
 	if err := iter.Err(); err != nil {
-		return nil, fmt.Errorf("iterate cgroup_agg_stats: %w", err)
+		log.Errorf("error iterating cgroup_agg_stats map: %v", err)
 	}
 
-	var deleteErrs []error
-	for _, cgroupID := range cgroupsToDelete {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		if err := aggMap.Delete(&cgroupID); err != nil {
-			if errors.Is(err, unix.ENOENT) {
-				// The entry got deleted between Iterate and Delete (concurrent
-				// removal by the eBPF side). Benign.
-				continue
-			}
-			deleteErrs = append(deleteErrs, fmt.Errorf("delete cgroup %d: %w", cgroupID, err))
+	for _, cgID := range cgroupsToDelete {
+		if err := aggMap.Delete(&cgID); err != nil {
+			log.Errorf("failed to delete cgroup %d from agg map: %v", cgID, err)
 		}
 	}
-	if err := errors.Join(deleteErrs...); err != nil {
-		return nil, fmt.Errorf("flush cgroup_agg_stats: %w", err)
-	}
 
-	return stats, nil
-}
-
-// aggregatePerCPU sums per-CPU counters for one cgroup into dst. Range by
-// index to avoid copying the 112-byte ebpfCgroupAggStats per iteration.
-func aggregatePerCPU(dst *model.Stats, cgroupID uint64, perCPU []ebpfCgroupAggStats) {
-	dst.CgroupID = cgroupID
-	for i := range perCPU {
-		cpuStat := &perCPU[i]
-		dst.SumLatenciesNs += cpuStat.Sum_latencies_ns
-		dst.EventCount += cpuStat.Event_count
-		dst.PreemptionCount += cpuStat.Preemption_count
-		dst.SumCycles += cpuStat.Sum_cycles
-		dst.SumInstructions += cpuStat.Sum_instructions
-		dst.SumLLCMisses += cpuStat.Sum_llc_misses
-		dst.SumITLBMisses += cpuStat.Sum_itlb_misses
-		dst.SumSoftirqNs += cpuStat.Sum_softirq_ns
-		dst.BlockIORequests += cpuStat.Block_io_requests
-		dst.SumBranchMisses += cpuStat.Sum_branch_misses
-		dst.SumCPUMigrations += cpuStat.Sum_cpu_migrations
-		dst.WakeupCount += cpuStat.Wakeup_count
-		dst.SumCacheReferences += cpuStat.Sum_cache_references
-		// pid_count is a global cgroup value (not per-CPU): take max, not sum.
-		dst.UniquePidCount = max(dst.UniquePidCount, cpuStat.Pid_count)
-	}
-}
-
-// hasActivity reports whether the cgroup had any observable scheduling,
-// softirq, block-IO, or wakeup activity in the window.
-func hasActivity(s *model.Stats) bool {
-	return s.EventCount != 0 || s.SumSoftirqNs != 0 || s.BlockIORequests != 0 || s.WakeupCount != 0
+	return nnstats
 }

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
@@ -10,8 +10,11 @@ package noisyneighbor
 
 import (
 	"fmt"
+	"runtime"
+	"unsafe"
 
 	manager "github.com/DataDog/ebpf-manager"
+	"golang.org/x/sys/unix"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe/noisyneighbor/model"
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
@@ -26,7 +29,8 @@ var minimumKernelVersion = kernel.VersionCode(6, 2, 0)
 
 // Probe is the eBPF side of the noisy neighbor check
 type Probe struct {
-	mgr *ddebpf.Manager
+	mgr    *ddebpf.Manager
+	pmuFDs []int
 }
 
 // NewProbe creates a [Probe]
@@ -55,7 +59,10 @@ func NewProbe(cfg *ddebpf.Config) (*Probe, error) {
 		}
 		p.mgr.Maps = []*manager.Map{
 			{Name: "runq_enqueued"},
+			{Name: "task_oncpu_pmu"},
 			{Name: "cgroup_agg_stats"},
+			{Name: "cycles_pmu"},
+			{Name: "instructions_pmu"},
 		}
 		if err := p.mgr.InitWithOptions(buf, &opts); err != nil {
 			return fmt.Errorf("failed to init ebpf manager: %w", err)
@@ -71,11 +78,88 @@ func NewProbe(cfg *ddebpf.Config) (*Probe, error) {
 		return nil, err
 	}
 	ddebpf.AddNameMappings(p.mgr.Manager, "noisy_neighbor")
+	p.attachPMU()
 	return p, nil
+}
+
+// attachPMU opens per-CPU hardware perf events for cycles and instructions,
+// inserting their file descriptors into the corresponding BPF perf-event-array
+// maps. On hosts where the PMU is unavailable (some virtualized environments,
+// restrictive perf_event_paranoid, missing CAP_PERF_MON) the perf event opens
+// will fail; we log once and proceed. The eBPF program checks the read-value
+// helper return code and skips CPI accumulation for those CPUs.
+func (p *Probe) attachPMU() {
+	cyclesMap, _, err := p.mgr.GetMap("cycles_pmu")
+	if err != nil || cyclesMap == nil {
+		log.Warnf("noisy_neighbor: cycles_pmu map missing, CPI metrics disabled: %v", err)
+		return
+	}
+	instMap, _, err := p.mgr.GetMap("instructions_pmu")
+	if err != nil || instMap == nil {
+		log.Warnf("noisy_neighbor: instructions_pmu map missing, CPI metrics disabled: %v", err)
+		return
+	}
+
+	numCPU := runtime.NumCPU()
+	var loggedPMU bool
+	for cpu := 0; cpu < numCPU; cpu++ {
+		cycFD, err := openHardwarePerfEvent(cpu, unix.PERF_COUNT_HW_CPU_CYCLES)
+		if err != nil {
+			if !loggedPMU {
+				log.Warnf("noisy_neighbor: PMU unavailable, cycles/instructions metrics will be zero: %v", err)
+				loggedPMU = true
+			}
+			continue
+		}
+		insFD, err := openHardwarePerfEvent(cpu, unix.PERF_COUNT_HW_INSTRUCTIONS)
+		if err != nil {
+			unix.Close(cycFD)
+			if !loggedPMU {
+				log.Warnf("noisy_neighbor: PMU unavailable, cycles/instructions metrics will be zero: %v", err)
+				loggedPMU = true
+			}
+			continue
+		}
+		key := uint32(cpu)
+		if err := cyclesMap.Put(key, uint32(cycFD)); err != nil {
+			log.Warnf("noisy_neighbor: failed to register cycles fd on cpu %d: %v", cpu, err)
+			unix.Close(cycFD)
+			unix.Close(insFD)
+			continue
+		}
+		if err := instMap.Put(key, uint32(insFD)); err != nil {
+			log.Warnf("noisy_neighbor: failed to register instructions fd on cpu %d: %v", cpu, err)
+			unix.Close(cycFD)
+			unix.Close(insFD)
+			continue
+		}
+		p.pmuFDs = append(p.pmuFDs, cycFD, insFD)
+	}
+}
+
+func openHardwarePerfEvent(cpu int, config uint64) (int, error) {
+	attr := &unix.PerfEventAttr{
+		Type:   unix.PERF_TYPE_HARDWARE,
+		Config: config,
+		Size:   uint32(unsafe.Sizeof(unix.PerfEventAttr{})),
+	}
+	fd, err := unix.PerfEventOpen(attr, -1, cpu, -1, unix.PERF_FLAG_FD_CLOEXEC)
+	if err != nil {
+		return -1, err
+	}
+	if err := unix.IoctlSetInt(fd, unix.PERF_EVENT_IOC_ENABLE, 0); err != nil {
+		unix.Close(fd)
+		return -1, fmt.Errorf("enable perf event: %w", err)
+	}
+	return fd, nil
 }
 
 // Close releases all associated resources
 func (p *Probe) Close() {
+	for _, fd := range p.pmuFDs {
+		unix.Close(fd)
+	}
+	p.pmuFDs = nil
 	if p.mgr != nil {
 		ddebpf.RemoveNameMappings(p.mgr.Manager)
 		if err := p.mgr.Stop(manager.CleanAll); err != nil {
@@ -105,10 +189,13 @@ func (p *Probe) GetAndFlush() []model.NoisyNeighborStats {
 
 	for iter.Next(&cgroupID, &perCPUStats) {
 		var cgroupLatencies, cgroupEvents, cgroupPreemptions, pidCount uint64
+		var cgroupCycles, cgroupInstructions uint64
 		for _, cpuStat := range perCPUStats {
 			cgroupLatencies += cpuStat.Sum_latencies_ns
 			cgroupEvents += cpuStat.Event_count
 			cgroupPreemptions += cpuStat.Preemption_count
+			cgroupCycles += cpuStat.Sum_cycles
+			cgroupInstructions += cpuStat.Sum_instructions
 			// pid_count is a global cgroup value (not per-CPU), so take the max rather than summing
 			if cpuStat.Pid_count > pidCount {
 				pidCount = cpuStat.Pid_count
@@ -127,6 +214,8 @@ func (p *Probe) GetAndFlush() []model.NoisyNeighborStats {
 			EventCount:      cgroupEvents,
 			PreemptionCount: cgroupPreemptions,
 			UniquePidCount:  pidCount,
+			SumCycles:       cgroupCycles,
+			SumInstructions: cgroupInstructions,
 		}
 
 		nnstats = append(nnstats, stat)

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
@@ -91,16 +91,8 @@ func NewProbe(cfg *ddebpf.Config, modCfg Config) (*Probe, error) {
 		return nil, err
 	}
 
-	// Skip mgr.Start() and attach probes manually. Start() runs cleanupTraceFS
-	// which tries to remove ALL orphaned kprobe events on the host and fails
-	// fatally if any are pinned (common on dev machines where a previous agent
-	// left tail-called kprobes behind). This module only uses tracepoints, so
-	// we don't need the perf/ring reader startup that Start() also handles.
-	// Stop() requires state >= initialized, which InitWithOptions already set.
-	for _, probe := range p.mgr.Probes {
-		if err := probe.Attach(); err != nil {
-			return nil, fmt.Errorf("failed to attach probe %s: %w", probe.EBPFFuncName, err)
-		}
+	if err := p.mgr.Start(); err != nil {
+		return nil, err
 	}
 	ddebpf.AddNameMappings(p.mgr.Manager, "noisy_neighbor")
 	p.attachPMU(modCfg.PMUMetrics)

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
@@ -37,7 +37,7 @@ type Probe struct {
 func NewProbe(cfg *ddebpf.Config) (*Probe, error) {
 	kv, err := kernel.HostVersion()
 	if err != nil {
-		return nil, fmt.Errorf("kernel version: %s", err)
+		return nil, fmt.Errorf("kernel version: %w", err)
 	}
 	if kv < minimumKernelVersion {
 		return nil, fmt.Errorf("minimum kernel version %s not met, read %s", minimumKernelVersion, kv)
@@ -68,6 +68,8 @@ func NewProbe(cfg *ddebpf.Config) (*Probe, error) {
 			{Name: "instructions_pmu"},
 			{Name: "llc_misses_pmu"},
 			{Name: "itlb_misses_pmu"},
+			{Name: "branch_misses_pmu"},
+			{Name: "cpu_migrations_pmu"},
 			{Name: "softirq_start_ns"},
 		}
 		if err := p.mgr.InitWithOptions(buf, &opts); err != nil {
@@ -95,7 +97,8 @@ func NewProbe(cfg *ddebpf.Config) (*Probe, error) {
 	return p, nil
 }
 
-// pmuEvent describes one hardware counter we want per-CPU.
+// pmuEvent describes one perf event (hardware or software counter) that we
+// open per-CPU and expose to BPF via a perf-event-array map.
 type pmuEvent struct {
 	mapName    string
 	humanLabel string
@@ -108,18 +111,19 @@ const itlbLoadMissesConfig = uint64(unix.PERF_COUNT_HW_CACHE_ITLB) |
 	(uint64(unix.PERF_COUNT_HW_CACHE_OP_READ) << 8) |
 	(uint64(unix.PERF_COUNT_HW_CACHE_RESULT_MISS) << 16)
 
-// attachPMU opens per-CPU hardware perf events and inserts their fds into the
-// corresponding BPF perf-event-array maps. On hosts where a given event isn't
-// supported (virtualized envs, restrictive perf_event_paranoid, missing
-// CAP_PERF_MON, or µarch lacking the event) opens fail and we log once per
-// event type. Other events still attach independently, and the eBPF program
-// checks each read-value return code and skips just that counter's deltas.
+// attachPMU opens per-CPU perf events for every counter we track and
+// populates the corresponding BPF perf-event-array maps. See attachPMUEvent
+// for per-event semantics and failure modes.
 func (p *Probe) attachPMU() {
 	events := []pmuEvent{
 		{"cycles_pmu", "cycles", unix.PERF_TYPE_HARDWARE, unix.PERF_COUNT_HW_CPU_CYCLES},
 		{"instructions_pmu", "instructions", unix.PERF_TYPE_HARDWARE, unix.PERF_COUNT_HW_INSTRUCTIONS},
 		{"llc_misses_pmu", "LLC misses", unix.PERF_TYPE_HARDWARE, unix.PERF_COUNT_HW_CACHE_MISSES},
 		{"itlb_misses_pmu", "iTLB misses", unix.PERF_TYPE_HW_CACHE, itlbLoadMissesConfig},
+		{"branch_misses_pmu", "branch misses", unix.PERF_TYPE_HARDWARE, unix.PERF_COUNT_HW_BRANCH_MISSES},
+		// CPU migrations is a software counter — doesn't compete for hardware
+		// PMU counters and is always available regardless of µarch.
+		{"cpu_migrations_pmu", "CPU migrations", unix.PERF_TYPE_SOFTWARE, unix.PERF_COUNT_SW_CPU_MIGRATIONS},
 	}
 	numCPU := runtime.NumCPU()
 	for _, ev := range events {
@@ -127,6 +131,12 @@ func (p *Probe) attachPMU() {
 	}
 }
 
+// attachPMUEvent opens one perf event per CPU and inserts the fds into the
+// associated BPF perf-event-array map. On hosts where the event isn't
+// supported (virtualized envs, restrictive perf_event_paranoid, missing
+// CAP_PERF_MON, or µarch lacking the event) opens fail and we log once per
+// event type. Other events still attach independently, and the eBPF program
+// checks each read-value return code and skips just that counter's deltas.
 func (p *Probe) attachPMUEvent(ev pmuEvent, numCPU int) {
 	m, _, err := p.mgr.GetMap(ev.mapName)
 	if err != nil || m == nil {
@@ -145,7 +155,7 @@ func (p *Probe) attachPMUEvent(ev pmuEvent, numCPU int) {
 		}
 		if err := m.Put(uint32(cpu), uint32(fd)); err != nil {
 			log.Warnf("noisy_neighbor: failed to register %s fd on cpu %d: %v", ev.humanLabel, cpu, err)
-			unix.Close(fd)
+			_ = unix.Close(fd)
 			continue
 		}
 		p.pmuFDs = append(p.pmuFDs, fd)
@@ -163,7 +173,7 @@ func openHardwarePerfEvent(perfType uint32, config uint64, cpu int) (int, error)
 		return -1, err
 	}
 	if err := unix.IoctlSetInt(fd, unix.PERF_EVENT_IOC_ENABLE, 0); err != nil {
-		unix.Close(fd)
+		_ = unix.Close(fd)
 		return -1, fmt.Errorf("enable perf event: %w", err)
 	}
 	return fd, nil
@@ -172,7 +182,9 @@ func openHardwarePerfEvent(perfType uint32, config uint64, cpu int) (int, error)
 // Close releases all associated resources
 func (p *Probe) Close() {
 	for _, fd := range p.pmuFDs {
-		unix.Close(fd)
+		if err := unix.Close(fd); err != nil {
+			log.Warnf("noisy_neighbor: failed to close PMU fd %d: %v", fd, err)
+		}
 	}
 	p.pmuFDs = nil
 	if p.mgr != nil {
@@ -183,7 +195,10 @@ func (p *Probe) Close() {
 	}
 }
 
-// GetAndFlush gets the stats
+// GetAndFlush returns aggregated per-cgroup stats for the current window
+// and atomically deletes each returned cgroup's entry from the BPF map.
+// Cgroups with zero observable activity (no events, softirq, block-IO,
+// or wakeups) are filtered out of the return slice but still flushed.
 func (p *Probe) GetAndFlush() []model.NoisyNeighborStats {
 	var nnstats []model.NoisyNeighborStats
 
@@ -207,6 +222,7 @@ func (p *Probe) GetAndFlush() []model.NoisyNeighborStats {
 		var cgroupCycles, cgroupInstructions uint64
 		var cgroupLLCMisses, cgroupITLBMisses uint64
 		var cgroupSoftirqNs, cgroupBlockIO uint64
+		var cgroupBranchMisses, cgroupCPUMigrations, cgroupWakeups uint64
 		for _, cpuStat := range perCPUStats {
 			cgroupLatencies += cpuStat.Sum_latencies_ns
 			cgroupEvents += cpuStat.Event_count
@@ -217,6 +233,9 @@ func (p *Probe) GetAndFlush() []model.NoisyNeighborStats {
 			cgroupITLBMisses += cpuStat.Sum_itlb_misses
 			cgroupSoftirqNs += cpuStat.Sum_softirq_ns
 			cgroupBlockIO += cpuStat.Block_io_requests
+			cgroupBranchMisses += cpuStat.Sum_branch_misses
+			cgroupCPUMigrations += cpuStat.Sum_cpu_migrations
+			cgroupWakeups += cpuStat.Wakeup_count
 			// pid_count is a global cgroup value (not per-CPU), so take the max rather than summing
 			if cpuStat.Pid_count > pidCount {
 				pidCount = cpuStat.Pid_count
@@ -225,22 +244,25 @@ func (p *Probe) GetAndFlush() []model.NoisyNeighborStats {
 
 		cgroupsToDelete = append(cgroupsToDelete, cgroupID)
 
-		if cgroupEvents == 0 && cgroupSoftirqNs == 0 && cgroupBlockIO == 0 {
+		if cgroupEvents == 0 && cgroupSoftirqNs == 0 && cgroupBlockIO == 0 && cgroupWakeups == 0 {
 			continue
 		}
 
 		stat := model.NoisyNeighborStats{
-			CgroupID:        cgroupID,
-			SumLatenciesNs:  cgroupLatencies,
-			EventCount:      cgroupEvents,
-			PreemptionCount: cgroupPreemptions,
-			UniquePidCount:  pidCount,
-			SumCycles:       cgroupCycles,
-			SumInstructions: cgroupInstructions,
-			SumLLCMisses:    cgroupLLCMisses,
-			SumITLBMisses:   cgroupITLBMisses,
-			SumSoftirqNs:    cgroupSoftirqNs,
-			BlockIORequests: cgroupBlockIO,
+			CgroupID:         cgroupID,
+			SumLatenciesNs:   cgroupLatencies,
+			EventCount:       cgroupEvents,
+			PreemptionCount:  cgroupPreemptions,
+			UniquePidCount:   pidCount,
+			SumCycles:        cgroupCycles,
+			SumInstructions:  cgroupInstructions,
+			SumLLCMisses:     cgroupLLCMisses,
+			SumITLBMisses:    cgroupITLBMisses,
+			SumSoftirqNs:     cgroupSoftirqNs,
+			BlockIORequests:  cgroupBlockIO,
+			SumBranchMisses:  cgroupBranchMisses,
+			SumCPUMigrations: cgroupCPUMigrations,
+			WakeupCount:      cgroupWakeups,
 		}
 
 		nnstats = append(nnstats, stat)

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
@@ -75,7 +75,7 @@ func NewProbe(cfg *ddebpf.Config, modCfg Config) (*Probe, error) {
 			{Name: "cgroup_agg_stats"},
 			{Name: "cycles_pmu"},
 			{Name: "instructions_pmu"},
-			{Name: "llc_misses_pmu"},
+			{Name: "cache_misses_pmu"},
 			{Name: "itlb_misses_pmu"},
 			{Name: "branch_misses_pmu"},
 			{Name: "cpu_migrations_pmu"},
@@ -123,13 +123,13 @@ func (p *Probe) attachPMU(pmuEnabled map[string]bool) {
 	events := []pmuEvent{
 		{mapName: "cycles_pmu", humanLabel: "cycles", perfType: unix.PERF_TYPE_HARDWARE, perfConfig: unix.PERF_COUNT_HW_CPU_CYCLES},
 		{mapName: "instructions_pmu", humanLabel: "instructions", perfType: unix.PERF_TYPE_HARDWARE, perfConfig: unix.PERF_COUNT_HW_INSTRUCTIONS},
-		{mapName: "llc_misses_pmu", humanLabel: "LLC misses", perfType: unix.PERF_TYPE_HARDWARE, perfConfig: unix.PERF_COUNT_HW_CACHE_MISSES},
+		{mapName: "cache_misses_pmu", humanLabel: "cache misses", perfType: unix.PERF_TYPE_HARDWARE, perfConfig: unix.PERF_COUNT_HW_CACHE_MISSES},
 		{mapName: "itlb_misses_pmu", humanLabel: "iTLB misses", perfType: unix.PERF_TYPE_HW_CACHE, perfConfig: itlbLoadMissesConfig},
 		{mapName: "branch_misses_pmu", humanLabel: "branch misses", perfType: unix.PERF_TYPE_HARDWARE, perfConfig: unix.PERF_COUNT_HW_BRANCH_MISSES},
 		// CPU migrations is a software counter — doesn't compete for hardware
 		// PMU counters and is always available regardless of µarch.
 		{mapName: "cpu_migrations_pmu", humanLabel: "CPU migrations", perfType: unix.PERF_TYPE_SOFTWARE, perfConfig: unix.PERF_COUNT_SW_CPU_MIGRATIONS},
-		// Cache references pairs with llc_misses to give LLC hit-rate: under
+		// Cache references pairs with cache_misses to give cache hit-rate: under
 		// cache thrashing the rate moves even when absolute miss count stays
 		// flat for memory-bound workloads already at floor miss rate.
 		{mapName: "cache_references_pmu", humanLabel: "cache references", perfType: unix.PERF_TYPE_HARDWARE, perfConfig: unix.PERF_COUNT_HW_CACHE_REFERENCES},
@@ -242,7 +242,7 @@ func (p *Probe) GetAndFlush() []model.NoisyNeighborStats {
 			stat.PreemptionCount += cpuStat.Preemption_count
 			stat.SumCycles += cpuStat.Sum_cycles
 			stat.SumInstructions += cpuStat.Sum_instructions
-			stat.SumLLCMisses += cpuStat.Sum_llc_misses
+			stat.SumCacheMisses += cpuStat.Sum_cache_misses
 			stat.SumITLBMisses += cpuStat.Sum_itlb_misses
 			stat.SumSoftirqNs += cpuStat.Sum_softirq_ns
 			stat.BlockIORequests += cpuStat.Block_io_requests
@@ -263,7 +263,7 @@ func (p *Probe) GetAndFlush() []model.NoisyNeighborStats {
 		// start and gets switched out exactly once (PMU stamp delta accrued,
 		// no schedule-on event) isn't silently flushed.
 		if stat.EventCount == 0 && stat.SumSoftirqNs == 0 && stat.BlockIORequests == 0 && stat.WakeupCount == 0 &&
-			stat.SumCycles == 0 && stat.SumInstructions == 0 && stat.SumLLCMisses == 0 && stat.SumCacheReferences == 0 &&
+			stat.SumCycles == 0 && stat.SumInstructions == 0 && stat.SumCacheMisses == 0 && stat.SumCacheReferences == 0 &&
 			stat.SumITLBMisses == 0 && stat.SumBranchMisses == 0 && stat.SumCPUMigrations == 0 {
 			continue
 		}

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
@@ -9,8 +9,11 @@
 package noisyneighbor
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"runtime"
+	"sync"
 	"unsafe"
 
 	manager "github.com/DataDog/ebpf-manager"
@@ -24,32 +27,80 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// 5.13 for kfuncs, 6.2 for bpf_rcu_read_lock kfunc
+// minimumKernelVersion is 6.2.0, the first kernel with bpf_rcu_read_lock,
+// which the probe uses to walk task_struct pointers safely.
 var minimumKernelVersion = kernel.VersionCode(6, 2, 0)
 
-// Probe is the eBPF side of the noisy neighbor check
+// ErrKernelTooOld is returned by NewProbe when the host kernel is below
+// minimumKernelVersion. Callers can use errors.Is to skip the module silently
+// on unsupported hosts.
+var ErrKernelTooOld = errors.New("kernel version below minimum")
+
+// Probe is the eBPF side of the noisy neighbor check. Construct only via
+// NewProbe — the zero value is not usable.
 type Probe struct {
-	mgr    *ddebpf.Manager
-	pmuFDs []int
+	// mgr and closeFn are set once during NewProbe (before *Probe is
+	// published to other goroutines) and never reassigned afterward; safe
+	// to read without holding mu.
+	mgr     *ddebpf.Manager
+	closeFn func()
+
+	// mu serializes GetAndFlush against doClose and guards pmuFds against
+	// concurrent shutdown. pmuFds is written by attachPMU (pre-publication,
+	// no lock required) and read/cleared in doClose under mu.
+	mu     sync.Mutex
+	pmuFds []int
 }
 
-// NewProbe creates a [Probe]
+// NewProbe loads the noisy_neighbor eBPF asset, attaches its tracepoints,
+// and opens per-CPU PMU counters. Returns an error wrapping ErrKernelTooOld
+// on unsupported hosts (callers can use errors.Is). PMU events that fail to
+// open are logged and skipped — the returned Probe is still usable, but the
+// affected counters report zero. On any error after manager initialization,
+// resources are released before the error is returned. The caller must
+// invoke Close to release the probe on the success path.
 func NewProbe(cfg *ddebpf.Config) (*Probe, error) {
-	kv, err := kernel.HostVersion()
-	if err != nil {
-		return nil, fmt.Errorf("kernel version: %w", err)
-	}
-	if kv < minimumKernelVersion {
-		return nil, fmt.Errorf("minimum kernel version %s not met, read %s", minimumKernelVersion, kv)
+	if err := checkKernelVersion(); err != nil {
+		return nil, err
 	}
 
 	p := &Probe{}
+	// Wire close before any resource-acquiring step so cleanup paths can
+	// rely on p.closeFn() to release everything.
+	p.closeFn = sync.OnceFunc(p.doClose)
 
+	if err := p.loadManager(cfg); err != nil {
+		return nil, err
+	}
+	if err := p.attachProbes(); err != nil {
+		p.closeFn()
+		return nil, err
+	}
+	ddebpf.AddNameMappings(p.mgr.Manager, "noisy_neighbor")
+	p.attachPMU()
+	return p, nil
+}
+
+func checkKernelVersion() error {
+	kv, err := kernel.HostVersion()
+	if err != nil {
+		return fmt.Errorf("kernel version: %w", err)
+	}
+	if kv < minimumKernelVersion {
+		return fmt.Errorf("%w: minimum %s, got %s", ErrKernelTooOld, minimumKernelVersion, kv)
+	}
+	return nil
+}
+
+// loadManager selects the noisy-neighbor BPF asset (debug or release) and
+// initializes the ebpf-manager with the tracepoints and maps the kernel
+// program expects.
+func (p *Probe) loadManager(cfg *ddebpf.Config) error {
 	filename := "noisy-neighbor.o"
 	if cfg.BPFDebug {
 		filename = "noisy-neighbor-debug.o"
 	}
-	err = ddebpf.LoadCOREAsset(filename, func(buf bytecode.AssetReader, opts manager.Options) error {
+	err := ddebpf.LoadCOREAsset(filename, func(r bytecode.AssetReader, opts manager.Options) error {
 		p.mgr = ddebpf.NewManagerWithDefault(&manager.Manager{}, "noisy_neighbor", &ebpftelemetry.ErrorsTelemetryModifier{})
 		const uid = "noisy"
 		p.mgr.Probes = []*manager.Probe{
@@ -73,29 +124,35 @@ func NewProbe(cfg *ddebpf.Config) (*Probe, error) {
 			{Name: "cache_references_pmu"},
 			{Name: "softirq_start_ns"},
 		}
-		if err := p.mgr.InitWithOptions(buf, &opts); err != nil {
-			return fmt.Errorf("failed to init ebpf manager: %w", err)
+		if err := p.mgr.InitWithOptions(r, &opts); err != nil {
+			return fmt.Errorf("init ebpf manager: %w", err)
 		}
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		return fmt.Errorf("load CO-RE asset %s: %w", filename, err)
 	}
+	return nil
+}
 
-	// Skip mgr.Start() and attach probes manually. Start() runs cleanupTraceFS
-	// which tries to remove ALL orphaned kprobe events on the host and fails
-	// fatally if any are pinned (common on dev machines where a previous agent
-	// left tail-called kprobes behind). This module only uses tracepoints, so
-	// we don't need the perf/ring reader startup that Start() also handles.
-	// Stop() requires state >= initialized, which InitWithOptions already set.
+// attachProbes attaches each manager probe sequentially. On failure the
+// caller (NewProbe) is expected to invoke p.closeFn() so the partially-
+// loaded manager and any prior attachments are torn down by doClose.
+//
+// We skip mgr.Start() and attach probes manually: Start() runs
+// cleanupTraceFS which tries to remove ALL orphaned kprobe events on the
+// host and fails fatally if any are pinned (common on dev machines where
+// a previous agent left tail-called kprobes behind). This module only
+// uses tracepoints, so we don't need the perf/ring reader startup that
+// Start() also handles. Stop() requires state >= initialized, which
+// InitWithOptions already set.
+func (p *Probe) attachProbes() error {
 	for _, probe := range p.mgr.Probes {
 		if err := probe.Attach(); err != nil {
-			return nil, fmt.Errorf("failed to attach probe %s: %w", probe.EBPFFuncName, err)
+			return fmt.Errorf("attach probe %s: %w", probe.EBPFFuncName, err)
 		}
 	}
-	ddebpf.AddNameMappings(p.mgr.Manager, "noisy_neighbor")
-	p.attachPMU()
-	return p, nil
+	return nil
 }
 
 // pmuEvent describes one perf event (hardware or software counter) that we
@@ -113,24 +170,27 @@ const itlbLoadMissesConfig = uint64(unix.PERF_COUNT_HW_CACHE_ITLB) |
 	(uint64(unix.PERF_COUNT_HW_CACHE_RESULT_MISS) << 16)
 
 // attachPMU opens per-CPU perf events for every counter we track and
-// populates the corresponding BPF perf-event-array maps. See attachPMUEvent
-// for per-event semantics and failure modes.
+// populates the corresponding BPF perf-event-array maps. Called only from
+// NewProbe before the Probe is published to other goroutines, so writes to
+// p.pmuFds need no synchronization. See attachPMUEvent for per-event
+// semantics and failure modes.
 func (p *Probe) attachPMU() {
 	events := []pmuEvent{
-		{"cycles_pmu", "cycles", unix.PERF_TYPE_HARDWARE, unix.PERF_COUNT_HW_CPU_CYCLES},
-		{"instructions_pmu", "instructions", unix.PERF_TYPE_HARDWARE, unix.PERF_COUNT_HW_INSTRUCTIONS},
-		{"llc_misses_pmu", "LLC misses", unix.PERF_TYPE_HARDWARE, unix.PERF_COUNT_HW_CACHE_MISSES},
-		{"itlb_misses_pmu", "iTLB misses", unix.PERF_TYPE_HW_CACHE, itlbLoadMissesConfig},
-		{"branch_misses_pmu", "branch misses", unix.PERF_TYPE_HARDWARE, unix.PERF_COUNT_HW_BRANCH_MISSES},
+		{mapName: "cycles_pmu", humanLabel: "cycles", perfType: unix.PERF_TYPE_HARDWARE, perfConfig: unix.PERF_COUNT_HW_CPU_CYCLES},
+		{mapName: "instructions_pmu", humanLabel: "instructions", perfType: unix.PERF_TYPE_HARDWARE, perfConfig: unix.PERF_COUNT_HW_INSTRUCTIONS},
+		{mapName: "llc_misses_pmu", humanLabel: "LLC misses", perfType: unix.PERF_TYPE_HARDWARE, perfConfig: unix.PERF_COUNT_HW_CACHE_MISSES},
+		{mapName: "itlb_misses_pmu", humanLabel: "iTLB misses", perfType: unix.PERF_TYPE_HW_CACHE, perfConfig: itlbLoadMissesConfig},
+		{mapName: "branch_misses_pmu", humanLabel: "branch misses", perfType: unix.PERF_TYPE_HARDWARE, perfConfig: unix.PERF_COUNT_HW_BRANCH_MISSES},
 		// CPU migrations is a software counter — doesn't compete for hardware
 		// PMU counters and is always available regardless of µarch.
-		{"cpu_migrations_pmu", "CPU migrations", unix.PERF_TYPE_SOFTWARE, unix.PERF_COUNT_SW_CPU_MIGRATIONS},
+		{mapName: "cpu_migrations_pmu", humanLabel: "CPU migrations", perfType: unix.PERF_TYPE_SOFTWARE, perfConfig: unix.PERF_COUNT_SW_CPU_MIGRATIONS},
 		// Cache references pairs with llc_misses to give LLC hit-rate: under
 		// cache thrashing the rate moves even when absolute miss count stays
 		// flat for memory-bound workloads already at floor miss rate.
-		{"cache_references_pmu", "cache references", unix.PERF_TYPE_HARDWARE, unix.PERF_COUNT_HW_CACHE_REFERENCES},
+		{mapName: "cache_references_pmu", humanLabel: "cache references", perfType: unix.PERF_TYPE_HARDWARE, perfConfig: unix.PERF_COUNT_HW_CACHE_REFERENCES},
 	}
 	numCPU := runtime.NumCPU()
+	p.pmuFds = make([]int, 0, len(events)*numCPU)
 	for _, ev := range events {
 		p.attachPMUEvent(ev, numCPU)
 	}
@@ -144,13 +204,17 @@ func (p *Probe) attachPMU() {
 // checks each read-value return code and skips just that counter's deltas.
 func (p *Probe) attachPMUEvent(ev pmuEvent, numCPU int) {
 	m, _, err := p.mgr.GetMap(ev.mapName)
-	if err != nil || m == nil {
-		log.Warnf("noisy_neighbor: %s map (%s) missing: %v", ev.humanLabel, ev.mapName, err)
+	if err != nil {
+		log.Warnf("noisy_neighbor: %s map (%s) lookup failed: %v", ev.humanLabel, ev.mapName, err)
+		return
+	}
+	if m == nil {
+		log.Warnf("noisy_neighbor: %s map (%s) not registered in manager", ev.humanLabel, ev.mapName)
 		return
 	}
 	var logged bool
-	for cpu := 0; cpu < numCPU; cpu++ {
-		fd, err := openHardwarePerfEvent(ev.perfType, ev.perfConfig, cpu)
+	for cpu := range numCPU {
+		fd, err := openPerfEvent(ev.perfType, ev.perfConfig, cpu)
 		if err != nil {
 			if !logged {
 				log.Warnf("noisy_neighbor: %s PMU event unavailable, metric will be zero: %v", ev.humanLabel, err)
@@ -160,43 +224,64 @@ func (p *Probe) attachPMUEvent(ev pmuEvent, numCPU int) {
 		}
 		if err := m.Put(uint32(cpu), uint32(fd)); err != nil {
 			log.Warnf("noisy_neighbor: failed to register %s fd on cpu %d: %v", ev.humanLabel, cpu, err)
-			_ = unix.Close(fd)
+			if cerr := unix.Close(fd); cerr != nil {
+				log.Warnf("noisy_neighbor: failed to close orphaned %s fd on cpu %d: %v", ev.humanLabel, cpu, cerr)
+			}
 			continue
 		}
-		p.pmuFDs = append(p.pmuFDs, fd)
+		p.pmuFds = append(p.pmuFds, fd)
 	}
 }
 
-func openHardwarePerfEvent(perfType uint32, config uint64, cpu int) (int, error) {
+// openPerfEvent opens a single perf event of any type (hardware, software,
+// or hw_cache) on the given CPU and returns the fd. unsafe.Sizeof is
+// required by the kernel ABI for perf_event_attr.size.
+func openPerfEvent(typ uint32, config uint64, cpu int) (int, error) {
 	attr := &unix.PerfEventAttr{
-		Type:   perfType,
+		Type:   typ,
 		Config: config,
 		Size:   uint32(unsafe.Sizeof(unix.PerfEventAttr{})),
 	}
 	fd, err := unix.PerfEventOpen(attr, -1, cpu, -1, unix.PERF_FLAG_FD_CLOEXEC)
 	if err != nil {
-		return -1, err
+		return -1, fmt.Errorf("perf_event_open(type=%d, config=%#x, cpu=%d): %w", typ, config, cpu, err)
 	}
 	if err := unix.IoctlSetInt(fd, unix.PERF_EVENT_IOC_ENABLE, 0); err != nil {
-		_ = unix.Close(fd)
+		if cerr := unix.Close(fd); cerr != nil {
+			return -1, fmt.Errorf("enable perf event: %w (also close failed: %v)", err, cerr)
+		}
 		return -1, fmt.Errorf("enable perf event: %w", err)
 	}
 	return fd, nil
 }
 
-// Close releases all associated resources
+// Close releases all associated resources. Safe to call multiple times.
 func (p *Probe) Close() {
-	for _, fd := range p.pmuFDs {
+	p.closeFn()
+}
+
+// doClose is the unguarded shutdown path. It runs exactly once, gated by
+// p.closeFn = sync.OnceFunc(p.doClose).
+func (p *Probe) doClose() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	var errs []error
+	for _, fd := range p.pmuFds {
 		if err := unix.Close(fd); err != nil {
-			log.Warnf("noisy_neighbor: failed to close PMU fd %d: %v", fd, err)
+			errs = append(errs, fmt.Errorf("close PMU fd %d: %w", fd, err))
 		}
 	}
-	p.pmuFDs = nil
+	p.pmuFds = nil
 	if p.mgr != nil {
 		ddebpf.RemoveNameMappings(p.mgr.Manager)
 		if err := p.mgr.Stop(manager.CleanAll); err != nil {
-			log.Warnf("error stopping ebpf manager: %s", err)
+			// Manager stop failure is operationally critical: orphan kprobes
+			// can pin the next startup.
+			errs = append(errs, fmt.Errorf("stop ebpf manager: %w", err))
 		}
+	}
+	if err := errors.Join(errs...); err != nil {
+		log.Errorf("noisy_neighbor: shutdown errors: %v", err)
 	}
 }
 
@@ -204,86 +289,100 @@ func (p *Probe) Close() {
 // and atomically deletes each returned cgroup's entry from the BPF map.
 // Cgroups with zero observable activity (no events, softirq, block-IO,
 // or wakeups) are filtered out of the return slice but still flushed.
-func (p *Probe) GetAndFlush() []model.NoisyNeighborStats {
-	var nnstats []model.NoisyNeighborStats
+//
+// A non-nil error means the returned slice is nil and callers must not
+// emit metrics — the next cycle will double-count any cgroups whose Delete
+// failed. ctx cancellation aborts iteration between map operations.
+//
+// GetAndFlush holds p.mu for the entire iteration; Close blocks for the
+// same duration. Callers serialize at a higher layer (the system-probe
+// HTTP handler uses WithConcurrencyLimit(1)).
+func (p *Probe) GetAndFlush(ctx context.Context) ([]model.Stats, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 
 	aggMap, found, err := p.mgr.GetMap("cgroup_agg_stats")
 	if err != nil {
-		log.Errorf("failed to get cgroup_agg_stats map: %v", err)
-		return nnstats
+		return nil, fmt.Errorf("get cgroup_agg_stats map: %w", err)
 	}
 	if !found {
-		log.Warn("cgroup_agg_stats map not found")
-		return nnstats
+		return nil, errors.New("cgroup_agg_stats map not found")
 	}
+
+	// No capacity hint: the BPF map is sized for worst case (4096) but
+	// typical hosts carry tens to low hundreds of active cgroups, so
+	// pre-allocating would waste hundreds of KB per call.
+	var stats []model.Stats
+	var cgroupsToDelete []uint64
 
 	iter := aggMap.Iterate()
 	var cgroupID uint64
-	var perCPUStats []ebpfCgroupAggStats
-	var cgroupsToDelete []uint64
+	perCPUStats := make([]ebpfCgroupAggStats, runtime.NumCPU())
 
 	for iter.Next(&cgroupID, &perCPUStats) {
-		var cgroupLatencies, cgroupEvents, cgroupPreemptions, pidCount uint64
-		var cgroupCycles, cgroupInstructions uint64
-		var cgroupLLCMisses, cgroupITLBMisses uint64
-		var cgroupSoftirqNs, cgroupBlockIO uint64
-		var cgroupBranchMisses, cgroupCPUMigrations, cgroupWakeups, cgroupCacheReferences uint64
-		for _, cpuStat := range perCPUStats {
-			cgroupLatencies += cpuStat.Sum_latencies_ns
-			cgroupEvents += cpuStat.Event_count
-			cgroupPreemptions += cpuStat.Preemption_count
-			cgroupCycles += cpuStat.Sum_cycles
-			cgroupInstructions += cpuStat.Sum_instructions
-			cgroupLLCMisses += cpuStat.Sum_llc_misses
-			cgroupITLBMisses += cpuStat.Sum_itlb_misses
-			cgroupSoftirqNs += cpuStat.Sum_softirq_ns
-			cgroupBlockIO += cpuStat.Block_io_requests
-			cgroupBranchMisses += cpuStat.Sum_branch_misses
-			cgroupCPUMigrations += cpuStat.Sum_cpu_migrations
-			cgroupWakeups += cpuStat.Wakeup_count
-			cgroupCacheReferences += cpuStat.Sum_cache_references
-			// pid_count is a global cgroup value (not per-CPU), so take the max rather than summing
-			if cpuStat.Pid_count > pidCount {
-				pidCount = cpuStat.Pid_count
-			}
+		if err := ctx.Err(); err != nil {
+			return nil, err
 		}
-
 		cgroupsToDelete = append(cgroupsToDelete, cgroupID)
-
-		if cgroupEvents == 0 && cgroupSoftirqNs == 0 && cgroupBlockIO == 0 && cgroupWakeups == 0 {
+		var agg model.Stats
+		aggregatePerCPU(&agg, cgroupID, perCPUStats)
+		if !hasActivity(&agg) {
 			continue
 		}
-
-		stat := model.NoisyNeighborStats{
-			CgroupID:           cgroupID,
-			SumLatenciesNs:     cgroupLatencies,
-			EventCount:         cgroupEvents,
-			PreemptionCount:    cgroupPreemptions,
-			UniquePidCount:     pidCount,
-			SumCycles:          cgroupCycles,
-			SumInstructions:    cgroupInstructions,
-			SumLLCMisses:       cgroupLLCMisses,
-			SumITLBMisses:      cgroupITLBMisses,
-			SumSoftirqNs:       cgroupSoftirqNs,
-			BlockIORequests:    cgroupBlockIO,
-			SumBranchMisses:    cgroupBranchMisses,
-			SumCPUMigrations:   cgroupCPUMigrations,
-			WakeupCount:        cgroupWakeups,
-			SumCacheReferences: cgroupCacheReferences,
-		}
-
-		nnstats = append(nnstats, stat)
+		stats = append(stats, agg)
 	}
 
 	if err := iter.Err(); err != nil {
-		log.Errorf("error iterating cgroup_agg_stats map: %v", err)
+		return nil, fmt.Errorf("iterate cgroup_agg_stats: %w", err)
 	}
 
-	for _, cgID := range cgroupsToDelete {
-		if err := aggMap.Delete(&cgID); err != nil {
-			log.Errorf("failed to delete cgroup %d from agg map: %v", cgID, err)
+	var deleteErrs []error
+	for _, cgroupID := range cgroupsToDelete {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if err := aggMap.Delete(&cgroupID); err != nil {
+			if errors.Is(err, unix.ENOENT) {
+				// The entry got deleted between Iterate and Delete (concurrent
+				// removal by the eBPF side). Benign.
+				continue
+			}
+			deleteErrs = append(deleteErrs, fmt.Errorf("delete cgroup %d: %w", cgroupID, err))
 		}
 	}
+	if err := errors.Join(deleteErrs...); err != nil {
+		return nil, fmt.Errorf("flush cgroup_agg_stats: %w", err)
+	}
 
-	return nnstats
+	return stats, nil
+}
+
+// aggregatePerCPU sums per-CPU counters for one cgroup into dst. Range by
+// index to avoid copying the 112-byte ebpfCgroupAggStats per iteration.
+func aggregatePerCPU(dst *model.Stats, cgroupID uint64, perCPU []ebpfCgroupAggStats) {
+	dst.CgroupID = cgroupID
+	for i := range perCPU {
+		cpuStat := &perCPU[i]
+		dst.SumLatenciesNs += cpuStat.Sum_latencies_ns
+		dst.EventCount += cpuStat.Event_count
+		dst.PreemptionCount += cpuStat.Preemption_count
+		dst.SumCycles += cpuStat.Sum_cycles
+		dst.SumInstructions += cpuStat.Sum_instructions
+		dst.SumLLCMisses += cpuStat.Sum_llc_misses
+		dst.SumITLBMisses += cpuStat.Sum_itlb_misses
+		dst.SumSoftirqNs += cpuStat.Sum_softirq_ns
+		dst.BlockIORequests += cpuStat.Block_io_requests
+		dst.SumBranchMisses += cpuStat.Sum_branch_misses
+		dst.SumCPUMigrations += cpuStat.Sum_cpu_migrations
+		dst.WakeupCount += cpuStat.Wakeup_count
+		dst.SumCacheReferences += cpuStat.Sum_cache_references
+		// pid_count is a global cgroup value (not per-CPU): take max, not sum.
+		dst.UniquePidCount = max(dst.UniquePidCount, cpuStat.Pid_count)
+	}
+}
+
+// hasActivity reports whether the cgroup had any observable scheduling,
+// softirq, block-IO, or wakeup activity in the window.
+func hasActivity(s *model.Stats) bool {
+	return s.EventCount != 0 || s.SumSoftirqNs != 0 || s.BlockIORequests != 0 || s.WakeupCount != 0
 }

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
@@ -27,6 +27,15 @@ import (
 // 5.13 for kfuncs, 6.2 for bpf_rcu_read_lock kfunc
 var minimumKernelVersion = kernel.VersionCode(6, 2, 0)
 
+// Config holds noisy_neighbor-specific runtime knobs read from system-probe
+// config. PMUMetrics keys are the BPF perf-event-array map names (e.g.
+// "cycles_pmu"); a missing key or a false value disables the corresponding
+// counter: no perf fds are opened for it, the eBPF program reads -ENOENT
+// and skips the deltas for that event.
+type Config struct {
+	PMUMetrics map[string]bool
+}
+
 // Probe is the eBPF side of the noisy neighbor check
 type Probe struct {
 	mgr    *ddebpf.Manager
@@ -34,7 +43,7 @@ type Probe struct {
 }
 
 // NewProbe creates a [Probe]
-func NewProbe(cfg *ddebpf.Config) (*Probe, error) {
+func NewProbe(cfg *ddebpf.Config, modCfg Config) (*Probe, error) {
 	kv, err := kernel.HostVersion()
 	if err != nil {
 		return nil, fmt.Errorf("kernel version: %w", err)
@@ -94,7 +103,7 @@ func NewProbe(cfg *ddebpf.Config) (*Probe, error) {
 		}
 	}
 	ddebpf.AddNameMappings(p.mgr.Manager, "noisy_neighbor")
-	p.attachPMU()
+	p.attachPMU(modCfg.PMUMetrics)
 	return p, nil
 }
 
@@ -112,10 +121,13 @@ const itlbLoadMissesConfig = uint64(unix.PERF_COUNT_HW_CACHE_ITLB) |
 	(uint64(unix.PERF_COUNT_HW_CACHE_OP_READ) << 8) |
 	(uint64(unix.PERF_COUNT_HW_CACHE_RESULT_MISS) << 16)
 
-// attachPMU opens per-CPU perf events for every counter we track and
-// populates the corresponding BPF perf-event-array maps. See attachPMUEvent
-// for per-event semantics and failure modes.
-func (p *Probe) attachPMU() {
+// attachPMU opens per-CPU perf events for every counter enabled via
+// pmuEnabled (keyed by BPF map name) and populates the corresponding BPF
+// perf-event-array maps. Events absent from the map or set to false are
+// skipped — no perf fds are opened, the eBPF read returns -ENOENT, and
+// deltas for that event are dropped. See attachPMUEvent for per-event
+// semantics and failure modes.
+func (p *Probe) attachPMU(pmuEnabled map[string]bool) {
 	events := []pmuEvent{
 		{mapName: "cycles_pmu", humanLabel: "cycles", perfType: unix.PERF_TYPE_HARDWARE, perfConfig: unix.PERF_COUNT_HW_CPU_CYCLES},
 		{mapName: "instructions_pmu", humanLabel: "instructions", perfType: unix.PERF_TYPE_HARDWARE, perfConfig: unix.PERF_COUNT_HW_INSTRUCTIONS},
@@ -132,6 +144,10 @@ func (p *Probe) attachPMU() {
 	}
 	numCPU := runtime.NumCPU()
 	for _, ev := range events {
+		if !pmuEnabled[ev.mapName] {
+			log.Debugf("noisy_neighbor: %s PMU event disabled by config, skipping", ev.humanLabel)
+			continue
+		}
 		p.attachPMUEvent(ev, numCPU)
 	}
 }

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
@@ -258,7 +258,13 @@ func (p *Probe) GetAndFlush() []model.NoisyNeighborStats {
 
 		cgroupsToDelete = append(cgroupsToDelete, cgroupID)
 
-		if stat.EventCount == 0 && stat.SumSoftirqNs == 0 && stat.BlockIORequests == 0 && stat.WakeupCount == 0 {
+		// Drop only when there is no observable activity from any source.
+		// PMU sums are included so a task that was already on-CPU at window
+		// start and gets switched out exactly once (PMU stamp delta accrued,
+		// no schedule-on event) isn't silently flushed.
+		if stat.EventCount == 0 && stat.SumSoftirqNs == 0 && stat.BlockIORequests == 0 && stat.WakeupCount == 0 &&
+			stat.SumCycles == 0 && stat.SumInstructions == 0 && stat.SumLLCMisses == 0 && stat.SumCacheReferences == 0 &&
+			stat.SumITLBMisses == 0 && stat.SumBranchMisses == 0 && stat.SumCPUMigrations == 0 {
 			continue
 		}
 

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
@@ -56,6 +56,9 @@ func NewProbe(cfg *ddebpf.Config) (*Probe, error) {
 			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "tp_sched_wakeup", UID: uid}},
 			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "tp_sched_wakeup_new", UID: uid}},
 			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "tp_sched_switch", UID: uid}},
+			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "tp_softirq_entry", UID: uid}},
+			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "tp_softirq_exit", UID: uid}},
+			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "tp_block_rq_issue", UID: uid}},
 		}
 		p.mgr.Maps = []*manager.Map{
 			{Name: "runq_enqueued"},
@@ -63,6 +66,9 @@ func NewProbe(cfg *ddebpf.Config) (*Probe, error) {
 			{Name: "cgroup_agg_stats"},
 			{Name: "cycles_pmu"},
 			{Name: "instructions_pmu"},
+			{Name: "llc_misses_pmu"},
+			{Name: "itlb_misses_pmu"},
+			{Name: "softirq_start_ns"},
 		}
 		if err := p.mgr.InitWithOptions(buf, &opts); err != nil {
 			return fmt.Errorf("failed to init ebpf manager: %w", err)
@@ -82,64 +88,66 @@ func NewProbe(cfg *ddebpf.Config) (*Probe, error) {
 	return p, nil
 }
 
-// attachPMU opens per-CPU hardware perf events for cycles and instructions,
-// inserting their file descriptors into the corresponding BPF perf-event-array
-// maps. On hosts where the PMU is unavailable (some virtualized environments,
-// restrictive perf_event_paranoid, missing CAP_PERF_MON) the perf event opens
-// will fail; we log once and proceed. The eBPF program checks the read-value
-// helper return code and skips CPI accumulation for those CPUs.
-func (p *Probe) attachPMU() {
-	cyclesMap, _, err := p.mgr.GetMap("cycles_pmu")
-	if err != nil || cyclesMap == nil {
-		log.Warnf("noisy_neighbor: cycles_pmu map missing, CPI metrics disabled: %v", err)
-		return
-	}
-	instMap, _, err := p.mgr.GetMap("instructions_pmu")
-	if err != nil || instMap == nil {
-		log.Warnf("noisy_neighbor: instructions_pmu map missing, CPI metrics disabled: %v", err)
-		return
-	}
+// pmuEvent describes one hardware counter we want per-CPU.
+type pmuEvent struct {
+	mapName    string
+	humanLabel string
+	perfType   uint32
+	perfConfig uint64
+}
 
+// iTLB-load-misses encoded for PERF_TYPE_HW_CACHE: cache_id | (op << 8) | (result << 16).
+const itlbLoadMissesConfig = uint64(unix.PERF_COUNT_HW_CACHE_ITLB) |
+	(uint64(unix.PERF_COUNT_HW_CACHE_OP_READ) << 8) |
+	(uint64(unix.PERF_COUNT_HW_CACHE_RESULT_MISS) << 16)
+
+// attachPMU opens per-CPU hardware perf events and inserts their fds into the
+// corresponding BPF perf-event-array maps. On hosts where a given event isn't
+// supported (virtualized envs, restrictive perf_event_paranoid, missing
+// CAP_PERF_MON, or µarch lacking the event) opens fail and we log once per
+// event type. Other events still attach independently, and the eBPF program
+// checks each read-value return code and skips just that counter's deltas.
+func (p *Probe) attachPMU() {
+	events := []pmuEvent{
+		{"cycles_pmu", "cycles", unix.PERF_TYPE_HARDWARE, unix.PERF_COUNT_HW_CPU_CYCLES},
+		{"instructions_pmu", "instructions", unix.PERF_TYPE_HARDWARE, unix.PERF_COUNT_HW_INSTRUCTIONS},
+		{"llc_misses_pmu", "LLC misses", unix.PERF_TYPE_HARDWARE, unix.PERF_COUNT_HW_CACHE_MISSES},
+		{"itlb_misses_pmu", "iTLB misses", unix.PERF_TYPE_HW_CACHE, itlbLoadMissesConfig},
+	}
 	numCPU := runtime.NumCPU()
-	var loggedPMU bool
-	for cpu := 0; cpu < numCPU; cpu++ {
-		cycFD, err := openHardwarePerfEvent(cpu, unix.PERF_COUNT_HW_CPU_CYCLES)
-		if err != nil {
-			if !loggedPMU {
-				log.Warnf("noisy_neighbor: PMU unavailable, cycles/instructions metrics will be zero: %v", err)
-				loggedPMU = true
-			}
-			continue
-		}
-		insFD, err := openHardwarePerfEvent(cpu, unix.PERF_COUNT_HW_INSTRUCTIONS)
-		if err != nil {
-			unix.Close(cycFD)
-			if !loggedPMU {
-				log.Warnf("noisy_neighbor: PMU unavailable, cycles/instructions metrics will be zero: %v", err)
-				loggedPMU = true
-			}
-			continue
-		}
-		key := uint32(cpu)
-		if err := cyclesMap.Put(key, uint32(cycFD)); err != nil {
-			log.Warnf("noisy_neighbor: failed to register cycles fd on cpu %d: %v", cpu, err)
-			unix.Close(cycFD)
-			unix.Close(insFD)
-			continue
-		}
-		if err := instMap.Put(key, uint32(insFD)); err != nil {
-			log.Warnf("noisy_neighbor: failed to register instructions fd on cpu %d: %v", cpu, err)
-			unix.Close(cycFD)
-			unix.Close(insFD)
-			continue
-		}
-		p.pmuFDs = append(p.pmuFDs, cycFD, insFD)
+	for _, ev := range events {
+		p.attachPMUEvent(ev, numCPU)
 	}
 }
 
-func openHardwarePerfEvent(cpu int, config uint64) (int, error) {
+func (p *Probe) attachPMUEvent(ev pmuEvent, numCPU int) {
+	m, _, err := p.mgr.GetMap(ev.mapName)
+	if err != nil || m == nil {
+		log.Warnf("noisy_neighbor: %s map (%s) missing: %v", ev.humanLabel, ev.mapName, err)
+		return
+	}
+	var logged bool
+	for cpu := 0; cpu < numCPU; cpu++ {
+		fd, err := openHardwarePerfEvent(ev.perfType, ev.perfConfig, cpu)
+		if err != nil {
+			if !logged {
+				log.Warnf("noisy_neighbor: %s PMU event unavailable, metric will be zero: %v", ev.humanLabel, err)
+				logged = true
+			}
+			continue
+		}
+		if err := m.Put(uint32(cpu), uint32(fd)); err != nil {
+			log.Warnf("noisy_neighbor: failed to register %s fd on cpu %d: %v", ev.humanLabel, cpu, err)
+			unix.Close(fd)
+			continue
+		}
+		p.pmuFDs = append(p.pmuFDs, fd)
+	}
+}
+
+func openHardwarePerfEvent(perfType uint32, config uint64, cpu int) (int, error) {
 	attr := &unix.PerfEventAttr{
-		Type:   unix.PERF_TYPE_HARDWARE,
+		Type:   perfType,
 		Config: config,
 		Size:   uint32(unsafe.Sizeof(unix.PerfEventAttr{})),
 	}
@@ -190,12 +198,18 @@ func (p *Probe) GetAndFlush() []model.NoisyNeighborStats {
 	for iter.Next(&cgroupID, &perCPUStats) {
 		var cgroupLatencies, cgroupEvents, cgroupPreemptions, pidCount uint64
 		var cgroupCycles, cgroupInstructions uint64
+		var cgroupLLCMisses, cgroupITLBMisses uint64
+		var cgroupSoftirqNs, cgroupBlockIO uint64
 		for _, cpuStat := range perCPUStats {
 			cgroupLatencies += cpuStat.Sum_latencies_ns
 			cgroupEvents += cpuStat.Event_count
 			cgroupPreemptions += cpuStat.Preemption_count
 			cgroupCycles += cpuStat.Sum_cycles
 			cgroupInstructions += cpuStat.Sum_instructions
+			cgroupLLCMisses += cpuStat.Sum_llc_misses
+			cgroupITLBMisses += cpuStat.Sum_itlb_misses
+			cgroupSoftirqNs += cpuStat.Sum_softirq_ns
+			cgroupBlockIO += cpuStat.Block_io_requests
 			// pid_count is a global cgroup value (not per-CPU), so take the max rather than summing
 			if cpuStat.Pid_count > pidCount {
 				pidCount = cpuStat.Pid_count
@@ -204,7 +218,7 @@ func (p *Probe) GetAndFlush() []model.NoisyNeighborStats {
 
 		cgroupsToDelete = append(cgroupsToDelete, cgroupID)
 
-		if cgroupEvents == 0 {
+		if cgroupEvents == 0 && cgroupSoftirqNs == 0 && cgroupBlockIO == 0 {
 			continue
 		}
 
@@ -216,6 +230,10 @@ func (p *Probe) GetAndFlush() []model.NoisyNeighborStats {
 			UniquePidCount:  pidCount,
 			SumCycles:       cgroupCycles,
 			SumInstructions: cgroupInstructions,
+			SumLLCMisses:    cgroupLLCMisses,
+			SumITLBMisses:   cgroupITLBMisses,
+			SumSoftirqNs:    cgroupSoftirqNs,
+			BlockIORequests: cgroupBlockIO,
 		}
 
 		nnstats = append(nnstats, stat)

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
@@ -10,7 +10,6 @@ package noisyneighbor
 
 import (
 	"fmt"
-	"runtime"
 	"unsafe"
 
 	manager "github.com/DataDog/ebpf-manager"
@@ -119,7 +118,24 @@ const itlbLoadMissesConfig = uint64(unix.PERF_COUNT_HW_CACHE_ITLB) |
 // skipped — no perf fds are opened, the eBPF read returns -ENOENT, and
 // deltas for that event are dropped. See attachPMUEvent for per-event
 // semantics and failure modes.
+//
+// The CPU list comes from kernel.OnlineCPUs() rather than runtime.NumCPU().
+// runtime.NumCPU() returns the size of the caller's sched_getaffinity mask,
+// so on a cpuset-restricted system-probe (e.g. a Guaranteed-QoS pod under
+// the kubelet static CPU manager) it can be smaller than the host CPU id
+// range. Tracepoints fire on every online CPU regardless of the loader's
+// affinity, so any host CPU missing from the perf-event-array reads -ENOENT
+// on the BPF side and silently undercounts.
+//
+// CPU hotplug is not handled: the online set is snapshotted once here. A
+// CPU brought online after init will have an empty map slot and its PMU
+// samples will be dropped until the probe is reloaded.
 func (p *Probe) attachPMU(pmuEnabled map[string]bool) {
+	cpus, err := kernel.OnlineCPUs()
+	if err != nil {
+		log.Warnf("noisy_neighbor: cannot enumerate online CPUs (%v); PMU counters disabled", err)
+		return
+	}
 	events := []pmuEvent{
 		{mapName: "cycles_pmu", humanLabel: "cycles", perfType: unix.PERF_TYPE_HARDWARE, perfConfig: unix.PERF_COUNT_HW_CPU_CYCLES},
 		{mapName: "instructions_pmu", humanLabel: "instructions", perfType: unix.PERF_TYPE_HARDWARE, perfConfig: unix.PERF_COUNT_HW_INSTRUCTIONS},
@@ -134,23 +150,23 @@ func (p *Probe) attachPMU(pmuEnabled map[string]bool) {
 		// flat for memory-bound workloads already at floor miss rate.
 		{mapName: "cache_references_pmu", humanLabel: "cache references", perfType: unix.PERF_TYPE_HARDWARE, perfConfig: unix.PERF_COUNT_HW_CACHE_REFERENCES},
 	}
-	numCPU := runtime.NumCPU()
 	for _, ev := range events {
 		if !pmuEnabled[ev.mapName] {
 			log.Debugf("noisy_neighbor: %s PMU event disabled by config, skipping", ev.humanLabel)
 			continue
 		}
-		p.attachPMUEvent(ev, numCPU)
+		p.attachPMUEvent(ev, cpus)
 	}
 }
 
-// attachPMUEvent opens one perf event per CPU and inserts the fds into the
-// associated BPF perf-event-array map. On hosts where the event isn't
+// attachPMUEvent opens one perf event per online CPU and inserts the fds
+// into the associated BPF perf-event-array map at the host CPU id (matching
+// BPF_F_CURRENT_CPU on the reader side). On hosts where the event isn't
 // supported (virtualized envs, restrictive perf_event_paranoid, missing
 // CAP_PERF_MON, or µarch lacking the event) opens fail and we log once per
 // event type. Other events still attach independently, and the eBPF program
 // checks each read-value return code and skips just that counter's deltas.
-func (p *Probe) attachPMUEvent(ev pmuEvent, numCPU int) {
+func (p *Probe) attachPMUEvent(ev pmuEvent, cpus []uint) {
 	m, _, err := p.mgr.GetMap(ev.mapName)
 	if err != nil {
 		log.Warnf("noisy_neighbor: %s map (%s) lookup failed: %v", ev.humanLabel, ev.mapName, err)
@@ -161,11 +177,11 @@ func (p *Probe) attachPMUEvent(ev pmuEvent, numCPU int) {
 		return
 	}
 	var logged bool
-	for cpu := 0; cpu < numCPU; cpu++ {
-		fd, err := openHardwarePerfEvent(ev.perfType, ev.perfConfig, cpu)
+	for _, cpu := range cpus {
+		fd, err := openHardwarePerfEvent(ev.perfType, ev.perfConfig, int(cpu))
 		if err != nil {
 			if !logged {
-				log.Warnf("noisy_neighbor: %s PMU event unavailable, metric will be zero: %v", ev.humanLabel, err)
+				log.Warnf("noisy_neighbor: %s PMU event unavailable on cpu %d, metric will be zero for that CPU: %v", ev.humanLabel, cpu, err)
 				logged = true
 			}
 			continue

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
@@ -70,6 +70,7 @@ func NewProbe(cfg *ddebpf.Config) (*Probe, error) {
 			{Name: "itlb_misses_pmu"},
 			{Name: "branch_misses_pmu"},
 			{Name: "cpu_migrations_pmu"},
+			{Name: "cache_references_pmu"},
 			{Name: "softirq_start_ns"},
 		}
 		if err := p.mgr.InitWithOptions(buf, &opts); err != nil {
@@ -124,6 +125,10 @@ func (p *Probe) attachPMU() {
 		// CPU migrations is a software counter — doesn't compete for hardware
 		// PMU counters and is always available regardless of µarch.
 		{"cpu_migrations_pmu", "CPU migrations", unix.PERF_TYPE_SOFTWARE, unix.PERF_COUNT_SW_CPU_MIGRATIONS},
+		// Cache references pairs with llc_misses to give LLC hit-rate: under
+		// cache thrashing the rate moves even when absolute miss count stays
+		// flat for memory-bound workloads already at floor miss rate.
+		{"cache_references_pmu", "cache references", unix.PERF_TYPE_HARDWARE, unix.PERF_COUNT_HW_CACHE_REFERENCES},
 	}
 	numCPU := runtime.NumCPU()
 	for _, ev := range events {
@@ -222,7 +227,7 @@ func (p *Probe) GetAndFlush() []model.NoisyNeighborStats {
 		var cgroupCycles, cgroupInstructions uint64
 		var cgroupLLCMisses, cgroupITLBMisses uint64
 		var cgroupSoftirqNs, cgroupBlockIO uint64
-		var cgroupBranchMisses, cgroupCPUMigrations, cgroupWakeups uint64
+		var cgroupBranchMisses, cgroupCPUMigrations, cgroupWakeups, cgroupCacheReferences uint64
 		for _, cpuStat := range perCPUStats {
 			cgroupLatencies += cpuStat.Sum_latencies_ns
 			cgroupEvents += cpuStat.Event_count
@@ -236,6 +241,7 @@ func (p *Probe) GetAndFlush() []model.NoisyNeighborStats {
 			cgroupBranchMisses += cpuStat.Sum_branch_misses
 			cgroupCPUMigrations += cpuStat.Sum_cpu_migrations
 			cgroupWakeups += cpuStat.Wakeup_count
+			cgroupCacheReferences += cpuStat.Sum_cache_references
 			// pid_count is a global cgroup value (not per-CPU), so take the max rather than summing
 			if cpuStat.Pid_count > pidCount {
 				pidCount = cpuStat.Pid_count
@@ -249,20 +255,21 @@ func (p *Probe) GetAndFlush() []model.NoisyNeighborStats {
 		}
 
 		stat := model.NoisyNeighborStats{
-			CgroupID:         cgroupID,
-			SumLatenciesNs:   cgroupLatencies,
-			EventCount:       cgroupEvents,
-			PreemptionCount:  cgroupPreemptions,
-			UniquePidCount:   pidCount,
-			SumCycles:        cgroupCycles,
-			SumInstructions:  cgroupInstructions,
-			SumLLCMisses:     cgroupLLCMisses,
-			SumITLBMisses:    cgroupITLBMisses,
-			SumSoftirqNs:     cgroupSoftirqNs,
-			BlockIORequests:  cgroupBlockIO,
-			SumBranchMisses:  cgroupBranchMisses,
-			SumCPUMigrations: cgroupCPUMigrations,
-			WakeupCount:      cgroupWakeups,
+			CgroupID:           cgroupID,
+			SumLatenciesNs:     cgroupLatencies,
+			EventCount:         cgroupEvents,
+			PreemptionCount:    cgroupPreemptions,
+			UniquePidCount:     pidCount,
+			SumCycles:          cgroupCycles,
+			SumInstructions:    cgroupInstructions,
+			SumLLCMisses:       cgroupLLCMisses,
+			SumITLBMisses:      cgroupITLBMisses,
+			SumSoftirqNs:       cgroupSoftirqNs,
+			BlockIORequests:    cgroupBlockIO,
+			SumBranchMisses:    cgroupBranchMisses,
+			SumCPUMigrations:   cgroupCPUMigrations,
+			WakeupCount:        cgroupWakeups,
+			SumCacheReferences: cgroupCacheReferences,
 		}
 
 		nnstats = append(nnstats, stat)

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
@@ -117,18 +117,18 @@ const itlbLoadMissesConfig = uint64(unix.PERF_COUNT_HW_CACHE_ITLB) |
 // for per-event semantics and failure modes.
 func (p *Probe) attachPMU() {
 	events := []pmuEvent{
-		{"cycles_pmu", "cycles", unix.PERF_TYPE_HARDWARE, unix.PERF_COUNT_HW_CPU_CYCLES},
-		{"instructions_pmu", "instructions", unix.PERF_TYPE_HARDWARE, unix.PERF_COUNT_HW_INSTRUCTIONS},
-		{"llc_misses_pmu", "LLC misses", unix.PERF_TYPE_HARDWARE, unix.PERF_COUNT_HW_CACHE_MISSES},
-		{"itlb_misses_pmu", "iTLB misses", unix.PERF_TYPE_HW_CACHE, itlbLoadMissesConfig},
-		{"branch_misses_pmu", "branch misses", unix.PERF_TYPE_HARDWARE, unix.PERF_COUNT_HW_BRANCH_MISSES},
+		{mapName: "cycles_pmu", humanLabel: "cycles", perfType: unix.PERF_TYPE_HARDWARE, perfConfig: unix.PERF_COUNT_HW_CPU_CYCLES},
+		{mapName: "instructions_pmu", humanLabel: "instructions", perfType: unix.PERF_TYPE_HARDWARE, perfConfig: unix.PERF_COUNT_HW_INSTRUCTIONS},
+		{mapName: "llc_misses_pmu", humanLabel: "LLC misses", perfType: unix.PERF_TYPE_HARDWARE, perfConfig: unix.PERF_COUNT_HW_CACHE_MISSES},
+		{mapName: "itlb_misses_pmu", humanLabel: "iTLB misses", perfType: unix.PERF_TYPE_HW_CACHE, perfConfig: itlbLoadMissesConfig},
+		{mapName: "branch_misses_pmu", humanLabel: "branch misses", perfType: unix.PERF_TYPE_HARDWARE, perfConfig: unix.PERF_COUNT_HW_BRANCH_MISSES},
 		// CPU migrations is a software counter — doesn't compete for hardware
 		// PMU counters and is always available regardless of µarch.
-		{"cpu_migrations_pmu", "CPU migrations", unix.PERF_TYPE_SOFTWARE, unix.PERF_COUNT_SW_CPU_MIGRATIONS},
+		{mapName: "cpu_migrations_pmu", humanLabel: "CPU migrations", perfType: unix.PERF_TYPE_SOFTWARE, perfConfig: unix.PERF_COUNT_SW_CPU_MIGRATIONS},
 		// Cache references pairs with llc_misses to give LLC hit-rate: under
 		// cache thrashing the rate moves even when absolute miss count stays
 		// flat for memory-bound workloads already at floor miss rate.
-		{"cache_references_pmu", "cache references", unix.PERF_TYPE_HARDWARE, unix.PERF_COUNT_HW_CACHE_REFERENCES},
+		{mapName: "cache_references_pmu", humanLabel: "cache references", perfType: unix.PERF_TYPE_HARDWARE, perfConfig: unix.PERF_COUNT_HW_CACHE_REFERENCES},
 	}
 	numCPU := runtime.NumCPU()
 	for _, ev := range events {
@@ -144,8 +144,12 @@ func (p *Probe) attachPMU() {
 // checks each read-value return code and skips just that counter's deltas.
 func (p *Probe) attachPMUEvent(ev pmuEvent, numCPU int) {
 	m, _, err := p.mgr.GetMap(ev.mapName)
-	if err != nil || m == nil {
-		log.Warnf("noisy_neighbor: %s map (%s) missing: %v", ev.humanLabel, ev.mapName, err)
+	if err != nil {
+		log.Warnf("noisy_neighbor: %s map (%s) lookup failed: %v", ev.humanLabel, ev.mapName, err)
+		return
+	}
+	if m == nil {
+		log.Warnf("noisy_neighbor: %s map (%s) not registered in manager", ev.humanLabel, ev.mapName)
 		return
 	}
 	var logged bool
@@ -223,53 +227,31 @@ func (p *Probe) GetAndFlush() []model.NoisyNeighborStats {
 	var cgroupsToDelete []uint64
 
 	for iter.Next(&cgroupID, &perCPUStats) {
-		var cgroupLatencies, cgroupEvents, cgroupPreemptions, pidCount uint64
-		var cgroupCycles, cgroupInstructions uint64
-		var cgroupLLCMisses, cgroupITLBMisses uint64
-		var cgroupSoftirqNs, cgroupBlockIO uint64
-		var cgroupBranchMisses, cgroupCPUMigrations, cgroupWakeups, cgroupCacheReferences uint64
+		stat := model.NoisyNeighborStats{CgroupID: cgroupID}
 		for _, cpuStat := range perCPUStats {
-			cgroupLatencies += cpuStat.Sum_latencies_ns
-			cgroupEvents += cpuStat.Event_count
-			cgroupPreemptions += cpuStat.Preemption_count
-			cgroupCycles += cpuStat.Sum_cycles
-			cgroupInstructions += cpuStat.Sum_instructions
-			cgroupLLCMisses += cpuStat.Sum_llc_misses
-			cgroupITLBMisses += cpuStat.Sum_itlb_misses
-			cgroupSoftirqNs += cpuStat.Sum_softirq_ns
-			cgroupBlockIO += cpuStat.Block_io_requests
-			cgroupBranchMisses += cpuStat.Sum_branch_misses
-			cgroupCPUMigrations += cpuStat.Sum_cpu_migrations
-			cgroupWakeups += cpuStat.Wakeup_count
-			cgroupCacheReferences += cpuStat.Sum_cache_references
+			stat.SumLatenciesNs += cpuStat.Sum_latencies_ns
+			stat.EventCount += cpuStat.Event_count
+			stat.PreemptionCount += cpuStat.Preemption_count
+			stat.SumCycles += cpuStat.Sum_cycles
+			stat.SumInstructions += cpuStat.Sum_instructions
+			stat.SumLLCMisses += cpuStat.Sum_llc_misses
+			stat.SumITLBMisses += cpuStat.Sum_itlb_misses
+			stat.SumSoftirqNs += cpuStat.Sum_softirq_ns
+			stat.BlockIORequests += cpuStat.Block_io_requests
+			stat.SumBranchMisses += cpuStat.Sum_branch_misses
+			stat.SumCPUMigrations += cpuStat.Sum_cpu_migrations
+			stat.WakeupCount += cpuStat.Wakeup_count
+			stat.SumCacheReferences += cpuStat.Sum_cache_references
 			// pid_count is a global cgroup value (not per-CPU), so take the max rather than summing
-			if cpuStat.Pid_count > pidCount {
-				pidCount = cpuStat.Pid_count
+			if cpuStat.Pid_count > stat.UniquePidCount {
+				stat.UniquePidCount = cpuStat.Pid_count
 			}
 		}
 
 		cgroupsToDelete = append(cgroupsToDelete, cgroupID)
 
-		if cgroupEvents == 0 && cgroupSoftirqNs == 0 && cgroupBlockIO == 0 && cgroupWakeups == 0 {
+		if stat.EventCount == 0 && stat.SumSoftirqNs == 0 && stat.BlockIORequests == 0 && stat.WakeupCount == 0 {
 			continue
-		}
-
-		stat := model.NoisyNeighborStats{
-			CgroupID:           cgroupID,
-			SumLatenciesNs:     cgroupLatencies,
-			EventCount:         cgroupEvents,
-			PreemptionCount:    cgroupPreemptions,
-			UniquePidCount:     pidCount,
-			SumCycles:          cgroupCycles,
-			SumInstructions:    cgroupInstructions,
-			SumLLCMisses:       cgroupLLCMisses,
-			SumITLBMisses:      cgroupITLBMisses,
-			SumSoftirqNs:       cgroupSoftirqNs,
-			BlockIORequests:    cgroupBlockIO,
-			SumBranchMisses:    cgroupBranchMisses,
-			SumCPUMigrations:   cgroupCPUMigrations,
-			WakeupCount:        cgroupWakeups,
-			SumCacheReferences: cgroupCacheReferences,
 		}
 
 		nnstats = append(nnstats, stat)

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
@@ -79,9 +79,16 @@ func NewProbe(cfg *ddebpf.Config) (*Probe, error) {
 		return nil, err
 	}
 
-	err = p.mgr.Start()
-	if err != nil {
-		return nil, err
+	// Skip mgr.Start() and attach probes manually. Start() runs cleanupTraceFS
+	// which tries to remove ALL orphaned kprobe events on the host and fails
+	// fatally if any are pinned (common on dev machines where a previous agent
+	// left tail-called kprobes behind). This module only uses tracepoints, so
+	// we don't need the perf/ring reader startup that Start() also handles.
+	// Stop() requires state >= initialized, which InitWithOptions already set.
+	for _, probe := range p.mgr.Probes {
+		if err := probe.Attach(); err != nil {
+			return nil, fmt.Errorf("failed to attach probe %s: %w", probe.EBPFFuncName, err)
+		}
 	}
 	ddebpf.AddNameMappings(p.mgr.Manager, "noisy_neighbor")
 	p.attachPMU()

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe_test.go
@@ -36,7 +36,7 @@ func TestNoisyNeighborProbe(t *testing.T) {
 		t.Logf("testing on %s", os.Getenv("CI_JOB_NAME"))
 
 		cfg := testConfig()
-		probe, err := NewProbe(cfg)
+		probe, err := NewProbe(cfg, Config{PMUMetrics: allPMUMetricsEnabled()})
 		require.NoError(t, err)
 		t.Cleanup(probe.Close)
 
@@ -54,4 +54,18 @@ func TestNoisyNeighborProbe(t *testing.T) {
 func testConfig() *ebpf.Config {
 	cfg := ebpf.NewConfig()
 	return cfg
+}
+
+// allPMUMetricsEnabled returns the PMU-metrics map that NewProbe expects,
+// with every counter enabled — the default tested configuration.
+func allPMUMetricsEnabled() map[string]bool {
+	return map[string]bool{
+		"cycles_pmu":           true,
+		"instructions_pmu":     true,
+		"llc_misses_pmu":       true,
+		"cache_references_pmu": true,
+		"itlb_misses_pmu":      true,
+		"branch_misses_pmu":    true,
+		"cpu_migrations_pmu":   true,
+	}
 }

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe_test.go
@@ -5,210 +5,53 @@
 
 //go:build linux_bpf
 
+// Package noisyneighbor is the system-probe side of the Noisy Neighbor check.
 package noisyneighbor
 
 import (
-	"context"
 	"os"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
-	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe/noisyneighbor/model"
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
+var kv = kernel.MustHostVersion()
+
 func TestNoisyNeighborProbe(t *testing.T) {
-	ebpftest.TestBuildModes(t, []ebpftest.BuildMode{ebpftest.RuntimeCompiled, ebpftest.CORE}, "", func(t *testing.T) {
-		kv, err := kernel.HostVersion()
-		if err != nil {
-			t.Skipf("could not detect kernel version: %v", err)
-		}
+	ebpftest.TestBuildMode(t, ebpftest.CORE, "", func(t *testing.T) {
 		if kv < minimumKernelVersion {
-			t.Skipf("kernel version %v is below minimum %v", kv, minimumKernelVersion)
+			t.Skipf("Kernel version %v is not supported by the Noisy Neighbor probe", kv)
 		}
 
-		// TODO: Fedora 38 CI runners lack the perf_event_paranoid settings
-		// needed for HW PMU events. Re-enable once the runner image is fixed.
 		if strings.Contains(os.Getenv("CI_JOB_NAME"), "fedora_38") {
-			t.Skipf("PMU events unavailable on %s", os.Getenv("CI_JOB_NAME"))
+			t.Skipf("Noisy Neighbor probe is not supported on this environment: %s", os.Getenv("CI_JOB_NAME"))
 		}
 
-		cfg := ebpf.NewConfig()
+		t.Logf("testing on %s", os.Getenv("CI_JOB_NAME"))
+
+		cfg := testConfig()
 		probe, err := NewProbe(cfg)
-		if err != nil {
-			t.Fatalf("NewProbe(BPFDebug=%v) error = %v, want nil", cfg.BPFDebug, err)
-		}
+		require.NoError(t, err)
 		t.Cleanup(probe.Close)
 
-		var (
-			observed model.Stats
-			lastErr  error
-			lastLen  int
-		)
-		deadline := time.After(10 * time.Second)
-		tick := time.NewTicker(500 * time.Millisecond)
-		defer tick.Stop()
-		var found bool
-		for !found {
-			select {
-			case <-deadline:
-				t.Fatalf("Probe.GetAndFlush() produced no active cgroup within 10s; last error=%v, last record count=%d", lastErr, lastLen)
-			case <-tick.C:
-				stats, err := probe.GetAndFlush(context.Background())
-				lastErr = err
-				lastLen = len(stats)
-				if err != nil {
-					continue
-				}
-				for _, r := range stats {
-					if r.EventCount > 0 && r.UniquePidCount > 0 {
-						observed = r
-						found = true
-						break
-					}
+		require.Eventually(t, func() bool {
+			for _, r := range probe.GetAndFlush() {
+				if r.EventCount > 0 || r.PreemptionCount > 0 {
+					return true
 				}
 			}
-		}
-
-		// EventCount and UniquePidCount are non-zero on any host where any
-		// process is scheduled — they don't depend on HW PMU support.
-		if observed.EventCount == 0 {
-			t.Errorf("Probe.GetAndFlush() Stats{CgroupID:%d}.EventCount = 0, want > 0 (full record: %+v)", observed.CgroupID, observed)
-		}
-		if observed.UniquePidCount == 0 {
-			t.Errorf("Probe.GetAndFlush() Stats{CgroupID:%d}.UniquePidCount = 0, want > 0 (full record: %+v)", observed.CgroupID, observed)
-		}
-		if observed.SumLatenciesNs == 0 {
-			t.Errorf("Probe.GetAndFlush() Stats{CgroupID:%d}.SumLatenciesNs = 0, want > 0 (full record: %+v)", observed.CgroupID, observed)
-		}
-		if observed.WakeupCount == 0 {
-			t.Errorf("Probe.GetAndFlush() Stats{CgroupID:%d}.WakeupCount = 0, want > 0 (full record: %+v)", observed.CgroupID, observed)
-		}
+			return false
+		}, 10*time.Second, 500*time.Millisecond, "failed to get noisy neighbor stats")
 	})
 }
 
-func TestAggregatePerCPU(t *testing.T) {
-	tests := []struct {
-		name string
-		in   []ebpfCgroupAggStats
-		want model.Stats
-	}{
-		{
-			name: "empty",
-			in:   nil,
-			want: model.Stats{CgroupID: 42},
-		},
-		{
-			name: "single CPU sums into output",
-			in: []ebpfCgroupAggStats{
-				{
-					Sum_latencies_ns:     100,
-					Event_count:          5,
-					Preemption_count:     2,
-					Pid_count:            3,
-					Sum_cycles:           1000,
-					Sum_instructions:     2000,
-					Sum_llc_misses:       10,
-					Sum_itlb_misses:      4,
-					Sum_softirq_ns:       7,
-					Block_io_requests:    1,
-					Sum_branch_misses:    20,
-					Sum_cpu_migrations:   8,
-					Wakeup_count:         9,
-					Sum_cache_references: 50,
-				},
-			},
-			want: model.Stats{
-				CgroupID:           42,
-				SumLatenciesNs:     100,
-				EventCount:         5,
-				PreemptionCount:    2,
-				UniquePidCount:     3,
-				SumCycles:          1000,
-				SumInstructions:    2000,
-				SumLLCMisses:       10,
-				SumITLBMisses:      4,
-				SumSoftirqNs:       7,
-				BlockIORequests:    1,
-				SumBranchMisses:    20,
-				SumCPUMigrations:   8,
-				WakeupCount:        9,
-				SumCacheReferences: 50,
-			},
-		},
-		{
-			name: "pid_count is max across CPUs, other counters are summed",
-			in: []ebpfCgroupAggStats{
-				{Sum_latencies_ns: 50, Event_count: 1, Pid_count: 5},
-				{Sum_latencies_ns: 50, Event_count: 2, Pid_count: 3},
-				{Sum_latencies_ns: 50, Event_count: 4, Pid_count: 7},
-			},
-			want: model.Stats{
-				CgroupID:       42,
-				SumLatenciesNs: 150,
-				EventCount:     7,
-				UniquePidCount: 7,
-			},
-		},
-		{
-			name: "multi-CPU sums all PMU counters",
-			in: []ebpfCgroupAggStats{
-				{Sum_cycles: 100, Sum_instructions: 50, Sum_branch_misses: 3, Sum_llc_misses: 10, Sum_itlb_misses: 2, Sum_cpu_migrations: 1, Sum_cache_references: 30, Sum_softirq_ns: 5, Block_io_requests: 2, Wakeup_count: 4, Event_count: 1, Pid_count: 2},
-				{Sum_cycles: 200, Sum_instructions: 75, Sum_branch_misses: 4, Sum_llc_misses: 15, Sum_itlb_misses: 3, Sum_cpu_migrations: 2, Sum_cache_references: 40, Sum_softirq_ns: 6, Block_io_requests: 3, Wakeup_count: 5, Event_count: 1, Pid_count: 2},
-			},
-			want: model.Stats{
-				CgroupID:           42,
-				SumCycles:          300,
-				SumInstructions:    125,
-				SumBranchMisses:    7,
-				SumLLCMisses:       25,
-				SumITLBMisses:      5,
-				SumCPUMigrations:   3,
-				SumCacheReferences: 70,
-				SumSoftirqNs:       11,
-				BlockIORequests:    5,
-				WakeupCount:        9,
-				EventCount:         2,
-				UniquePidCount:     2,
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var got model.Stats
-			aggregatePerCPU(&got, 42, tt.in)
-			if !assert.ObjectsAreEqual(tt.want, got) {
-				t.Errorf("aggregatePerCPU(42, %+v):\n got: %+v\nwant: %+v", tt.in, got, tt.want)
-			}
-		})
-	}
-}
-
-func TestHasActivity(t *testing.T) {
-	tests := []struct {
-		name string
-		in   model.Stats
-		want bool
-	}{
-		{"zero", model.Stats{}, false},
-		{"events only", model.Stats{EventCount: 1}, true},
-		{"softirq only", model.Stats{SumSoftirqNs: 1}, true},
-		{"block io only", model.Stats{BlockIORequests: 1}, true},
-		{"wakeups only", model.Stats{WakeupCount: 1}, true},
-		{"latencies without events does not count", model.Stats{SumLatenciesNs: 999}, false},
-		{"cycles without events does not count", model.Stats{SumCycles: 999}, false},
-		{"preemption without events does not count", model.Stats{PreemptionCount: 5}, false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := hasActivity(&tt.in); got != tt.want {
-				t.Errorf("hasActivity(%+v) = %t, want %t", tt.in, got, tt.want)
-			}
-		})
-	}
+func testConfig() *ebpf.Config {
+	cfg := ebpf.NewConfig()
+	return cfg
 }

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe_test.go
@@ -5,53 +5,210 @@
 
 //go:build linux_bpf
 
-// Package noisyneighbor is the system-probe side of the Noisy Neighbor check.
 package noisyneighbor
 
 import (
+	"context"
 	"os"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe/noisyneighbor/model"
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
-var kv = kernel.MustHostVersion()
-
 func TestNoisyNeighborProbe(t *testing.T) {
-	ebpftest.TestBuildMode(t, ebpftest.CORE, "", func(t *testing.T) {
+	ebpftest.TestBuildModes(t, []ebpftest.BuildMode{ebpftest.RuntimeCompiled, ebpftest.CORE}, "", func(t *testing.T) {
+		kv, err := kernel.HostVersion()
+		if err != nil {
+			t.Skipf("could not detect kernel version: %v", err)
+		}
 		if kv < minimumKernelVersion {
-			t.Skipf("Kernel version %v is not supported by the Noisy Neighbor probe", kv)
+			t.Skipf("kernel version %v is below minimum %v", kv, minimumKernelVersion)
 		}
 
+		// TODO: Fedora 38 CI runners lack the perf_event_paranoid settings
+		// needed for HW PMU events. Re-enable once the runner image is fixed.
 		if strings.Contains(os.Getenv("CI_JOB_NAME"), "fedora_38") {
-			t.Skipf("Noisy Neighbor probe is not supported on this environment: %s", os.Getenv("CI_JOB_NAME"))
+			t.Skipf("PMU events unavailable on %s", os.Getenv("CI_JOB_NAME"))
 		}
 
-		t.Logf("testing on %s", os.Getenv("CI_JOB_NAME"))
-
-		cfg := testConfig()
+		cfg := ebpf.NewConfig()
 		probe, err := NewProbe(cfg)
-		require.NoError(t, err)
+		if err != nil {
+			t.Fatalf("NewProbe(BPFDebug=%v) error = %v, want nil", cfg.BPFDebug, err)
+		}
 		t.Cleanup(probe.Close)
 
-		require.Eventually(t, func() bool {
-			for _, r := range probe.GetAndFlush() {
-				if r.EventCount > 0 || r.PreemptionCount > 0 {
-					return true
+		var (
+			observed model.Stats
+			lastErr  error
+			lastLen  int
+		)
+		deadline := time.After(10 * time.Second)
+		tick := time.NewTicker(500 * time.Millisecond)
+		defer tick.Stop()
+		var found bool
+		for !found {
+			select {
+			case <-deadline:
+				t.Fatalf("Probe.GetAndFlush() produced no active cgroup within 10s; last error=%v, last record count=%d", lastErr, lastLen)
+			case <-tick.C:
+				stats, err := probe.GetAndFlush(context.Background())
+				lastErr = err
+				lastLen = len(stats)
+				if err != nil {
+					continue
+				}
+				for _, r := range stats {
+					if r.EventCount > 0 && r.UniquePidCount > 0 {
+						observed = r
+						found = true
+						break
+					}
 				}
 			}
-			return false
-		}, 10*time.Second, 500*time.Millisecond, "failed to get noisy neighbor stats")
+		}
+
+		// EventCount and UniquePidCount are non-zero on any host where any
+		// process is scheduled — they don't depend on HW PMU support.
+		if observed.EventCount == 0 {
+			t.Errorf("Probe.GetAndFlush() Stats{CgroupID:%d}.EventCount = 0, want > 0 (full record: %+v)", observed.CgroupID, observed)
+		}
+		if observed.UniquePidCount == 0 {
+			t.Errorf("Probe.GetAndFlush() Stats{CgroupID:%d}.UniquePidCount = 0, want > 0 (full record: %+v)", observed.CgroupID, observed)
+		}
+		if observed.SumLatenciesNs == 0 {
+			t.Errorf("Probe.GetAndFlush() Stats{CgroupID:%d}.SumLatenciesNs = 0, want > 0 (full record: %+v)", observed.CgroupID, observed)
+		}
+		if observed.WakeupCount == 0 {
+			t.Errorf("Probe.GetAndFlush() Stats{CgroupID:%d}.WakeupCount = 0, want > 0 (full record: %+v)", observed.CgroupID, observed)
+		}
 	})
 }
 
-func testConfig() *ebpf.Config {
-	cfg := ebpf.NewConfig()
-	return cfg
+func TestAggregatePerCPU(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []ebpfCgroupAggStats
+		want model.Stats
+	}{
+		{
+			name: "empty",
+			in:   nil,
+			want: model.Stats{CgroupID: 42},
+		},
+		{
+			name: "single CPU sums into output",
+			in: []ebpfCgroupAggStats{
+				{
+					Sum_latencies_ns:     100,
+					Event_count:          5,
+					Preemption_count:     2,
+					Pid_count:            3,
+					Sum_cycles:           1000,
+					Sum_instructions:     2000,
+					Sum_llc_misses:       10,
+					Sum_itlb_misses:      4,
+					Sum_softirq_ns:       7,
+					Block_io_requests:    1,
+					Sum_branch_misses:    20,
+					Sum_cpu_migrations:   8,
+					Wakeup_count:         9,
+					Sum_cache_references: 50,
+				},
+			},
+			want: model.Stats{
+				CgroupID:           42,
+				SumLatenciesNs:     100,
+				EventCount:         5,
+				PreemptionCount:    2,
+				UniquePidCount:     3,
+				SumCycles:          1000,
+				SumInstructions:    2000,
+				SumLLCMisses:       10,
+				SumITLBMisses:      4,
+				SumSoftirqNs:       7,
+				BlockIORequests:    1,
+				SumBranchMisses:    20,
+				SumCPUMigrations:   8,
+				WakeupCount:        9,
+				SumCacheReferences: 50,
+			},
+		},
+		{
+			name: "pid_count is max across CPUs, other counters are summed",
+			in: []ebpfCgroupAggStats{
+				{Sum_latencies_ns: 50, Event_count: 1, Pid_count: 5},
+				{Sum_latencies_ns: 50, Event_count: 2, Pid_count: 3},
+				{Sum_latencies_ns: 50, Event_count: 4, Pid_count: 7},
+			},
+			want: model.Stats{
+				CgroupID:       42,
+				SumLatenciesNs: 150,
+				EventCount:     7,
+				UniquePidCount: 7,
+			},
+		},
+		{
+			name: "multi-CPU sums all PMU counters",
+			in: []ebpfCgroupAggStats{
+				{Sum_cycles: 100, Sum_instructions: 50, Sum_branch_misses: 3, Sum_llc_misses: 10, Sum_itlb_misses: 2, Sum_cpu_migrations: 1, Sum_cache_references: 30, Sum_softirq_ns: 5, Block_io_requests: 2, Wakeup_count: 4, Event_count: 1, Pid_count: 2},
+				{Sum_cycles: 200, Sum_instructions: 75, Sum_branch_misses: 4, Sum_llc_misses: 15, Sum_itlb_misses: 3, Sum_cpu_migrations: 2, Sum_cache_references: 40, Sum_softirq_ns: 6, Block_io_requests: 3, Wakeup_count: 5, Event_count: 1, Pid_count: 2},
+			},
+			want: model.Stats{
+				CgroupID:           42,
+				SumCycles:          300,
+				SumInstructions:    125,
+				SumBranchMisses:    7,
+				SumLLCMisses:       25,
+				SumITLBMisses:      5,
+				SumCPUMigrations:   3,
+				SumCacheReferences: 70,
+				SumSoftirqNs:       11,
+				BlockIORequests:    5,
+				WakeupCount:        9,
+				EventCount:         2,
+				UniquePidCount:     2,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got model.Stats
+			aggregatePerCPU(&got, 42, tt.in)
+			if !assert.ObjectsAreEqual(tt.want, got) {
+				t.Errorf("aggregatePerCPU(42, %+v):\n got: %+v\nwant: %+v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasActivity(t *testing.T) {
+	tests := []struct {
+		name string
+		in   model.Stats
+		want bool
+	}{
+		{"zero", model.Stats{}, false},
+		{"events only", model.Stats{EventCount: 1}, true},
+		{"softirq only", model.Stats{SumSoftirqNs: 1}, true},
+		{"block io only", model.Stats{BlockIORequests: 1}, true},
+		{"wakeups only", model.Stats{WakeupCount: 1}, true},
+		{"latencies without events does not count", model.Stats{SumLatenciesNs: 999}, false},
+		{"cycles without events does not count", model.Stats{SumCycles: 999}, false},
+		{"preemption without events does not count", model.Stats{PreemptionCount: 5}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasActivity(&tt.in); got != tt.want {
+				t.Errorf("hasActivity(%+v) = %t, want %t", tt.in, got, tt.want)
+			}
+		})
+	}
 }

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe_test.go
@@ -62,7 +62,7 @@ func allPMUMetricsEnabled() map[string]bool {
 	return map[string]bool{
 		"cycles_pmu":           true,
 		"instructions_pmu":     true,
-		"llc_misses_pmu":       true,
+		"cache_misses_pmu":     true,
 		"cache_references_pmu": true,
 		"itlb_misses_pmu":      true,
 		"branch_misses_pmu":    true,


### PR DESCRIPTION
### What does this PR do?

Adds per-cgroup victim-detection signals to the `noisy_neighbor` eBPF check.

**PMU counters** — each gated by `noisy_neighbor.pmu_metrics.<name>`, all default **`false`**:
`cycles`, `instructions`, `cache_misses`, `cache_references`, `itlb_misses`, `branch_misses`, `cpu_migrations`.

**Tracepoint counters** — always on, cheap:
`wakeups`, `softirq_ns`, `block_io_requests`.

Plus a PMU multiplexing scaling correction so deltas under hardware-counter contention recover the true count via `enabled/running` (the standard `tools/perf/Documentation/perf-stat.txt` formula).

Also: `noisyNeighborModule.Close()` waits for in-flight `/check` handlers via a `sync.WaitGroup` before tearing down the BPF manager (was previously vulnerable to `mgr.Stop(CleanAll)` invalidating maps mid-iteration).


**How it works**

*Probe setup.* For each PMU event enabled by config, system-probe calls `perf_event_open` once per CPU and inserts the resulting fd into a dedicated BPF perf-event-array map (`cycles_pmu`, `instructions_pmu`, etc., one map per event). The eBPF program reads the current per-CPU counter value at runtime via `bpf_perf_event_read_value(&<event>_pmu, BPF_F_CURRENT_CPU, …)`. `cpu_migrations` uses `PERF_TYPE_SOFTWARE`, `itlb_misses` uses `PERF_TYPE_HW_CACHE` with a bit-packed `(cache, op, result)` config, and the remaining events are `PERF_TYPE_HARDWARE` enum values. Disabling an event in config skips its `perf_event_open` entirely — the map stays empty, the eBPF read returns `-ENOENT`, and that event's deltas are dropped (no overhead, no emission).

*Per-cgroup sampling.* Hardware PMU counters are monotonic — each is an odometer for some event (cycles elapsed, instructions retired, cache misses observed, etc.). To get a "how much happened during this window" number, you read the odometer at both ends of the window and subtract. We do that on every context switch. When the kernel switches a task **off** CPU, the BPF program reads each enabled counter's current value, subtracts the value it recorded when this same task was last switched **on**, and adds the difference into a per-cgroup running total (a BPF hash map keyed by cgroup id whose entries accumulate the per-metric counts). When a task is switched **on**, the BPF program reads the current counter values and stashes them in per-task BPF storage (a kernel-managed key-value store attached to the `task_struct`, auto-freed on task exit) as that task's new baseline — so the next switch-off can compute its delta against it. Net effect: every counter increment that happens while a task is on CPU is attributed to exactly that task's cgroup. The always-on tracepoint counters (`wakeups`, `softirq_ns`, `block_io_requests`) skip the stamp/delta dance — each kernel tracepoint hit increments the corresponding per-cgroup counter directly.

Userspace: every 10 s the agent-side `noisy_neighbor` check hits the system-probe `/check` endpoint over a Unix socket, which iterates the per-cgroup hash map, atomically flushes each entry, and returns the accumulated counts. The check maps each cgroup id to a `container_id` via the cgroup tagger and emits the counts as Datadog metrics tagged by container.

*PMU multiplexing correction.* CPUs expose only a fixed number of programmable PMU counters per core (often 4–8). When userspace opens more events than there are counters, the kernel time-slices them: each event runs on real hardware for only a fraction of the wall window and reports zero for the rest. The kernel surfaces this via two fields the read helper returns alongside the counter — `enabled` (wall time the event was scheduled to run) and `running` (actual time it had a hardware counter). A raw counter delta therefore under-reports by `running/enabled`, and we recover the true count via `scaled_delta = raw_delta × enabled_delta / running_delta` — the standard `tools/perf/Documentation/perf-stat.txt` formula. If `running_delta == 0` (the event was paused for the entire window), the sample carries no information and we return 0 rather than divide. Scaling is applied per event independently, so an event that wasn't multiplexed pays no correction cost. ([docs from linux perf tool on this](https://perfwiki.github.io/main/tutorial/#multiplexing-and-scaling-events))

### Motivation

Expanding the signal set to surface stronger discriminators for the noisy-neighbor victim-detection use case. Why each metric is in the set:

| Metric | Why it's useful for NN detection | Literature |
|---|---|---|
| `branch_misses` | Front-end pressure indicator. Normalized per instruction, branch-misprediction rate rises when a noisy co-tenant brings competing code paths that evict the victim's BTB/branch-predictor state. Discriminates by workload class — tight predictable loops keep predictor state warm and stay flat, while memory-traversing workloads (e.g. STREAM) show a large jump under contention. Useful where CPI saturates because OoO absorbs the stalls. | Kambadur SC'12, DeepDive, ProteanCode |
| `cache_references` | Companion to `cache_misses`. Lets the backend compute cache hit-rate `1 − miss/ref`, which is more informative than raw misses when miss-count is already at floor (memory-bound workloads where every load misses). Normalizing to working-set size makes the signal comparable across workloads with different cache footprints. | VM Survey, IntelMBA (LLC miss ratio) |
| `cache_misses` | `PERF_COUNT_HW_CACHE_MISSES` — typically last-level cache misses on modern CPUs. Most-cited cache-contention signal in the literature: a co-tenant evicting the victim's cache lines drives miss-count up. The canonical "noisy neighbor stomping on my cache" signal. Pair with `cache_references` and `instructions` to disambiguate "working set grew" from "co-tenant evicting us". Can floor for memory-bound workloads — useful but not sufficient alone. | Lias, PARTIES, OSML, Caladan, Pythia |
| `itlb_misses` | Instruction-TLB pressure. Rises when co-tenant code execution pollutes shared TLB structures, forcing the victim to re-walk page tables for its own instruction fetches. Lias found `iTLB-loads` to be the single most discriminating PMU counter on `img-dnn`; surfaces a contention class the data-side LLC signal misses. | Lias, iBench |
| `cycles` / `instructions` | CPI (`cycles/instructions`) is the most-cited single signal in the entire NN literature — rises under almost all microarchitectural contention (LLC, MemBW, SMT, even some I/O stalls). Acts as numerator/denominator for CPI and as denominator for every per-instruction rate (branch-miss rate, LLC-miss rate, iTLB rate) that strips out throughput variation. Known weakness: out-of-order execution can absorb stalls so CPI may stay flat for OoO-friendly workloads — keep as broad indicator, not sole alert. | CPI² (EuroSys'13), PANDA, DeepDive, C-Koordinator, Lias, Heracles |
| `cpu_migrations` | Direct scheduler-disruption signal. A busy host's load-balancer thrashes tasks across runqueues, so per-cgroup migration count jumps when the system is overcommitted — without needing a PMU slot. Cheaper proxy for the same shape Volpert ICPE'25 captures with PSL/PSP. Moves with system load rather than workload character, so it's an overcommit indicator more than a sensitivity indicator. | Lias |
| `wakeups` | Scheduling-frequency / runqueue-depth proxy. UFO (NSDI'24) shows wakeup/scheduling frequency tracks P99 latency without any app instrumentation, which is exactly the position an external observability vendor sits in. Caveat: tight CPU-loop workloads don't block much, so this concentrates in the host root cgroup and short-lived tasks — most useful as a host-overcommit indicator. | UFO NSDI'24, Lias, Reconciling |
| `softirq_ns` | Per-cgroup softirq time. Iron (NSDI'18) showed the kernel charges network/timer softirq processing to whichever cgroup happens to be on-CPU, not to the cgroup whose packets are being handled — causing up to 6× slowdown that's invisible in standard cgroup CPU accounting. Surfacing softirq time per cgroup fixes that attribution blind spot for network-heavy noisy neighbors. | Iron NSDI'18 |
| `block_io_requests` | Per-cgroup block-I/O request rate. Storage contention from a noisy co-tenant (page reclaim, log churn, fio-style workloads) doesn't show up in CPU or cache signals at all — this is the I/O-dimension counterpart. Same pattern Volpert ICPE'24 uses for OCI runtime isolation analysis. | Volpert ICPE'24 OCI, DC-Store |

### Describe how you validated your changes

Validated in a local kind cluster and deployed to a staging cluster:
- [Dashboard](https://ddstaging.datadoghq.com/dashboard/68k-c5q-vvj/noisy-neighbor-victim-detection-v3?fromUser=true&refresh_mode=paused&tpl_var_kube_node%5B0%5D=ip-10-114-3-76.ec2.internal&tpl_var_pod_name%5B0%5D=cpu%2A&tpl_var_pod_name%5B1%5D=ephemera%2A&from_ts=1778538501104&to_ts=1778538801104&live=false) showing all PMU metrics for ephemera + cpuburn test


### Additional Notes

- `ebpf_types_linux.go` is hand-edited; `verify_generated_files` will fail until regenerated in a clang/kernel-headers environment.



