### PR TITLE
Add sketch support to fake intake.

### DIFF
--- a/test/fakeintake/AGENTS.md
+++ b/test/fakeintake/AGENTS.md
@@ -25,6 +25,7 @@ test/fakeintake/
 | Route | Aggregator | Client method |
 |-------|-----------|---------------|
 | `/api/v2/series` | MetricAggregator | `FilterMetrics()` |
+| `/api/beta/sketches` | SketchAggregator | `FilterSketches()` |
 | `/api/v1/check_run` | CheckRunAggregator | `FilterCheckRuns()` |
 | `/api/v2/logs` | LogAggregator | `FilterLogs()` |
 | `/intake/` | EventAggregator | `FilterEvents()` |

--- a/test/fakeintake/aggregator/sketchAggregator.go
+++ b/test/fakeintake/aggregator/sketchAggregator.go
@@ -1,0 +1,71 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package aggregator
+
+import (
+	"time"
+
+	metricspb "github.com/DataDog/agent-payload/v5/gogen"
+
+	"github.com/DataDog/datadog-agent/test/fakeintake/api"
+)
+
+// Sketch wraps a single sketch entry from a SketchPayload (one per metric +
+// tagset combination posted by the agent to /api/beta/sketches).
+type Sketch struct {
+	metricspb.SketchPayload_Sketch
+
+	collectedTime time.Time
+}
+
+func (s *Sketch) name() string {
+	return s.Metric
+}
+
+// GetTags returns the tags attached to this sketch by the agent, after any
+// agent-side tag filtering (filterlist) has been applied.
+func (s *Sketch) GetTags() []string {
+	return s.Tags
+}
+
+// GetCollectedTime returns when fakeintake received the payload.
+func (s *Sketch) GetCollectedTime() time.Time {
+	return s.collectedTime
+}
+
+// ParseSketches decodes a /api/beta/sketches payload (compressed protobuf) into
+// individual Sketch entries, one per (metric, host, tagset) sketch in the
+// payload's sketches array.
+func ParseSketches(payload api.Payload) ([]*Sketch, error) {
+	inflated, err := inflate(payload.Data, payload.Encoding)
+	if err != nil {
+		return nil, err
+	}
+	pb := new(metricspb.SketchPayload)
+	if err := pb.Unmarshal(inflated); err != nil {
+		return nil, err
+	}
+	out := make([]*Sketch, 0, len(pb.Sketches))
+	for i := range pb.Sketches {
+		out = append(out, &Sketch{
+			SketchPayload_Sketch: pb.Sketches[i],
+			collectedTime:        payload.Timestamp,
+		})
+	}
+	return out, nil
+}
+
+// SketchAggregator stores sketch payloads received on /api/beta/sketches.
+type SketchAggregator struct {
+	Aggregator[*Sketch]
+}
+
+// NewSketchAggregator returns a new SketchAggregator.
+func NewSketchAggregator() SketchAggregator {
+	return SketchAggregator{
+		Aggregator: newAggregator(ParseSketches),
+	}
+}

--- a/test/fakeintake/aggregator/sketchAggregator_test.go
+++ b/test/fakeintake/aggregator/sketchAggregator_test.go
@@ -1,0 +1,75 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package aggregator
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	metricspb "github.com/DataDog/agent-payload/v5/gogen"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/test/fakeintake/api"
+)
+
+func TestParseSketches(t *testing.T) {
+	pb := metricspb.SketchPayload{
+		Sketches: []metricspb.SketchPayload_Sketch{
+			{
+				Metric: "test.dist",
+				Host:   "h1",
+				Tags:   []string{"env:prod", "service:api"},
+			},
+			{
+				Metric: "test.dist",
+				Host:   "h1",
+				Tags:   []string{"env:dev"},
+			},
+			{
+				Metric: "other.dist",
+				Tags:   []string{"k:v"},
+			},
+		},
+	}
+	raw, err := pb.Marshal()
+	assert.NoError(t, err)
+
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	out, err := ParseSketches(api.Payload{
+		Data:        raw,
+		ContentType: "application/x-protobuf",
+		Timestamp:   now,
+	})
+	assert.NoError(t, err)
+	assert.Len(t, out, 3)
+	assert.Equal(t, "test.dist", out[0].name())
+	assert.Equal(t, now, out[0].GetCollectedTime())
+	got := out[0].GetTags()
+	sort.Strings(got)
+	assert.Equal(t, []string{"env:prod", "service:api"}, got)
+}
+
+func TestSketchAggregatorByName(t *testing.T) {
+	pb := metricspb.SketchPayload{
+		Sketches: []metricspb.SketchPayload_Sketch{
+			{Metric: "a"},
+			{Metric: "b"},
+			{Metric: "a"},
+		},
+	}
+	raw, err := pb.Marshal()
+	assert.NoError(t, err)
+
+	agg := NewSketchAggregator()
+	err = agg.UnmarshallPayloads([]api.Payload{{Data: raw, ContentType: "application/x-protobuf"}})
+	assert.NoError(t, err)
+
+	a := agg.GetPayloadsByName("a")
+	assert.Len(t, a, 2)
+	names := agg.GetNames()
+	assert.Equal(t, []string{"a", "b"}, names)
+}

