### PR TITLE
Add config schemas for comp/otelcol components

### DIFF
--- a/comp/otelcol/.schemagen.yaml
+++ b/comp/otelcol/.schemagen.yaml
@@ -33,6 +33,12 @@ mappings:
   go.opentelemetry.io/collector/component:
     ID:
       schemaType: string
+  github.com/DataDog/datadog-agent/comp/core/tagger/types:
+    # TagCardinality is a typed int (iota: 0=low, 1=orchestrator, 2=high,
+    # 3=none, 4=checks-config). YAML accepts the integer form; there is no
+    # UnmarshalText hook today, so the schema mirrors that.
+    TagCardinality:
+      schemaType: integer
 allowedRefs:
   - go.opentelemetry.io/collector
   - github.com/open-telemetry/opentelemetry-collector-contrib

--- a/comp/otelcol/.schemagen.yaml
+++ b/comp/otelcol/.schemagen.yaml
@@ -1,0 +1,21 @@
+namespace: github.com/DataDog/datadog-agent
+mappings:
+  time:
+    Time:
+      schemaType: string
+      format: date-time
+      skipAnnotation: true
+    Duration:
+      schemaType: string
+      format: duration
+      skipAnnotation: true
+  go.opentelemetry.io/collector/component:
+    ID:
+      schemaType: string
+allowedRefs:
+  - go.opentelemetry.io/collector
+  - github.com/open-telemetry/opentelemetry-collector-contrib
+  - github.com/DataDog/datadog-agent
+componentOverrides:
+  exporter/serializer:
+    configName: ExporterConfig

--- a/comp/otelcol/.schemagen.yaml
+++ b/comp/otelcol/.schemagen.yaml
@@ -1,3 +1,24 @@
+# Settings for upstream's schemagen tool.
+# https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/cmd/schemagen
+#
+# To regenerate a component's config.schema.yaml:
+#
+#   1. Build the tool from a local checkout of opentelemetry-collector-contrib:
+#        (cd /path/to/opentelemetry-collector-contrib/cmd/schemagen && go build -o /tmp/schemagen .)
+#   2. Run it against the component's directory (the one containing config.go and metadata.yaml):
+#        /tmp/schemagen comp/otelcol/<component>/...
+#
+# The tool walks up from CWD to find this file, so it must remain at or above
+# every component path it generates schemas for. See ./README.md and individual
+# component metadata.yaml files for context.
+#
+# Known limitation: schemagen treats every Go-embedded field as squashed,
+# regardless of the explicit mapstructure tag value. Components with embedded
+# pointer fields (e.g. ddflareextension's *confighttp.ServerConfig) or embedded
+# fields with a non-squash mapstructure key (e.g. serializerexporter's
+# configtls.ClientConfig with mapstructure:"tls") need hand-tuning after
+# regeneration.
+
 namespace: github.com/DataDog/datadog-agent
 mappings:
   time:

--- a/comp/otelcol/ddflareextension/impl/config.schema.yaml
+++ b/comp/otelcol/ddflareextension/impl/config.schema.yaml
@@ -1,0 +1,5 @@
+description: Config has the configuration for the extension enabling the health check extension, used to report the health status of the service.
+type: object
+allOf:
+  - x-pointer: true
+    $ref: go.opentelemetry.io/collector/config/confighttp.server_config

--- a/comp/otelcol/ddflareextension/impl/metadata.yaml
+++ b/comp/otelcol/ddflareextension/impl/metadata.yaml
@@ -1,9 +1,9 @@
 type: ddflare
+display_name: Datadog Flare Extension
 
 status:
   class: extension
   stability:
     beta: [extension]
-  distributions: []
   codeowners:
     active: [DataDog/opentelemetry]

--- a/comp/otelcol/ddflareextension/impl/metadata.yaml
+++ b/comp/otelcol/ddflareextension/impl/metadata.yaml
@@ -1,0 +1,9 @@
+type: ddflare
+
+status:
+  class: extension
+  stability:
+    beta: [extension]
+  distributions: []
+  codeowners:
+    active: [DataDog/opentelemetry]

