### PR TITLE
Make `TestRelativeError` tractable without `-short`

### DIFF
--- a/pkg/util/quantile/config_test.go
+++ b/pkg/util/quantile/config_test.go
@@ -154,32 +154,24 @@ func (s *score) update(v, qv float64) {
 }
 
 func TestRelativeError(t *testing.T) {
+	c := Default()
+	start, stop := c.key(1e-6), c.key(float64(float32(math.MaxInt64)))
 
-	var (
-		c                   = Default()
-		posinf              = float32(math.Inf(1))
-		start, stop float32 = 1e-6, math.MaxInt64
-		isPow2              = func(v float64) bool {
-			if v <= 1 {
-				return false
-			}
-			f, _ := math.Frexp(v)
-			return f == .5
-		}
-	)
-
-	if testing.Short() {
-		// this test takes a really really long time for the whole range of float32s
-		start, stop = 1, float32(math.Pow(c.gamma.v, 5))
-	}
-
+	// key(v) == k for all v in [f64(k)/√γ, f64(k)·√γ), so qv = f64(k) is constant and the relative
+	// error is monotone in both directions from f64(k), peaking at 1−1/√γ at both boundaries.
+	// The upper boundary for key k is the lower boundary for key k+1, so iterating all keys covers
+	// every boundary exactly once - equivalent to the exhaustive float32 scan, since no float32
+	// can sit closer to a boundary than our float64 sample.
 	s := &score{}
-	for v32 := start; v32 <= stop; v32 = math.Nextafter32(v32, posinf) {
-		v := float64(v32)
+	sqrtGamma := math.Sqrt(c.gamma.v)
+	_, prevExp := math.Frexp(c.f64(start))
+	for k := start; k <= stop; k++ {
+		v := math.Nextafter(c.f64(k)*sqrtGamma, 0)
 		qv := c.f64(c.key(v))
 		s.update(v, qv)
-		if isPow2(v) {
+		if _, exp := math.Frexp(v); exp != prevExp {
 			s.print()
+			prevExp = exp
 		}
 
 		if limit := .01; s.relerr.max > limit {


### PR DESCRIPTION
### What does this PR do?
Replace the exhaustive `math.Nextafter32` scan with a key-based loop that checks the **worst-case** point for each key, i.e. the upper boundary `math.Nextafter(f64(k)·√γ, 0)`.
Intermediate prints now fire on exponent changes ("octave" crossings) rather than exact powers of 2.

### Motivation
`TestRelativeError` iterated over ~700M `float32` values, taking ~45s per run.
The scan is analytically redundant: `key(v) == k` for all `v` in `[f64(k)/√γ, f64(k)·√γ)`, so the relative error is monotone in both directions from `f64(k)` and peaks at both boundaries.
The upper boundary for key `k` is the lower boundary for key `k+1`, so iterating all keys covers every boundary exactly once.
`float64` samples are more conservative than `float32` ones (closer to the boundary, hence a slightly larger error estimate), so the check cannot weaken by switching.

### Describe how you validated your changes
Measured with:
```
go test -v -count 10 -run 'TestRelativeError$' ./pkg/util/quantile/
```
```
before (10 samples): 51.32 51.89 43.08 41.16 41.20 42.17 40.98 40.44
                     46.96 39.53 s, avg 43.87 s
```
```
after  (10 samples): avg 0.00 s (sub-millisecond, truncated by go test)
```

### Additional Notes
stdout before (head / tail):
```
2: qv=2.009... n=175753284 relative_err:(max=0.007722..., avg=0.003866...)
4: qv=3.974... n=184141892 relative_err:(max=0.007722..., avg=0.003865...)
...
9.22e+18: qv=9.288... n=695846980 relative_err:(max=0.007722..., avg=0.003866...)
9.22e+18: qv=9.288... n=695846980 relative_err:(max=0.007722..., avg=0.003866...)
--- PASS: TestRelativeError (51.32s)
```

stdout after (head / tail):
```
1.94e-06: qv=1.920... n=43   relative_err:(max=0.007722..., avg=0.007722...)
3.83e-06: qv=3.799... n=87   relative_err:(max=0.007722..., avg=0.003861...)
...
9.36e+18: qv=9.433... n=3709 relative_err:(max=0.007722..., avg=0.007722...)
9.36e+18: qv=9.433... n=3709 relative_err:(max=0.007722..., avg=0.007722...)
--- PASS: TestRelativeError (0.00s)
```

Observable differences:
- `n` at last line: `695846980` -> `3709`,
- `avg` ~ `max/2` before (uniform sampling) vs `avg` ~ `max` after (worst-case sampling), both well under the `0.01` limit,
- prints trigger at exact powers of 2 before vs at octave-boundary values after (e.g. `1.94e-06` instead of `2e-06`).