--- a/test/fakeintake/client/client.go
+++ b/test/fakeintake/client/client.go
@@ -66,6 +66,7 @@ import (
 const (
 	fakeintakeIDHeader           = "Fakeintake-ID"
 	metricsEndpoint              = "/api/v2/series"
+	sketchesEndpoint             = "/api/beta/sketches"
 	intakeEndpoint               = "/intake/"
 	checkRunsEndpoint            = "/api/v1/check_run"
 	logsEndpoint                 = "/api/v2/logs"
@@ -129,6 +130,7 @@ type Client struct {
 	getBackoffDelay   time.Duration
 
 	metricAggregator               aggregator.MetricAggregator
+	sketchAggregator               aggregator.SketchAggregator
 	checkRunAggregator             aggregator.CheckRunAggregator
 	eventAggregator                aggregator.EventAggregator
 	logAggregator                  aggregator.LogAggregator
@@ -162,6 +164,7 @@ func NewClient(fakeIntakeURL string, opts ...Option) *Client {
 		getBackoffDelay:                5 * time.Second,
 		fakeIntakeURL:                  strings.TrimSuffix(fakeIntakeURL, "/"),
 		metricAggregator:               aggregator.NewMetricAggregator(),
+		sketchAggregator:               aggregator.NewSketchAggregator(),
 		checkRunAggregator:             aggregator.NewCheckRunAggregator(),
 		eventAggregator:                aggregator.NewEventAggregator(),
 		logAggregator:                  aggregator.NewLogAggregator(),
@@ -358,6 +361,14 @@ func (c *Client) getHostTags() error {
 	return c.hostAggregator.UnmarshallPayloads(payloads)
 }
 
+func (c *Client) getSketches() error {
+	payloads, err := c.getFakePayloads(sketchesEndpoint)
+	if err != nil {
+		return err
+	}
+	return c.sketchAggregator.UnmarshallPayloads(payloads)
+}
+
 func (c *Client) getAgentHealth() error {
 	payloads, err := c.getFakePayloads(agentHealthEndpoint)
 	if err != nil {
@@ -374,6 +385,16 @@ func (c *Client) FilterMetrics(name string, options ...MatchOpt[*aggregator.Metr
 		return nil, err
 	}
 	return filterPayload(metrics, options...)
+}
+
+// FilterSketches fetches fakeintake on `/api/beta/sketches` and returns sketches
+// matching `name` and any [MatchOpt](#MatchOpt) options. Use this for distribution
+// metrics — counters/gauges go through FilterMetrics instead.
+func (c *Client) FilterSketches(name string, options ...MatchOpt[*aggregator.Sketch]) ([]*aggregator.Sketch, error) {
+	if err := c.getSketches(); err != nil {
+		return nil, err
+	}
+	return filterPayload(c.sketchAggregator.GetPayloadsByName(name), options...)
 }
 
 // FilterCheckRuns fetches fakeintake on `/api/v1/check_run` endpoint and returns
@@ -515,6 +536,15 @@ func (c *Client) GetMetricNames() ([]string, error) {
 		return nil, err
 	}
 	return c.metricAggregator.GetNames(), nil
+}
+
+// GetSketchNames fetches fakeintake on `/api/beta/sketches` and returns every
+// distinct sketch metric name received.
+func (c *Client) GetSketchNames() ([]string, error) {
+	if err := c.getSketches(); err != nil {
+		return nil, err
+	}
+	return c.sketchAggregator.GetNames(), nil
 }
 
 // WithTags filters by `tags`
@@ -680,6 +710,7 @@ func (c *Client) FlushServerAndResetAggregators() error {
 	c.checkRunAggregator.Reset()
 	c.connectionAggregator.Reset()
 	c.metricAggregator.Reset()
+	c.sketchAggregator.Reset()
 	c.logAggregator.Reset()
 	c.apmStatsAggregator.Reset()
 	c.traceAggregator.Reset()

--- a/test/fakeintake/cmd/client/cmd/filtersketches.go
+++ b/test/fakeintake/cmd/client/cmd/filtersketches.go
@@ -1,0 +1,57 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
+	"github.com/DataDog/datadog-agent/test/fakeintake/client"
+)
+
+// NewFilterSketchesCommand returns the filter sketches command
+func NewFilterSketchesCommand(cl **client.Client) (cmd *cobra.Command) {
+	var name string
+	var tags []string
+
+	cmd = &cobra.Command{
+		Use:     "sketches",
+		Short:   "Filter sketches (distribution metrics)",
+		Example: "fakeintakectl --url http://internal-lenaic-eks-fakeintake-2062862526.us-east-1.elb.amazonaws.com filter sketches --name my.distribution --tags env:prod",
+		RunE: func(cmd *cobra.Command, _ []string) (err error) {
+			var opts []client.MatchOpt[*aggregator.Sketch]
+			if cmd.Flag("tags").Changed {
+				opts = append(opts, client.WithTags[*aggregator.Sketch](tags))
+			}
+
+			sketches, err := (*cl).FilterSketches(name, opts...)
+			if err != nil {
+				return err
+			}
+
+			output, err := json.MarshalIndent(sketches, "", "  ")
+			if err != nil {
+				return err
+			}
+
+			fmt.Println(string(output))
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Name of the sketch metric")
+	cmd.Flags().StringSliceVar(&tags, "tags", []string{}, "Tags to filter on")
+
+	if err := cmd.MarkFlagRequired("name"); err != nil {
+		return nil
+	}
+
+	return cmd
+}

--- a/test/fakeintake/cmd/client/cmd/get.go
+++ b/test/fakeintake/cmd/client/cmd/get.go
@@ -29,6 +29,7 @@ func NewGetCommand(cl **client.Client) (cmd *cobra.Command) {
 		NewGetLogServiceCommand(cl),
 		NewGetMetadataCommand(cl),
 		NewGetMetricCommand(cl),
+		NewGetSketchCommand(cl),
 		NewGetProcessDiscoveriesCommand(cl),
 		NewGetProcessesCommand(cl),
 		NewGetSBOMCommand(cl),

--- a/test/fakeintake/cmd/client/cmd/getsketch.go
+++ b/test/fakeintake/cmd/client/cmd/getsketch.go
@@ -11,21 +11,14 @@ import (
 	"github.com/DataDog/datadog-agent/test/fakeintake/client"
 )
 
-// NewFilterCommand returns the filter command
-func NewFilterCommand(cl **client.Client) (cmd *cobra.Command) {
+// NewGetMetricCommand returns the get sketch command
+func NewGetSketchCommand(cl **client.Client) (cmd *cobra.Command) {
 	cmd = &cobra.Command{
-		Use:   "filter",
-		Short: "Filter metrics, logs, etc.",
+		Use: "sketch",
 	}
 
 	cmd.AddCommand(
-		NewFilterContainerImagesCommand(cl),
-		NewFilterEventsCommand(cl),
-		NewFilterLogsCommand(cl),
-		NewFilterMetricsCommand(cl),
-		NewFilterSketchesCommand(cl),
-		NewFilterSBOMCommand(cl),
-		NewFilterHostTagsCommand(cl),
+		NewGetSketchNamesCommand(cl),
 	)
 
 	return cmd

--- a/test/fakeintake/cmd/client/cmd/getsketchnames.go
+++ b/test/fakeintake/cmd/client/cmd/getsketchnames.go
@@ -1,0 +1,36 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/DataDog/datadog-agent/test/fakeintake/client"
+)
+
+// NewGetSketchNamesCommand returns the get sketch names command
+func NewGetSketchNamesCommand(cl **client.Client) (cmd *cobra.Command) {
+	cmd = &cobra.Command{
+		Use:   "names",
+		Short: "Get sketch names",
+		RunE: func(*cobra.Command, []string) error {
+			names, err := (*cl).GetSketchNames()
+			if err != nil {
+				return err
+			}
+
+			for _, name := range names {
+				fmt.Println(name)
+			}
+
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/test/fakeintake/server/serverstore/parser.go
+++ b/test/fakeintake/server/serverstore/parser.go
@@ -18,6 +18,7 @@ var parserMap = map[string]parserFunc{
 	"/api/v1/series":      getV1MetricPayLoadJSON,
 	"/api/v1/check_run":   getCheckRunPayLoadJSON,
 	"/api/v1/connections": getConnectionsPayLoadProtobuf,
+	"/api/beta/sketches":  getSketchPayloadProtobuf,
 }
 
 func getLogPayLoadJSON(payload api.Payload) (interface{}, error) {
@@ -38,6 +39,10 @@ func getCheckRunPayLoadJSON(payload api.Payload) (interface{}, error) {
 
 func getConnectionsPayLoadProtobuf(payload api.Payload) (interface{}, error) {
 	return aggregator.ParseConnections(payload)
+}
+
+func getSketchPayloadProtobuf(payload api.Payload) (interface{}, error) {
+	return aggregator.ParseSketches(payload)
 }
 
 // IsRouteHandled checks if a route is handled by the Datadog parsed store


### PR DESCRIPTION
### What does this PR do?

This adds sketch support via the `api/beta/sketches` endpoint to `fakeintake`.

### Motivation

A lot of the work I'm doing on the agent at the minute involves distributions, so this will be handy for testing that. This is the first part of porting things in `fakedd` that I see missing from `fakeintake`.

### Describe how you validated your changes

Configure the agent to point to `fakeintake`, ensure dogstatsd is enabled, send a distribution metric:

```
echo "dist.metric:234|d|#thing:thong,thang:thung" | nc -u -w 1 localhost 8125
```

Ensure the sketch has been received:

```
$ build/fakeintakectl get sketch names --url http://localhost:2020
$ build/fakeintakectl filter sketches --name dist.metric --url http://localhost:2020
```


### Additional Notes