--- a/comp/otelcol/ddprofilingextension/impl/config.go
+++ b/comp/otelcol/ddprofilingextension/impl/config.go
@@ -9,8 +9,8 @@ package ddprofilingextensionimpl
 // Config contains the config of the profiler.
 type Config struct {
 	ProfilerOptions ProfilerOptions `mapstructure:"profiler_options"`
-	// Endpoint reports the endpoint used for profiles.
-	// Default: BuildInfo.Version (e.g. v0.117.0)
+	// Endpoint is the local port the profiling HTTP server listens on; used as "localhost:<endpoint>".
+	// Default: "7501"
 	Endpoint string `mapstructure:"endpoint"`
 }
 

--- a/comp/otelcol/ddprofilingextension/impl/config.schema.yaml
+++ b/comp/otelcol/ddprofilingextension/impl/config.schema.yaml
@@ -1,0 +1,30 @@
+$defs:
+  profiler_options:
+    description: ProfilerOptions defines settings relevant to the profiler.
+    type: object
+    properties:
+      env:
+        description: 'Env the profiler will report with. Default: none'
+        type: string
+      period:
+        description: 'Period in seconds the profiler will report with. Default: 60s'
+        type: integer
+      profile_types:
+        description: ProfileTypes specifies additional profile types to enable. supported values are blockprofile, mutexprofile and goroutineprofile. By default CPU and Heap profiles are enabled.
+        type: array
+        items:
+          type: string
+      service:
+        description: 'Service the profiler will report with. Default: BuildInfo.Command (e.g. otel-agent)'
+        type: string
+      version:
+        description: 'Version the profiler will report with. Default: BuildInfo.Version (e.g. v0.117.0)'
+        type: string
+description: Config contains the config of the profiler.
+type: object
+properties:
+  endpoint:
+    description: 'Endpoint reports the endpoint used for profiles. Default: BuildInfo.Version (e.g. v0.117.0)'
+    type: string
+  profiler_options:
+    $ref: profiler_options

--- a/comp/otelcol/ddprofilingextension/impl/config.schema.yaml
+++ b/comp/otelcol/ddprofilingextension/impl/config.schema.yaml
@@ -24,7 +24,7 @@ description: Config contains the config of the profiler.
 type: object
 properties:
   endpoint:
-    description: 'Endpoint reports the endpoint used for profiles. Default: BuildInfo.Version (e.g. v0.117.0)'
+    description: 'Endpoint is the local port the profiling HTTP server listens on; used as "localhost:<endpoint>". Default: "7501"'
     type: string
   profiler_options:
     $ref: profiler_options

--- a/comp/otelcol/ddprofilingextension/impl/metadata.yaml
+++ b/comp/otelcol/ddprofilingextension/impl/metadata.yaml
@@ -1,9 +1,9 @@
 type: ddprofiling
+display_name: Datadog Profiling Extension
 
 status:
   class: extension
   stability:
-    beta: [extension]
-  distributions: []
+    development: [extension]
   codeowners:
     active: [DataDog/opentelemetry]

--- a/comp/otelcol/ddprofilingextension/impl/metadata.yaml
+++ b/comp/otelcol/ddprofilingextension/impl/metadata.yaml
@@ -1,0 +1,9 @@
+type: ddprofiling
+
+status:
+  class: extension
+  stability:
+    beta: [extension]
+  distributions: []
+  codeowners:
+    active: [DataDog/opentelemetry]

