### PR TITLE
packaging/aix: declare bos.perf.libperfstat as installp prerequisite

### DIFF
--- a/packaging/aix/gen.template.in
+++ b/packaging/aix/gen.template.in
@@ -15,7 +15,7 @@ Fileset
  Bosboot required: N
  License agreement acceptance required: N
  Include license files in this package: N
- Requisites:
+ Requisites: *prereq bos.perf.libperfstat 7.1.0.0;
  ROOT Part: Y
  USRFiles
 __FILE_LIST__


### PR DESCRIPTION
### What does this PR do?

Adds `*prereq bos.perf.libperfstat 7.1.0.0` to the installp `Requisites:` field in `gen.template.in`.

### Motivation

`libperfstat.a(shr_64.o)` is a startup-time dynamic dependency of the agent binary and trace-agent. If absent, neither binary loads and the agent fails completely with a cryptic `0509-022 Cannot load module` error. Declaring it as a prerequisite causes `installp` to fail at install time with a clear message instead.

`bos.perf.libperfstat` is part of the AIX base OS and is present on all non-stripped installs, so this prerequisite is a no-op on standard systems — it only triggers on minimal installs where the fileset was explicitly removed.

### Describe how you validated your changes

Rebuilding the BFF and confirming `installp -l` shows the requisite, and that installation still works on the 7.2 host.

### Additional Notes

N/A