### PR TITLE
Exclude vendor from gazelle.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -836,6 +836,7 @@ exports_files(glob(
 # gazelle:exclude tools/host-profiler
 # gazelle:exclude tools/retry_file_dump
 # gazelle:exclude tools/windows
+# gazelle:exclude vendor
 # Proto definitions under pkg/proto/datadog/ use pre-generated Go code checked
 # into pkg/proto/pbgo/. Gazelle's proto mode is disabled because multiple proto
 # directories share the same go_package ("pkg/proto/pbgo/core"), making


### PR DESCRIPTION
### What does this PR do?

Add vendor to the gazelle exclude list

### Motivation

vendor gets filled with vendored Go modules during certain dda build processes. We don't want Gazelle creating BUILD files for them.

### Describe how you validated your changes
Before:
- remove an exclude on a package
- `bazel run //:gazelle`
- see dozens of BUILD files in vendor
After:
- remove an exclude on a package
- `bazel run //:gazelle`
- Only the newly excluded package has a build file.