### PR TITLE
dyninst/symdb: put more info in the upload message

### DIFF
--- a/pkg/dyninst/symdb/uploader/symdb.go
+++ b/pkg/dyninst/symdb/uploader/symdb.go
@@ -267,9 +267,7 @@ func (s *uploader) uploadInner(ctx context.Context, compressedData []byte) error
 "ddsource": "dd_debugger",
 "service": "` + s.service + `",
 "runtimeId": "` + s.runtimeID + `",
-"debugger": {
-	"type": "symdb"
-}
+"type": "symdb"
 }`)
 	if _, err := eventPart.Write(meta); err != nil {
 		return fmt.Errorf("failed to write event data: %w", err)

--- a/pkg/dyninst/symdb/uploader/symdb.go
+++ b/pkg/dyninst/symdb/uploader/symdb.go
@@ -166,9 +166,21 @@ func NewBatchEncoder(
 func (b *BatchEncoder) AddScope(scope Scope) error {
 	if !b.prefixWritten {
 		b.batchNum++
-		prefix := `{"service":"` + b.up.service +
-			`","version":"` + b.up.version +
-			`","language":"go","upload_id":"` + b.uploadID.String() +
+
+		// JSON-encode service and version, in case they contain funky
+		// characters.
+		serviceJSON, err := json.Marshal(b.up.service)
+		if err != nil {
+			return fmt.Errorf("failed to marshal service: %w", err)
+		}
+		versionJSON, err := json.Marshal(b.up.version)
+		if err != nil {
+			return fmt.Errorf("failed to marshal version: %w", err)
+		}
+
+		prefix := `{"service":` + string(serviceJSON) +
+			`,"version":` + string(versionJSON) +
+			`,"language":"go","upload_id":"` + b.uploadID.String() +
 			`","batch_num":` + strconv.Itoa(b.batchNum) +
 			`,"scopes":[`
 		if _, err := b.gz.Write([]byte(prefix)); err != nil {

--- a/pkg/dyninst/symdb/uploader/symdb.go
+++ b/pkg/dyninst/symdb/uploader/symdb.go
@@ -250,6 +250,10 @@ func (s *uploader) uploadInner(ctx context.Context, compressedData []byte) error
 		return fmt.Errorf("failed to write compressed SymDB data: %w", err)
 	}
 
+	// Add a part containing the JSON that will eventually become the EvP event
+	// (as opposed to the part above, which will become an EvP attachment). The
+	// name="event" is recognized by EvP intake:
+	// https://github.com/DataDog/logs-backend/blob/038d9b05a3904b60b06c32e03db1aebb757ba41d/domains/intake/libs/intake-backend/edge/src/main/java/com/dd/evp/intake_backend/edge/http/multipart/V2MultiPartMessageDecoder.java#L40
 	eventHeader := make(textproto.MIMEHeader)
 	eventHeader.Set("Content-Disposition", `form-data; name="event"; filename="event.json"`)
 	eventHeader.Set("Content-Type", "application/json")

--- a/pkg/dyninst/symdb/uploader/symdb.go
+++ b/pkg/dyninst/symdb/uploader/symdb.go
@@ -263,12 +263,21 @@ func (s *uploader) uploadInner(ctx context.Context, compressedData []byte) error
 		return fmt.Errorf("failed to create event part: %w", err)
 	}
 
-	meta := []byte(`{
-"ddsource": "dd_debugger",
-"service": "` + s.service + `",
-"runtimeId": "` + s.runtimeID + `",
-"type": "symdb"
-}`)
+	event := struct {
+		DDSource  string `json:"ddsource"`
+		Service   string `json:"service"`
+		RuntimeID string `json:"runtimeId"`
+		Type      string `json:"type"`
+	}{
+		DDSource:  "dd_debugger",
+		Service:   s.service,
+		RuntimeID: s.runtimeID,
+		Type:      "symdb",
+	}
+	meta, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("failed to marshal event meta: %w", err)
+	}
 	if _, err := eventPart.Write(meta); err != nil {
 		return fmt.Errorf("failed to write event data: %w", err)
 	}

