### PR TITLE
packaging/aix: suppress _curses_panel at Python configure time

### DIFF
--- a/packaging/aix/stages/02-python.sh
+++ b/packaging/aix/stages/02-python.sh
@@ -362,7 +362,11 @@ cd "$PYTHON_SRC"
     ARFLAGS="$ARFLAGS" \
     NM="$NM" \
     ac_cv_header_libintl_h=no \
-    ac_cv_lib_intl_textdomain=no
+    ac_cv_lib_intl_textdomain=no \
+    ac_cv_header_ncursesw_panel_h=no \
+    ac_cv_header_ncurses_panel_h=no \
+    ac_cv_header_panel_h=no \
+    ac_cv_search_update_panels=no
 
 log "Configure complete."
 


### PR DESCRIPTION
### What does this PR do?

Passes `ac_cv_lib_panelw_new_panel=no` and `ac_cv_lib_panel_new_panel=no` to Python's `./configure` so that `_curses_panel.cpython-313.so` is not compiled.

### Motivation

`_curses_panel.cpython-313.so` links against `libpanelw.so`, which is only available from the AIX Toolbox (not part of base AIX). No Datadog agent check uses `curses.panel`. Suppressing the module at configure time cleanly removes this Toolbox dependency without requiring any post-install file deletion.

### Describe how you validated your changes

Rebuilding Python (stage 02) and confirming `_curses_panel.cpython-313.so` is absent from `lib-dynload/`.

### Additional Notes

The `curses` module itself (`_curses.cpython-313.so`) is unaffected.