### PR TITLE
[observer] Route OpenMetrics buckets through aggregator sender path

### DIFF
--- a/pkg/aggregator/sender/aggregating_sender.go
+++ b/pkg/aggregator/sender/aggregating_sender.go
@@ -203,14 +203,14 @@ func (s *AggregatingSender) HistogramBucket(metric string, value int64, lowerBou
 	s.mu.Unlock()
 }
 
-// OpenmetricsBucket forwards directly to backend; the observer doesn't model
-// OpenMetrics buckets distinctly from histogram buckets.
-// TODO(agent-q): OpenmetricsBucket bypasses local interval aggregation — if an OpenMetrics check
-// ever runs through the hfrunner, buckets will be emitted at 1s cadence instead of originalInterval.
-// Add localAggregator support for OpenMetrics buckets to fix this.
-// https://github.com/DataDog/datadog-agent/pull/50297/changes/BASE..0cc0c644f7d8f54adf6e827b2c718c1b48cb4de9#r3181897116
+// OpenmetricsBucket sends to observer and accumulates for backend
 func (s *AggregatingSender) OpenmetricsBucket(metric string, value int64, lowerBound, upperBound float64, monotonic bool, hostname string, tags []string, flushFirstValue bool) {
-	s.backendSender.OpenmetricsBucket(metric, value, lowerBound, upperBound, monotonic, hostname, tags, flushFirstValue)
+	if s.observerHandle != nil {
+		s.observerHandle.ObserveMetric(s.newObserverSample(metric, float64(value), metrics.HistogramType, hostname, tags, 0))
+	}
+	s.mu.Lock()
+	s.aggregator.addOpenmetricsBucket(metric, value, lowerBound, upperBound, monotonic, hostname, tags, flushFirstValue)
+	s.mu.Unlock()
 }
 
 // Event forwards directly to backend
