### PR TITLE
SQG: Add per-wire relative threshold mechanism

### DIFF
--- a/tasks/static_quality_gates/decisions.py
+++ b/tasks/static_quality_gates/decisions.py
@@ -6,13 +6,17 @@ from enum import Enum
 from tasks.libs.common.color import color_message
 from tasks.static_quality_gates.gates import GateExecutionError, GateMetricHandler, GateResult, byte_to_string
 
-PER_PR_THRESHOLD = 600 * 1024
+PER_PR_THRESHOLDS = {
+    "on_disk": 600 * 1024,
+    "on_wire": 5 * 1024 * 1024,
+}
 EXCEPTION_APPROVERS = {"cmourot", "dd-ddamien"}
 
 
 class GateFailureKind(Enum):
     AbsoluteLimitExceeded = "AbsoluteLimitExceeded"
     PerPRThresholdExceeded = "PerPRThresholdExceeded"
+    PerPRWireThresholdExceeded = "PerPRWireThresholdExceeded"
     ExecutionError = "ExecutionError"
 
     def __str__(self):
@@ -89,11 +93,13 @@ def evaluate_gates(
     exception_note = None
     if exception_granted_by:
         per_pr_excepted = [
-            v for v in verdicts if v.failure == GateFailureKind.PerPRThresholdExceeded and not v.blocking
+            v
+            for v in verdicts
+            if v.failure in (GateFailureKind.PerPRThresholdExceeded, GateFailureKind.PerPRWireThresholdExceeded)
+            and not v.blocking
         ]
         if per_pr_excepted:
-            threshold_str = byte_to_string(PER_PR_THRESHOLD)
-            exception_note = f"**Exception granted by @{exception_granted_by}**: this PR exceeds the per-PR size threshold ({threshold_str}) but will not be blocked.\n"
+            exception_note = f"**Exception granted by @{exception_granted_by}**: this PR exceeds the per-PR size thresholds but will not be blocked.\n"
     return GateEvaluationResult(
         verdicts=verdicts,
         has_blocking_failures=has_blocking_failures,
@@ -142,17 +148,32 @@ def evaluate_gate(
     # Check per-PR threshold: if a gate increased by more than PER_PR_THRESHOLD, mark it as failing.
     # Skip on merge queue jobs: the MQ working branch is an ephemeral merge preview, not a PR.
     if not is_on_main_branch and not is_merge_queue:
-        delta = metric_handler.metrics.get(outcome.config.gate_name, {}).get("relative_on_disk_size", 0)
-        if delta > PER_PR_THRESHOLD:
-            threshold_str = byte_to_string(PER_PR_THRESHOLD)
-            print(color_message(f"Per-PR threshold ({threshold_str}) exceeded by: {outcome.config.gate_name}", "red"))
+        gate_metrics = metric_handler.metrics.get(outcome.config.gate_name, {})
+        disk_delta = gate_metrics.get("relative_on_disk_size", 0)
+        wire_delta = gate_metrics.get("relative_on_wire_size", 0)
+        disk_exceeded = disk_delta > PER_PR_THRESHOLDS["on_disk"]
+        wire_exceeded = wire_delta > PER_PR_THRESHOLDS["on_wire"]
+
+        if wire_exceeded:
+            print(color_message(f"Per-PR wire threshold exceeded by: {outcome.config.gate_name}", "red"))
+            approver = exception_checker.get()
+            return GateVerdict(
+                name=outcome.config.gate_name,
+                failure=GateFailureKind.PerPRWireThresholdExceeded,
+                blocking=approver is None,
+                blocking_note=f"non-blocking: exception granted by @{approver}" if approver else "",
+                message=f"On-wire size increase of {byte_to_string(wire_delta)} exceeds the per-PR wire threshold of {byte_to_string(PER_PR_THRESHOLDS['on_wire'])}",
+            )
+
+        if disk_exceeded:
+            print(color_message(f"Per-PR threshold exceeded by: {outcome.config.gate_name}", "red"))
             approver = exception_checker.get()
             return GateVerdict(
                 name=outcome.config.gate_name,
                 failure=GateFailureKind.PerPRThresholdExceeded,
                 blocking=approver is None,
                 blocking_note=f"non-blocking: exception granted by @{approver}" if approver else "",
-                message=f"On-disk size increase of {byte_to_string(delta)} exceeds the per-PR threshold of {threshold_str}",
+                message=f"On-disk size increase of {byte_to_string(disk_delta)} exceeds the per-PR threshold of {byte_to_string(PER_PR_THRESHOLDS['on_disk'])}",
             )
 
     return GateVerdict(

--- a/tasks/static_quality_gates/decisions.py
+++ b/tasks/static_quality_gates/decisions.py
@@ -8,6 +8,9 @@ from tasks.static_quality_gates.gates import GateExecutionError, GateMetricHandl
 
 PER_PR_THRESHOLDS = {
     "on_disk": 600 * 1024,
+    # The 5 MiB limit for on-wire size increases is intended solely as a safety check to
+    # catch packaging/compression anomalies that are not accompanied by a proportional
+    # on-disk increase - that's why this threshold is much higher than the one for on-disk.
     "on_wire": 5 * 1024 * 1024,
 }
 EXCEPTION_APPROVERS = {"cmourot", "dd-ddamien"}

--- a/tasks/static_quality_gates/pr_comment.py
+++ b/tasks/static_quality_gates/pr_comment.py
@@ -208,6 +208,10 @@ def display_pr_comment(
 
             if gate.failure == GateFailureKind.PerPRThresholdExceeded:
                 body_error += f"|{status_char}|{gate_name} (per-PR threshold)|{change_str}|{limit_bounds}|\n"
+            elif gate.failure == GateFailureKind.PerPRWireThresholdExceeded:
+                body_error += (
+                    f"|{status_char}|{gate_name} (per-PR wire threshold)|{wire_change_str}|{wire_limit_bounds}|\n"
+                )
             else:
                 # This is probably way more convoluted than it should be, but the best we can do
                 # without refactoring the data structures involved

--- a/tasks/unit_tests/static_quality_gates/tasks_tests.py
+++ b/tasks/unit_tests/static_quality_gates/tasks_tests.py
@@ -352,6 +352,7 @@ class TestQualityGatesIntegration(unittest.TestCase):
                 parse_and_trigger_gates(ctx, config_path)
             mock_generate_reports.assert_called_once()
             mock_pr_commenter.assert_called_once()
+            self.assertIn("per-PR threshold", mock_pr_commenter.call_args.kwargs["body"])
 
     @patch.dict('os.environ', _PR_ENV_VARS, clear=True)
     def test_gate_fails_per_pr_disk_threshold_exception_approval(self):
@@ -400,6 +401,103 @@ class TestQualityGatesIntegration(unittest.TestCase):
             mock_generate_reports.assert_called_once()
             mock_pr_commenter.assert_called_once()
             self.assertIs(mock_pr_commenter.call_args.kwargs["pr"], approved_pr)
+            body = mock_pr_commenter.call_args.kwargs["body"]
+            self.assertIn("per-PR threshold", body)
+            self.assertIn("Exception granted by @cmourot", body)
+
+    @patch.dict('os.environ', _PR_ENV_VARS, clear=True)
+    def test_gate_fails_per_pr_wire_threshold(self):
+        """Gate passes absolute limits but on-wire delta exceeds per-PR threshold."""
+        gate_scenarios = [
+            GateScenario(
+                name=_DEB_GATE,
+                ancestor_disk=100 * _MiB,
+                ancestor_wire=50 * _MiB,
+                current_disk=100 * _MiB,
+                current_wire=50 * _MiB + 5.1 * _MiB,  # > 5 MiB wire threshold
+                max_disk=105 * _MiB,
+                max_wire=60 * _MiB,
+            ),
+            GateScenario(
+                name=_DOCKER_GATE,
+                ancestor_disk=600 * _MiB,
+                ancestor_wire=240 * _MiB,
+                current_disk=600 * _MiB + 20 * _KiB,
+                current_wire=240 * _MiB,
+                max_disk=700 * _MiB,
+                max_wire=250 * _MiB,
+            ),
+        ]
+        with (
+            _gate_scenarios_fixture(*gate_scenarios, ancestor_sha=_ANCESTOR_SHA) as config_path,
+            patch("tasks.quality_gates.get_ancestor", return_value=_ANCESTOR_SHA),
+            patch("tasks.quality_gates.get_commit_sha", return_value=_CI_COMMIT_SHA),
+            patch("tasks.static_quality_gates.github.GithubAPI", new=FakeGithubAPI),
+            patch("tasks.static_quality_gates.gates.send_metrics"),
+            patch("tasks.static_quality_gates.pr_comment.pr_commenter") as mock_pr_commenter,
+            patch(
+                "tasks.static_quality_gates.gates.GateMetricHandler.generate_metric_reports"
+            ) as mock_generate_reports,
+        ):
+            ctx = MockContext(
+                run={"datadog-ci tag --level job --tags static_quality_gates:\"failure\"": Result("Done")}
+            )
+            with self.assertRaises(Exit):
+                parse_and_trigger_gates(ctx, config_path)
+            mock_generate_reports.assert_called_once()
+            mock_pr_commenter.assert_called_once()
+            self.assertIn("per-PR wire threshold", mock_pr_commenter.call_args.kwargs["body"])
+
+    @patch.dict('os.environ', _PR_ENV_VARS, clear=True)
+    def test_gate_fails_per_pr_wire_threshold_exception_approval(self):
+        """Gate exceeds per-PR wire threshold but an exception approver has approved, making it pass."""
+        approved_pr = SimpleNamespace(
+            number=12345,
+            title="fix(somewhere): did something",
+            user=SimpleNamespace(login="some-author"),
+            get_reviews=lambda: [SimpleNamespace(state="APPROVED", user=SimpleNamespace(login="cmourot"))],
+        )
+        gate_scenarios = [
+            GateScenario(
+                name=_DEB_GATE,
+                ancestor_disk=100 * _MiB,
+                ancestor_wire=50 * _MiB,
+                current_disk=100 * _MiB,
+                current_wire=50 * _MiB + 5.1 * _MiB,  # > 5 MiB wire threshold
+                max_disk=105 * _MiB,
+                max_wire=60 * _MiB,
+            ),
+            GateScenario(
+                name=_DOCKER_GATE,
+                ancestor_disk=600 * _MiB,
+                ancestor_wire=240 * _MiB,
+                current_disk=600 * _MiB + 20 * _KiB,
+                current_wire=240 * _MiB,
+                max_disk=700 * _MiB,
+                max_wire=250 * _MiB,
+            ),
+        ]
+        with (
+            _gate_scenarios_fixture(*gate_scenarios, ancestor_sha=_ANCESTOR_SHA) as config_path,
+            patch("tasks.quality_gates.get_ancestor", return_value=_ANCESTOR_SHA),
+            patch("tasks.quality_gates.get_commit_sha", return_value=_CI_COMMIT_SHA),
+            patch("tasks.quality_gates.get_pr_for_branch", return_value=approved_pr),
+            patch("tasks.static_quality_gates.gates.send_metrics"),
+            patch("tasks.static_quality_gates.pr_comment.pr_commenter") as mock_pr_commenter,
+            patch(
+                "tasks.static_quality_gates.gates.GateMetricHandler.generate_metric_reports"
+            ) as mock_generate_reports,
+        ):
+            ctx = MockContext(
+                run={"datadog-ci tag --level job --tags static_quality_gates:\"failure\"": Result("Done")}
+            )
+            parse_and_trigger_gates(ctx, config_path)
+            mock_generate_reports.assert_called_once()
+            mock_pr_commenter.assert_called_once()
+            self.assertIs(mock_pr_commenter.call_args.kwargs["pr"], approved_pr)
+            body = mock_pr_commenter.call_args.kwargs["body"]
+            self.assertIn("per-PR wire threshold", body)
+            self.assertIn("Exception granted by @cmourot", body)
 
     @patch.dict('os.environ', _PR_ENV_VARS, clear=True)
     def test_gate_fails_absolute_limit_non_blocking_unchanged_from_ancestor(self):


### PR DESCRIPTION
### What does this PR do?

It makes Static Quality Gates block for on-wire size increases above 5 MiB, leveraging the same mechanism used for on-disk relative size violations – and therefore, being overridable by _blessed_ reviewers.

### Motivation

[ABLD-450](https://datadoghq.atlassian.net/browse/ABLD-450): Add a safety net before making on-wire gates non-blocking on absolute thresholds.

### Describe how you validated your changes

Tests.

### Additional Notes

Given that we currently can only have one "result" per gate, I decided to give priority to the on-wire mechanism when there's a tie. This is probably fine because it should be a rare occurrence. Eventually we may look into having 1-to-many relationships between individual gates and violations, but for now I'll defer that work.

[ABLD-450]: https://datadoghq.atlassian.net/browse/ABLD-450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