### PR TITLE
Remove erroneous package exclusions

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -24,7 +24,6 @@ exports_files(glob(
 # gazelle:exclude cmd/installer/subcommands
 # gazelle:exclude cmd/installer/user
 # gazelle:exclude cmd/installer/windows_resources
-# gazelle:exclude cmd/internal
 # gazelle:exclude cmd/iot-agent
 # gazelle:exclude cmd/loader
 # gazelle:exclude cmd/otel-agent
@@ -40,8 +39,6 @@ exports_files(glob(
 # gazelle:exclude cmd/secrethelper
 # gazelle:exclude cmd/security-agent
 # gazelle:exclude cmd/serverless-init
-# gazelle:exclude cmd/system-probe/api
-# gazelle:exclude cmd/system-probe/command
 # gazelle:exclude cmd/system-probe/modules
 # gazelle:exclude cmd/system-probe/subcommands/compliance
 # gazelle:exclude cmd/system-probe/subcommands/config
@@ -123,7 +120,6 @@ exports_files(glob(
 # gazelle:exclude comp/core/remoteagentregistry/fx
 # gazelle:exclude comp/core/remoteagentregistry/impl
 # gazelle:exclude comp/core/remoteagentregistry/status
-# gazelle:exclude comp/core/remoteagentregistry/util
 # gazelle:exclude comp/core/settings
 # gazelle:exclude comp/core/sysprobeconfig
 # gazelle:exclude comp/core/tagger/collectors
@@ -157,7 +153,6 @@ exports_files(glob(
 # gazelle:exclude comp/dataobs/queryactions/impl
 # gazelle:exclude comp/dogstatsd/constants
 # gazelle:exclude comp/dogstatsd/http
-# gazelle:exclude comp/dogstatsd/mapper
 # gazelle:exclude comp/dogstatsd/pidmap
 # gazelle:exclude comp/dogstatsd/replay/fx
 # gazelle:exclude comp/dogstatsd/replay/impl
@@ -181,7 +176,6 @@ exports_files(glob(
 # gazelle:exclude comp/host-profiler/collector/impl/receiver
 # gazelle:exclude comp/host-profiler/flare
 # gazelle:exclude comp/host-profiler/symboluploader/pclntab
-# gazelle:exclude comp/host-profiler/symboluploader/pipeline
 # gazelle:exclude comp/host-profiler/symboluploader/symbol
 # gazelle:exclude comp/host-profiler/symboluploader/symbolcopier
 # gazelle:exclude comp/languagedetection/client/fx
@@ -192,7 +186,8 @@ exports_files(glob(
 # gazelle:exclude comp/logs-library/processor
 # gazelle:exclude comp/logs-library/sender
 # gazelle:exclude comp/logs/adscheduler
-# gazelle:exclude comp/logs/agent
+# gazelle:exclude comp/logs/agent/agentimpl
+# gazelle:exclude comp/logs/agent/flare
 # gazelle:exclude comp/logs/auditor
 # gazelle:exclude comp/logs/integrations
 # gazelle:exclude comp/logs/streamlogs/def
@@ -225,7 +220,6 @@ exports_files(glob(
 # gazelle:exclude comp/netflow/testutil
 # gazelle:exclude comp/netflow/topn
 # gazelle:exclude comp/networkpath/npcollector/fx
-# gazelle:exclude comp/networkpath/npcollector/impl/connfilter
 # gazelle:exclude comp/networkpath/npcollector/mock
 # gazelle:exclude comp/networkpath/npcollector/model
 # gazelle:exclude comp/networkpath/traceroute/fx-local
@@ -297,7 +291,6 @@ exports_files(glob(
 # gazelle:exclude comp/snmptraps/forwarder/impl
 # gazelle:exclude comp/snmptraps/listener/fx
 # gazelle:exclude comp/snmptraps/listener/impl
-# gazelle:exclude comp/snmptraps/packet
 # gazelle:exclude comp/snmptraps/senderhelper
 # gazelle:exclude comp/snmptraps/server
 # gazelle:exclude comp/snmptraps/snmplog
@@ -321,7 +314,7 @@ exports_files(glob(
 # gazelle:exclude comp/trace/status
 # gazelle:exclude comp/workloadselection/def
 # gazelle:exclude internal/remote-agent
-# gazelle:exclude internal/third_party
+# gazelle:exclude internal/third_party/client-go
 # gazelle:exclude pkg/aggregator/mocksender
 # gazelle:exclude pkg/aggregator/sender
 # gazelle:exclude pkg/cli/standalone
@@ -389,7 +382,6 @@ exports_files(glob(
 # gazelle:exclude pkg/collector/corechecks/system
 # gazelle:exclude pkg/collector/corechecks/systemd
 # gazelle:exclude pkg/collector/corechecks/telemetry
-# gazelle:exclude pkg/collector/externalhost
 # gazelle:exclude pkg/collector/loaders
 # gazelle:exclude pkg/collector/python
 # gazelle:exclude pkg/collector/runner
@@ -416,7 +408,6 @@ exports_files(glob(
 # gazelle:exclude pkg/diagnose/connectivity
 # gazelle:exclude pkg/diagnose/ports
 # gazelle:exclude pkg/discovery/apm
-# gazelle:exclude pkg/discovery/core
 # gazelle:exclude pkg/discovery/envs
 # gazelle:exclude pkg/discovery/language
 # gazelle:exclude pkg/discovery/model
@@ -442,7 +433,6 @@ exports_files(glob(
 # gazelle:exclude pkg/dyninst/loader
 # gazelle:exclude pkg/dyninst/module
 # gazelle:exclude pkg/dyninst/object
-# gazelle:exclude pkg/dyninst/output
 # gazelle:exclude pkg/dyninst/process
 # gazelle:exclude pkg/dyninst/procsubscribe
 # gazelle:exclude pkg/dyninst/symbol
@@ -465,14 +455,12 @@ exports_files(glob(
 # gazelle:exclude pkg/ebpf/verifier
 # gazelle:exclude pkg/eventmonitor
 # gazelle:exclude pkg/flare
-# gazelle:exclude pkg/fleet/daemon
 # gazelle:exclude pkg/fleet/installer/packages/embedded/tmpl
 # gazelle:exclude pkg/gpu/config
 # gazelle:exclude pkg/gpu/containers
 # gazelle:exclude pkg/gpu/ebpf
 # gazelle:exclude pkg/gpu/integrationtests
 # gazelle:exclude pkg/gpu/safenvml
-# gazelle:exclude pkg/gpu/tags
 # gazelle:exclude pkg/gpu/testutil
 # gazelle:exclude pkg/hosttags
 # gazelle:exclude pkg/jmxfetch
@@ -495,7 +483,6 @@ exports_files(glob(
 # gazelle:exclude pkg/logs/pipeline
 # gazelle:exclude pkg/logs/processor
 # gazelle:exclude pkg/logs/schedulers
-# gazelle:exclude pkg/logs/service
 # gazelle:exclude pkg/logs/sources
 # gazelle:exclude pkg/logs/status/builder.go
 # gazelle:exclude pkg/logs/status/status.go
@@ -503,7 +490,6 @@ exports_files(glob(
 # gazelle:exclude pkg/logs/status/test_utils.go
 # gazelle:exclude pkg/logs/tailers
 # gazelle:exclude pkg/logs/util/windowsevent
-# gazelle:exclude pkg/network/config
 # gazelle:exclude pkg/network/containers
 # gazelle:exclude pkg/network/dns
 # gazelle:exclude pkg/network/ebpf
@@ -575,14 +561,12 @@ exports_files(glob(
 # gazelle:exclude pkg/proto/datadog
 # gazelle:exclude pkg/proto/protodep
 # gazelle:exclude pkg/redact
-# gazelle:exclude pkg/runtime
 # gazelle:exclude pkg/sbom/collectors/docker
 # gazelle:exclude pkg/sbom/collectors/host
 # gazelle:exclude pkg/sbom/collectors/procfs
 # gazelle:exclude pkg/sbom/scanner
 # gazelle:exclude pkg/security/agent
 # gazelle:exclude pkg/security/clihelpers
-# gazelle:exclude pkg/security/common
 # gazelle:exclude pkg/security/config
 # gazelle:exclude pkg/security/ebpf
 # gazelle:exclude pkg/security/events
@@ -598,12 +582,10 @@ exports_files(glob(
 # gazelle:exclude pkg/security/probe/eventstream
 # gazelle:exclude pkg/security/probe/kfilters
 # gazelle:exclude pkg/security/probe/monitors
-# gazelle:exclude pkg/security/probe/procfs
 # gazelle:exclude pkg/security/probe/selftests
 # gazelle:exclude pkg/security/probe/testdata
 # gazelle:exclude pkg/security/process_list
 # gazelle:exclude pkg/security/proto/api
-# gazelle:exclude pkg/security/ptracer
 # gazelle:exclude pkg/security/rconfig
 # gazelle:exclude pkg/security/reporter
 # gazelle:exclude pkg/security/resolvers/dentry
@@ -629,14 +611,15 @@ exports_files(glob(
 # gazelle:exclude pkg/security/tests
 # gazelle:exclude pkg/security/utils/k8sutils
 # gazelle:exclude pkg/security/utils/lru/internal
-# gazelle:exclude pkg/security/utils/pathutils
 # gazelle:exclude pkg/serializer/internal
 # gazelle:exclude pkg/serverless/logs
 # gazelle:exclude pkg/serverless/metrics
 # gazelle:exclude pkg/serverless/otlp
 # gazelle:exclude pkg/serverless/streamlogs
 # gazelle:exclude pkg/serverless/trace
-# gazelle:exclude pkg/snmp
+# gazelle:exclude pkg/snmp/devicededuper
+# gazelle:exclude pkg/snmp/gosnmplib
+# gazelle:exclude pkg/snmp/snmpparse
 # gazelle:exclude pkg/status/clusteragent
 # gazelle:exclude pkg/status/collector
 # gazelle:exclude pkg/status/endpoints
@@ -694,7 +677,6 @@ exports_files(glob(
 # gazelle:exclude pkg/util/kubernetes/clustername
 # gazelle:exclude pkg/util/kubernetes/hostinfo
 # gazelle:exclude pkg/util/kubernetes/kubelet
-# gazelle:exclude pkg/util/os
 # gazelle:exclude pkg/util/port
 # gazelle:exclude pkg/util/profiling
 # gazelle:exclude pkg/util/tags

--- a/cmd/cws-instrumentation/subcommands/tracecmd/BUILD.bazel
+++ b/cmd/cws-instrumentation/subcommands/tracecmd/BUILD.bazel
@@ -9,13 +9,13 @@ go_library(
         "@rules_go//go/platform:android": [
             "//cmd/cws-instrumentation/subcommands/selftestscmd",
             "//pkg/config/setup/constants",
-            "@//pkg/security/ptracer",
+            "//pkg/security/ptracer",
             "@com_github_spf13_cobra//:cobra",
         ],
         "@rules_go//go/platform:linux": [
             "//cmd/cws-instrumentation/subcommands/selftestscmd",
             "//pkg/config/setup/constants",
-            "@//pkg/security/ptracer",
+            "//pkg/security/ptracer",
             "@com_github_spf13_cobra//:cobra",
         ],
         "//conditions:default": [],

--- a/cmd/system-probe/subcommands/version/BUILD.bazel
+++ b/cmd/system-probe/subcommands/version/BUILD.bazel
@@ -6,8 +6,8 @@ go_library(
     importpath = "github.com/DataDog/datadog-agent/cmd/system-probe/subcommands/version",
     visibility = ["//visibility:public"],
     deps = [
+        "//cmd/system-probe/command",
         "//pkg/cli/subcommands/version",
-        "@//cmd/system-probe/command",
         "@com_github_spf13_cobra//:cobra",
     ],
 )

--- a/comp/core/remoteagentregistry/util/BUILD.bazel
+++ b/comp/core/remoteagentregistry/util/BUILD.bazel
@@ -11,4 +11,5 @@ go_test(
     name = "util_test",
     srcs = ["sanitize_test.go"],
     embed = [":util"],
+    gotags = ["test"],
 )

--- a/comp/dogstatsd/mapper/BUILD.bazel
+++ b/comp/dogstatsd/mapper/BUILD.bazel
@@ -18,6 +18,7 @@ go_test(
         "mapper_test.go",
     ],
     embed = [":mapper"],
+    gotags = ["test"],
     deps = [
         "//comp/core/config",
         "//pkg/config/structure",

--- a/comp/host-profiler/symboluploader/pipeline/BUILD.bazel
+++ b/comp/host-profiler/symboluploader/pipeline/BUILD.bazel
@@ -15,6 +15,7 @@ go_test(
     name = "pipeline_test",
     srcs = ["pipeline_test.go"],
     embed = [":pipeline"],
+    gotags = ["test"],
     deps = [
         "@com_github_jonboulle_clockwork//:clockwork",
         "@com_github_stretchr_testify//require",

--- a/comp/logs/agent/config/BUILD.bazel
+++ b/comp/logs/agent/config/BUILD.bazel
@@ -49,6 +49,7 @@ go_test(
         "//pkg/config/setup",
         "//pkg/config/utils",
         "//pkg/logs/types",
+        "//pkg/util/log",
         "//pkg/util/pointer",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/comp/netflow/config/def/BUILD.bazel
+++ b/comp/netflow/config/def/BUILD.bazel
@@ -13,7 +13,7 @@ go_library(
         "//comp/core/log/def",
         "//comp/netflow/common",
         "//pkg/config/structure",
-        "@//pkg/snmp/utils",
+        "//pkg/snmp/utils",
     ],
 )
 

--- a/comp/networkpath/npcollector/impl/connfilter/BUILD.bazel
+++ b/comp/networkpath/npcollector/impl/connfilter/BUILD.bazel
@@ -8,7 +8,7 @@ go_library(
         "defaultconnfilters.go",
         "utils.go",
     ],
-    importpath = "github.com/DataDog/datadog-agent/comp/networkpath/npcollector/npcollectorimpl/connfilter",
+    importpath = "github.com/DataDog/datadog-agent/comp/networkpath/npcollector/impl/connfilter",
     visibility = ["//visibility:public"],
 )
 
@@ -19,6 +19,7 @@ go_test(
         "testutils_test.go",
     ],
     embed = [":connfilter"],
+    gotags = ["test"],
     deps = [
         "//comp/core/config",
         "//pkg/config/structure",

--- a/comp/snmptraps/formatter/def/BUILD.bazel
+++ b/comp/snmptraps/formatter/def/BUILD.bazel
@@ -5,5 +5,5 @@ go_library(
     srcs = ["component.go"],
     importpath = "github.com/DataDog/datadog-agent/comp/snmptraps/formatter/def",
     visibility = ["//visibility:public"],
-    deps = ["@//comp/snmptraps/packet"],
+    deps = ["//comp/snmptraps/packet"],
 )

--- a/comp/snmptraps/listener/def/BUILD.bazel
+++ b/comp/snmptraps/listener/def/BUILD.bazel
@@ -5,5 +5,5 @@ go_library(
     srcs = ["component.go"],
     importpath = "github.com/DataDog/datadog-agent/comp/snmptraps/listener/def",
     visibility = ["//visibility:public"],
-    deps = ["@//comp/snmptraps/packet"],
+    deps = ["//comp/snmptraps/packet"],
 )

--- a/comp/updater/localapi/def/BUILD.bazel
+++ b/comp/updater/localapi/def/BUILD.bazel
@@ -5,5 +5,5 @@ go_library(
     srcs = ["component.go"],
     importpath = "github.com/DataDog/datadog-agent/comp/updater/localapi/def",
     visibility = ["//visibility:public"],
-    deps = ["@//pkg/fleet/daemon"],
+    deps = ["//pkg/fleet/daemon"],
 )

--- a/comp/updater/localapi/impl/BUILD.bazel
+++ b/comp/updater/localapi/impl/BUILD.bazel
@@ -11,6 +11,6 @@ go_library(
         "//comp/def",
         "//comp/updater/localapi/def",
         "//comp/updater/updater/def",
-        "@//pkg/fleet/daemon",
+        "//pkg/fleet/daemon",
     ],
 )

--- a/comp/updater/localapiclient/def/BUILD.bazel
+++ b/comp/updater/localapiclient/def/BUILD.bazel
@@ -5,5 +5,5 @@ go_library(
     srcs = ["component.go"],
     importpath = "github.com/DataDog/datadog-agent/comp/updater/localapiclient/def",
     visibility = ["//visibility:public"],
-    deps = ["@//pkg/fleet/daemon"],
+    deps = ["//pkg/fleet/daemon"],
 )

--- a/comp/updater/localapiclient/impl/BUILD.bazel
+++ b/comp/updater/localapiclient/impl/BUILD.bazel
@@ -7,6 +7,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//comp/updater/localapiclient/def",
-        "@//pkg/fleet/daemon",
+        "//pkg/fleet/daemon",
     ],
 )

--- a/comp/updater/updater/def/BUILD.bazel
+++ b/comp/updater/updater/def/BUILD.bazel
@@ -5,5 +5,5 @@ go_library(
     srcs = ["component.go"],
     importpath = "github.com/DataDog/datadog-agent/comp/updater/updater/def",
     visibility = ["//visibility:public"],
-    deps = ["@//pkg/fleet/daemon"],
+    deps = ["//pkg/fleet/daemon"],
 )

--- a/comp/updater/updater/impl/BUILD.bazel
+++ b/comp/updater/updater/impl/BUILD.bazel
@@ -12,8 +12,8 @@ go_library(
         "//comp/def",
         "//comp/remote-config/rcservice/def",
         "//comp/updater/updater/def",
+        "//pkg/fleet/daemon",
         "//pkg/util/option",
-        "@//pkg/fleet/daemon",
     ],
 )
 

--- a/internal/third_party/golang/expansion/BUILD.bazel
+++ b/internal/third_party/golang/expansion/BUILD.bazel
@@ -185,6 +185,7 @@ go_test(
     name = "expansion_test",
     srcs = ["expand_test.go"],
     embed = [":expansion"],
+    gotags = ["test"],
     tags = ["manual"],  # keep (pre-existing test bug in vendored third-party code)
     deps = ["@io_k8s_api//core/v1:core"],
 )

--- a/internal/third_party/kubernetes/pkg/kubelet/types/BUILD.bazel
+++ b/internal/third_party/kubernetes/pkg/kubelet/types/BUILD.bazel
@@ -186,6 +186,7 @@ go_test(
     name = "types_test",
     srcs = ["pod_update_test.go"],
     embed = [":types"],
+    gotags = ["test"],
     deps = [
         "@com_github_stretchr_testify//assert",
         "@io_k8s_api//core/v1:core",

--- a/pkg/collector/externalhost/BUILD.bazel
+++ b/pkg/collector/externalhost/BUILD.bazel
@@ -15,5 +15,6 @@ go_test(
     name = "externalhost_test",
     srcs = ["externalhost_test.go"],
     embed = [":externalhost"],
+    gotags = ["test"],
     deps = ["@com_github_stretchr_testify//assert"],
 )

--- a/pkg/discovery/core/BUILD.bazel
+++ b/pkg/discovery/core/BUILD.bazel
@@ -25,6 +25,7 @@ go_test(
     name = "core_test",
     srcs = ["core_test.go"],
     embed = [":core"],
+    gotags = ["test"],
     deps = select({
         "@rules_go//go/platform:android": [
             "@com_github_stretchr_testify//assert",

--- a/pkg/dyninst/eventbuf/BUILD.bazel
+++ b/pkg/dyninst/eventbuf/BUILD.bazel
@@ -10,8 +10,8 @@ go_library(
     importpath = "github.com/DataDog/datadog-agent/pkg/dyninst/eventbuf",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/dyninst/output",
         "//pkg/util/log",
-        "@//pkg/dyninst/output",
         "@com_github_google_btree//:btree",
     ],
 )
@@ -30,7 +30,7 @@ go_test(
     embed = [":eventbuf"],
     gotags = ["test"],
     deps = [
-        "@//pkg/dyninst/output",
+        "//pkg/dyninst/output",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@in_yaml_go_yaml_v3//:yaml",

--- a/pkg/gpu/tags/BUILD.bazel
+++ b/pkg/gpu/tags/BUILD.bazel
@@ -12,12 +12,12 @@ go_library(
     visibility = ["//visibility:public"],
     deps = select({
         "@rules_go//go/platform:android": [
+            "//pkg/util/kernel",
             "//pkg/util/log",
-            "@//pkg/util/kernel",
         ],
         "@rules_go//go/platform:linux": [
+            "//pkg/util/kernel",
             "//pkg/util/log",
-            "@//pkg/util/kernel",
         ],
         "//conditions:default": [],
     }),
@@ -27,13 +27,14 @@ go_test(
     name = "tags_test",
     srcs = ["tags_test.go"],
     embed = [":tags"],
+    gotags = ["test"],
     deps = select({
         "@rules_go//go/platform:android": [
-            "@//pkg/util/kernel",
+            "//pkg/util/kernel",
             "@com_github_stretchr_testify//assert",
         ],
         "@rules_go//go/platform:linux": [
-            "@//pkg/util/kernel",
+            "//pkg/util/kernel",
             "@com_github_stretchr_testify//assert",
         ],
         "//conditions:default": [],

--- a/pkg/network/config/sysctl/BUILD.bazel
+++ b/pkg/network/config/sysctl/BUILD.bazel
@@ -14,6 +14,7 @@ go_test(
     name = "sysctl_test",
     srcs = ["sysctl_test.go"],
     embed = [":sysctl"],
+    gotags = ["test"],
     deps = select({
         "@rules_go//go/platform:android": [
             "@com_github_stretchr_testify//assert",

--- a/pkg/security/common/usergrouputils/BUILD.bazel
+++ b/pkg/security/common/usergrouputils/BUILD.bazel
@@ -15,4 +15,5 @@ go_test(
         "group.sample",
         "passwd.sample",
     ],
+    gotags = ["test"],
 )

--- a/pkg/security/probe/procfs/BUILD.bazel
+++ b/pkg/security/probe/procfs/BUILD.bazel
@@ -12,15 +12,15 @@ go_library(
     deps = select({
         "@rules_go//go/platform:android": [
             "//pkg/security/secl/model",
+            "//pkg/util/kernel",
             "@//pkg/security/seclog",
-            "@//pkg/util/kernel",
             "@com_github_shirou_gopsutil_v4//process",
             "@org_golang_x_sys//unix",
         ],
         "@rules_go//go/platform:linux": [
             "//pkg/security/secl/model",
+            "//pkg/util/kernel",
             "@//pkg/security/seclog",
-            "@//pkg/util/kernel",
             "@com_github_shirou_gopsutil_v4//process",
             "@org_golang_x_sys//unix",
         ],

--- a/pkg/security/ptracer/BUILD.bazel
+++ b/pkg/security/ptracer/BUILD.bazel
@@ -25,12 +25,12 @@ go_library(
     visibility = ["//visibility:public"],
     deps = select({
         "@rules_go//go/platform:android": [
+            "//pkg/security/common/usergrouputils",
             "//pkg/security/proto/ebpfless",
             "//pkg/security/secl/containerutils",
             "//pkg/security/secl/model/sharedconsts",
             "//pkg/security/secl/model/utils",
             "//pkg/util/safeelf",
-            "@//pkg/security/common/usergrouputils",
             "@com_github_avast_retry_go_v4//:retry-go",
             "@com_github_elastic_go_seccomp_bpf//:go-seccomp-bpf",
             "@com_github_elastic_go_seccomp_bpf//arch",
@@ -40,12 +40,12 @@ go_library(
             "@org_golang_x_time//rate",
         ],
         "@rules_go//go/platform:linux": [
+            "//pkg/security/common/usergrouputils",
             "//pkg/security/proto/ebpfless",
             "//pkg/security/secl/containerutils",
             "//pkg/security/secl/model/sharedconsts",
             "//pkg/security/secl/model/utils",
             "//pkg/util/safeelf",
-            "@//pkg/security/common/usergrouputils",
             "@com_github_avast_retry_go_v4//:retry-go",
             "@com_github_elastic_go_seccomp_bpf//:go-seccomp-bpf",
             "@com_github_elastic_go_seccomp_bpf//arch",

--- a/pkg/security/utils/pathutils/BUILD.bazel
+++ b/pkg/security/utils/pathutils/BUILD.bazel
@@ -27,6 +27,7 @@ go_test(
     name = "pathutils_test",
     srcs = ["path_linux_test.go"],
     embed = [":pathutils"],
+    gotags = ["test"],
     deps = select({
         "@rules_go//go/platform:android": [
             "@com_github_stretchr_testify//assert",

--- a/pkg/snmp/snmpintegration/BUILD.bazel
+++ b/pkg/snmp/snmpintegration/BUILD.bazel
@@ -11,6 +11,7 @@ go_test(
     name = "snmpintegration_test",
     srcs = ["config_test.go"],
     embed = [":snmpintegration"],
+    gotags = ["test"],
     deps = [
         "@com_github_stretchr_testify//assert",
         "@in_yaml_go_yaml_v2//:yaml",

--- a/pkg/snmp/utils/BUILD.bazel
+++ b/pkg/snmp/utils/BUILD.bazel
@@ -11,5 +11,6 @@ go_test(
     name = "utils_test",
     srcs = ["utils_test.go"],
     embed = [":utils"],
+    gotags = ["test"],
     deps = ["@com_github_stretchr_testify//assert"],
 )

--- a/pkg/util/os/BUILD.bazel
+++ b/pkg/util/os/BUILD.bazel
@@ -7,10 +7,10 @@ go_library(
     visibility = ["//visibility:public"],
     deps = select({
         "@rules_go//go/platform:android": [
-            "@//pkg/util/kernel",
+            "//pkg/util/kernel",
         ],
         "@rules_go//go/platform:linux": [
-            "@//pkg/util/kernel",
+            "//pkg/util/kernel",
         ],
         "//conditions:default": [],
     }),


### PR DESCRIPTION
### What does this PR do?

Remove exclusion of already migrated packages (and regenerate BUILD files so that they are fully up to date)

### Motivation

In another branch, I'm working on checking the test coverage parity, and having some packages with a BUILD.bazel files but not handled by gazelle makes this more complex than it should be.
And overall, we migrated the packages and there's no real reason to exclude them anymore

### Describe how you validated your changes

CI

### Additional Notes