--- a/pkg/dyninst/symdb/uploader/symdb.go
+++ b/pkg/dyninst/symdb/uploader/symdb.go
@@ -219,7 +219,7 @@ func (b *BatchEncoder) Flush(ctx context.Context, final bool) error {
 	if err := b.gz.Close(); err != nil {
 		return fmt.Errorf("failed to close gzip writer: %w", err)
 	}
-	if err := b.up.uploadInner(ctx, b.buf.Bytes()); err != nil {
+	if err := b.up.uploadInner(ctx, b.buf.Bytes(), b.uploadID, b.batchNum, final); err != nil {
 		return fmt.Errorf("%w: %w", ErrUpload, err)
 	}
 	b.buf.Reset()
@@ -230,7 +230,7 @@ func (b *BatchEncoder) Flush(ctx context.Context, final bool) error {
 	return nil
 }
 
-func (s *uploader) uploadInner(ctx context.Context, compressedData []byte) error {
+func (s *uploader) uploadInner(ctx context.Context, compressedData []byte, uploadID uuid.UUID, batchNum int, final bool) error {
 	// The upload is a multipart containing metadata expected by the event platform
 	// and the gzipped SymDB data.
 
@@ -263,16 +263,33 @@ func (s *uploader) uploadInner(ctx context.Context, compressedData []byte) error
 		return fmt.Errorf("failed to create event part: %w", err)
 	}
 
+	// Some of the fields in here are duplicated inside the envelope in the
+	// attachment file; that's on purpose: having them in this message allows
+	// the debugger backend to have enough information for its bookkeeping
+	// without downloading the attachment. Having the info in the attachment is
+	// useful in order to make attachments self-contained.
 	event := struct {
-		DDSource  string `json:"ddsource"`
-		Service   string `json:"service"`
-		RuntimeID string `json:"runtimeId"`
-		Type      string `json:"type"`
+		DDSource       string    `json:"ddsource"`
+		Service        string    `json:"service"`
+		Version        string    `json:"version"`
+		Language       string    `json:"language"`
+		RuntimeID      string    `json:"runtimeId"`
+		Type           string    `json:"type"`
+		UploadID       uuid.UUID `json:"upload_id"`
+		BatchNum       int       `json:"batch_num"`
+		Final          bool      `json:"final"`
+		AttachmentSize int       `json:"attachment_size"`
 	}{
-		DDSource:  "dd_debugger",
-		Service:   s.service,
-		RuntimeID: s.runtimeID,
-		Type:      "symdb",
+		DDSource:       "dd_debugger",
+		Service:        s.service,
+		Version:        s.version,
+		Language:       "go",
+		RuntimeID:      s.runtimeID,
+		Type:           "symdb",
+		UploadID:       uploadID,
+		BatchNum:       batchNum,
+		Final:          final,
+		AttachmentSize: len(compressedData),
 	}
 	meta, err := json.Marshal(event)
 	if err != nil {

--- a/pkg/dyninst/symdb/uploader/uploader_test.go
+++ b/pkg/dyninst/symdb/uploader/uploader_test.go
@@ -41,9 +41,16 @@ type SymDBRoot struct {
 }
 
 type EventMetadata struct {
-	DDSource  string `json:"ddsource"`
-	Service   string `json:"service"`
-	RuntimeID string `json:"runtimeId"`
+	DDSource       string `json:"ddsource"`
+	Service        string `json:"service"`
+	Version        string `json:"version"`
+	Language       string `json:"language"`
+	RuntimeID      string `json:"runtimeId"`
+	Type           string `json:"type"`
+	UploadID       string `json:"upload_id"`
+	BatchNum       int    `json:"batch_num"`
+	Final          bool   `json:"final"`
+	AttachmentSize int    `json:"attachment_size"`
 }
 
 type testServer struct {
@@ -93,7 +100,7 @@ func newTestServer() *testServer {
 }
 func validateSymDBRequest(
 	t *testing.T,
-	expectedService, expectedRuntimeID string,
+	expectedService, expectedVersion, expectedRuntimeID string,
 	expectedUploadID uuid.UUID,
 	req *http.Request,
 ) {
@@ -141,9 +148,19 @@ func validateSymDBRequest(
 
 	var eventMetadata EventMetadata
 	require.NoError(t, json.Unmarshal(eventData, &eventMetadata))
-	require.Equal(t, "dd_debugger", eventMetadata.DDSource)
-	require.Equal(t, expectedService, eventMetadata.Service)
-	require.Equal(t, expectedRuntimeID, eventMetadata.RuntimeID)
+	expectedEvent := EventMetadata{
+		DDSource:       "dd_debugger",
+		Service:        expectedService,
+		Version:        expectedVersion,
+		Language:       "go",
+		RuntimeID:      expectedRuntimeID,
+		Type:           "symdb",
+		UploadID:       expectedUploadID.String(),
+		BatchNum:       1,
+		Final:          true,
+		AttachmentSize: len(fileData),
+	}
+	require.Equal(t, expectedEvent, eventMetadata)
 
 	// Validate file part - it should always be compressed as file.gz
 	require.Equal(t, "file.gz", filePart.FileName())
@@ -283,7 +300,7 @@ func TestBatchEncoder(t *testing.T) {
 			}()
 
 			req := <-ts.requests
-			validateSymDBRequest(t, "service1", "dummy-runtime-id", uploadID, req.r)
+			validateSymDBRequest(t, "service1", "1.0.0", "dummy-runtime-id", uploadID, req.r)
 			if injectError {
 				req.w.WriteHeader(http.StatusInternalServerError)
 			} else {


### PR DESCRIPTION
By duplicating some metadata out of the SymDB attachment body into the
EvP event body, we can avoid having to download the attachment in the
backend when we receive the upload.
