### PR TITLE
SQG refactor: replace mutable `gate_state` dict with typed objects

### DIFF
--- a/tasks/quality_gates.py
+++ b/tasks/quality_gates.py
@@ -93,7 +93,6 @@ def parse_and_trigger_gates(ctx, config_path: str = GATE_CONFIG_PATH) -> list[St
     :param config_path: Static quality gates configuration file path
     :return: List of quality gates
     """
-    final_state = "success"
     gate_states = []
     metric_handler = GateMetricHandler(
         git_ref=os.environ["CI_COMMIT_REF_SLUG"], bucket_branch=os.environ["BUCKET_BRANCH"]
@@ -254,8 +253,7 @@ def parse_and_trigger_gates(ctx, config_path: str = GATE_CONFIG_PATH) -> list[St
                     gate_state["blocking"] = exception_checker.get() is None
 
     # Compute final_state now that all post-processing is done.
-    if any(gs["state"] is False for gs in gate_states):
-        final_state = "failure"
+    final_state = "failure" if any(gs["state"] is False for gs in gate_states) else "success"
     ctx.run(f"datadog-ci tag --level job --tags static_quality_gates:\"{final_state}\"")
 
     # Print summary table directly with composition-based gates and metric handler

--- a/tasks/quality_gates.py
+++ b/tasks/quality_gates.py
@@ -60,13 +60,6 @@ def _print_quality_gates_report(gate_states: list[dict[str, typing.Any]]):
     for gate in sorted(gate_states, key=lambda x: x["error_type"] is not None):
         if gate["error_type"] is None:
             print(color_message(f"Gate {gate['name']} succeeded {SUCCESS_CHAR}", "blue"))
-        elif gate["error_type"] == "AssertionError":
-            print(
-                color_message(
-                    f"Gate {gate['name']} failed {FAIL_CHAR} because of the following assertion failures :\n{gate['message']}",
-                    "orange",
-                )
-            )
         else:
             print(
                 color_message(

--- a/tasks/quality_gates.py
+++ b/tasks/quality_gates.py
@@ -19,7 +19,6 @@ from tasks.libs.package.size import InfraError
 from tasks.static_quality_gates.decisions import (
     PER_PR_THRESHOLD,
     ExceptionApprovalChecker,
-    identify_gates_exceeding_pr_threshold,
     should_bypass_failure,
 )
 from tasks.static_quality_gates.experimental_gates import (
@@ -146,10 +145,46 @@ def parse_and_trigger_gates(ctx, config_path: str = GATE_CONFIG_PATH) -> list[St
         raise Exit(code=42) from e
     executor.shutdown(wait=False)
 
-    # Process results in original gate order
+    # Register measurement values with the metrics handler
     for gate in gate_list:
         outcome = gate_results[gate]
+        if isinstance(outcome, GateExecutionError):
+            continue
 
+        gate_tags = {
+            "gate_name": gate.config.gate_name,
+            "arch": gate.config.arch,
+            "os": gate.config.os,
+            "pipeline_id": os.environ["CI_PIPELINE_ID"],
+            "ci_commit_ref_slug": os.environ["CI_COMMIT_REF_SLUG"],
+            "ci_commit_sha": os.environ["CI_COMMIT_SHA"],
+        }
+        if pr_number:
+            gate_tags["pr_number"] = pr_number
+        if pr_author:
+            gate_tags["pr_author"] = pr_author
+
+        # Only register current sizes if gate executed successfully and we have a result
+        metric_handler.register_gate_tags(gate.config.gate_name, **gate_tags)
+        metric_handler.register_metric(gate.config.gate_name, "max_on_wire_size", gate.config.max_on_wire_size)
+        metric_handler.register_metric(gate.config.gate_name, "max_on_disk_size", gate.config.max_on_disk_size)
+        metric_handler.register_metric(gate.config.gate_name, "current_on_wire_size", outcome.measurement.on_wire_size)
+        metric_handler.register_metric(gate.config.gate_name, "current_on_disk_size", outcome.measurement.on_disk_size)
+
+    # Calculate relative sizes (delta from ancestor) before sending metrics
+    # This is done for all branches to include delta metrics in Datadog
+    # Use get_ancestor_base_branch to correctly handle PRs targeting release branches
+    ancestor = get_ancestor(ctx, branch)
+    metric_handler.generate_relative_size(ancestor=ancestor)
+    metric_handler.send_metrics_to_datadog()
+    current_commit = get_commit_sha(ctx)
+    is_on_main_branch = ancestor == current_commit
+    is_merge_queue = branch.startswith("mq-working-branch-")
+    exception_checker = ExceptionApprovalChecker(pr)
+
+    # Take a decision on gate results based on measurements
+    for gate in gate_list:
+        outcome = gate_results[gate]
         if isinstance(outcome, GateExecutionError):
             gate_state = {
                 "name": outcome.name,
@@ -159,8 +194,6 @@ def parse_and_trigger_gates(ctx, config_path: str = GATE_CONFIG_PATH) -> list[St
                 "blocking": True,
             }
         else:
-            if not outcome.success:
-                print(color_message(outcome.violation_message, "red"))
             gate_state = {
                 "name": outcome.config.gate_name,
                 "state": outcome.success,
@@ -169,81 +202,48 @@ def parse_and_trigger_gates(ctx, config_path: str = GATE_CONFIG_PATH) -> list[St
                 "blocking": not outcome.success,
             }
 
-            gate_tags = {
-                "gate_name": gate.config.gate_name,
-                "arch": gate.config.arch,
-                "os": gate.config.os,
-                "pipeline_id": os.environ["CI_PIPELINE_ID"],
-                "ci_commit_ref_slug": os.environ["CI_COMMIT_REF_SLUG"],
-                "ci_commit_sha": os.environ["CI_COMMIT_SHA"],
-            }
-            if pr_number:
-                gate_tags["pr_number"] = pr_number
-            if pr_author:
-                gate_tags["pr_author"] = pr_author
+            if not outcome.success:
+                print(color_message(outcome.violation_message, "red"))
+                # mark as non-blocking if delta <= 0
+                # This tolerance only applies to PRs - on main branch, failures should always block unconditionally
+                # This means on PRs, the size issue existed before this PR and wasn't introduced by current changes
+                if not is_on_main_branch and should_bypass_failure(outcome.config.gate_name, metric_handler):
+                    gate_state = {
+                        "name": outcome.config.gate_name,
+                        "state": False,
+                        "error_type": "StaticQualityGateFailed",
+                        "message": outcome.violation_message,
+                        "blocking": False,
+                    }
+                    print(
+                        color_message(
+                            f"Gate {gate_state['name']} failure is non-blocking (size unchanged from ancestor)",
+                            "orange",
+                        )
+                    )
+            # Check per-PR threshold: if any gate increased by more than PER_PR_THRESHOLD, mark it as failing
+            # Skip for merge queue jobs: the MQ working branch is an ephemeral merge preview, not a PR
+            elif not is_on_main_branch and not is_merge_queue:
+                delta = metric_handler.metrics.get(outcome.config.gate_name, {}).get("relative_on_disk_size", 0)
+                if delta > PER_PR_THRESHOLD:
+                    threshold_str = byte_to_string(PER_PR_THRESHOLD)
 
-            # Only register current sizes if gate executed successfully and we have a result
-            metric_handler.register_gate_tags(gate.config.gate_name, **gate_tags)
-            metric_handler.register_metric(gate.config.gate_name, "max_on_wire_size", gate.config.max_on_wire_size)
-            metric_handler.register_metric(gate.config.gate_name, "max_on_disk_size", gate.config.max_on_disk_size)
-            metric_handler.register_metric(
-                gate.config.gate_name, "current_on_wire_size", outcome.measurement.on_wire_size
-            )
-            metric_handler.register_metric(
-                gate.config.gate_name, "current_on_disk_size", outcome.measurement.on_disk_size
-            )
+                    gate_state = {
+                        "name": outcome.config.gate_name,
+                        "state": False,
+                        "error_type": "PerPRThresholdExceeded",
+                        "message": f"On-disk size increase of {byte_to_string(delta)} exceeds the per-PR threshold of {threshold_str}",
+                        "blocking": exception_checker.get() is None,
+                    }
+
+                    print(
+                        color_message(
+                            f"Per-PR threshold ({threshold_str}) exceeded by: {gate_state['name']}",
+                            "red",
+                        )
+                    )
 
         gate_states.append(gate_state)
-
-    # Calculate relative sizes (delta from ancestor) before sending metrics
-    # This is done for all branches to include delta metrics in Datadog
-    # Use get_ancestor_base_branch to correctly handle PRs targeting release branches
-    ancestor = get_ancestor(ctx, branch)
-    current_commit = get_commit_sha(ctx)
-    is_on_main_branch = ancestor == current_commit
-    is_merge_queue = branch.startswith("mq-working-branch-")
-    metric_handler.generate_relative_size(ancestor=ancestor)
-    metric_handler.send_metrics_to_datadog()
-
-    # Post-process gate failures: mark as non-blocking if delta <= 0
-    # This tolerance only applies to PRs - on main branch, failures should always block unconditionally
-    # This means on PRs, the size issue existed before this PR and wasn't introduced by current changes
-    if not is_on_main_branch:
-        for gate_state in gate_states:
-            if gate_state["state"] is False and gate_state.get("blocking", True):
-                # Only StaticQualityGateFailed errors are eligible for bypass (not StackTrace errors)
-                if gate_state["error_type"] == "StaticQualityGateFailed":
-                    if should_bypass_failure(gate_state["name"], metric_handler):
-                        gate_state["blocking"] = False
-                        print(
-                            color_message(
-                                f"Gate {gate_state['name']} failure is non-blocking (size unchanged from ancestor)",
-                                "orange",
-                            )
-                        )
-
-    # Check per-PR threshold: if any gate increased by more than PER_PR_THRESHOLD, mark it as failing
-    # Skip for merge queue jobs: the MQ working branch is an ephemeral merge preview, not a PR
-    exception_checker = ExceptionApprovalChecker(pr)
-    if not is_on_main_branch and not is_merge_queue:
-        per_pr_exceeding = identify_gates_exceeding_pr_threshold(metric_handler)
-        if per_pr_exceeding:
-            threshold_str = byte_to_string(PER_PR_THRESHOLD)
-            print(
-                color_message(
-                    f"Per-PR threshold ({threshold_str}) exceeded by: {', '.join(per_pr_exceeding)}",
-                    "red",
-                )
-            )
-            for gate_state in gate_states:
-                if gate_state["name"] in per_pr_exceeding and gate_state["state"] is True:
-                    delta = metric_handler.metrics.get(gate_state["name"], {}).get("relative_on_disk_size", 0)
-                    gate_state["state"] = False
-                    gate_state["error_type"] = "PerPRThresholdExceeded"
-                    gate_state["message"] = (
-                        f"On-disk size increase of {byte_to_string(delta)} exceeds the per-PR threshold of {threshold_str}"
-                    )
-                    gate_state["blocking"] = exception_checker.get() is None
 
     # Compute final_state now that all post-processing is done.
     final_state = "failure" if any(gs["state"] is False for gs in gate_states) else "success"

--- a/tasks/quality_gates.py
+++ b/tasks/quality_gates.py
@@ -17,9 +17,7 @@ from tasks.libs.common.git import (
 )
 from tasks.libs.package.size import InfraError
 from tasks.static_quality_gates.decisions import (
-    PER_PR_THRESHOLD,
-    ExceptionApprovalChecker,
-    should_bypass_failure,
+    evaluate_gates,
 )
 from tasks.static_quality_gates.experimental_gates import (
     measure_image_local as _measure_image_local,
@@ -180,70 +178,17 @@ def parse_and_trigger_gates(ctx, config_path: str = GATE_CONFIG_PATH) -> list[St
     current_commit = get_commit_sha(ctx)
     is_on_main_branch = ancestor == current_commit
     is_merge_queue = branch.startswith("mq-working-branch-")
-    exception_checker = ExceptionApprovalChecker(pr)
 
     # Take a decision on gate results based on measurements
-    for gate in gate_list:
-        outcome = gate_results[gate]
-        if isinstance(outcome, GateExecutionError):
-            gate_state = {
-                "name": outcome.name,
-                "state": False,
-                "error_type": "StackTrace",
-                "message": outcome.traceback,
-                "blocking": True,
-            }
-        else:
-            gate_state = {
-                "name": outcome.config.gate_name,
-                "state": outcome.success,
-                "error_type": "StaticQualityGateFailed" if not outcome.success else None,
-                "message": outcome.violation_message,
-                "blocking": not outcome.success,
-            }
-
-            if not outcome.success:
-                print(color_message(outcome.violation_message, "red"))
-                # mark as non-blocking if delta <= 0
-                # This tolerance only applies to PRs - on main branch, failures should always block unconditionally
-                # This means on PRs, the size issue existed before this PR and wasn't introduced by current changes
-                if not is_on_main_branch and should_bypass_failure(outcome.config.gate_name, metric_handler):
-                    gate_state = {
-                        "name": outcome.config.gate_name,
-                        "state": False,
-                        "error_type": "StaticQualityGateFailed",
-                        "message": outcome.violation_message,
-                        "blocking": False,
-                    }
-                    print(
-                        color_message(
-                            f"Gate {gate_state['name']} failure is non-blocking (size unchanged from ancestor)",
-                            "orange",
-                        )
-                    )
-            # Check per-PR threshold: if any gate increased by more than PER_PR_THRESHOLD, mark it as failing
-            # Skip for merge queue jobs: the MQ working branch is an ephemeral merge preview, not a PR
-            elif not is_on_main_branch and not is_merge_queue:
-                delta = metric_handler.metrics.get(outcome.config.gate_name, {}).get("relative_on_disk_size", 0)
-                if delta > PER_PR_THRESHOLD:
-                    threshold_str = byte_to_string(PER_PR_THRESHOLD)
-
-                    gate_state = {
-                        "name": outcome.config.gate_name,
-                        "state": False,
-                        "error_type": "PerPRThresholdExceeded",
-                        "message": f"On-disk size increase of {byte_to_string(delta)} exceeds the per-PR threshold of {threshold_str}",
-                        "blocking": exception_checker.get() is None,
-                    }
-
-                    print(
-                        color_message(
-                            f"Per-PR threshold ({threshold_str}) exceeded by: {gate_state['name']}",
-                            "red",
-                        )
-                    )
-
-        gate_states.append(gate_state)
+    evaluation = evaluate_gates(
+        gate_list,
+        gate_results,
+        metric_handler,
+        is_on_main_branch=is_on_main_branch,
+        is_merge_queue=is_merge_queue,
+        pr=pr,
+    )
+    gate_states = evaluation.gate_states
 
     # Compute final_state now that all post-processing is done.
     final_state = "failure" if any(gs["state"] is False for gs in gate_states) else "success"
@@ -258,19 +203,22 @@ def parse_and_trigger_gates(ctx, config_path: str = GATE_CONFIG_PATH) -> list[St
 
     # We don't need a PR notification nor gate failures on release branches
     if not is_a_release_branch(ctx, branch):
-        # Determine if there are blocking failures (non-blocking failures have delta=0)
-        has_blocking_failures = any(gs["state"] is False and gs.get("blocking", True) for gs in gate_states)
-
         # Reuse cached PR lookup from earlier
         if pr:
             # Pass True for final_state if there are no blocking failures
             display_pr_comment(
-                ctx, not has_blocking_failures, gate_states, metric_handler, ancestor, pr, exception_checker.get()
+                ctx,
+                not evaluation.has_blocking_failures,
+                gate_states,
+                metric_handler,
+                ancestor,
+                pr,
+                evaluation.exception_granted_by,
             )
 
         # Nightly pipelines have different package size and gates thresholds are unreliable for nightly pipelines
         # Only fail for blocking failures (non-blocking failures have delta=0 and don't block the PR)
-        if has_blocking_failures and not nightly_run:
+        if evaluation.has_blocking_failures and not nightly_run:
             metric_handler.generate_metric_reports(ctx, branch=branch, is_nightly=nightly_run)
             raise Exit(code=1)
     # We are generating our metric reports at the end to include relative size metrics

--- a/tasks/quality_gates.py
+++ b/tasks/quality_gates.py
@@ -29,7 +29,9 @@ from tasks.static_quality_gates.experimental_gates import (
     measure_package_local as _measure_package_local,
 )
 from tasks.static_quality_gates.gates import (
+    GateExecutionError,
     GateMetricHandler,
+    GateResult,
     QualityGateFactory,
     StaticQualityGate,
     byte_to_string,
@@ -74,48 +76,13 @@ def _print_quality_gates_report(gate_states: list[dict[str, typing.Any]]):
             )
 
 
-def _run_gate(ctx, gate: StaticQualityGate):
+def _run_gate(ctx, gate: StaticQualityGate) -> GateResult | GateExecutionError:
     try:
-        result = gate.execute_gate(ctx)
-        error_message = None
-        error_type = None
-        if not result.success:
-            violation_messages = []
-            for violation in result.violations:
-                current_mb = violation.current_size / (1024 * 1024)
-                max_mb = violation.max_size / (1024 * 1024)
-                excess_mb = violation.excess_bytes / (1024 * 1024)
-                if excess_mb < 1:
-                    excess_kb = violation.excess_bytes / 1024
-                    excess_str = f"{excess_kb:.1f} KB"
-                else:
-                    excess_str = f"{excess_mb:.1f} MB"
-                violation_messages.append(
-                    f"{violation.measurement_type.title()} size {current_mb:.1f} MB "
-                    f"exceeds limit of {max_mb:.1f} MB by {excess_str}"
-                )
-            error_message = f"{gate.config.gate_name} failed!\n" + "\n".join(violation_messages)
-            error_type = "StaticQualityGateFailed"
-            print(color_message(error_message, "red"))
-        return {
-            "name": result.config.gate_name,
-            "state": result.success,
-            "error_type": error_type,
-            "message": error_message,
-            "result": result,
-            "blocking": not result.success,
-        }
-    # re-raise the InfraError as is, don't swallow it as Exception
+        return gate.execute_gate(ctx)
     except InfraError:
         raise
     except Exception:
-        return {
-            "name": gate.config.gate_name,
-            "state": False,
-            "error_type": "StackTrace",
-            "message": traceback.format_exc(),
-            "blocking": True,  # StackTrace errors are always blocking
-        }
+        return GateExecutionError(name=gate.config.gate_name, traceback=traceback.format_exc())
 
 
 @task
@@ -170,7 +137,7 @@ def parse_and_trigger_gates(ctx, config_path: str = GATE_CONFIG_PATH) -> list[St
                     print(color_message(f"PR author: {pr_author}", "cyan"))
 
     # Run all gates in parallel (I/O-bound: pulling images, measuring packages)
-    gate_results: dict[StaticQualityGate, dict] = {}
+    gate_results: dict[StaticQualityGate, GateResult | GateExecutionError] = {}
     executor = ThreadPoolExecutor()
     future_to_gate = {executor.submit(_run_gate, ctx, gate): gate for gate in gate_list}
     try:
@@ -189,37 +156,54 @@ def parse_and_trigger_gates(ctx, config_path: str = GATE_CONFIG_PATH) -> list[St
 
     # Process results in original gate order
     for gate in gate_list:
-        gate_result = gate_results[gate]
-        gate_states.append(gate_result)
-        if 'blocking' in gate_result and gate_result['blocking']:
+        outcome = gate_results[gate]
+
+        if isinstance(outcome, GateExecutionError):
+            gate_state = {
+                "name": outcome.name,
+                "state": False,
+                "error_type": "StackTrace",
+                "message": outcome.traceback,
+                "blocking": True,
+            }
+        else:
+            if not outcome.success:
+                print(color_message(outcome.violation_message, "red"))
+            gate_state = {
+                "name": outcome.config.gate_name,
+                "state": outcome.success,
+                "error_type": "StaticQualityGateFailed" if not outcome.success else None,
+                "message": outcome.violation_message,
+                "blocking": not outcome.success,
+            }
+
+            gate_tags = {
+                "gate_name": gate.config.gate_name,
+                "arch": gate.config.arch,
+                "os": gate.config.os,
+                "pipeline_id": os.environ["CI_PIPELINE_ID"],
+                "ci_commit_ref_slug": os.environ["CI_COMMIT_REF_SLUG"],
+                "ci_commit_sha": os.environ["CI_COMMIT_SHA"],
+            }
+            if pr_number:
+                gate_tags["pr_number"] = pr_number
+            if pr_author:
+                gate_tags["pr_author"] = pr_author
+
+            # Only register current sizes if gate executed successfully and we have a result
+            metric_handler.register_gate_tags(gate.config.gate_name, **gate_tags)
+            metric_handler.register_metric(gate.config.gate_name, "max_on_wire_size", gate.config.max_on_wire_size)
+            metric_handler.register_metric(gate.config.gate_name, "max_on_disk_size", gate.config.max_on_disk_size)
+            metric_handler.register_metric(
+                gate.config.gate_name, "current_on_wire_size", outcome.measurement.on_wire_size
+            )
+            metric_handler.register_metric(
+                gate.config.gate_name, "current_on_disk_size", outcome.measurement.on_disk_size
+            )
+
+        gate_states.append(gate_state)
+        if gate_state["blocking"]:
             final_state = "failure"
-        result = gate_result.get('result')
-        # Build tags dict - only include pr_number and pr_author if we have a PR
-        gate_tags = {
-            "gate_name": gate.config.gate_name,
-            "arch": gate.config.arch,
-            "os": gate.config.os,
-            "pipeline_id": os.environ["CI_PIPELINE_ID"],
-            "ci_commit_ref_slug": os.environ["CI_COMMIT_REF_SLUG"],
-            "ci_commit_sha": os.environ["CI_COMMIT_SHA"],
-        }
-        if pr_number:
-            gate_tags["pr_number"] = pr_number
-        if pr_author:
-            gate_tags["pr_author"] = pr_author
-
-        metric_handler.register_gate_tags(gate.config.gate_name, **gate_tags)
-        metric_handler.register_metric(gate.config.gate_name, "max_on_wire_size", gate.config.max_on_wire_size)
-        metric_handler.register_metric(gate.config.gate_name, "max_on_disk_size", gate.config.max_on_disk_size)
-
-        # Only register current sizes if gate executed successfully and we have a result
-        if result is not None:
-            metric_handler.register_metric(
-                gate.config.gate_name, "current_on_wire_size", result.measurement.on_wire_size
-            )
-            metric_handler.register_metric(
-                gate.config.gate_name, "current_on_disk_size", result.measurement.on_disk_size
-            )
 
     # Calculate relative sizes (delta from ancestor) before sending metrics
     # This is done for all branches to include delta metrics in Datadog

--- a/tasks/quality_gates.py
+++ b/tasks/quality_gates.py
@@ -211,6 +211,7 @@ def parse_and_trigger_gates(ctx, config_path: str = GATE_CONFIG_PATH) -> list[St
     is_on_main_branch = ancestor == current_commit
     is_merge_queue = branch.startswith("mq-working-branch-")
     metric_handler.generate_relative_size(ancestor=ancestor)
+    metric_handler.send_metrics_to_datadog()
 
     # Post-process gate failures: mark as non-blocking if delta <= 0
     # This tolerance only applies to PRs - on main branch, failures should always block unconditionally
@@ -257,11 +258,6 @@ def parse_and_trigger_gates(ctx, config_path: str = GATE_CONFIG_PATH) -> list[St
     if any(gs["state"] is False for gs in gate_states):
         final_state = "failure"
     ctx.run(f"datadog-ci tag --level job --tags static_quality_gates:\"{final_state}\"")
-
-    # Reporting part
-    # Send metrics to Datadog (now includes delta metrics)
-    # and then print the summary table in the job's log
-    metric_handler.send_metrics_to_datadog()
 
     # Print summary table directly with composition-based gates and metric handler
     QualityGateOutputFormatter.print_summary_table(gate_list, gate_states, metric_handler)

--- a/tasks/quality_gates.py
+++ b/tasks/quality_gates.py
@@ -1,6 +1,5 @@
 import os
 import traceback
-import typing
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
@@ -17,6 +16,7 @@ from tasks.libs.common.git import (
 )
 from tasks.libs.package.size import InfraError
 from tasks.static_quality_gates.decisions import (
+    GateVerdict,
     evaluate_gates,
 )
 from tasks.static_quality_gates.experimental_gates import (
@@ -52,15 +52,15 @@ from tasks.static_quality_gates.thresholds import (
 )
 
 
-def _print_quality_gates_report(gate_states: list[dict[str, typing.Any]]):
+def _print_quality_gates_report(verdicts: list[GateVerdict]):
     print(color_message("======== Static Quality Gates Report ========", "magenta"))
-    for gate in sorted(gate_states, key=lambda x: x["error_type"] is not None):
-        if gate["error_type"] is None:
-            print(color_message(f"Gate {gate['name']} succeeded {SUCCESS_CHAR}", "blue"))
+    for verdict in sorted(verdicts, key=lambda v: v.failure is not None):
+        if verdict.failure is None:
+            print(color_message(f"Gate {verdict.name} succeeded {SUCCESS_CHAR}", "blue"))
         else:
             print(
                 color_message(
-                    f"Gate {gate['name']} failed {FAIL_CHAR} with the following stack trace :\n{gate['message']}",
+                    f"Gate {verdict.name} failed {FAIL_CHAR} with the following message:\n{verdict.message}",
                     "orange",
                 )
             )
@@ -83,7 +83,6 @@ def parse_and_trigger_gates(ctx, config_path: str = GATE_CONFIG_PATH) -> list[St
     :param config_path: Static quality gates configuration file path
     :return: List of quality gates
     """
-    gate_states = []
     metric_handler = GateMetricHandler(
         git_ref=os.environ["CI_COMMIT_REF_SLUG"], bucket_branch=os.environ["BUCKET_BRANCH"]
     )
@@ -188,18 +187,17 @@ def parse_and_trigger_gates(ctx, config_path: str = GATE_CONFIG_PATH) -> list[St
         is_merge_queue=is_merge_queue,
         pr=pr,
     )
-    gate_states = evaluation.gate_states
 
     # Compute final_state now that all post-processing is done.
-    final_state = "failure" if any(gs["state"] is False for gs in gate_states) else "success"
+    final_state = "failure" if any(v.failure is not None for v in evaluation.verdicts) else "success"
     ctx.run(f"datadog-ci tag --level job --tags static_quality_gates:\"{final_state}\"")
 
     # Print summary table directly with composition-based gates and metric handler
-    QualityGateOutputFormatter.print_summary_table(gate_list, gate_states, metric_handler)
+    QualityGateOutputFormatter.print_summary_table(gate_list, evaluation.verdicts, metric_handler)
 
-    # Then print the traditional report for any failures
-    if final_state != "success":
-        _print_quality_gates_report(gate_states)
+    # Then print the traditional report for any failures (blocking or non-blocking)
+    if any(v.failure is not None for v in evaluation.verdicts):
+        _print_quality_gates_report(evaluation.verdicts)
 
     # We don't need a PR notification nor gate failures on release branches
     if not is_a_release_branch(ctx, branch):
@@ -209,7 +207,7 @@ def parse_and_trigger_gates(ctx, config_path: str = GATE_CONFIG_PATH) -> list[St
             display_pr_comment(
                 ctx,
                 not evaluation.has_blocking_failures,
-                gate_states,
+                evaluation.verdicts,
                 metric_handler,
                 ancestor,
                 pr,

--- a/tasks/quality_gates.py
+++ b/tasks/quality_gates.py
@@ -203,16 +203,7 @@ def parse_and_trigger_gates(ctx, config_path: str = GATE_CONFIG_PATH) -> list[St
     if not is_a_release_branch(ctx, branch):
         # Reuse cached PR lookup from earlier
         if pr:
-            # Pass True for final_state if there are no blocking failures
-            display_pr_comment(
-                ctx,
-                not evaluation.has_blocking_failures,
-                evaluation.verdicts,
-                metric_handler,
-                ancestor,
-                pr,
-                evaluation.exception_granted_by,
-            )
+            display_pr_comment(ctx, evaluation, metric_handler, ancestor, pr)
 
         # Nightly pipelines have different package size and gates thresholds are unreliable for nightly pipelines
         # Only fail for blocking failures (non-blocking failures have delta=0 and don't block the PR)

--- a/tasks/quality_gates.py
+++ b/tasks/quality_gates.py
@@ -216,8 +216,6 @@ def parse_and_trigger_gates(ctx, config_path: str = GATE_CONFIG_PATH) -> list[St
     # Post-process gate failures: mark as non-blocking if delta <= 0
     # This tolerance only applies to PRs - on main branch, failures should always block unconditionally
     # This means on PRs, the size issue existed before this PR and wasn't introduced by current changes
-    exception_checker = ExceptionApprovalChecker(pr)
-
     if not is_on_main_branch:
         for gate_state in gate_states:
             if gate_state["state"] is False and gate_state.get("blocking", True):
@@ -232,27 +230,28 @@ def parse_and_trigger_gates(ctx, config_path: str = GATE_CONFIG_PATH) -> list[St
                             )
                         )
 
-        # Check per-PR threshold: if any gate increased by more than PER_PR_THRESHOLD, mark it as failing
-        # Skip for merge queue jobs: the MQ working branch is an ephemeral merge preview, not a PR
-        if not is_merge_queue:
-            per_pr_exceeding = identify_gates_exceeding_pr_threshold(metric_handler)
-            if per_pr_exceeding:
-                threshold_str = byte_to_string(PER_PR_THRESHOLD)
-                print(
-                    color_message(
-                        f"Per-PR threshold ({threshold_str}) exceeded by: {', '.join(per_pr_exceeding)}",
-                        "red",
-                    )
+    # Check per-PR threshold: if any gate increased by more than PER_PR_THRESHOLD, mark it as failing
+    # Skip for merge queue jobs: the MQ working branch is an ephemeral merge preview, not a PR
+    exception_checker = ExceptionApprovalChecker(pr)
+    if not is_on_main_branch and not is_merge_queue:
+        per_pr_exceeding = identify_gates_exceeding_pr_threshold(metric_handler)
+        if per_pr_exceeding:
+            threshold_str = byte_to_string(PER_PR_THRESHOLD)
+            print(
+                color_message(
+                    f"Per-PR threshold ({threshold_str}) exceeded by: {', '.join(per_pr_exceeding)}",
+                    "red",
                 )
-                for gate_state in gate_states:
-                    if gate_state["name"] in per_pr_exceeding and gate_state["state"] is True:
-                        delta = metric_handler.metrics.get(gate_state["name"], {}).get("relative_on_disk_size", 0)
-                        gate_state["state"] = False
-                        gate_state["error_type"] = "PerPRThresholdExceeded"
-                        gate_state["message"] = (
-                            f"On-disk size increase of {byte_to_string(delta)} exceeds the per-PR threshold of {threshold_str}"
-                        )
-                        gate_state["blocking"] = exception_checker.get() is None
+            )
+            for gate_state in gate_states:
+                if gate_state["name"] in per_pr_exceeding and gate_state["state"] is True:
+                    delta = metric_handler.metrics.get(gate_state["name"], {}).get("relative_on_disk_size", 0)
+                    gate_state["state"] = False
+                    gate_state["error_type"] = "PerPRThresholdExceeded"
+                    gate_state["message"] = (
+                        f"On-disk size increase of {byte_to_string(delta)} exceeds the per-PR threshold of {threshold_str}"
+                    )
+                    gate_state["blocking"] = exception_checker.get() is None
 
     # Compute final_state now that all post-processing is done.
     if any(gs["state"] is False for gs in gate_states):

--- a/tasks/quality_gates.py
+++ b/tasks/quality_gates.py
@@ -202,8 +202,6 @@ def parse_and_trigger_gates(ctx, config_path: str = GATE_CONFIG_PATH) -> list[St
             )
 
         gate_states.append(gate_state)
-        if gate_state["blocking"]:
-            final_state = "failure"
 
     # Calculate relative sizes (delta from ancestor) before sending metrics
     # This is done for all branches to include delta metrics in Datadog
@@ -255,8 +253,7 @@ def parse_and_trigger_gates(ctx, config_path: str = GATE_CONFIG_PATH) -> list[St
                         )
                         gate_state["blocking"] = exception_checker.get() is None
 
-    # Recompute final_state now that all post-processing is done (bypass logic and per-PR threshold
-    # can both change gate states after the initial gate execution loop).
+    # Compute final_state now that all post-processing is done.
     if any(gs["state"] is False for gs in gate_states):
         final_state = "failure"
     ctx.run(f"datadog-ci tag --level job --tags static_quality_gates:\"{final_state}\"")

--- a/tasks/static_quality_gates/decisions.py
+++ b/tasks/static_quality_gates/decisions.py
@@ -25,6 +25,7 @@ class GateVerdict:
     failure: GateFailureKind | None
     blocking: bool = False
     message: str | None = None
+    blocking_note: str = ""
 
 
 class ExceptionApprovalChecker:
@@ -67,6 +68,7 @@ class GateEvaluationResult:
     verdicts: list[GateVerdict] = field(default_factory=list)
     has_blocking_failures: bool = False
     exception_granted_by: str | None = None
+    exception_note: str | None = None
 
 
 def evaluate_gates(
@@ -91,10 +93,20 @@ def evaluate_gates(
         for gate in gate_list
     ]
     has_blocking_failures = any(v.blocking for v in verdicts)
+    exception_granted_by = exception_checker.get()
+    exception_note = None
+    if exception_granted_by:
+        per_pr_excepted = [
+            v for v in verdicts if v.failure == GateFailureKind.PerPRThresholdExceeded and not v.blocking
+        ]
+        if per_pr_excepted:
+            threshold_str = byte_to_string(PER_PR_THRESHOLD)
+            exception_note = f"**Exception granted by @{exception_granted_by}**: this PR exceeds the per-PR size threshold ({threshold_str}) but will not be blocked.\n"
     return GateEvaluationResult(
         verdicts=verdicts,
         has_blocking_failures=has_blocking_failures,
-        exception_granted_by=exception_checker.get(),
+        exception_granted_by=exception_granted_by,
+        exception_note=exception_note,
     )
 
 
@@ -132,6 +144,7 @@ def evaluate_gate(
             name=outcome.config.gate_name,
             failure=GateFailureKind.AbsoluteLimitExceeded,
             blocking=blocking,
+            blocking_note="" if blocking else "non-blocking: size unchanged from ancestor",
             message=outcome.violation_message,
         )
 
@@ -142,10 +155,12 @@ def evaluate_gate(
         if delta > PER_PR_THRESHOLD:
             threshold_str = byte_to_string(PER_PR_THRESHOLD)
             print(color_message(f"Per-PR threshold ({threshold_str}) exceeded by: {outcome.config.gate_name}", "red"))
+            approver = exception_checker.get()
             return GateVerdict(
                 name=outcome.config.gate_name,
                 failure=GateFailureKind.PerPRThresholdExceeded,
-                blocking=exception_checker.get() is None,
+                blocking=approver is None,
+                blocking_note=f"non-blocking: exception granted by @{approver}" if approver else "",
                 message=f"On-disk size increase of {byte_to_string(delta)} exceeds the per-PR threshold of {threshold_str}",
             )
 

--- a/tasks/static_quality_gates/decisions.py
+++ b/tasks/static_quality_gates/decisions.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+from dataclasses import dataclass, field
+
 from tasks.libs.common.color import color_message
-from tasks.static_quality_gates.gates import GateMetricHandler
+from tasks.static_quality_gates.gates import GateExecutionError, GateMetricHandler, GateResult, byte_to_string
 
 PER_PR_THRESHOLD = 600 * 1024
 EXCEPTION_APPROVERS = {"cmourot", "dd-ddamien"}
@@ -33,6 +35,110 @@ class ExceptionApprovalChecker:
             if self._result:
                 print(color_message(f"Exception granted by @{self._result}", "orange"))
         return self._result
+
+
+@dataclass
+class GateEvaluationResult:
+    gate_states: list[dict] = field(default_factory=list)
+    has_blocking_failures: bool = False
+    exception_granted_by: str | None = None
+
+
+def evaluate_gates(
+    gate_list,
+    gate_results: dict,
+    metric_handler: GateMetricHandler,
+    *,
+    is_on_main_branch: bool,
+    is_merge_queue: bool,
+    pr,
+) -> GateEvaluationResult:
+    """Evaluate all gate outcomes and return a structured result."""
+    exception_checker = ExceptionApprovalChecker(pr)
+    gate_states = [
+        evaluate_gate(
+            gate_results[gate],
+            metric_handler,
+            is_on_main_branch=is_on_main_branch,
+            is_merge_queue=is_merge_queue,
+            exception_checker=exception_checker,
+        )
+        for gate in gate_list
+    ]
+    has_blocking_failures = any(gs["state"] is False and gs.get("blocking", True) for gs in gate_states)
+    return GateEvaluationResult(
+        gate_states=gate_states,
+        has_blocking_failures=has_blocking_failures,
+        exception_granted_by=exception_checker.get(),
+    )
+
+
+def evaluate_gate(
+    outcome: GateResult | GateExecutionError,
+    metric_handler: GateMetricHandler,
+    *,
+    is_on_main_branch: bool,
+    is_merge_queue: bool,
+    exception_checker: ExceptionApprovalChecker,
+) -> dict:
+    """Evaluate a single gate outcome and return its gate_state dict."""
+    if isinstance(outcome, GateExecutionError):
+        return {
+            "name": outcome.name,
+            "state": False,
+            "error_type": "StackTrace",
+            "message": outcome.traceback,
+            "blocking": True,
+        }
+
+    if not outcome.success:
+        print(color_message(outcome.violation_message, "red"))
+        # Mark as non-blocking if delta <= 0
+        # this tolerance only applies to PRs - on main branch, failures always block unconditionally.
+        # A non-positive delta means the size issue existed before this PR and wasn't introduced by the current changes.
+        if not is_on_main_branch and should_bypass_failure(outcome.config.gate_name, metric_handler):
+            print(
+                color_message(
+                    f"Gate {outcome.config.gate_name} failure is non-blocking (size unchanged from ancestor)", "orange"
+                )
+            )
+            return {
+                "name": outcome.config.gate_name,
+                "state": False,
+                "error_type": "StaticQualityGateFailed",
+                "message": outcome.violation_message,
+                "blocking": False,
+            }
+        return {
+            "name": outcome.config.gate_name,
+            "state": False,
+            "error_type": "StaticQualityGateFailed",
+            "message": outcome.violation_message,
+            "blocking": True,
+        }
+
+    # Check per-PR threshold: if a gate increased by more than PER_PR_THRESHOLD, mark it as failing.
+    # Skip on merge queue jobs: the MQ working branch is an ephemeral merge preview, not a PR.
+    if not is_on_main_branch and not is_merge_queue:
+        delta = metric_handler.metrics.get(outcome.config.gate_name, {}).get("relative_on_disk_size", 0)
+        if delta > PER_PR_THRESHOLD:
+            threshold_str = byte_to_string(PER_PR_THRESHOLD)
+            print(color_message(f"Per-PR threshold ({threshold_str}) exceeded by: {outcome.config.gate_name}", "red"))
+            return {
+                "name": outcome.config.gate_name,
+                "state": False,
+                "error_type": "PerPRThresholdExceeded",
+                "message": f"On-disk size increase of {byte_to_string(delta)} exceeds the per-PR threshold of {threshold_str}",
+                "blocking": exception_checker.get() is None,
+            }
+
+    return {
+        "name": outcome.config.gate_name,
+        "state": True,
+        "error_type": None,
+        "message": outcome.violation_message,
+        "blocking": False,
+    }
 
 
 def should_bypass_failure(gate_name: str, metric_handler: GateMetricHandler) -> bool:

--- a/tasks/static_quality_gates/decisions.py
+++ b/tasks/static_quality_gates/decisions.py
@@ -1,12 +1,30 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import Enum
 
 from tasks.libs.common.color import color_message
 from tasks.static_quality_gates.gates import GateExecutionError, GateMetricHandler, GateResult, byte_to_string
 
 PER_PR_THRESHOLD = 600 * 1024
 EXCEPTION_APPROVERS = {"cmourot", "dd-ddamien"}
+
+
+class GateFailureKind(Enum):
+    AbsoluteLimitExceeded = "AbsoluteLimitExceeded"
+    PerPRThresholdExceeded = "PerPRThresholdExceeded"
+    ExecutionError = "ExecutionError"
+
+    def __str__(self):
+        return self.value
+
+
+@dataclass
+class GateVerdict:
+    name: str
+    failure: GateFailureKind | None
+    blocking: bool = False
+    message: str | None = None
 
 
 class ExceptionApprovalChecker:
@@ -37,9 +55,16 @@ class ExceptionApprovalChecker:
         return self._result
 
 
+_FAILURE_KIND_TO_ERROR_TYPE: dict[GateFailureKind, str] = {
+    GateFailureKind.AbsoluteLimitExceeded: "StaticQualityGateFailed",
+    GateFailureKind.PerPRThresholdExceeded: "PerPRThresholdExceeded",
+    GateFailureKind.ExecutionError: "StackTrace",
+}
+
+
 @dataclass
 class GateEvaluationResult:
-    gate_states: list[dict] = field(default_factory=list)
+    verdicts: list[GateVerdict] = field(default_factory=list)
     has_blocking_failures: bool = False
     exception_granted_by: str | None = None
 
@@ -55,7 +80,7 @@ def evaluate_gates(
 ) -> GateEvaluationResult:
     """Evaluate all gate outcomes and return a structured result."""
     exception_checker = ExceptionApprovalChecker(pr)
-    gate_states = [
+    verdicts = [
         evaluate_gate(
             gate_results[gate],
             metric_handler,
@@ -65,9 +90,9 @@ def evaluate_gates(
         )
         for gate in gate_list
     ]
-    has_blocking_failures = any(gs["state"] is False and gs.get("blocking", True) for gs in gate_states)
+    has_blocking_failures = any(v.blocking for v in verdicts)
     return GateEvaluationResult(
-        gate_states=gate_states,
+        verdicts=verdicts,
         has_blocking_failures=has_blocking_failures,
         exception_granted_by=exception_checker.get(),
     )
@@ -80,42 +105,35 @@ def evaluate_gate(
     is_on_main_branch: bool,
     is_merge_queue: bool,
     exception_checker: ExceptionApprovalChecker,
-) -> dict:
-    """Evaluate a single gate outcome and return its gate_state dict."""
+) -> GateVerdict:
+    """Evaluate a single gate outcome and return its verdict."""
     if isinstance(outcome, GateExecutionError):
-        return {
-            "name": outcome.name,
-            "state": False,
-            "error_type": "StackTrace",
-            "message": outcome.traceback,
-            "blocking": True,
-        }
+        return GateVerdict(
+            name=outcome.name,
+            failure=GateFailureKind.ExecutionError,
+            blocking=True,
+            message=outcome.traceback,
+        )
 
     if not outcome.success:
         print(color_message(outcome.violation_message, "red"))
         # Mark as non-blocking if delta <= 0
         # this tolerance only applies to PRs - on main branch, failures always block unconditionally.
         # A non-positive delta means the size issue existed before this PR and wasn't introduced by the current changes.
+        blocking = True
         if not is_on_main_branch and should_bypass_failure(outcome.config.gate_name, metric_handler):
+            blocking = False
             print(
                 color_message(
                     f"Gate {outcome.config.gate_name} failure is non-blocking (size unchanged from ancestor)", "orange"
                 )
             )
-            return {
-                "name": outcome.config.gate_name,
-                "state": False,
-                "error_type": "StaticQualityGateFailed",
-                "message": outcome.violation_message,
-                "blocking": False,
-            }
-        return {
-            "name": outcome.config.gate_name,
-            "state": False,
-            "error_type": "StaticQualityGateFailed",
-            "message": outcome.violation_message,
-            "blocking": True,
-        }
+        return GateVerdict(
+            name=outcome.config.gate_name,
+            failure=GateFailureKind.AbsoluteLimitExceeded,
+            blocking=blocking,
+            message=outcome.violation_message,
+        )
 
     # Check per-PR threshold: if a gate increased by more than PER_PR_THRESHOLD, mark it as failing.
     # Skip on merge queue jobs: the MQ working branch is an ephemeral merge preview, not a PR.
@@ -124,21 +142,19 @@ def evaluate_gate(
         if delta > PER_PR_THRESHOLD:
             threshold_str = byte_to_string(PER_PR_THRESHOLD)
             print(color_message(f"Per-PR threshold ({threshold_str}) exceeded by: {outcome.config.gate_name}", "red"))
-            return {
-                "name": outcome.config.gate_name,
-                "state": False,
-                "error_type": "PerPRThresholdExceeded",
-                "message": f"On-disk size increase of {byte_to_string(delta)} exceeds the per-PR threshold of {threshold_str}",
-                "blocking": exception_checker.get() is None,
-            }
+            return GateVerdict(
+                name=outcome.config.gate_name,
+                failure=GateFailureKind.PerPRThresholdExceeded,
+                blocking=exception_checker.get() is None,
+                message=f"On-disk size increase of {byte_to_string(delta)} exceeds the per-PR threshold of {threshold_str}",
+            )
 
-    return {
-        "name": outcome.config.gate_name,
-        "state": True,
-        "error_type": None,
-        "message": outcome.violation_message,
-        "blocking": False,
-    }
+    return GateVerdict(
+        name=outcome.config.gate_name,
+        failure=None,
+        blocking=False,
+        message=None,
+    )
 
 
 def should_bypass_failure(gate_name: str, metric_handler: GateMetricHandler) -> bool:

--- a/tasks/static_quality_gates/decisions.py
+++ b/tasks/static_quality_gates/decisions.py
@@ -56,18 +56,10 @@ class ExceptionApprovalChecker:
         return self._result
 
 
-_FAILURE_KIND_TO_ERROR_TYPE: dict[GateFailureKind, str] = {
-    GateFailureKind.AbsoluteLimitExceeded: "StaticQualityGateFailed",
-    GateFailureKind.PerPRThresholdExceeded: "PerPRThresholdExceeded",
-    GateFailureKind.ExecutionError: "StackTrace",
-}
-
-
 @dataclass
 class GateEvaluationResult:
     verdicts: list[GateVerdict] = field(default_factory=list)
     has_blocking_failures: bool = False
-    exception_granted_by: str | None = None
     exception_note: str | None = None
 
 
@@ -105,7 +97,6 @@ def evaluate_gates(
     return GateEvaluationResult(
         verdicts=verdicts,
         has_blocking_failures=has_blocking_failures,
-        exception_granted_by=exception_granted_by,
         exception_note=exception_note,
     )
 

--- a/tasks/static_quality_gates/decisions.py
+++ b/tasks/static_quality_gates/decisions.py
@@ -35,20 +35,6 @@ class ExceptionApprovalChecker:
         return self._result
 
 
-def identify_gates_exceeding_pr_threshold(metric_handler: GateMetricHandler) -> list[str]:
-    """
-    Identify gates where the on-disk size increase exceeds PER_PR_THRESHOLD.
-
-    Returns gate names where relative_on_disk_size > PER_PR_THRESHOLD.
-    """
-    exceeding = []
-    for gate_name, gate_metrics in metric_handler.metrics.items():
-        delta = gate_metrics.get("relative_on_disk_size")
-        if delta is not None and delta > PER_PR_THRESHOLD:
-            exceeding.append(gate_name)
-    return exceeding
-
-
 def should_bypass_failure(gate_name: str, metric_handler: GateMetricHandler) -> bool:
     """
     Check if a gate failure should be non-blocking because on-disk size delta is 0 or negative.

--- a/tasks/static_quality_gates/gates.py
+++ b/tasks/static_quality_gates/gates.py
@@ -203,6 +203,34 @@ class GateResult:
         """Remaining disk size capacity in bytes"""
         return max(0, self.config.max_on_disk_size - self.measurement.on_disk_size)
 
+    @property
+    def violation_message(self) -> str | None:
+        if self.success:
+            return None
+        violation_messages = []
+        for violation in self.violations:
+            current_mb = violation.current_size / (1024 * 1024)
+            max_mb = violation.max_size / (1024 * 1024)
+            excess_mb = violation.excess_bytes / (1024 * 1024)
+            if excess_mb < 1:
+                excess_kb = violation.excess_bytes / 1024
+                excess_str = f"{excess_kb:.1f} KB"
+            else:
+                excess_str = f"{excess_mb:.1f} MB"
+            violation_messages.append(
+                f"{violation.measurement_type.title()} size {current_mb:.1f} MB "
+                f"exceeds limit of {max_mb:.1f} MB by {excess_str}"
+            )
+        return f"{self.config.gate_name} failed!\n" + "\n".join(violation_messages)
+
+
+@dataclass(frozen=True)
+class GateExecutionError:
+    """Represents an unexpected exception that prevented a gate from running."""
+
+    name: str
+    traceback: str
+
 
 class ArtifactMeasurer(Protocol):
     """

--- a/tasks/static_quality_gates/gates_reporter.py
+++ b/tasks/static_quality_gates/gates_reporter.py
@@ -3,9 +3,8 @@ Static Quality Gates Reporter.
 Provides clear, customer-friendly reporting and output formatting for external users.
 """
 
-import typing
-
 from tasks.libs.common.color import color_message
+from tasks.static_quality_gates.decisions import GateVerdict
 
 
 class QualityGateOutputFormatter:
@@ -74,13 +73,13 @@ class QualityGateOutputFormatter:
             return f"{agent_type} {package_type} ({arch}){fips}"
 
     @staticmethod
-    def print_summary_table(gate_list, gate_states: list[dict[str, typing.Any]], metric_handler=None) -> None:
+    def print_summary_table(gate_list, gate_verdicts: list[GateVerdict], metric_handler=None) -> None:
         """
         Print a comprehensive summary table of all quality gates with their metrics
 
         Args:
             gate_list: List of StaticQualityGate objects (composition-based)
-            gate_states: List of gate state dictionaries with execution results
+            gate_verdicts: List of GateVerdicts with decisions on gates
             metric_handler: Optional GateMetricHandler for getting measurement data
         """
         print(color_message("\n" + "=" * 132, "magenta"))
@@ -88,7 +87,7 @@ class QualityGateOutputFormatter:
         print(color_message("=" * 132, "magenta"))
 
         # Create a lookup for gate states
-        state_lookup = {state["name"]: state for state in gate_states}
+        verdict_lookup = {verdict.name: verdict for verdict in gate_verdicts}
 
         # Table header
         header = f"{'Gate Name':<40} {'Status':<8} {'Compressed':<20} {'Uncompressed':<20} {'Comp Remain':<12} {'Uncomp Remain':<14}"
@@ -99,7 +98,7 @@ class QualityGateOutputFormatter:
         failed_count = 0
 
         for gate in sorted(gate_list, key=lambda x: x.config.gate_name):
-            state = state_lookup.get(gate.config.gate_name, {})
+            verdict = verdict_lookup.get(gate.config.gate_name, {})
 
             # Get display name
             display_name = QualityGateOutputFormatter.get_display_name(gate.config.gate_name)
@@ -107,7 +106,7 @@ class QualityGateOutputFormatter:
                 display_name = display_name[:35] + "..."
 
             # Status
-            if state.get("error_type") is None:
+            if not verdict.failure:
                 status = color_message("PASS", "green")
                 passed_count += 1
             else:

--- a/tasks/static_quality_gates/gates_reporter.py
+++ b/tasks/static_quality_gates/gates_reporter.py
@@ -98,7 +98,7 @@ class QualityGateOutputFormatter:
         failed_count = 0
 
         for gate in sorted(gate_list, key=lambda x: x.config.gate_name):
-            verdict = verdict_lookup.get(gate.config.gate_name, {})
+            verdict = verdict_lookup[gate.config.gate_name]
 
             # Get display name
             display_name = QualityGateOutputFormatter.get_display_name(gate.config.gate_name)

--- a/tasks/static_quality_gates/pr_comment.py
+++ b/tasks/static_quality_gates/pr_comment.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 
 from tasks.github_tasks import pr_commenter
-from tasks.static_quality_gates.decisions import PER_PR_THRESHOLD, GateFailureKind, GateVerdict
+from tasks.static_quality_gates.decisions import PER_PR_THRESHOLD, GateEvaluationResult, GateFailureKind
 from tasks.static_quality_gates.gates import GateMetricHandler, byte_to_string
 
 FAIL_CHAR = "❌"
@@ -131,21 +131,17 @@ def get_change_metrics(
 
 def display_pr_comment(
     ctx,
-    final_state: bool,
-    gate_verdicts: list[GateVerdict],
+    evaluation: GateEvaluationResult,
     metric_handler: GateMetricHandler,
     ancestor: str,
     pr,
-    exception_granted_by: str | None = None,
 ):
     """
     Display a comment on a PR with results from our static quality gates checks
     :param ctx: Invoke task context
-    :param final_state: Boolean that represents the overall state of quality gates checks
-    :param gate_verdicts: Verdict of each quality gate
+    :param evaluation: Result of gate evaluation (verdicts, blocking failures, exception info)
     :param metric_handler: Precise metrics of each quality gate
     :param ancestor: Ancestor used for relative size comparaison
-    :param exception_granted_by: Login of the reviewer who granted a per-PR threshold exception, or None
     :return:
     """
     title = "Static quality checks"
@@ -174,7 +170,7 @@ def display_pr_comment(
     has_na_change = False
 
     # Sort gates by error_types to group failures first
-    for gate in sorted(gate_verdicts, key=lambda x: x.failure is None):
+    for gate in sorted(evaluation.verdicts, key=lambda x: x.failure is None):
         gate_name = gate.name.replace("static_quality_gate_", "")
         gate_metrics = metric_handler.metrics.get(gate.name, {})
 
@@ -225,7 +221,7 @@ def display_pr_comment(
 
             error_message = gate.message.replace('\n', '<br>')
             if not gate.blocking and gate.failure == GateFailureKind.PerPRThresholdExceeded:
-                blocking_note = f" (non-blocking: exception granted by @{exception_granted_by})"
+                blocking_note = f" (non-blocking: exception granted by @{evaluation.exception_granted_by})"
             elif not gate.blocking:
                 blocking_note = " (non-blocking: size unchanged from ancestor)"
             else:
@@ -253,13 +249,13 @@ def display_pr_comment(
         final_error_body = ""
 
     exception_banner = ""
-    if exception_granted_by:
+    if evaluation.exception_granted_by:
         per_pr_excepted = [
-            gs for gs in gate_verdicts if gs.failure == GateFailureKind.PerPRThresholdExceeded and not gs.blocking
+            gs for gs in evaluation.verdicts if gs.failure == GateFailureKind.PerPRThresholdExceeded and not gs.blocking
         ]
         if per_pr_excepted:
             threshold_str = byte_to_string(PER_PR_THRESHOLD)
-            exception_banner = f"{WARNING_CHAR} **Exception granted by @{exception_granted_by}**: this PR exceeds the per-PR size threshold ({threshold_str}) but will not be blocked.\n"
+            exception_banner = f"{WARNING_CHAR} **Exception granted by @{evaluation.exception_granted_by}**: this PR exceeds the per-PR size threshold ({threshold_str}) but will not be blocked.\n"
 
     # Build successful checks section
     success_section = ""
@@ -284,6 +280,6 @@ def display_pr_comment(
     if has_na_change and job_url:
         retry_hint = f"SOME SIZE DELTAS ARE N/A (ANCESTOR METRICS NOT YET AVAILABLE). [RETRY JOB]({job_url})\n"
 
-    body = f"{SUCCESS_CHAR if final_state else FAIL_CHAR} Please find below the results from static quality gates\n{ancestor_info}{dashboard_link}{job_link}{retry_hint}{exception_banner}{final_error_body}\n\n{success_section}\n{wire_section}"
+    body = f"{FAIL_CHAR if evaluation.has_blocking_failures else SUCCESS_CHAR} Please find below the results from static quality gates\n{ancestor_info}{dashboard_link}{job_link}{retry_hint}{exception_banner}{final_error_body}\n\n{success_section}\n{wire_section}"
 
     pr_commenter(ctx, title=title, body=body, pr=pr)

--- a/tasks/static_quality_gates/pr_comment.py
+++ b/tasks/static_quality_gates/pr_comment.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 
 from tasks.github_tasks import pr_commenter
-from tasks.static_quality_gates.decisions import PER_PR_THRESHOLD, GateEvaluationResult, GateFailureKind
+from tasks.static_quality_gates.decisions import GateEvaluationResult, GateFailureKind
 from tasks.static_quality_gates.gates import GateMetricHandler, byte_to_string
 
 FAIL_CHAR = "❌"
@@ -220,13 +220,8 @@ def display_pr_comment(
             body_wire += f"|{status_char}|{gate_name}|{wire_change_str}|{wire_limit_bounds}|\n"
 
             error_message = gate.message.replace('\n', '<br>')
-            if not gate.blocking and gate.failure == GateFailureKind.PerPRThresholdExceeded:
-                blocking_note = f" (non-blocking: exception granted by @{evaluation.exception_granted_by})"
-            elif not gate.blocking:
-                blocking_note = " (non-blocking: size unchanged from ancestor)"
-            else:
-                blocking_note = ""
-            body_error_footer += f"|{gate_name}|{gate.failure}{blocking_note}|{error_message}|\n"
+            note_suffix = f" ({gate.blocking_note})" if gate.blocking_note else ""
+            body_error_footer += f"|{gate_name}|{gate.failure}{note_suffix}|{error_message}|\n"
 
             if gate.blocking:
                 with_blocking_error = True
@@ -248,14 +243,7 @@ def display_pr_comment(
     else:
         final_error_body = ""
 
-    exception_banner = ""
-    if evaluation.exception_granted_by:
-        per_pr_excepted = [
-            gs for gs in evaluation.verdicts if gs.failure == GateFailureKind.PerPRThresholdExceeded and not gs.blocking
-        ]
-        if per_pr_excepted:
-            threshold_str = byte_to_string(PER_PR_THRESHOLD)
-            exception_banner = f"{WARNING_CHAR} **Exception granted by @{evaluation.exception_granted_by}**: this PR exceeds the per-PR size threshold ({threshold_str}) but will not be blocked.\n"
+    exception_banner = f"{WARNING_CHAR} {evaluation.exception_note}" if evaluation.exception_note else ""
 
     # Build successful checks section
     success_section = ""

--- a/tasks/static_quality_gates/pr_comment.py
+++ b/tasks/static_quality_gates/pr_comment.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 import os
-import typing
 
 from tasks.github_tasks import pr_commenter
-from tasks.static_quality_gates.decisions import PER_PR_THRESHOLD
+from tasks.static_quality_gates.decisions import PER_PR_THRESHOLD, GateFailureKind, GateVerdict
 from tasks.static_quality_gates.gates import GateMetricHandler, byte_to_string
 
 FAIL_CHAR = "❌"
@@ -133,7 +132,7 @@ def get_change_metrics(
 def display_pr_comment(
     ctx,
     final_state: bool,
-    gate_states: list[dict[str, typing.Any]],
+    gate_verdicts: list[GateVerdict],
     metric_handler: GateMetricHandler,
     ancestor: str,
     pr,
@@ -143,7 +142,7 @@ def display_pr_comment(
     Display a comment on a PR with results from our static quality gates checks
     :param ctx: Invoke task context
     :param final_state: Boolean that represents the overall state of quality gates checks
-    :param gate_states: State of each quality gate
+    :param gate_verdicts: Verdict of each quality gate
     :param metric_handler: Precise metrics of each quality gate
     :param ancestor: Ancestor used for relative size comparaison
     :param exception_granted_by: Login of the reviewer who granted a per-PR threshold exception, or None
@@ -174,20 +173,20 @@ def display_pr_comment(
     collapsed_success_count = 0
     has_na_change = False
 
-    # Sort gates by error_types to group in between NoError, AssertionError and StackTrace
-    for gate in sorted(gate_states, key=lambda x: x["error_type"] is None):
-        gate_name = gate['name'].replace("static_quality_gate_", "")
-        gate_metrics = metric_handler.metrics.get(gate['name'], {})
+    # Sort gates by error_types to group failures first
+    for gate in sorted(gate_verdicts, key=lambda x: x.failure is None):
+        gate_name = gate.name.replace("static_quality_gate_", "")
+        gate_metrics = metric_handler.metrics.get(gate.name, {})
 
         # Get change metrics for on-disk (delta with percentage and limit bounds)
-        change_str, limit_bounds, is_neutral = get_change_metrics(gate['name'], metric_handler, metric_type="disk")
+        change_str, limit_bounds, is_neutral = get_change_metrics(gate.name, metric_handler, metric_type="disk")
         if change_str == "N/A":
             has_na_change = True
 
         # Get change metrics for on-wire
-        wire_change_str, wire_limit_bounds, _ = get_change_metrics(gate['name'], metric_handler, metric_type="wire")
+        wire_change_str, wire_limit_bounds, _ = get_change_metrics(gate.name, metric_handler, metric_type="wire")
 
-        if gate["error_type"] is None:
+        if gate.failure is None:
             if is_neutral:
                 # Neutral changes go to collapsed section (just show current size)
                 current_disk = gate_metrics.get("current_on_disk_size")
@@ -209,10 +208,9 @@ def display_pr_comment(
             body_wire += f"|{SUCCESS_CHAR}|{gate_name}|{wire_change_str}|{wire_limit_bounds}|\n"
         else:
             # Check if this is a blocking or non-blocking failure
-            is_blocking = gate.get("blocking", True)
-            status_char = FAIL_CHAR if is_blocking else WARNING_CHAR
+            status_char = FAIL_CHAR if gate.blocking else WARNING_CHAR
 
-            if gate["error_type"] == "PerPRThresholdExceeded":
+            if gate.failure == GateFailureKind.PerPRThresholdExceeded:
                 body_error += f"|{status_char}|{gate_name} (per-PR threshold)|{change_str}|{limit_bounds}|\n"
             else:
                 # This is probably way more convoluted than it should be, but the best we can do
@@ -225,16 +223,16 @@ def display_pr_comment(
             # Add to wire table for errors too
             body_wire += f"|{status_char}|{gate_name}|{wire_change_str}|{wire_limit_bounds}|\n"
 
-            error_message = gate['message'].replace('\n', '<br>')
-            if not is_blocking and gate["error_type"] == "PerPRThresholdExceeded":
+            error_message = gate.message.replace('\n', '<br>')
+            if not gate.blocking and gate.failure == GateFailureKind.PerPRThresholdExceeded:
                 blocking_note = f" (non-blocking: exception granted by @{exception_granted_by})"
-            elif not is_blocking:
+            elif not gate.blocking:
                 blocking_note = " (non-blocking: size unchanged from ancestor)"
             else:
                 blocking_note = ""
-            body_error_footer += f"|{gate_name}|{gate['error_type']}{blocking_note}|{error_message}|\n"
+            body_error_footer += f"|{gate_name}|{gate.failure}{blocking_note}|{error_message}|\n"
 
-            if is_blocking:
+            if gate.blocking:
                 with_blocking_error = True
             else:
                 with_non_blocking_error = True
@@ -257,9 +255,7 @@ def display_pr_comment(
     exception_banner = ""
     if exception_granted_by:
         per_pr_excepted = [
-            gs
-            for gs in gate_states
-            if gs.get("error_type") == "PerPRThresholdExceeded" and not gs.get("blocking", True)
+            gs for gs in gate_verdicts if gs.failure == GateFailureKind.PerPRThresholdExceeded and not gs.blocking
         ]
         if per_pr_excepted:
             threshold_str = byte_to_string(PER_PR_THRESHOLD)

--- a/tasks/unit_tests/static_quality_gates/decisions_tests.py
+++ b/tasks/unit_tests/static_quality_gates/decisions_tests.py
@@ -3,9 +3,7 @@ from unittest.mock import MagicMock, patch
 
 from tasks.static_quality_gates.decisions import (
     EXCEPTION_APPROVERS,
-    PER_PR_THRESHOLD,
     ExceptionApprovalChecker,
-    identify_gates_exceeding_pr_threshold,
     should_bypass_failure,
 )
 from tasks.static_quality_gates.gates import GateMetricHandler
@@ -191,48 +189,6 @@ class TestBlockingFailureDetection(unittest.TestCase):
         ]
         has_blocking = any(gs["state"] is False and gs.get("blocking", True) for gs in gate_states)
         self.assertFalse(has_blocking)
-
-
-class TestIdentifyGatesExceedingPrThreshold(unittest.TestCase):
-    """Test identify_gates_exceeding_pr_threshold against PER_PR_THRESHOLD."""
-
-    def setUp(self):
-        self.threshold = PER_PR_THRESHOLD
-        self.handler = GateMetricHandler("main", "dev")
-
-    def test_no_gates_exceeding(self):
-        """Gates with delta below the threshold are not returned."""
-        self.handler.metrics["gate_a"] = {"relative_on_disk_size": self.threshold - 1}
-        self.handler.metrics["gate_b"] = {"relative_on_disk_size": 0}
-        self.assertEqual(identify_gates_exceeding_pr_threshold(self.handler), [])
-
-    def test_gate_exactly_at_threshold_not_returned(self):
-        """A gate at exactly the threshold is not considered exceeding."""
-        self.handler.metrics["gate_a"] = {"relative_on_disk_size": self.threshold}
-        self.assertEqual(identify_gates_exceeding_pr_threshold(self.handler), [])
-
-    def test_gate_exceeding_threshold(self):
-        """A gate with delta strictly above the threshold is returned."""
-        self.handler.metrics["gate_a"] = {"relative_on_disk_size": self.threshold + 1}
-        self.assertIn("gate_a", identify_gates_exceeding_pr_threshold(self.handler))
-
-    def test_only_exceeding_gates_returned(self):
-        """Only the gates that exceed the threshold are returned."""
-        self.handler.metrics["gate_ok"] = {"relative_on_disk_size": self.threshold - 1}
-        self.handler.metrics["gate_bad"] = {"relative_on_disk_size": self.threshold + 1}
-        result = identify_gates_exceeding_pr_threshold(self.handler)
-        self.assertIn("gate_bad", result)
-        self.assertNotIn("gate_ok", result)
-
-    def test_missing_delta_ignored(self):
-        """Gates with no relative_on_disk_size are ignored."""
-        self.handler.metrics["gate_a"] = {"current_on_disk_size": 10_000_000}
-        self.assertEqual(identify_gates_exceeding_pr_threshold(self.handler), [])
-
-    def test_negative_delta_not_returned(self):
-        """Gates with a negative delta (size reduction) are not returned."""
-        self.handler.metrics["gate_a"] = {"relative_on_disk_size": -1_000_000}
-        self.assertEqual(identify_gates_exceeding_pr_threshold(self.handler), [])
 
 
 class TestExceptionApprovalChecker(unittest.TestCase):

--- a/tasks/unit_tests/static_quality_gates/gates_reporter_tests.py
+++ b/tasks/unit_tests/static_quality_gates/gates_reporter_tests.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
+from tasks.static_quality_gates.decisions import GateFailureKind, GateVerdict
 from tasks.static_quality_gates.gates_reporter import QualityGateOutputFormatter
 
 
@@ -113,10 +114,10 @@ class TestQualityGateOutputFormatter(unittest.TestCase):
 
         gate_list = [mock_gate1, mock_gate2]
 
-        # Create gate states (all passed)
-        gate_states = [
-            {"name": "static_quality_gate_agent_deb_amd64", "error_type": None},
-            {"name": "static_quality_gate_docker_agent_amd64", "error_type": None},
+        # Create gate verdicts (all passed)
+        gate_verdicts = [
+            GateVerdict(name="static_quality_gate_agent_deb_amd64", failure=None),
+            GateVerdict(name="static_quality_gate_docker_agent_amd64", failure=None),
         ]
 
         # Mock metric handler with measurement data
@@ -132,7 +133,7 @@ class TestQualityGateOutputFormatter(unittest.TestCase):
             },
         }
 
-        QualityGateOutputFormatter.print_summary_table(gate_list, gate_states, mock_metric_handler)
+        QualityGateOutputFormatter.print_summary_table(gate_list, gate_verdicts, mock_metric_handler)
 
         # Verify print was called multiple times for the table
         self.assertGreater(mock_print.call_count, 10)
@@ -181,10 +182,14 @@ class TestQualityGateOutputFormatter(unittest.TestCase):
 
         gate_list = [mock_gate1, mock_gate2]
 
-        # Create gate states (one failed)
-        gate_states = [
-            {"name": "static_quality_gate_agent_deb_amd64", "error_type": None},
-            {"name": "static_quality_gate_docker_agent_amd64", "error_type": "AssertionError"},
+        # Create gate verdicts (one failed)
+        gate_verdicts = [
+            GateVerdict(name="static_quality_gate_agent_deb_amd64", failure=None),
+            GateVerdict(
+                name="static_quality_gate_docker_agent_amd64",
+                failure=GateFailureKind.AbsoluteLimitExceeded,
+                blocking=True,
+            ),
         ]
 
         # Mock metric handler with measurement data (gate2 over limit)
@@ -200,7 +205,7 @@ class TestQualityGateOutputFormatter(unittest.TestCase):
             },
         }
 
-        QualityGateOutputFormatter.print_summary_table(gate_list, gate_states, mock_metric_handler)
+        QualityGateOutputFormatter.print_summary_table(gate_list, gate_verdicts, mock_metric_handler)
 
         calls = [str(call) for call in mock_print.call_args_list]
         output_text = ' '.join(calls)
@@ -226,10 +231,10 @@ class TestQualityGateOutputFormatter(unittest.TestCase):
         mock_gate.config.max_on_disk_size = 2000 * 1024 * 1024  # 2000MB
 
         gate_list = [mock_gate]
-        gate_states = [{"name": "static_quality_gate_test", "error_type": None}]
+        gate_verdicts = [GateVerdict(name="static_quality_gate_test", failure=None)]
 
         # No metric handler provided, so no measurement data
-        QualityGateOutputFormatter.print_summary_table(gate_list, gate_states, None)
+        QualityGateOutputFormatter.print_summary_table(gate_list, gate_verdicts, None)
 
         calls = [str(call) for call in mock_print.call_args_list]
         output_text = ' '.join(calls)

--- a/tasks/unit_tests/static_quality_gates/pr_comment_tests.py
+++ b/tasks/unit_tests/static_quality_gates/pr_comment_tests.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
+from tasks.static_quality_gates.decisions import GateFailureKind, GateVerdict
 from tasks.static_quality_gates.gates import GateMetricHandler
 from tasks.static_quality_gates.pr_comment import (
     display_pr_comment,
@@ -222,8 +223,8 @@ class TestQualityGatesPrMessage(unittest.TestCase):
             c,
             True,
             [
-                {'name': 'gateA', 'error_type': None, 'message': None},
-                {'name': 'gateB', 'error_type': None, 'message': None},
+                GateVerdict(name='gateA', failure=None),
+                GateVerdict(name='gateB', failure=None),
             ],
             gate_metric_handler,
             "value",
@@ -282,8 +283,8 @@ class TestQualityGatesPrMessage(unittest.TestCase):
             c,
             True,
             [
-                {'name': 'gateA', 'error_type': None, 'message': None},
-                {'name': 'gateB', 'error_type': None, 'message': None},
+                GateVerdict(name='gateA', failure=None),
+                GateVerdict(name='gateB', failure=None),
             ],
             gate_metric_handler,
             "value",
@@ -339,8 +340,8 @@ class TestQualityGatesPrMessage(unittest.TestCase):
             c,
             True,
             [
-                {'name': 'gateA', 'error_type': None, 'message': None},
-                {'name': 'gateB', 'error_type': None, 'message': None},
+                GateVerdict(name='gateA', failure=None),
+                GateVerdict(name='gateB', failure=None),
             ],
             gate_metric_handler,
             "value",
@@ -374,8 +375,12 @@ class TestQualityGatesPrMessage(unittest.TestCase):
             c,
             False,
             [
-                {'name': 'gateA', 'error_type': 'AssertionError', 'message': 'some_msg_A'},
-                {'name': 'gateB', 'error_type': 'AssertionError', 'message': 'some_msg_B'},
+                GateVerdict(
+                    name='gateA', failure=GateFailureKind.AbsoluteLimitExceeded, blocking=True, message='some_msg_A'
+                ),
+                GateVerdict(
+                    name='gateB', failure=GateFailureKind.AbsoluteLimitExceeded, blocking=True, message='some_msg_B'
+                ),
             ],
             gate_metric_handler,
             "value",
@@ -425,8 +430,10 @@ class TestQualityGatesPrMessage(unittest.TestCase):
             c,
             False,
             [
-                {'name': 'gateA', 'error_type': 'AssertionError', 'message': 'some_msg_A'},
-                {'name': 'gateB', 'error_type': None, 'message': None},
+                GateVerdict(
+                    name='gateA', failure=GateFailureKind.AbsoluteLimitExceeded, blocking=True, message='some_msg_A'
+                ),
+                GateVerdict(name='gateB', failure=None),
             ],
             gate_metric_handler,
             "value",
@@ -465,7 +472,9 @@ class TestQualityGatesPrMessage(unittest.TestCase):
             c,
             False,
             [
-                {'name': 'gateA', 'error_type': 'AssertionError', 'message': 'some_msg_A'},
+                GateVerdict(
+                    name='gateA', failure=GateFailureKind.AbsoluteLimitExceeded, blocking=True, message='some_msg_A'
+                ),
             ],
             gate_metric_handler,
             "value",
@@ -505,7 +514,7 @@ class TestQualityGatesPrMessage(unittest.TestCase):
             c,
             True,
             [
-                {'name': 'gateA', 'error_type': None, 'message': None},
+                GateVerdict(name='gateA', failure=None),
             ],
             gate_metric_handler,
             "value",
@@ -547,7 +556,9 @@ class TestQualityGatesPrMessage(unittest.TestCase):
             c,
             False,
             [
-                {'name': 'gateA', 'error_type': 'AssertionError', 'message': 'some_msg_A'},
+                GateVerdict(
+                    name='gateA', failure=GateFailureKind.AbsoluteLimitExceeded, blocking=True, message='some_msg_A'
+                ),
             ],
             gate_metric_handler,
             "value",
@@ -566,7 +577,7 @@ class TestQualityGatesPrMessage(unittest.TestCase):
                 "",
                 "|Quality gate|Error type|Error message|",
                 "|----|---|--------|",
-                "|gateA|AssertionError|some_msg_A|",
+                "|gateA|AbsoluteLimitExceeded|some_msg_A|",
             ]
         )
         self.assertIn(expected.strip(), body)
@@ -595,12 +606,9 @@ class TestNonBlockingPrComment(unittest.TestCase):
             c,
             True,  # final_state is success (no blocking failures)
             [
-                {
-                    'name': 'gateA',
-                    'error_type': 'StaticQualityGateFailed',
-                    'message': 'size exceeded',
-                    'blocking': False,
-                },
+                GateVerdict(
+                    name='gateA', failure=GateFailureKind.AbsoluteLimitExceeded, blocking=False, message='size exceeded'
+                ),
             ],
             gate_metric_handler,
             "ancestor123",
@@ -636,12 +644,9 @@ class TestNonBlockingPrComment(unittest.TestCase):
             c,
             False,  # final_state is failure (has blocking failures)
             [
-                {
-                    'name': 'gateA',
-                    'error_type': 'StaticQualityGateFailed',
-                    'message': 'size exceeded',
-                    'blocking': True,
-                },
+                GateVerdict(
+                    name='gateA', failure=GateFailureKind.AbsoluteLimitExceeded, blocking=True, message='size exceeded'
+                ),
             ],
             gate_metric_handler,
             "ancestor123",
@@ -675,18 +680,12 @@ class TestNonBlockingPrComment(unittest.TestCase):
             c,
             False,  # final_state is failure (has blocking failures)
             [
-                {
-                    'name': 'gateA',
-                    'error_type': 'StaticQualityGateFailed',
-                    'message': 'size exceeded',
-                    'blocking': True,
-                },
-                {
-                    'name': 'gateB',
-                    'error_type': 'StaticQualityGateFailed',
-                    'message': 'size exceeded',
-                    'blocking': False,
-                },
+                GateVerdict(
+                    name='gateA', failure=GateFailureKind.AbsoluteLimitExceeded, blocking=True, message='size exceeded'
+                ),
+                GateVerdict(
+                    name='gateB', failure=GateFailureKind.AbsoluteLimitExceeded, blocking=False, message='size exceeded'
+                ),
             ],
             gate_metric_handler,
             "ancestor123",

--- a/tasks/unit_tests/static_quality_gates/pr_comment_tests.py
+++ b/tasks/unit_tests/static_quality_gates/pr_comment_tests.py
@@ -596,7 +596,7 @@ class TestNonBlockingPrComment(unittest.TestCase):
     )
     @patch("tasks.static_quality_gates.pr_comment.pr_commenter")
     def test_non_blocking_failure_shows_warning_indicator(self, pr_commenter_mock):
-        """Non-blocking failures should show warning indicator, not error."""
+        """Non-blocking failures should show warning indicator and per-verdict note in the footer."""
         from invoke import MockContext
 
         c = MockContext()
@@ -612,6 +612,7 @@ class TestNonBlockingPrComment(unittest.TestCase):
                         failure=GateFailureKind.AbsoluteLimitExceeded,
                         blocking=False,
                         message='size exceeded',
+                        blocking_note='non-blocking: size unchanged from ancestor',
                     ),
                 ],
             ),
@@ -626,8 +627,8 @@ class TestNonBlockingPrComment(unittest.TestCase):
         self.assertIn('⚠️', body)
         # Should NOT contain the blocking failure message
         self.assertNotIn('prevent the PR to merge', body)
-        # Should contain the non-blocking note
-        self.assertIn('non-blocking', body)
+        # Footer should carry the per-verdict blocking note
+        self.assertIn('AbsoluteLimitExceeded (non-blocking: size unchanged from ancestor)', body)
 
     @patch.dict(
         'os.environ',
@@ -717,6 +718,77 @@ class TestNonBlockingPrComment(unittest.TestCase):
         self.assertIn('⚠️', body)
         # Should contain the blocking failure message (since there's a blocking failure)
         self.assertIn('prevent the PR to merge', body)
+
+
+class TestExceptionBanner(unittest.TestCase):
+    """Test that exception_note from GateEvaluationResult renders as the banner."""
+
+    @patch.dict(
+        'os.environ',
+        {
+            'CI_COMMIT_REF_NAME': 'pikachu',
+            'CI_COMMIT_BRANCH': 'sequoia',
+        },
+    )
+    @patch("tasks.static_quality_gates.pr_comment.pr_commenter")
+    def test_exception_note_renders_as_banner(self, pr_commenter_mock):
+        """exception_note on GateEvaluationResult should appear prefixed with the warning emoji."""
+        from invoke import MockContext
+
+        c = MockContext()
+        gate_metric_handler = GateMetricHandler("main", "dev")
+        mock_pr = MagicMock()
+        mock_pr.number = 12345
+        display_pr_comment(
+            c,
+            GateEvaluationResult(
+                verdicts=[
+                    GateVerdict(
+                        name='gateA',
+                        failure=GateFailureKind.PerPRThresholdExceeded,
+                        blocking=False,
+                        message='size exceeded',
+                        blocking_note='non-blocking: exception granted by @granter',
+                    ),
+                ],
+                exception_note='**Exception granted by @granter**: this PR exceeds the per-PR size threshold (600.0 KiB) but will not be blocked.\n',
+            ),
+            gate_metric_handler,
+            "ancestor123",
+            mock_pr,
+        )
+        pr_commenter_mock.assert_called_once()
+        body = pr_commenter_mock.call_args[1]['body']
+        self.assertIn('⚠️ **Exception granted by @granter**', body)
+
+    @patch.dict(
+        'os.environ',
+        {
+            'CI_COMMIT_REF_NAME': 'pikachu',
+            'CI_COMMIT_BRANCH': 'sequoia',
+        },
+    )
+    @patch("tasks.static_quality_gates.pr_comment.pr_commenter")
+    def test_no_exception_note_no_banner(self, pr_commenter_mock):
+        """When exception_note is None, no exception banner should appear."""
+        from invoke import MockContext
+
+        c = MockContext()
+        gate_metric_handler = GateMetricHandler("main", "dev")
+        mock_pr = MagicMock()
+        mock_pr.number = 12345
+        display_pr_comment(
+            c,
+            GateEvaluationResult(
+                verdicts=[GateVerdict(name='gateA', failure=None)],
+            ),
+            gate_metric_handler,
+            "ancestor123",
+            mock_pr,
+        )
+        pr_commenter_mock.assert_called_once()
+        body = pr_commenter_mock.call_args[1]['body']
+        self.assertNotIn('Exception granted', body)
 
 
 if __name__ == '__main__':

--- a/tasks/unit_tests/static_quality_gates/pr_comment_tests.py
+++ b/tasks/unit_tests/static_quality_gates/pr_comment_tests.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from tasks.static_quality_gates.decisions import GateFailureKind, GateVerdict
+from tasks.static_quality_gates.decisions import GateEvaluationResult, GateFailureKind, GateVerdict
 from tasks.static_quality_gates.gates import GateMetricHandler
 from tasks.static_quality_gates.pr_comment import (
     display_pr_comment,
@@ -221,11 +221,9 @@ class TestQualityGatesPrMessage(unittest.TestCase):
         mock_pr.number = 12345
         display_pr_comment(
             c,
-            True,
-            [
-                GateVerdict(name='gateA', failure=None),
-                GateVerdict(name='gateB', failure=None),
-            ],
+            GateEvaluationResult(
+                verdicts=[GateVerdict(name='gateA', failure=None), GateVerdict(name='gateB', failure=None)]
+            ),
             gate_metric_handler,
             "value",
             mock_pr,
@@ -281,11 +279,9 @@ class TestQualityGatesPrMessage(unittest.TestCase):
         mock_pr.number = 12345
         display_pr_comment(
             c,
-            True,
-            [
-                GateVerdict(name='gateA', failure=None),
-                GateVerdict(name='gateB', failure=None),
-            ],
+            GateEvaluationResult(
+                verdicts=[GateVerdict(name='gateA', failure=None), GateVerdict(name='gateB', failure=None)]
+            ),
             gate_metric_handler,
             "value",
             mock_pr,
@@ -338,11 +334,9 @@ class TestQualityGatesPrMessage(unittest.TestCase):
         mock_pr.number = 12345
         display_pr_comment(
             c,
-            True,
-            [
-                GateVerdict(name='gateA', failure=None),
-                GateVerdict(name='gateB', failure=None),
-            ],
+            GateEvaluationResult(
+                verdicts=[GateVerdict(name='gateA', failure=None), GateVerdict(name='gateB', failure=None)]
+            ),
             gate_metric_handler,
             "value",
             mock_pr,
@@ -373,15 +367,17 @@ class TestQualityGatesPrMessage(unittest.TestCase):
         mock_pr.number = 12345
         display_pr_comment(
             c,
-            False,
-            [
-                GateVerdict(
-                    name='gateA', failure=GateFailureKind.AbsoluteLimitExceeded, blocking=True, message='some_msg_A'
-                ),
-                GateVerdict(
-                    name='gateB', failure=GateFailureKind.AbsoluteLimitExceeded, blocking=True, message='some_msg_B'
-                ),
-            ],
+            GateEvaluationResult(
+                verdicts=[
+                    GateVerdict(
+                        name='gateA', failure=GateFailureKind.AbsoluteLimitExceeded, blocking=True, message='some_msg_A'
+                    ),
+                    GateVerdict(
+                        name='gateB', failure=GateFailureKind.AbsoluteLimitExceeded, blocking=True, message='some_msg_B'
+                    ),
+                ],
+                has_blocking_failures=True,
+            ),
             gate_metric_handler,
             "value",
             mock_pr,
@@ -428,13 +424,15 @@ class TestQualityGatesPrMessage(unittest.TestCase):
         mock_pr.number = 12345
         display_pr_comment(
             c,
-            False,
-            [
-                GateVerdict(
-                    name='gateA', failure=GateFailureKind.AbsoluteLimitExceeded, blocking=True, message='some_msg_A'
-                ),
-                GateVerdict(name='gateB', failure=None),
-            ],
+            GateEvaluationResult(
+                verdicts=[
+                    GateVerdict(
+                        name='gateA', failure=GateFailureKind.AbsoluteLimitExceeded, blocking=True, message='some_msg_A'
+                    ),
+                    GateVerdict(name='gateB', failure=None),
+                ],
+                has_blocking_failures=True,
+            ),
             gate_metric_handler,
             "value",
             mock_pr,
@@ -470,12 +468,14 @@ class TestQualityGatesPrMessage(unittest.TestCase):
         mock_pr.number = 12345
         display_pr_comment(
             c,
-            False,
-            [
-                GateVerdict(
-                    name='gateA', failure=GateFailureKind.AbsoluteLimitExceeded, blocking=True, message='some_msg_A'
-                ),
-            ],
+            GateEvaluationResult(
+                verdicts=[
+                    GateVerdict(
+                        name='gateA', failure=GateFailureKind.AbsoluteLimitExceeded, blocking=True, message='some_msg_A'
+                    )
+                ],
+                has_blocking_failures=True,
+            ),
             gate_metric_handler,
             "value",
             mock_pr,
@@ -512,10 +512,9 @@ class TestQualityGatesPrMessage(unittest.TestCase):
         mock_pr.number = 12345
         display_pr_comment(
             c,
-            True,
-            [
-                GateVerdict(name='gateA', failure=None),
-            ],
+            GateEvaluationResult(
+                verdicts=[GateVerdict(name='gateA', failure=None)],
+            ),
             gate_metric_handler,
             "value",
             mock_pr,
@@ -554,12 +553,14 @@ class TestQualityGatesPrMessage(unittest.TestCase):
         mock_pr.number = 12345
         display_pr_comment(
             c,
-            False,
-            [
-                GateVerdict(
-                    name='gateA', failure=GateFailureKind.AbsoluteLimitExceeded, blocking=True, message='some_msg_A'
-                ),
-            ],
+            GateEvaluationResult(
+                verdicts=[
+                    GateVerdict(
+                        name='gateA', failure=GateFailureKind.AbsoluteLimitExceeded, blocking=True, message='some_msg_A'
+                    ),
+                ],
+                has_blocking_failures=True,
+            ),
             gate_metric_handler,
             "value",
             mock_pr,
@@ -604,12 +605,16 @@ class TestNonBlockingPrComment(unittest.TestCase):
         mock_pr.number = 12345
         display_pr_comment(
             c,
-            True,  # final_state is success (no blocking failures)
-            [
-                GateVerdict(
-                    name='gateA', failure=GateFailureKind.AbsoluteLimitExceeded, blocking=False, message='size exceeded'
-                ),
-            ],
+            GateEvaluationResult(
+                verdicts=[
+                    GateVerdict(
+                        name='gateA',
+                        failure=GateFailureKind.AbsoluteLimitExceeded,
+                        blocking=False,
+                        message='size exceeded',
+                    ),
+                ],
+            ),
             gate_metric_handler,
             "ancestor123",
             mock_pr,
@@ -642,12 +647,17 @@ class TestNonBlockingPrComment(unittest.TestCase):
         mock_pr.number = 12345
         display_pr_comment(
             c,
-            False,  # final_state is failure (has blocking failures)
-            [
-                GateVerdict(
-                    name='gateA', failure=GateFailureKind.AbsoluteLimitExceeded, blocking=True, message='size exceeded'
-                ),
-            ],
+            GateEvaluationResult(
+                verdicts=[
+                    GateVerdict(
+                        name='gateA',
+                        failure=GateFailureKind.AbsoluteLimitExceeded,
+                        blocking=True,
+                        message='size exceeded',
+                    ),
+                ],
+                has_blocking_failures=True,
+            ),
             gate_metric_handler,
             "ancestor123",
             mock_pr,
@@ -678,15 +688,23 @@ class TestNonBlockingPrComment(unittest.TestCase):
         mock_pr.number = 12345
         display_pr_comment(
             c,
-            False,  # final_state is failure (has blocking failures)
-            [
-                GateVerdict(
-                    name='gateA', failure=GateFailureKind.AbsoluteLimitExceeded, blocking=True, message='size exceeded'
-                ),
-                GateVerdict(
-                    name='gateB', failure=GateFailureKind.AbsoluteLimitExceeded, blocking=False, message='size exceeded'
-                ),
-            ],
+            GateEvaluationResult(
+                verdicts=[
+                    GateVerdict(
+                        name='gateA',
+                        failure=GateFailureKind.AbsoluteLimitExceeded,
+                        blocking=True,
+                        message='size exceeded',
+                    ),
+                    GateVerdict(
+                        name='gateB',
+                        failure=GateFailureKind.AbsoluteLimitExceeded,
+                        blocking=False,
+                        message='size exceeded',
+                    ),
+                ],
+                has_blocking_failures=True,
+            ),
             gate_metric_handler,
             "ancestor123",
             mock_pr,

--- a/tasks/unit_tests/static_quality_gates/tasks_tests.py
+++ b/tasks/unit_tests/static_quality_gates/tasks_tests.py
@@ -401,6 +401,48 @@ class TestQualityGatesIntegration(unittest.TestCase):
             mock_pr_commenter.assert_called_once()
             self.assertIs(mock_pr_commenter.call_args.kwargs["pr"], approved_pr)
 
+    @patch.dict('os.environ', _PR_ENV_VARS, clear=True)
+    def test_gate_fails_absolute_limit_non_blocking_unchanged_from_ancestor(self):
+        """Gate exceeds absolute disk limit but size is unchanged from ancestor — failure is non-blocking."""
+        gate_scenarios = [
+            GateScenario(
+                name=_DEB_GATE,
+                ancestor_disk=110 * _MiB,  # ancestor was already over the 105 MiB limit
+                ancestor_wire=50 * _MiB,
+                current_disk=110 * _MiB,  # no increase from ancestor (delta = 0)
+                current_wire=50 * _MiB,
+                max_disk=105 * _MiB,
+                max_wire=55 * _MiB,
+            ),
+            GateScenario(
+                name=_DOCKER_GATE,
+                ancestor_disk=600 * _MiB,
+                ancestor_wire=240 * _MiB,
+                current_disk=600 * _MiB + 20 * _KiB,
+                current_wire=240 * _MiB,
+                max_disk=700 * _MiB,
+                max_wire=250 * _MiB,
+            ),
+        ]
+        with (
+            _gate_scenarios_fixture(*gate_scenarios, ancestor_sha=_ANCESTOR_SHA) as config_path,
+            patch("tasks.quality_gates.get_ancestor", return_value=_ANCESTOR_SHA),
+            patch("tasks.quality_gates.get_commit_sha", return_value=_CI_COMMIT_SHA),
+            patch("tasks.static_quality_gates.github.GithubAPI", new=FakeGithubAPI),
+            patch("tasks.static_quality_gates.gates.send_metrics"),
+            patch("tasks.static_quality_gates.pr_comment.pr_commenter") as mock_pr_commenter,
+            patch(
+                "tasks.static_quality_gates.gates.GateMetricHandler.generate_metric_reports"
+            ) as mock_generate_reports,
+        ):
+            ctx = MockContext(
+                run={"datadog-ci tag --level job --tags static_quality_gates:\"failure\"": Result("Done")}
+            )
+            # Should NOT raise Exit — failure is non-blocking because size is unchanged from ancestor
+            parse_and_trigger_gates(ctx, config_path)
+            mock_generate_reports.assert_called_once()
+            mock_pr_commenter.assert_called_once()
+
     @patch.dict(
         'os.environ',
         {
@@ -443,38 +485,50 @@ class TestQualityGatesIntegration(unittest.TestCase):
     @patch.dict(
         'os.environ',
         {
+            'BUCKET_BRANCH': 'main',
             'CI_COMMIT_BRANCH': 'mq-working-branch-12345',
             'CI_COMMIT_REF_SLUG': 'mq-working-branch-12345',
-            'BUCKET_BRANCH': 'main',
-            'CI_PIPELINE_ID': '71580015',
-            'CI_COMMIT_SHA': '1234567890abcdef',
-            'CI_COMMIT_SHORT_SHA': '1234567',
+            'CI_PIPELINE_ID': _CI_PIPELINE_ID,
+            'CI_COMMIT_SHA': _CI_COMMIT_SHA,
         },
+        clear=True,
     )
-    @patch(
-        "tasks.static_quality_gates.gates.PackageArtifactMeasurer._find_package_paths",
-        return_value={'primary': '/fake/path'},
-    )
-    @patch("tasks.static_quality_gates.gates.PackageArtifactMeasurer._calculate_package_sizes", return_value=(0, 0))
-    @patch("tasks.static_quality_gates.gates.DockerArtifactMeasurer._calculate_image_wire_size", return_value=0)
-    @patch("tasks.static_quality_gates.gates.DockerArtifactMeasurer._calculate_image_disk_size", return_value=0)
-    @patch("tasks.static_quality_gates.gates.GateMetricHandler.send_metrics_to_datadog", new=MagicMock())
-    @patch("tasks.static_quality_gates.gates.GateMetricHandler.generate_relative_size", new=MagicMock())
-    @patch("tasks.static_quality_gates.gates.GateMetricHandler.generate_metric_reports", new=MagicMock())
-    @patch("tasks.quality_gates.get_ancestor", return_value="ancestor-sha")
-    @patch("tasks.quality_gates.get_commit_sha", return_value="current-sha")
-    @patch("tasks.quality_gates.get_pr_for_branch", new=MagicMock(return_value=None))
-    @patch("tasks.quality_gates.identify_gates_exceeding_pr_threshold")
-    def test_per_pr_threshold_skipped_on_merge_queue(self, mock_identify, _mock_commit, _mock_ancestor, *_):
+    def test_per_pr_threshold_skipped_on_merge_queue(self):
         """Per-PR threshold check is not applied on merge queue branches."""
-        ctx = MockContext(
-            run={
-                "datadog-ci tag --level job --tags static_quality_gates:\"success\"": Result("Done"),
-                "datadog-ci tag --level job --tags static_quality_gates:\"failure\"": Result("Done"),
-            }
-        )
-        parse_and_trigger_gates(ctx, "tasks/unit_tests/testdata/quality_gate_config_test.yml")
-        mock_identify.assert_not_called()
+        gate_scenarios = [
+            GateScenario(
+                name=_DEB_GATE,
+                ancestor_disk=100 * _MiB,
+                ancestor_wire=50 * _MiB,
+                current_disk=100 * _MiB + 700 * _KiB,  # delta > PER_PR_THRESHOLD, within absolute limit
+                current_wire=50 * _MiB,
+                max_disk=105 * _MiB,
+                max_wire=55 * _MiB,
+            ),
+            GateScenario(
+                name=_DOCKER_GATE,
+                ancestor_disk=600 * _MiB,
+                ancestor_wire=240 * _MiB,
+                current_disk=600 * _MiB + 20 * _KiB,
+                current_wire=240 * _MiB,
+                max_disk=700 * _MiB,
+                max_wire=250 * _MiB,
+            ),
+        ]
+        with (
+            _gate_scenarios_fixture(*gate_scenarios, ancestor_sha=_ANCESTOR_SHA) as config_path,
+            patch("tasks.quality_gates.get_ancestor", return_value=_ANCESTOR_SHA),
+            patch("tasks.quality_gates.get_commit_sha", return_value=_CI_COMMIT_SHA),
+            patch("tasks.quality_gates.get_pr_for_branch", return_value=None),
+            patch("tasks.quality_gates.get_pr_number_from_commit", return_value=None),
+            patch("tasks.static_quality_gates.gates.send_metrics"),
+            patch("tasks.static_quality_gates.gates.GateMetricHandler.generate_metric_reports"),
+        ):
+            ctx = MockContext(
+                run={"datadog-ci tag --level job --tags static_quality_gates:\"success\"": Result("Done")}
+            )
+            # Should NOT raise Exit — per-PR threshold is skipped on merge queue branches
+            parse_and_trigger_gates(ctx, config_path)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### What does this PR do?

It implements a refactor of the SQG code around the `gate_state` dictionary.
- It creates a new set of types to track the decision related information that was previously tracked by `gate_state` and other variables.
- It attempts to group logic into more clearly defined steps, in particular trying to isolate the decision-making phase into a unit.
- It changes where certain fields are computed so that `display_pr_comment` requires less deciding logic.
- Adds a few more tests.

### Motivation

I was finding it hard to track what `gate_state` was and its shape and possible values. In particular, the `state` field in it was unclear (does true mean pass or fail?), and it was unclear what "error type"'s we had.

The other main motivator is [ABLD-450](https://datadoghq.atlassian.net/browse/ABLD-450), where I wanted to add an on-wire relative limit and finding it awkward to wire things together – these changes should help.

### Describe how you validated your changes

Tests.

### Additional Notes

There are tiny changes of behavior:
- Names of error types (as displayed on error in PR comments) have slightly changed.
- No metrics are now registered when the measurement failed (on "GateExecutionError").

There's still a lot of problems with the current data model that make things unnecessarily awkward, but more effort is not warranted at this point.

[ABLD-450]: https://datadoghq.atlassian.net/browse/ABLD-450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