### PR TITLE
tasks/agent: skip schema compression on AIX

### DIFF
--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -164,7 +164,10 @@ def build(
 
     flavor_cmd = "iot-agent" if flavor.is_iot() else "agent"
 
-    schema_compress(ctx)
+    # AIX build hosts do not have bazel; the compressed schema files are
+    # committed to the repo and do not need regeneration there.
+    if sys.platform != "aix":
+        schema_compress(ctx)
 
     with gitlab_section("Build agent", collapsed=True):
         go_build(


### PR DESCRIPTION
### What does this PR do?

Skips the `schema_compress()` step in `inv agent.build` when running on AIX.

### Motivation

AIX build hosts do not have bazel installed. The `schema_compress()` call runs `bazel run //pkg/config/schema:write_compressed`, which fails without bazel. The compressed schema files are committed to the repo and do not need regeneration during an AIX build.

### Describe how you validated your changes

Tested on AIX 7.3: `inv agent.build` completes without a bazel stub in place.

### Additional Notes

N/A