@@ -320,6 +320,11 @@ func (s *AggregatingSender) flush() {
 	// Flush histogram buckets
 	for _, hb := range s.aggregator.flushHistogramBuckets() {
 		s.backendSender.HistogramBucket(hb.name, hb.value, hb.lowerBound, hb.upperBound, hb.monotonic, hb.hostname, hb.tags, hb.flushFirstValue)
+	}
+
+	// Flush OpenMetrics buckets
+	for _, ob := range s.aggregator.flushOpenmetricsBuckets() {
+		s.backendSender.OpenmetricsBucket(ob.name, ob.value, ob.lowerBound, ob.upperBound, ob.monotonic, ob.hostname, ob.tags, ob.flushFirstValue)
 	}
 
 	// Commit to backend at original interval

--- a/pkg/aggregator/sender/aggregating_sender_test.go
+++ b/pkg/aggregator/sender/aggregating_sender_test.go
@@ -99,6 +99,7 @@ func TestAggregatingSender_SourcePopulated(t *testing.T) {
 		{"GaugeWithTimestamp", func() { s.GaugeWithTimestamp("m", 1, "", nil, 0) }}, //nolint:errcheck
 		{"CountWithTimestamp", func() { s.CountWithTimestamp("m", 1, "", nil, 0) }}, //nolint:errcheck
 		{"HistogramBucket", func() { s.HistogramBucket("m", 1, 0, 1, false, "", nil, false) }},
+		{"OpenmetricsBucket", func() { s.OpenmetricsBucket("m", 1, 0, 1, false, "", nil, false) }},
 	}
 
 	for _, c := range calls {

--- a/pkg/aggregator/sender/local_aggregator.go
+++ b/pkg/aggregator/sender/local_aggregator.go
@@ -212,11 +212,18 @@ func (a *localAggregator) addHistogramBucket(name string, value int64, lowerBoun
 	}
 }
 
-// addOpenmetricsBucket adds an OpenMetrics histogram bucket, summing values for identical keys
+// addOpenmetricsBucket accumulates an OpenMetrics histogram bucket.
+// Monotonic buckets store the latest raw cumulative value; downstream delta logic in
+// CheckSampler.addBucket computes rawValue - lastBucketValue, so summing would inflate deltas.
+// Non-monotonic buckets are summed across samples within the flush window.
 func (a *localAggregator) addOpenmetricsBucket(name string, value int64, lowerBound, upperBound float64, monotonic bool, hostname string, tags []string, flushFirstValue bool) {
 	key := metricKey(name, tags, hostname)
 	if existing, found := a.openmetricsBuckets[key]; found {
-		existing.value += value
+		if monotonic {
+			existing.value = value // keep latest cumulative
+		} else {
+			existing.value += value
+		}
 	} else {
 		a.openmetricsBuckets[key] = &aggregatedHistogramBucket{
 			name:            name,

--- a/pkg/aggregator/sender/local_aggregator.go
+++ b/pkg/aggregator/sender/local_aggregator.go
@@ -20,8 +20,9 @@ import (
 // - Monotonic counts: sum values
 // - Histograms: accumulate all values
 type localAggregator struct {
-	metrics          map[string]*aggregatedMetric
-	histogramBuckets map[string]*aggregatedHistogramBucket
+	metrics            map[string]*aggregatedMetric
+	histogramBuckets   map[string]*aggregatedHistogramBucket
+	openmetricsBuckets map[string]*aggregatedHistogramBucket
 }
 
 type aggregatedMetric struct {
@@ -48,8 +49,9 @@ type aggregatedHistogramBucket struct {
 
 func newLocalAggregator() *localAggregator {
 	return &localAggregator{
-		metrics:          make(map[string]*aggregatedMetric),
-		histogramBuckets: make(map[string]*aggregatedHistogramBucket),
+		metrics:            make(map[string]*aggregatedMetric),
+		histogramBuckets:   make(map[string]*aggregatedHistogramBucket),
+		openmetricsBuckets: make(map[string]*aggregatedHistogramBucket),
 	}
 }
 
@@ -208,6 +210,35 @@ func (a *localAggregator) addHistogramBucket(name string, value int64, lowerBoun
 			flushFirstValue: flushFirstValue,
 		}
 	}
+}
+
+// addOpenmetricsBucket adds an OpenMetrics histogram bucket, summing values for identical keys
+func (a *localAggregator) addOpenmetricsBucket(name string, value int64, lowerBound, upperBound float64, monotonic bool, hostname string, tags []string, flushFirstValue bool) {
+	key := metricKey(name, tags, hostname)
+	if existing, found := a.openmetricsBuckets[key]; found {
+		existing.value += value
+	} else {
+		a.openmetricsBuckets[key] = &aggregatedHistogramBucket{
+			name:            name,
+			value:           value,
+			lowerBound:      lowerBound,
+			upperBound:      upperBound,
+			monotonic:       monotonic,
+			hostname:        hostname,
+			tags:            tags,
+			flushFirstValue: flushFirstValue,
+		}
+	}
+}
+
+// flushOpenmetricsBuckets returns all aggregated OpenMetrics buckets and resets them
+func (a *localAggregator) flushOpenmetricsBuckets() []aggregatedHistogramBucket {
+	result := make([]aggregatedHistogramBucket, 0, len(a.openmetricsBuckets))
+	for _, bucket := range a.openmetricsBuckets {
+		result = append(result, *bucket)
+	}
+	a.openmetricsBuckets = make(map[string]*aggregatedHistogramBucket)
+	return result
 }
 
 // flush returns all aggregated metrics and resets the aggregator


### PR DESCRIPTION
### What does this PR do?

Routes `OpenmetricsBucket` through the same path as `HistogramBucket`: observer mirroring + local interval aggregation before backend flush. Previously it bypassed both, dropping samples from observer analysis and emitting at 1s cadence instead of `originalInterval`.

### Motivation

Addresses https://github.com/DataDog/datadog-agent/pull/50297#discussion_r3181897116.

### Describe how you validated your changes

All 13 unit tests in `pkg/aggregator/sender` pass. Added `OpenmetricsBucket` to `TestAggregatingSender_SourcePopulated`.

### Additional Notes