### PR TITLE
fleet/installer: decouple get-states subprocess from daemon shutdown context

### DIFF
--- a/pkg/fleet/daemon/daemon.go
+++ b/pkg/fleet/daemon/daemon.go
@@ -807,6 +807,10 @@ func (d *daemonImpl) refreshState(ctx context.Context) {
 		}
 	}
 
+	if ctx.Err() != nil {
+		return
+	}
+
 	configAndPackageStates, err := d.installer(d.env).ConfigAndPackageStates(ctx)
 	if err != nil {
 		// TODO: we should report this error through RC in some way

--- a/pkg/fleet/daemon/daemon_test.go
+++ b/pkg/fleet/daemon/daemon_test.go
@@ -670,3 +670,51 @@ func TestDecryptSecrets(t *testing.T) {
 		assert.Contains(t, err.Error(), "could not decrypt secret")
 	})
 }
+
+func TestRefreshStateSkipsWhenContextCanceled(t *testing.T) {
+	bm := &testBoostrapper{}
+	installExperimentFunc = bm.InstallExperiment
+	pm := &testPackageManager{}
+	pm.On("AvailableDiskSpace").Return(uint64(1000000000), nil)
+	pm.On("ConfigAndPackageStates", mock.Anything).Return(&repository.PackageStates{
+		States:       map[string]repository.State{},
+		ConfigStates: map[string]repository.State{},
+	}, nil)
+	rcc := newTestRemoteConfigClient(t)
+	rc := &remoteConfig{client: rcc}
+	taskDB, err := newTaskDB(filepath.Join(t.TempDir(), "tasks.db"))
+	require.NoError(t, err)
+	secretsPubKey, secretsPrivKey, err := box.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	daemon := newDaemon(
+		rc,
+		func(_ *env.Env) installer.Installer { return pm },
+		&env.Env{RemoteUpdates: true},
+		taskDB,
+		24*time.Hour, // long interval so the ticker does not fire during this test
+		1*time.Hour,
+		secretsPubKey,
+		secretsPrivKey,
+	)
+	i := &testInstaller{
+		daemonImpl: daemon,
+		rcc:        rcc,
+		pm:         pm,
+		bm:         bm,
+	}
+	i.Start(context.Background())
+	defer i.Stop()
+
+	// Start calls refreshState once synchronously; record that baseline.
+	pm.AssertNumberOfCalls(t, "ConfigAndPackageStates", 1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	i.daemonImpl.refreshState(ctx)
+
+	// The guard at the top of refreshState must prevent ConfigAndPackageStates
+	// from being invoked when the context is already canceled — this avoids
+	// spawning a get-states subprocess that would then linger after shutdown.
+	pm.AssertNumberOfCalls(t, "ConfigAndPackageStates", 1)
+}

--- a/pkg/fleet/installer/exec/installer_exec_nix.go
+++ b/pkg/fleet/installer/exec/installer_exec_nix.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/repository"
 )
@@ -32,7 +33,15 @@ func (i *InstallerExec) newInstallerCmdPlatform(cmd *exec.Cmd) *exec.Cmd {
 // getStates retrieves the state of all packages & their configuration from disk.
 // On Linux/macOS this spawns a subprocess for privilege escalation.
 func (i *InstallerExec) getStates(ctx context.Context) (repo *repository.PackageStates, err error) {
-	cmd := i.newInstallerCmd(ctx, "get-states")
+	// Decouple from the caller's cancellation: get-states is a short read-only
+	// operation and must not be interrupted by daemon shutdown. Without this,
+	// canceling the daemon context sends SIGINT to the subprocess; the subprocess's
+	// 10 s signal-handler grace period then causes db.New to return "context
+	// canceled", delaying every daemon stop by ~10 s.
+	// context.WithoutCancel preserves trace IDs for span propagation.
+	stateCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancel()
+	cmd := i.newInstallerCmd(stateCtx, "get-states")
 	defer func() { cmd.span.Finish(err) }()
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer


### PR DESCRIPTION
## What does this PR do?

Fixes a ~10 s shutdown stall in the fleet installer daemon on Linux/macOS.

## Root cause

During daemon shutdown, `Stop()`:
1. Cancels `d.ctx` (the daemon's lifetime context)
2. Waits to acquire `d.m.Lock()`

Meanwhile, the periodic state-refresh ticker may be holding `d.m.Lock()` while running `refreshState(d.ctx)`. On Linux, `refreshState` calls `InstallerExec.getStates`, which spawns a `datadog-installer get-states` subprocess via `exec.CommandContext(ctx, ...)`. Canceling `d.ctx` causes Go to deliver SIGINT to the subprocess.

The subprocess's signal handler (`handleSignals`) has a 10-second grace period: it sleeps 10 s before calling `stop()`, which cancels the subprocess's own context. This is intentional for write operations (install/upgrade cleanup), but for the read-only `get-states` command it just introduces a 10 s delay. During those 10 s, `db.New` is blocked waiting for the BoltDB file lock with a canceled context, eventually returning `"context canceled"`. Only then does `getStates` return, `refreshState` finishes, the mutex is released, and `Stop()` can proceed.

This was introduced in 7.78.0 alongside the context-aware `db.New` (previously BoltDB simply blocked for up to 90 s waiting for the file lock, silently).

**Sequence (before fix):**

```
Stop()                        ticker goroutine (holds d.m.Lock())
  │                               │
  │  d.cancel()                   │  getStates() → exec.CommandContext(d.ctx, …)
  │ ──────────────────────────>   │
  │                               │  ──SIGINT──> subprocess
  │                               │              handleSignals: sleep(10 s)
  │  d.m.Lock() ◄── blocked ~10s  │              db.New returns "context canceled"
  │  (waiting for mutex)          │  getStates returns
  │                               │  refreshState returns → d.m.Unlock()
  │  d.m.Lock() acquired          │
  │  Stop() completes             │
```

## Fix

**Primary fix (`installer_exec_nix.go`):** Wrap the subprocess context with `context.WithoutCancel(ctx)` + a 30 s timeout. The subprocess is now completely decoupled from daemon shutdown cancellation — it runs to completion regardless of what happens to `d.ctx`. `context.WithoutCancel` (Go 1.21) preserves context values (trace IDs, span propagation) while stripping the cancellation signal.

**Defense-in-depth (`daemon.go`):** Added `if ctx.Err() != nil { return }` in `refreshState` after persisting any in-flight task state but before calling `ConfigAndPackageStates`. This prevents a new subprocess from even being spawned on ticker ticks that fire after `Stop()` has already canceled `d.ctx`.

## Manual test plan

**Reproduce the stall (7.78.x host without fix):**
```sh
# On a Linux host running datadog-installer 7.78.x as a daemon
time systemctl stop datadog-installer
# Expected without fix: ~10–13 s; grep logs for "context canceled"
```

**Verify the fix (build from this branch):**
```sh
time systemctl stop datadog-installer
# Expected with fix: < 2 s; no "context canceled" in logs
```

**Regression checks:**
```sh
# Unit tests
go test ./pkg/fleet/daemon/ ./pkg/fleet/installer/exec/...

# Functional check: normal install/upgrade must still work end-to-end
# (subprocess decoupling must not affect write operations, which use their own context)
datadog-installer install oci://…
```