### PR TITLE
[ABLD-387] `bazel`ify proto generation: `trace/idx`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -568,7 +568,6 @@ exports_files(glob(
 # gazelle:exclude pkg/proto/datadog/remoteagent
 # gazelle:exclude pkg/proto/datadog/remoteconfig
 # gazelle:exclude pkg/proto/datadog/sbom
-# gazelle:exclude pkg/proto/datadog/trace
 # gazelle:exclude pkg/proto/datadog/workloadfilter
 # gazelle:exclude pkg/proto/datadog/workloadmeta
 # gazelle:exclude pkg/proto/protodep
@@ -895,6 +894,7 @@ _GAZELLE_BUILD_TAGS = [
     "zstd",
 ]
 
+# gazelle:resolve go github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace/idx //pkg/proto/pbgo/trace/idx
 gazelle(
     name = "gazelle",
     build_tags = _GAZELLE_BUILD_TAGS,

--- a/pkg/proto/datadog/trace/BUILD.bazel
+++ b/pkg/proto/datadog/trace/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
+load("@rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "trace_proto",
+    srcs = [
+        "agent_payload.proto",
+        "span.proto",
+        "stats.proto",
+        "tracer_payload.proto",
+    ],
+    strip_import_prefix = "/pkg/proto",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/proto/datadog/trace/idx:idx_proto"],
+)
+
+go_proto_library(
+    name = "trace_go_proto",
+    importpath = "pkg/proto/pbgo/trace",
+    proto = ":trace_proto",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/proto/datadog/trace/idx:idx_go_proto"],
+)

--- a/pkg/proto/datadog/trace/idx/BUILD.bazel
+++ b/pkg/proto/datadog/trace/idx/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
+load("@rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "idx_proto",
+    srcs = [
+        "span.proto",
+        "tracer_payload.proto",
+    ],
+    strip_import_prefix = "/pkg/proto",
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "idx_go_proto",
+    importpath = "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace/idx",
+    proto = ":idx_proto",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/proto/pbgo/trace/BUILD.bazel
+++ b/pkg/proto/pbgo/trace/BUILD.bazel
@@ -1,5 +1,8 @@
 load("@rules_go//go:def.bzl", "go_library", "go_test")
 
+# TODO(regis): remove this once protoc-go-inject-tag and msgp are plugged into //pkg/proto/datadog/trace:trace_go_proto
+# gazelle:write_pb_go off
+
 go_library(
     name = "trace",
     srcs = [

--- a/pkg/proto/pbgo/trace/idx/BUILD.bazel
+++ b/pkg/proto/pbgo/trace/idx/BUILD.bazel
@@ -1,4 +1,15 @@
 load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("//bazel/rules/write_pb_go:defs.bzl", "write_pb_go")
+
+write_pb_go(
+    name = "write_pb_go",
+    srcs = {
+        "//pkg/proto/datadog/trace/idx:idx_go_proto": [
+            "span.pb.go",
+            "tracer_payload.pb.go",
+        ],
+    },
+)
 
 go_library(
     name = "idx",

--- a/tasks/protobuf.py
+++ b/tasks/protobuf.py
@@ -20,19 +20,16 @@ PROTO_PKGS = {
     'privateactionrunner': False,
     'remoteagent': False,
     'autodiscovery': False,
-    'trace/idx': False,
     'workloadfilter': False,
     'dogstatsdhttp': False,
     'sbom': False,
 }
 
 CLI_EXTRAS = {
-    'trace/idx': '--go_opt=module=github.com/DataDog/datadog-agent',
     'privateactionrunner': '--go_opt=module=github.com/DataDog/datadog-agent',
 }
 
 CLI_EXTRAS_GRPC = {
-    'trace/idx': '--go-grpc_opt=module=github.com/DataDog/datadog-agent',
     'privateactionrunner': '--go-grpc_opt=module=github.com/DataDog/datadog-agent',
 }
 
@@ -80,6 +77,7 @@ def generate(ctx, pre_commit=False):
         # protobuf defs
         print(f"generating protobuf code from: {proto_root}")
         bazel(ctx, "run", "//pkg/proto/pbgo/languagedetection:write_pb_go")
+        bazel(ctx, "run", "//pkg/proto/pbgo/trace/idx:write_pb_go")
         for pkg, inject_tags in PROTO_PKGS.items():
             files = []
             pkg_root = Path(proto_root, "datadog", pkg)


### PR DESCRIPTION
### What does this PR do?
- migrate `pkg/proto/datadog/trace` from `gazelle`-excluded to `gazelle`-managed with:
  - `proto_library` + `go_proto_library` (standard),
  - `write_pb_go` in `pkg/proto/pbgo/trace/idx`: keeps `span.pb.go` and `tracer_payload.pb.go` in sync with the proto-generated output,
- add `# gazelle:resolve` in the root `BUILD.bazel` to disambiguate `idx_go_proto` (`importpath` = full module path) from the existing `go_library` in `pkg/proto/pbgo/trace/idx`,
- add `# gazelle:write_pb_go off` to `pkg/proto/pbgo/trace` to defer its `write_pb_go` until `protoc-go-inject-tag` and `msgp` can be plugged into `//pkg/proto/datadog/trace:trace_go_proto`,
- move `trace/idx` out of `PROTO_PKGS` in `tasks/protobuf.py`, delegating `.pb.go` generation to the topmost `bazel` command: `bazel run //pkg/proto/pbgo/trace/idx:write_pb_go` (left for didactic purposes).

### Motivation
Enable `bazel` to verify that the committed `span.pb.go` and `tracer_payload.pb.go` in `trace/idx` stay in sync with their proto source, using the `write_pb_go` adapter introduced in #49770.

See precedent _partially_ established by #49918 (`languagedetection`, _partially_ because it missed the corresponding `protobuf.py` change - addressed by #50394).

### Describe how you validated your changes
- `bazel run //:gazelle` produced no new warnings (stable),
- `bazel test //pkg/proto/pbgo/trace/idx:write_pb_go_tests` passes,
- `dda inv protobuf.generate` succeeds.

### Additional Notes
The main `trace/` package is deferred because its `.pb.go` files are post-processed by `protoc-go-inject-tag` and `msgp`, not yet wired into `bazel`.