### PR TITLE
`bazel`ify proto generation: `languagedetection` leftover

### DIFF
--- a/tasks/protobuf.py
+++ b/tasks/protobuf.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from invoke import Exit, task
 
-from tasks.libs.build.bazel import BazelTools
+from tasks.libs.build.bazel import BazelTools, bazel
 from tasks.libs.common.color import Color, color_message
 from tasks.libs.common.git import get_unstaged_files, get_untracked_files
 
@@ -17,7 +17,6 @@ PROTO_PKGS = {
     'process': False,
     'workloadmeta': False,
     'kubemetadata': False,
-    'languagedetection': False,
     'privateactionrunner': False,
     'remoteagent': False,
     'autodiscovery': False,
@@ -80,7 +79,7 @@ def generate(ctx, pre_commit=False):
     with ctx.cd(repo_root):
         # protobuf defs
         print(f"generating protobuf code from: {proto_root}")
-
+        bazel(ctx, "run", "//pkg/proto/pbgo/languagedetection:write_pb_go")
         for pkg, inject_tags in PROTO_PKGS.items():
             files = []
             pkg_root = Path(proto_root, "datadog", pkg)


### PR DESCRIPTION
### What does this PR do?
Move `languagedetection` out of `PROTO_PKGS` in `tasks/protobuf.py`, delegating `.pb.go` generation to the topmost `bazel` command: `bazel run //pkg/proto/pbgo/languagedetection:write_pb_go`.

### Motivation
Complete the `languagedetection` `bazel`ification started in #49918, which missed the corresponding `tasks/protobuf.py` change - sorry for that!

### Describe how you validated your changes
`dda inv protobuf.generate` succeeds.

### Additional Notes
`bazel run //pkg/proto/pbgo/languagedetection:write_pb_go` is merely left for didactic purposes so that colleagues get to know how such in-workspace files can be (re)generated.