### PR TITLE
[ACTP] Remove query-param runner info from OPMS health-check

### DIFF
--- a/pkg/privateactionrunner/adapters/constants/constants_adapter.go
+++ b/pkg/privateactionrunner/adapters/constants/constants_adapter.go
@@ -18,13 +18,6 @@ const (
 	ArchitectureHeaderName  = "X-Datadog-OnPrem-Architecture"
 	FlavorHeaderName        = "X-Datadog-OnPrem-Flavor"
 	ContainerizedHeaderName = "X-Datadog-OnPrem-Containerized"
-
-	RunnerVersionQueryParam = "runnerVersion"
-	ModesQueryParam         = "modes"
-	PlatformQueryParam      = "platform"
-	ArchitectureQueryParam  = "architecture"
-	FlavorQueryParam        = "flavor"
-	ContainerizedQueryParam = "containerized"
 )
 
 // HTTP Connection Constants

--- a/pkg/privateactionrunner/opms/opms.go
+++ b/pkg/privateactionrunner/opms/opms.go
@@ -314,15 +314,6 @@ func createHealthCheckData(headers http.Header) *HealthCheckData {
 
 func (c *client) HealthCheck(ctx context.Context) (*HealthCheckData, error) {
 	u, _ := url.Parse(c.endpointURL(healthCheckPath))
-	query := u.Query()
-	query.Add(app.RunnerVersionQueryParam, c.config.Version)
-	modesStr := modes.ToStrings(c.config.Modes)
-	query.Add(app.ModesQueryParam, strings.Join(modesStr, ","))
-	query.Add(app.PlatformQueryParam, runtime.GOOS)
-	query.Add(app.ArchitectureQueryParam, runtime.GOARCH)
-	query.Add(app.FlavorQueryParam, flavor.GetFlavor())
-	query.Add(app.ContainerizedQueryParam, strconv.FormatBool(env.IsContainerized()))
-	u.RawQuery = query.Encode()
 
 	_, resHeaders, err := c.makeRequest(ctx, http.MethodGet, u.String(), nil, nil, http.StatusOK)
 	if err != nil {


### PR DESCRIPTION
## Description
Remove `CollectRunnerInfoFromQuery` and its dead query-param plumbing from the OPMS health-check flow.

The health-check endpoint sits behind `ValidateJwt` middleware, so the private-runner already sends all observability metadata (`version`, `modes`, `platform`, `architecture`, `flavor`, `containerized`) as request headers via `makeRequest`. Reading the same fields again from query parameters was redundant.

Credits to @dd-gplassard for catching this

## Testing

- No behavior change on the OPMS side: runner metadata was already present in headers
- Unit tests for `RunnerInfo` methods (`Deployment`, `DeploymentMode`) are unaffected