### PR TITLE
[Backport 7.78.x] fix(installer): suppress stdout logging for status --json (#48233)

### DIFF
--- a/pkg/fleet/installer/commands/command.go
+++ b/pkg/fleet/installer/commands/command.go
@@ -47,6 +47,14 @@ const (
 // agentConfigDir is the directory containing datadog.yaml. Overridable in tests.
 var agentConfigDir = paths.AgentConfigDir
 
+type cmdOption func(*cmdConfig)
+type cmdConfig struct{ quiet bool }
+
+// withQuiet suppresses stdout logging for the command (e.g. when outputting structured JSON).
+func withQuiet() cmdOption {
+	return func(c *cmdConfig) { c.quiet = true }
+}
+
 type cmd struct {
 	t              *telemetry.Telemetry
 	span           *telemetry.Span
@@ -69,10 +77,14 @@ func setupStdoutLogger(_ *env.Env) {
 }
 
 // newCmd creates a new command
-func newCmd(operation string) *cmd {
+func newCmd(operation string, opts ...cmdOption) *cmd {
+	cfg := &cmdConfig{}
+	for _, o := range opts {
+		o(cfg)
+	}
 	env := env.FromEnv()
 	applyDatadogYAMLRegistryConfig(env)
-	if !env.IsFromDaemon {
+	if !env.IsFromDaemon && !cfg.quiet {
 		setupStdoutLogger(env)
 	}
 	t := newTelemetry(env)
@@ -118,8 +130,8 @@ type installerCmd struct {
 	installer.Installer
 }
 
-func newInstallerCmd(operation string) (_ *installerCmd, err error) {
-	cmd := newCmd(operation)
+func newInstallerCmd(operation string, opts ...cmdOption) (_ *installerCmd, err error) {
+	cmd := newCmd(operation, opts...)
 	defer func() {
 		if err != nil {
 			cmd.stop(err)
@@ -579,8 +591,8 @@ func isInstalledCommand() *cobra.Command {
 	return cmd
 }
 
-func getState() (*repository.PackageStates, error) {
-	i, err := newInstallerCmd("get_states")
+func getState(opts ...cmdOption) (*repository.PackageStates, error) {
+	i, err := newInstallerCmd("get_states", opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/fleet/installer/commands/status.go
+++ b/pkg/fleet/installer/commands/status.go
@@ -70,7 +70,12 @@ func status(debug bool, jsonOutput bool) error {
 	}
 
 	// Get states & convert to map[string]packageState
-	packageStates, err := getState()
+	var stateOpts []cmdOption
+	if jsonOutput {
+		// Suppress regular logging when outputting JSON.
+		stateOpts = append(stateOpts, withQuiet())
+	}
+	packageStates, err := getState(stateOpts...)
 	if err != nil {
 		return fmt.Errorf("error getting package states: %w", err)
 	}


### PR DESCRIPTION
Backport of #48233 to `7.78.x`.

The auto-backport bot was triggered via the `backport/7.78.x` label but did not produce a PR, so this is a manual backport.

## Why

`datadog-installer status --json` can emit telemetry warning lines on stdout *before* the JSON payload, which corrupts the output. In E2E tests this causes ` getInstallerStatus()` to fail `json.Unmarshal` and silently fall back to the legacy daemon-socket path, which uses different field mappings. Two consecutive status calls can therefore observe different views of \`States["datadog-agent"]\`.

This is the suspected root cause of the \`TestExperimentFailure\` flap reported in [INTERNAL] new-e2e-installer / new-e2e-installer-ansible incidents (53919 / 53920) on \`7.78.x\`, e.g.:

\`\`\`
expected: installer.stableExperimentStatus{Stable:"", Experiment:""}
actual:   installer.stableExperimentStatus{Stable:"7.78.3-rc.1", Experiment:""}
\`\`\`

## What

Cherry-pick of d276d1f6399. Conflicts in `pkg/fleet/installer/commands/command.go` (both sides additive — the 7.78 branch already added `agentConfigDir` and `applyDatadogYAMLRegistryConfig`); resolved by keeping both.

## Test plan

- [ ] Pipeline green on `7.78.x`
- [ ] `new-e2e-installer-ansible` no longer fails `TestExperimentFailure` with the State drift signature