### PR TITLE
[#incident-53970] Use images master for internal image publication

### DIFF
--- a/.gitlab/deploy/internal_image_deploy/internal_image_deploy.yml
+++ b/.gitlab/deploy/internal_image_deploy/internal_image_deploy.yml
@@ -17,7 +17,7 @@
         RELEASE_TAG_COMPRESSION_SUFFIX: "-zstd-nydus"
   script:
     # Constant variables
-    - export RELEASE_STAGING="true"
+    - export RELEASE_STAGING=""
     - export DYNAMIC_BUILD_RENDER_RULES="agent-build-only"
     - export IMAGES_GIT_REF="master"
     # Job specific variables
@@ -39,10 +39,8 @@
     - if [ "$BUCKET_BRANCH" = "dev" ]; then RELEASE_TAG="dev-${BASE_RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}${RELEASE_TAG_SUFFIX}${RELEASE_TAG_COMPRESSION_SUFFIX}"; fi
     - |
       # TODO: Remove this workaround once JIT replication is reliable for these
-      # images, or once DataDog/images@master can dynamically configure the
-      # replication target per triggered pipeline.
+      # images.
       if [ -z "$CI_COMMIT_TAG" ]; then
-        export IMAGES_GIT_REF="datadog-agent-staging-replication"
         export RELEASE_STAGING="true"
         export RELEASE_PROD=""
       fi


### PR DESCRIPTION
## Summary
- Stop pinning non-tag internal image builds to `DataDog/images@datadog-agent-staging-replication`.
- Keep the trigger on `DataDog/images@master` and rely on DataDog/images#9692 to make `RELEASE_STAGING=true` produce staging-target images from master.
- Set `RELEASE_STAGING=true` only for non-tag pipelines so tag/prod paths are not unintentionally downgraded to staging by the new images behavior.

## Context
- Builds on the workaround merged in DataDog/datadog-agent#50378.
- Depends on DataDog/images#9692.

## Validation
- [x] Make sure dev builds from branches have the target: staging annotation
- [ ] Make sure rcs have target:prod