### PR TITLE
bazel: analyze gRPC with grpcnotrace tag in go_deps

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -53,18 +53,6 @@ bazel_dep(name = "bazel_skylib", version = "1.9.0")
 bazel_dep(name = "gawk", version = "5.3.2.bcr.3")
 bazel_dep(name = "gazelle", version = "0.50.0")
 
-go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
-
-# grpcnotrace is in _GAZELLE_BUILD_TAGS (root BUILD.bazel) so our local
-# packages are analyzed with it active. Mirror that here so the go_deps
-# extension's internal Gazelle run sees the same tag and puts trace_notrace.go
-# (not trace_withtrace.go) into grpc's srcs — matching what our dd_go_test
-# targets see at compile time via gotags propagation.
-go_deps.gazelle_override(
-    path = "google.golang.org/grpc",
-    build_extra_args = ["-build_tags=grpcnotrace"],
-)
-
 bazel_dep(name = "gcc_toolchain", version = "0.9.2")
 bazel_dep(name = "libarchive", version = "3.8.1.bcr.2")
 bazel_dep(name = "platforms", version = "1.0.0")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -52,6 +52,19 @@ bazel_dep(name = "bazel_lib", version = "3.2.2")
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
 bazel_dep(name = "gawk", version = "5.3.2.bcr.3")
 bazel_dep(name = "gazelle", version = "0.50.0")
+
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+
+# grpcnotrace is in _GAZELLE_BUILD_TAGS (root BUILD.bazel) so our local
+# packages are analyzed with it active. Mirror that here so the go_deps
+# extension's internal Gazelle run sees the same tag and puts trace_notrace.go
+# (not trace_withtrace.go) into grpc's srcs — matching what our dd_go_test
+# targets see at compile time via gotags propagation.
+go_deps.gazelle_override(
+    path = "google.golang.org/grpc",
+    build_extra_args = ["-build_tags=grpcnotrace"],
+)
+
 bazel_dep(name = "gcc_toolchain", version = "0.9.2")
 bazel_dep(name = "libarchive", version = "3.8.1.bcr.2")
 bazel_dep(name = "platforms", version = "1.0.0")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -52,7 +52,6 @@ bazel_dep(name = "bazel_lib", version = "3.2.2")
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
 bazel_dep(name = "gawk", version = "5.3.2.bcr.3")
 bazel_dep(name = "gazelle", version = "0.50.0")
-
 bazel_dep(name = "gcc_toolchain", version = "0.9.2")
 bazel_dep(name = "libarchive", version = "3.8.1.bcr.2")
 bazel_dep(name = "platforms", version = "1.0.0")

--- a/deps/go.MODULE.bazel
+++ b/deps/go.MODULE.bazel
@@ -31,6 +31,10 @@ go_deps.gazelle_override(
     ],
     path = "github.com/google/cel-go",
 )
+go_deps.gazelle_override(
+    build_extra_args = ["-build_tags=grpcnotrace"],
+    path = "google.golang.org/grpc",
+)
 use_repo(
     go_deps,
     "cat_dario_mergo",


### PR DESCRIPTION
### What does this PR do?

Adds a `go_deps.gazelle_override` for `google.golang.org/grpc` that passes `-build_tags=grpcnotrace` to the `go_deps` extension's internal Gazelle analysis.

### Motivation

The `go_deps` extension runs its own Gazelle pass for external modules, separate from `bazel run //:gazelle`, and does not inherit `_GAZELLE_BUILD_TAGS`. Without this override, Gazelle analyzes gRPC without `grpcnotrace` and puts `trace_withtrace.go` in srcs. Our test targets propagate `grpcnotrace` transitively at compile time, causing `trace_withtrace.go` to be excluded by its `//go:build !grpcnotrace` constraint while `trace_notrace.go` (which defines `newTrace` etc.) is absent from srcs — resulting in undefined symbol errors on macOS CI.

### Describe how you validated your changes

Local builds & CI.

### Additional Notes