--- a/comp/otelcol/dogtelextension/impl/config.go
+++ b/comp/otelcol/dogtelextension/impl/config.go
@@ -12,46 +12,67 @@ import (
 
 // Config defines the configuration for the dogtelextension
 type Config struct {
-	// Metadata collection settings.
-	// EnableMetadataCollection is a pointer so that nil ("not set") is
-	// distinguishable from an explicit false, allowing NewConfigComponent to
-	// leave the DD agent default (true) intact when the field is absent.
+	// EnableMetadataCollection toggles metadata collection. Pointer so that
+	// nil ("not set") is distinguishable from an explicit false, allowing
+	// NewConfigComponent to leave the DD agent default (true) intact when
+	// the field is absent.
 	EnableMetadataCollection *bool `mapstructure:"enable_metadata_collection"`
-	MetadataInterval         int   `mapstructure:"metadata_interval"` // seconds; 0 = use agent default (1800)
+	// MetadataInterval is the metadata collection interval, in seconds.
+	// 0 uses the agent default (1800).
+	MetadataInterval int `mapstructure:"metadata_interval"`
 
-	// Tagger server settings
-	EnableTaggerServer      bool   `mapstructure:"enable_tagger_server"`
-	TaggerServerPort        int    `mapstructure:"tagger_server_port"`         // 0 = auto-assign
-	TaggerServerAddr        string `mapstructure:"tagger_server_addr"`         // Default: localhost
-	TaggerMaxMessageSize    int    `mapstructure:"tagger_max_message_size"`    // Default: 4MB
-	TaggerMaxConcurrentSync int    `mapstructure:"tagger_max_concurrent_sync"` // Default: 5
+	// EnableTaggerServer enables the tagger gRPC server.
+	EnableTaggerServer bool `mapstructure:"enable_tagger_server"`
+	// TaggerServerPort is the port the tagger server binds to. 0 auto-assigns.
+	TaggerServerPort int `mapstructure:"tagger_server_port"`
+	// TaggerServerAddr is the address the tagger server binds to. Default: localhost.
+	TaggerServerAddr string `mapstructure:"tagger_server_addr"`
+	// TaggerMaxMessageSize is the maximum gRPC message size in bytes. Default: 4MB.
+	TaggerMaxMessageSize int `mapstructure:"tagger_max_message_size"`
+	// TaggerMaxConcurrentSync is the maximum number of concurrent tag stream
+	// subscribers. Default: 5.
+	TaggerMaxConcurrentSync int `mapstructure:"tagger_max_concurrent_sync"`
 
-	// Standalone mode (controls secrets and other features)
-	// This is typically set via DD_OTEL_STANDALONE environment variable
+	// StandaloneMode controls whether the extension runs in standalone mode,
+	// enabling secrets resolution and other agent features. Typically set via
+	// the DD_OTEL_STANDALONE environment variable.
 	StandaloneMode bool `mapstructure:"standalone_mode"`
 
 	// Hostname overrides the agent hostname used in standalone mode.
-	// Maps to the "hostname" DD agent config key.
-	// When empty the agent resolves the hostname automatically.
+	// Maps to the "hostname" DD agent config key. When empty the agent
+	// resolves the hostname automatically.
 	Hostname string `mapstructure:"hostname"`
 
-	// Secrets backend settings (standalone mode).
-	// These map directly to the corresponding DD agent config keys so that
-	// ENC[] handles in the OTel config can be resolved without a separate
-	// datadog.yaml file.
-	SecretBackendCommand       string   `mapstructure:"secret_backend_command"`         // path to the resolver binary
-	SecretBackendArguments     []string `mapstructure:"secret_backend_arguments"`       // extra CLI arguments
-	SecretBackendTimeout       int      `mapstructure:"secret_backend_timeout"`         // seconds; 0 = agent default (30s)
-	SecretBackendOutputMaxSize int      `mapstructure:"secret_backend_output_max_size"` // bytes; 0 = agent default
+	// SecretBackendCommand is the path to the secret resolver binary
+	// (standalone mode). Maps to the "secret_backend_command" DD agent
+	// config key so ENC[] handles in the OTel config can be resolved
+	// without a separate datadog.yaml file.
+	SecretBackendCommand string `mapstructure:"secret_backend_command"`
+	// SecretBackendArguments are extra CLI arguments passed to the secret
+	// resolver binary.
+	SecretBackendArguments []string `mapstructure:"secret_backend_arguments"`
+	// SecretBackendTimeout is the secret-resolver execution timeout, in
+	// seconds. 0 uses the agent default (30s).
+	SecretBackendTimeout int `mapstructure:"secret_backend_timeout"`
+	// SecretBackendOutputMaxSize is the maximum secret-resolver output size,
+	// in bytes. 0 uses the agent default.
+	SecretBackendOutputMaxSize int `mapstructure:"secret_backend_output_max_size"`
 
-	// Kubernetes / kubelet settings for K8s tag enrichment (standalone mode).
-	// When the otel-agent runs on a Kubernetes node these allow the workloadmeta
-	// kubelet collector and the local tagger to reach the kubelet API without
+	// KubernetesKubeletHost is the kubelet host used for K8s tag enrichment
+	// in standalone mode (e.g. "status.hostIP" or an explicit IP). When the
+	// otel-agent runs on a Kubernetes node these settings let the workloadmeta
+	// kubelet collector and the local tagger reach the kubelet API without
 	// needing a separate datadog.yaml.
-	KubernetesKubeletHost      string `mapstructure:"kubernetes_kubelet_host"`       // e.g. "status.hostIP" or an explicit IP
-	KubeletTLSVerify           *bool  `mapstructure:"kubelet_tls_verify"`            // nil = keep DD agent default (true)
-	KubernetesHTTPKubeletPort  int    `mapstructure:"kubernetes_http_kubelet_port"`  // 0 = agent default (10255)
-	KubernetesHTTPSKubeletPort int    `mapstructure:"kubernetes_https_kubelet_port"` // 0 = agent default (10250)
+	KubernetesKubeletHost string `mapstructure:"kubernetes_kubelet_host"`
+	// KubeletTLSVerify controls TLS verification for the kubelet client.
+	// nil keeps the DD agent default (true).
+	KubeletTLSVerify *bool `mapstructure:"kubelet_tls_verify"`
+	// KubernetesHTTPKubeletPort is the kubelet HTTP port. 0 uses the agent
+	// default (10255).
+	KubernetesHTTPKubeletPort int `mapstructure:"kubernetes_http_kubelet_port"`
+	// KubernetesHTTPSKubeletPort is the kubelet HTTPS port. 0 uses the agent
+	// default (10250).
+	KubernetesHTTPSKubeletPort int `mapstructure:"kubernetes_https_kubelet_port"`
 }
 
 // Validate validates the configuration

--- a/comp/otelcol/dogtelextension/impl/config.schema.yaml
+++ b/comp/otelcol/dogtelextension/impl/config.schema.yaml
@@ -1,0 +1,47 @@
+description: Config defines the configuration for the dogtelextension
+type: object
+properties:
+  enable_metadata_collection:
+    description: Metadata collection settings. EnableMetadataCollection is a pointer so that nil ("not set") is distinguishable from an explicit false, allowing NewConfigComponent to leave the DD agent default (true) intact when the field is absent.
+    x-pointer: true
+    type: boolean
+  enable_tagger_server:
+    description: Tagger server settings
+    type: boolean
+  hostname:
+    description: Hostname overrides the agent hostname used in standalone mode. Maps to the "hostname" DD agent config key. When empty the agent resolves the hostname automatically.
+    type: string
+  kubelet_tls_verify:
+    x-pointer: true
+    type: boolean
+  kubernetes_http_kubelet_port:
+    type: integer
+  kubernetes_https_kubelet_port:
+    type: integer
+  kubernetes_kubelet_host:
+    description: Kubernetes / kubelet settings for K8s tag enrichment (standalone mode). When the otel-agent runs on a Kubernetes node these allow the workloadmeta kubelet collector and the local tagger to reach the kubelet API without needing a separate datadog.yaml.
+    type: string
+  metadata_interval:
+    type: integer
+  secret_backend_arguments:
+    type: array
+    items:
+      type: string
+  secret_backend_command:
+    description: Secrets backend settings (standalone mode). These map directly to the corresponding DD agent config keys so that ENC[] handles in the OTel config can be resolved without a separate datadog.yaml file.
+    type: string
+  secret_backend_output_max_size:
+    type: integer
+  secret_backend_timeout:
+    type: integer
+  standalone_mode:
+    description: Standalone mode (controls secrets and other features) This is typically set via DD_OTEL_STANDALONE environment variable
+    type: boolean
+  tagger_max_concurrent_sync:
+    type: integer
+  tagger_max_message_size:
+    type: integer
+  tagger_server_addr:
+    type: string
+  tagger_server_port:
+    type: integer

--- a/comp/otelcol/dogtelextension/impl/config.schema.yaml
+++ b/comp/otelcol/dogtelextension/impl/config.schema.yaml
@@ -2,46 +2,57 @@ description: Config defines the configuration for the dogtelextension
 type: object
 properties:
   enable_metadata_collection:
-    description: Metadata collection settings. EnableMetadataCollection is a pointer so that nil ("not set") is distinguishable from an explicit false, allowing NewConfigComponent to leave the DD agent default (true) intact when the field is absent.
+    description: EnableMetadataCollection toggles metadata collection. Pointer so that nil ("not set") is distinguishable from an explicit false, allowing NewConfigComponent to leave the DD agent default (true) intact when the field is absent.
     x-pointer: true
     type: boolean
   enable_tagger_server:
-    description: Tagger server settings
+    description: EnableTaggerServer enables the tagger gRPC server.
     type: boolean
   hostname:
     description: Hostname overrides the agent hostname used in standalone mode. Maps to the "hostname" DD agent config key. When empty the agent resolves the hostname automatically.
     type: string
   kubelet_tls_verify:
+    description: KubeletTLSVerify controls TLS verification for the kubelet client. nil keeps the DD agent default (true).
     x-pointer: true
     type: boolean
   kubernetes_http_kubelet_port:
+    description: KubernetesHTTPKubeletPort is the kubelet HTTP port. 0 uses the agent default (10255).
     type: integer
   kubernetes_https_kubelet_port:
+    description: KubernetesHTTPSKubeletPort is the kubelet HTTPS port. 0 uses the agent default (10250).
     type: integer
   kubernetes_kubelet_host:
-    description: Kubernetes / kubelet settings for K8s tag enrichment (standalone mode). When the otel-agent runs on a Kubernetes node these allow the workloadmeta kubelet collector and the local tagger to reach the kubelet API without needing a separate datadog.yaml.
+    description: KubernetesKubeletHost is the kubelet host used for K8s tag enrichment in standalone mode (e.g. "status.hostIP" or an explicit IP). When the otel-agent runs on a Kubernetes node these settings let the workloadmeta kubelet collector and the local tagger reach the kubelet API without needing a separate datadog.yaml.
     type: string
   metadata_interval:
+    description: MetadataInterval is the metadata collection interval, in seconds. 0 uses the agent default (1800).
     type: integer
   secret_backend_arguments:
+    description: SecretBackendArguments are extra CLI arguments passed to the secret resolver binary.
     type: array
     items:
       type: string
   secret_backend_command:
-    description: Secrets backend settings (standalone mode). These map directly to the corresponding DD agent config keys so that ENC[] handles in the OTel config can be resolved without a separate datadog.yaml file.
+    description: SecretBackendCommand is the path to the secret resolver binary (standalone mode). Maps to the "secret_backend_command" DD agent config key so ENC[] handles in the OTel config can be resolved without a separate datadog.yaml file.
     type: string
   secret_backend_output_max_size:
+    description: SecretBackendOutputMaxSize is the maximum secret-resolver output size, in bytes. 0 uses the agent default.
     type: integer
   secret_backend_timeout:
+    description: SecretBackendTimeout is the secret-resolver execution timeout, in seconds. 0 uses the agent default (30s).
     type: integer
   standalone_mode:
-    description: Standalone mode (controls secrets and other features) This is typically set via DD_OTEL_STANDALONE environment variable
+    description: StandaloneMode controls whether the extension runs in standalone mode, enabling secrets resolution and other agent features. Typically set via the DD_OTEL_STANDALONE environment variable.
     type: boolean
   tagger_max_concurrent_sync:
+    description: 'TaggerMaxConcurrentSync is the maximum number of concurrent tag stream subscribers. Default: 5.'
     type: integer
   tagger_max_message_size:
+    description: 'TaggerMaxMessageSize is the maximum gRPC message size in bytes. Default: 4MB.'
     type: integer
   tagger_server_addr:
+    description: 'TaggerServerAddr is the address the tagger server binds to. Default: localhost.'
     type: string
   tagger_server_port:
+    description: TaggerServerPort is the port the tagger server binds to. 0 auto-assigns.
     type: integer

--- a/comp/otelcol/dogtelextension/impl/metadata.yaml
+++ b/comp/otelcol/dogtelextension/impl/metadata.yaml
@@ -1,0 +1,9 @@
+type: dogtel
+
+status:
+  class: extension
+  stability:
+    beta: [extension]
+  distributions: []
+  codeowners:
+    active: [DataDog/opentelemetry]

--- a/comp/otelcol/dogtelextension/impl/metadata.yaml
+++ b/comp/otelcol/dogtelextension/impl/metadata.yaml
@@ -1,9 +1,9 @@
 type: dogtel
+display_name: Datadog Telemetry Extension
 
 status:
   class: extension
   stability:
     beta: [extension]
-  distributions: []
   codeowners:
     active: [DataDog/opentelemetry]

--- a/comp/otelcol/otlp/components/exporter/datadogexporter/README.md
+++ b/comp/otelcol/otlp/components/exporter/datadogexporter/README.md
@@ -1,0 +1,20 @@
+# Datadog Exporter
+
+This package provides the Datadog exporter factory used inside the Datadog
+Distribution of OpenTelemetry (DDOT) Collector. It builds on top of the
+[`serializerexporter`](../serializerexporter), [`logsagentexporter`](../logsagentexporter),
+and the trace agent component to send metrics, logs, and traces (plus APM
+stats) to Datadog using the agent's internal pipelines.
+
+## Configuration
+
+This factory does not define its own configuration struct. It accepts the
+same configuration as the upstream Datadog exporter in
+[`opentelemetry-collector-contrib`](https://github.com/open-telemetry/opentelemetry-collector-contrib),
+which is the `Config` type from
+[`pkg/datadog/config`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/datadog/config).
+
+The corresponding configuration schema is published upstream at
+[`pkg/datadog/config/config.schema.yaml`](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/datadog/config/config.schema.yaml).
+That single file is the source of truth for every option this exporter
+accepts (API, host metadata, metrics, traces, logs, retry, queue, etc.).

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/config.schema.yaml
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/config.schema.yaml
@@ -1,0 +1,9 @@
+description: Config defines configuration for the logs agent exporter.
+type: object
+properties:
+  host_metadata:
+    description: HostMetadata defines the host metadata specific configuration
+    $ref: github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog/config.host_metadata_config
+  sending_queue:
+    x-optional: true
+    $ref: go.opentelemetry.io/collector/exporter/exporterhelper.queue_batch_config

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/factory.go
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/factory.go
@@ -39,14 +39,14 @@ const (
 
 // Config defines configuration for the logs agent exporter.
 type Config struct {
-	OtelSource    string
-	LogSourceName string
+	OtelSource    string                                                   `mapstructure:"-"`
+	LogSourceName string                                                   `mapstructure:"-"`
 	QueueSettings configoptional.Optional[exporterhelper.QueueBatchConfig] `mapstructure:"sending_queue"`
 
 	// HostMetadata defines the host metadata specific configuration
 	HostMetadata datadogconfig.HostMetadataConfig `mapstructure:"host_metadata"`
 
-	OrchestratorConfig OrchestratorConfig
+	OrchestratorConfig OrchestratorConfig `mapstructure:"-"`
 }
 
 // OrchestratorConfig contains configuration for sending orchestrator data to Datadog.

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/metadata.yaml
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/metadata.yaml
@@ -1,9 +1,9 @@
 type: logsagent
+display_name: Datadog Logs Agent Exporter
 
 status:
   class: exporter
   stability:
     stable: [logs]
-  distributions: []
   codeowners:
     active: [DataDog/opentelemetry]

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/metadata.yaml
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/metadata.yaml
@@ -1,0 +1,9 @@
+type: logsagent
+
+status:
+  class: exporter
+  stability:
+    stable: [logs]
+  distributions: []
+  codeowners:
+    active: [DataDog/opentelemetry]

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/config.schema.yaml
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/config.schema.yaml
@@ -1,0 +1,31 @@
+$defs:
+  metrics_config:
+    description: MetricsConfig defines the metrics exporter specific configuration options
+    type: object
+    properties:
+      apm_stats_receiver_addr:
+        description: APMStatsReceiverAddr is the address to send APM stats to.
+        type: string
+      tags:
+        description: Tags is a comma-separated list of tags to add to all metrics.
+        type: string
+    allOf:
+      - $ref: github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog/config.metrics_config
+description: ExporterConfig defines configuration for the serializer exporter.
+type: object
+properties:
+  api:
+    description: API defines the Datadog API configuration. It is useful for OSS OpenTelemetry Collector or to use the serializer exporter with the OCB.
+    $ref: github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog/config.api_config
+  host_metadata:
+    description: HostMetadataConfig defines the host metadata related configuration.
+    $ref: github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog/config.host_metadata_config
+  metrics:
+    $ref: metrics_config
+  sending_queue:
+    x-optional: true
+    $ref: go.opentelemetry.io/collector/exporter/exporterhelper.queue_batch_config
+allOf:
+  - $ref: go.opentelemetry.io/collector/exporter/exporterhelper.timeout_config
+  - $ref: go.opentelemetry.io/collector/config/confighttp.client_config
+  - $ref: go.opentelemetry.io/collector/config/configtls.client_config

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/config.schema.yaml
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/config.schema.yaml
@@ -25,7 +25,8 @@ properties:
   sending_queue:
     x-optional: true
     $ref: go.opentelemetry.io/collector/exporter/exporterhelper.queue_batch_config
+  tls:
+    $ref: go.opentelemetry.io/collector/config/configtls.client_config
 allOf:
   - $ref: go.opentelemetry.io/collector/exporter/exporterhelper.timeout_config
   - $ref: go.opentelemetry.io/collector/config/confighttp.client_config
-  - $ref: go.opentelemetry.io/collector/config/configtls.client_config

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/metadata.yaml
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/metadata.yaml
@@ -1,9 +1,9 @@
 type: serializer
+display_name: Datadog Serializer Exporter
 
 status:
   class: exporter
   stability:
     stable: [metrics]
-  distributions: []
   codeowners:
     active: [DataDog/opentelemetry]

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/metadata.yaml
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/metadata.yaml
@@ -1,0 +1,9 @@
+type: serializer
+
+status:
+  class: exporter
+  stability:
+    stable: [metrics]
+  distributions: []
+  codeowners:
+    active: [DataDog/opentelemetry]

--- a/comp/otelcol/otlp/components/processor/infraattributesprocessor/config.go
+++ b/comp/otelcol/otlp/components/processor/infraattributesprocessor/config.go
@@ -13,6 +13,9 @@ import (
 
 // Config defines configuration for processor.
 type Config struct {
+	// Cardinality controls which tag cardinality is enriched onto the signal.
+	// Accepted values: 0 = low (host-level, default), 1 = orchestrator
+	// (per-pod/task), 2 = high (per-container/request).
 	Cardinality           types.TagCardinality `mapstructure:"cardinality"`
 	AllowHostnameOverride bool                 `mapstructure:"allow_hostname_override"`
 }

--- a/comp/otelcol/otlp/components/processor/infraattributesprocessor/config.schema.yaml
+++ b/comp/otelcol/otlp/components/processor/infraattributesprocessor/config.schema.yaml
@@ -4,4 +4,6 @@ properties:
   allow_hostname_override:
     type: boolean
   cardinality:
-    $ref: /comp/core/tagger/types.tag_cardinality
+    description: 'Cardinality controls which tag cardinality is enriched onto the signal. Accepted values: 0 = low (host-level, default), 1 = orchestrator (per-pod/task), 2 = high (per-container/request).'
+    type: integer
+    x-customType: github.com/DataDog/datadog-agent/comp/core/tagger/types.TagCardinality

--- a/comp/otelcol/otlp/components/processor/infraattributesprocessor/config.schema.yaml
+++ b/comp/otelcol/otlp/components/processor/infraattributesprocessor/config.schema.yaml
@@ -1,0 +1,7 @@
+description: Config defines configuration for processor.
+type: object
+properties:
+  allow_hostname_override:
+    type: boolean
+  cardinality:
+    $ref: /comp/core/tagger/types.tag_cardinality

--- a/comp/otelcol/otlp/components/processor/infraattributesprocessor/metadata.yaml
+++ b/comp/otelcol/otlp/components/processor/infraattributesprocessor/metadata.yaml
@@ -1,0 +1,9 @@
+type: infraattributes
+
+status:
+  class: processor
+  stability:
+    alpha: [traces, metrics, logs, profiles]
+  distributions: []
+  codeowners:
+    active: [DataDog/opentelemetry]

--- a/comp/otelcol/otlp/components/processor/infraattributesprocessor/metadata.yaml
+++ b/comp/otelcol/otlp/components/processor/infraattributesprocessor/metadata.yaml
@@ -1,9 +1,9 @@
 type: infraattributes
+display_name: Infrastructure Attributes Processor
 
 status:
   class: processor
   stability:
     alpha: [traces, metrics, logs, profiles]
-  distributions: []
   codeowners:
     active: [DataDog/opentelemetry]

--- a/pkg/trace/info/BUILD.bazel
+++ b/pkg/trace/info/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "info",
     srcs = [
         "endpoint.go",
+        "git_version.go",
         "info.go",
         "stats.go",
         "writer.go",

--- a/pkg/trace/info/BUILD.bazel
+++ b/pkg/trace/info/BUILD.bazel
@@ -4,7 +4,6 @@ go_library(
     name = "info",
     srcs = [
         "endpoint.go",
-        "git_version.go",
         "info.go",
         "stats.go",
         "writer.go",


### PR DESCRIPTION
### What does this PR do?

Adds upstream-style `config.schema.yaml` files for the OpenTelemetry Collector components living under `comp/otelcol/`, mirroring the JSON-Schema-as-YAML format used by [`opentelemetry-collector-contrib`](https://github.com/open-telemetry/opentelemetry-collector-contrib) (with `$defs` / `$ref` / `x-pointer` / `x-optional` extensions).

Components covered:

| Component | Source |
|---|---|
| `comp/otelcol/otlp/components/exporter/serializerexporter` | generated |
| `comp/otelcol/otlp/components/exporter/logsagentexporter` | generated |
| `comp/otelcol/otlp/components/processor/infraattributesprocessor` | generated |
| `comp/otelcol/ddflareextension/impl` | hand-written (see Additional Notes) |
| `comp/otelcol/ddprofilingextension/impl` | generated |
| `comp/otelcol/dogtelextension/impl` | generated |

For `comp/otelcol/otlp/components/exporter/datadogexporter`, which has no local `Config` struct and consumes the upstream `pkg/datadog/config.Config` directly, a `README.md` is added pointing to the upstream schema as the source of truth.

A `metadata.yaml` is also added next to each component's `config.go` so the generator can be re-run, and a `comp/otelcol/.schemagen.yaml` settings file declares our `namespace`, type mappings (`time.Duration` → `string`/`format: duration`, etc.) and `allowedRefs` (`go.opentelemetry.io/collector`, `opentelemetry-collector-contrib`, `DataDog/datadog-agent`).

### Motivation

Provide machine-readable, human-readable specifications of the YAML configuration accepted by each Datadog-authored OTel Collector component. This unblocks downstream tooling (validation, documentation generation, IDE support) and keeps the format in lockstep with how upstream OTel components advertise their config surface.

### Describe how you validated your changes

- Generated five of the six schemas using upstream's [`cmd/schemagen`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/cmd/schemagen) tool, with the settings file at `comp/otelcol/.schemagen.yaml`.
- Verified all six emitted YAML files parse with `yaml.safe_load` (Python).
- Sanity-checked field coverage and `\$ref` targets against each component's `Config` struct.
- Confirmed `schemagen` re-runs from the new settings location produce byte-identical output for an already-generated component.

### Additional Notes

- `ddflareextension`'s schema is hand-written because schemagen's `addEmbeddedField` only handles `*ast.Ident` and `*ast.SelectorExpr` — it errors on `*ast.StarExpr` (i.e. embedded *pointer* fields with `mapstructure:\",squash\"`). The local `Config` embeds `*confighttp.ServerConfig` in that shape. The four-line schema `\$ref`s `go.opentelemetry.io/collector/config/confighttp.server_config` via `allOf`. A small upstream patch to schemagen would let us regenerate this in future.
- `\$ref` paths to upstream OTel types use the **fully qualified form** (e.g. `github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog/config.api_config`) rather than the slash-prefixed form upstream uses internally. This is correct: from this repo's namespace those types are external, and schemagen produces the full path automatically. Both forms are valid JSON Schema URI references per RFC 3986.
- `metricsclient/`, `statsprocessor/`, and the now-empty `connector/datadogconnector/` directory are intentionally not covered: the first two are internal helper libraries (no `component.Config`), and the third no longer hosts a registered component (moved upstream in #43479; only a stale `module_test_output.json` remains).
- Fields without `mapstructure` tags are correctly omitted from the generated schemas (per schemagen's contract). For `logsagentexporter` this means `OtelSource`, `LogSourceName`, and `OrchestratorConfig` do not appear — they are runtime-injected, not user-configurable via YAML.