### PR TITLE
healthplatform: drop "check" terminology from the public API

### DIFF
--- a/comp/core/agenttelemetry/impl/config.go
+++ b/comp/core/agenttelemetry/impl/config.go
@@ -208,7 +208,7 @@ var defaultProfiles = `
         - name: pymem.inuse
         - name: health_platform.issues_detected
           aggregate_tags:
-            - health_check_id
+            - issue_type
     schedule:
       start_after: 30
       iterations: 0

--- a/comp/healthplatform/bundle_test.go
+++ b/comp/healthplatform/bundle_test.go
@@ -47,7 +47,7 @@ func TestBundleDependencies(t *testing.T) {
 // via the core component must (a) actually fire, (b) reach the in-memory store
 // (proves the reporter is wired before the first tick), and (c) be POSTed to the
 // intake (proves the provider is wired before the forwarder ticks). If a future
-// refactor flips SetReporter / SetProvider with RegisterCheck — or moves built-in
+// refactor flips SetReporter / SetProvider with ScheduleHealthCheck — or moves built-in
 // check registration back into New — the first tick is silently dropped and this
 // test fails.
 func TestBundleStartLifecycle(t *testing.T) {
@@ -112,7 +112,7 @@ func TestBundleStartLifecycle(t *testing.T) {
 		// so the registry's BuildIssue lookup succeeds.
 		testIssueID = "docker-file-tailing-disabled"
 	)
-	require.NoError(t, deps.HP.RegisterCheck(testCheckID, testCheckName, func() (*healthplatformpayload.IssueReport, error) {
+	require.NoError(t, deps.HP.ScheduleHealthCheck(testCheckID, testCheckName, func() (*healthplatformpayload.IssueReport, error) {
 		checkRunCount.Add(1)
 		return &healthplatformpayload.IssueReport{
 			IssueId: testIssueID,
@@ -128,7 +128,7 @@ func TestBundleStartLifecycle(t *testing.T) {
 		"check function never fired — checkrunner did not spawn its goroutine")
 
 	require.Eventually(t, func() bool {
-		return deps.HP.GetIssueForCheck(testCheckID) != nil
+		return deps.HP.GetIssue(testCheckID) != nil
 	}, 2*time.Second, 10*time.Millisecond,
 		"core never recorded the issue — reporter not wired before first check fired")
 

--- a/comp/healthplatform/noop-impl/health_platform_noop.go
+++ b/comp/healthplatform/noop-impl/health_platform_noop.go
@@ -46,7 +46,7 @@ func (n *noopHealthPlatform) ReportIssue(_ string, _ string, _ *healthplatformpa
 	return nil
 }
 
-func (n *noopHealthPlatform) RegisterCheck(_ string, _ string, _ healthplatformdef.HealthCheckFunc, _ time.Duration) error {
+func (n *noopHealthPlatform) ScheduleHealthCheck(_ string, _ string, _ healthplatformdef.HealthCheckFunc, _ time.Duration) error {
 	return nil
 }
 
@@ -54,14 +54,14 @@ func (n *noopHealthPlatform) GetAllIssues() (int, map[string]*healthplatformpayl
 	return 0, make(map[string]*healthplatformpayload.Issue)
 }
 
-func (n *noopHealthPlatform) GetIssueForCheck(_ string) *healthplatformpayload.Issue {
+func (n *noopHealthPlatform) GetIssue(_ string) *healthplatformpayload.Issue {
 	return nil
 }
 
-func (n *noopHealthPlatform) ClearIssuesForCheck(_ string) {
+func (n *noopHealthPlatform) ResolveIssue(_ string) {
 }
 
-func (n *noopHealthPlatform) ClearAllIssues() {
+func (n *noopHealthPlatform) ResolveAllIssues() {
 }
 
 func (n *noopHealthPlatform) getIssuesHandler(w http.ResponseWriter, _ *http.Request) {

--- a/comp/healthplatform/noop-impl/health_platform_noop_test.go
+++ b/comp/healthplatform/noop-impl/health_platform_noop_test.go
@@ -29,12 +29,12 @@ func TestReportIssueWithNilReportReturnsNilError(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestRegisterCheckReturnsNilError(t *testing.T) {
+func TestScheduleHealthCheckReturnsNilError(t *testing.T) {
 	provides := NewComponent()
 	checkFn := func() (*healthplatformpayload.IssueReport, error) {
 		return nil, nil
 	}
-	err := provides.Comp.RegisterCheck("check-1", "mycheck", checkFn, 0)
+	err := provides.Comp.ScheduleHealthCheck("check-1", "mycheck", checkFn, 0)
 	require.NoError(t, err)
 }
 
@@ -46,9 +46,9 @@ func TestGetAllIssuesReturnsZeroCountAndEmptyMap(t *testing.T) {
 	assert.Empty(t, issues)
 }
 
-func TestGetIssueForCheckReturnsNil(t *testing.T) {
+func TestGetIssueReturnsNil(t *testing.T) {
 	provides := NewComponent()
-	issue := provides.Comp.GetIssueForCheck("any-check")
+	issue := provides.Comp.GetIssue("any-check")
 	assert.Nil(t, issue)
 }
 
@@ -84,9 +84,9 @@ func TestFlareProviderCallbackReturnsNil(t *testing.T) {
 func TestClearMethodsDoNotPanic(t *testing.T) {
 	provides := NewComponent()
 	assert.NotPanics(t, func() {
-		provides.Comp.ClearIssuesForCheck("check-1")
+		provides.Comp.ResolveIssue("check-1")
 	})
 	assert.NotPanics(t, func() {
-		provides.Comp.ClearAllIssues()
+		provides.Comp.ResolveAllIssues()
 	})
 }

--- a/comp/healthplatform/scheduler/def/component.go
+++ b/comp/healthplatform/scheduler/def/component.go
@@ -18,24 +18,26 @@ import (
 // HealthCheckFunc is a function that performs a health check.
 type HealthCheckFunc func() (*healthplatformpayload.IssueReport, error)
 
-// IssueReporter receives check results from the check runner.
+// IssueReporter receives health-check results from the scheduler.
 type IssueReporter interface {
 	ReportIssue(checkID string, checkName string, report *healthplatformpayload.IssueReport) error
 }
 
-// Component is the check runner component.
+// Component is the health-platform scheduler component.
 type Component interface {
 	// SetReporter wires the issue reporter after construction, breaking the
-	// circular fx dependency between core and checkrunner.
-	// Must be called before the first check fires (i.e. from the core lifecycle start hook).
+	// circular fx dependency between store and scheduler.
+	// Must be called before the first health check fires (i.e. from the store
+	// lifecycle start hook).
 	SetReporter(reporter IssueReporter)
 
-	// RegisterCheck registers a periodic health check that runs at the given interval.
-	// The check is identified by checkID (must be unique) and checkName (human-readable label).
-	// If interval is zero or negative, a default interval is used.
-	RegisterCheck(checkID string, checkName string, fn HealthCheckFunc, interval time.Duration) error
+	// ScheduleHealthCheck registers a periodic health check that runs at the
+	// given interval. The check is identified by checkID (must be unique) and
+	// checkName (human-readable label). If interval is zero or negative, the
+	// scheduler's default interval is used.
+	ScheduleHealthCheck(checkID string, checkName string, fn HealthCheckFunc, interval time.Duration) error
 
-	// RunCheck executes a health check immediately, outside the periodic schedule.
-	// Results are reported to the registered IssueReporter.
-	RunCheck(checkID string, checkName string, fn HealthCheckFunc) error
+	// RunHealthCheck executes a health check immediately, outside the periodic
+	// schedule. Results are reported to the registered IssueReporter.
+	RunHealthCheck(checkID string, checkName string, fn HealthCheckFunc) error
 }

--- a/comp/healthplatform/scheduler/impl/scheduler.go
+++ b/comp/healthplatform/scheduler/impl/scheduler.go
@@ -97,8 +97,8 @@ func (r *checkRunner) SetReporter(reporter checkrunnerdef.IssueReporter) {
 	r.reporter = reporter
 }
 
-// RegisterCheck registers a new periodic health check
-func (r *checkRunner) RegisterCheck(checkID, checkName string, checkFn checkrunnerdef.HealthCheckFunc, interval time.Duration) error {
+// ScheduleHealthCheck registers a new periodic health check.
+func (r *checkRunner) ScheduleHealthCheck(checkID, checkName string, checkFn checkrunnerdef.HealthCheckFunc, interval time.Duration) error {
 	if checkID == "" {
 		return errors.New("check ID cannot be empty")
 	}
@@ -138,8 +138,8 @@ func (r *checkRunner) RegisterCheck(checkID, checkName string, checkFn checkrunn
 	return nil
 }
 
-// RunCheck runs a single health check immediately
-func (r *checkRunner) RunCheck(checkID, checkName string, checkFn checkrunnerdef.HealthCheckFunc) error {
+// RunHealthCheck runs a single health check immediately.
+func (r *checkRunner) RunHealthCheck(checkID, checkName string, checkFn checkrunnerdef.HealthCheckFunc) error {
 	if checkID == "" {
 		return errors.New("check ID cannot be empty")
 	}

--- a/comp/healthplatform/scheduler/impl/scheduler_test.go
+++ b/comp/healthplatform/scheduler/impl/scheduler_test.go
@@ -47,8 +47,8 @@ func newTestRunner(t *testing.T) (*checkRunner, *mockReporter) {
 	return r, reporter
 }
 
-// TestCheckRunnerRegisterCheck tests registering a health check
-func TestCheckRunnerRegisterCheck(t *testing.T) {
+// TestCheckRunnerScheduleHealthCheck tests registering a health check
+func TestCheckRunnerScheduleHealthCheck(t *testing.T) {
 	runner, _ := newTestRunner(t)
 
 	checkCalled := false
@@ -57,7 +57,7 @@ func TestCheckRunnerRegisterCheck(t *testing.T) {
 		return nil, nil
 	}
 
-	err := runner.RegisterCheck("test-check", "Test Check", checkFn, 1*time.Minute)
+	err := runner.ScheduleHealthCheck("test-check", "Test Check", checkFn, 1*time.Minute)
 	require.NoError(t, err)
 
 	// Verify check is registered
@@ -70,26 +70,26 @@ func TestCheckRunnerRegisterCheck(t *testing.T) {
 	assert.False(t, checkCalled)
 }
 
-// TestCheckRunnerRegisterCheckValidation tests validation of RegisterCheck
-func TestCheckRunnerRegisterCheckValidation(t *testing.T) {
+// TestCheckRunnerScheduleHealthCheckValidation tests validation of ScheduleHealthCheck
+func TestCheckRunnerScheduleHealthCheckValidation(t *testing.T) {
 	runner, _ := newTestRunner(t)
 
 	// Empty check ID
-	err := runner.RegisterCheck("", "Test Check", func() (*healthplatformpayload.IssueReport, error) { return nil, nil }, 0)
+	err := runner.ScheduleHealthCheck("", "Test Check", func() (*healthplatformpayload.IssueReport, error) { return nil, nil }, 0)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "check ID cannot be empty")
 
 	// Nil check function
-	err = runner.RegisterCheck("test-check", "Test Check", nil, 0)
+	err = runner.ScheduleHealthCheck("test-check", "Test Check", nil, 0)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "check function cannot be nil")
 
 	// Duplicate registration
 	checkFn := func() (*healthplatformpayload.IssueReport, error) { return nil, nil }
-	err = runner.RegisterCheck("test-check", "Test Check", checkFn, 0)
+	err = runner.ScheduleHealthCheck("test-check", "Test Check", checkFn, 0)
 	require.NoError(t, err)
 
-	err = runner.RegisterCheck("test-check", "Test Check 2", checkFn, 0)
+	err = runner.ScheduleHealthCheck("test-check", "Test Check 2", checkFn, 0)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "already registered")
 }
@@ -101,7 +101,7 @@ func TestCheckRunnerDefaultInterval(t *testing.T) {
 	checkFn := func() (*healthplatformpayload.IssueReport, error) { return nil, nil }
 
 	// Zero interval should use default
-	err := runner.RegisterCheck("test-check", "Test Check", checkFn, 0)
+	err := runner.ScheduleHealthCheck("test-check", "Test Check", checkFn, 0)
 	require.NoError(t, err)
 
 	runner.checkMux.RLock()
@@ -122,7 +122,7 @@ func TestCheckRunnerRunsChecks(t *testing.T) {
 	}
 
 	// Register with very short interval for testing
-	err := runner.RegisterCheck("test-check", "Test Check", checkFn, 50*time.Millisecond)
+	err := runner.ScheduleHealthCheck("test-check", "Test Check", checkFn, 50*time.Millisecond)
 	require.NoError(t, err)
 
 	// Start the runner
@@ -143,7 +143,7 @@ func TestCheckRunnerStartStop(t *testing.T) {
 		return nil, nil
 	}
 
-	err := runner.RegisterCheck("test-check", "Test Check", checkFn, 10*time.Millisecond)
+	err := runner.ScheduleHealthCheck("test-check", "Test Check", checkFn, 10*time.Millisecond)
 	require.NoError(t, err)
 
 	// Start and stop should complete gracefully

--- a/comp/healthplatform/scheduler/mock/mock.go
+++ b/comp/healthplatform/scheduler/mock/mock.go
@@ -18,10 +18,10 @@ import (
 type mockCheckRunner struct{}
 
 func (m *mockCheckRunner) SetReporter(_ checkrunner.IssueReporter) {}
-func (m *mockCheckRunner) RegisterCheck(_ string, _ string, _ checkrunner.HealthCheckFunc, _ time.Duration) error {
+func (m *mockCheckRunner) ScheduleHealthCheck(_ string, _ string, _ checkrunner.HealthCheckFunc, _ time.Duration) error {
 	return nil
 }
-func (m *mockCheckRunner) RunCheck(_ string, _ string, _ checkrunner.HealthCheckFunc) error {
+func (m *mockCheckRunner) RunHealthCheck(_ string, _ string, _ checkrunner.HealthCheckFunc) error {
 	return nil
 }
 

--- a/comp/healthplatform/store/def/component.go
+++ b/comp/healthplatform/store/def/component.go
@@ -22,37 +22,39 @@ import (
 // having to import checkrunner/def directly.
 type HealthCheckFunc = checkrunnerdef.HealthCheckFunc
 
-// Component is the health platform component interface
+// Component is the health platform store component interface.
 type Component interface {
-	// ReportIssue reports an issue with context, and the health platform fills in remediation
-	// This is the main way for integrations to report issues
-	// If report is nil, it clears any existing issue (issue resolution)
+	// ReportIssue reports an issue with context; the health platform fills in
+	// remediation from the issue template registry. It is the main way for
+	// integrations to report issues. If report is nil, any existing issue for
+	// the given checkID is resolved.
 	ReportIssue(checkID string, checkName string, report *healthplatformpayload.IssueReport) error
 
-	// RegisterCheck registers a function to be called periodically to check for issues
-	// Use this when you need the health platform to run your check at regular intervals
-	// If interval is 0 or negative, defaults to 15 minutes
-	RegisterCheck(checkID string, checkName string, checkFn HealthCheckFunc, interval time.Duration) error
+	// ScheduleHealthCheck schedules a function to be called periodically to
+	// check for issues. If interval is 0 or negative, the runner's default
+	// interval is used.
+	ScheduleHealthCheck(checkID string, checkName string, checkFn HealthCheckFunc, interval time.Duration) error
 
 	// =========================================================================
 	// Query Methods
 	// =========================================================================
 
-	// GetAllIssues returns the count and all issues from all checks (indexed by check ID)
-	// Returns the total number of issues and a map of issues (nil for checks with no issues)
+	// GetAllIssues returns the count and all active issues, indexed by checkID.
+	// The returned map contains deep copies; modifying it does not affect the store.
 	GetAllIssues() (int, map[string]*healthplatformpayload.Issue)
 
-	// GetIssueForCheck returns the issue for a specific check
-	// Returns nil if no issue
-	GetIssueForCheck(checkID string) *healthplatformpayload.Issue
+	// GetIssue returns the issue reported for the given checkID, or nil if
+	// no such issue is currently active.
+	GetIssue(checkID string) *healthplatformpayload.Issue
 
 	// =========================================================================
-	// Clear Methods
+	// Resolve Methods
 	// =========================================================================
 
-	// ClearIssuesForCheck clears issues for a specific check (useful when issues are resolved)
-	ClearIssuesForCheck(checkID string)
+	// ResolveIssue marks the issue for the given checkID as resolved.
+	// No-op if no issue is currently active for that checkID.
+	ResolveIssue(checkID string)
 
-	// ClearAllIssues clears all issues (useful for testing or when all issues are resolved)
-	ClearAllIssues()
+	// ResolveAllIssues marks every active issue as resolved.
+	ResolveAllIssues()
 }

--- a/comp/healthplatform/store/impl/store.go
+++ b/comp/healthplatform/store/impl/store.go
@@ -137,7 +137,9 @@ func pruneOldResolvedIssues(issues map[string]*PersistedIssue) {
 }
 
 // PersistedIssue tracks issue state for disk persistence.
-// Custom JSON marshaling keeps the on-disk format unchanged (state as string).
+// IssueID is the issue id as defined by Module.IssueID(), used to look up the
+// template in the registry on reload. Custom JSON marshaling keeps the on-disk
+// state field as a string.
 type PersistedIssue struct {
 	IssueID    string     `json:"issue_id"`
 	State      IssueState `json:"state"`
@@ -275,7 +277,7 @@ func NewComponent(reqs Requires) (Provides, error) {
 		issuesCounter: reqs.Telemetry.NewCounter(
 			"health_platform",
 			"issues_detected",
-			[]string{"health_check_id"},
+			[]string{"issue_type"},
 			"Number of health issues detected",
 		),
 	}
@@ -319,7 +321,7 @@ func (h *healthPlatformImpl) start(_ context.Context) error {
 		if check.Once {
 			continue
 		}
-		if err := h.RegisterCheck(check.ID, check.Name, check.CheckFn, check.Interval); err != nil {
+		if err := h.ScheduleHealthCheck(check.ID, check.Name, check.CheckFn, check.Interval); err != nil {
 			h.log.Warn("Failed to register health check " + check.ID + ": " + err.Error())
 		}
 	}
@@ -381,22 +383,22 @@ func (h *healthPlatformImpl) ReportIssue(checkID string, checkName string, repor
 	if newIssue != nil {
 		h.storeIssue(checkID, newIssue)
 	} else {
-		h.ClearIssuesForCheck(checkID)
+		h.ResolveIssue(checkID)
 	}
 
 	return nil
 }
 
-// RegisterCheck registers a periodic health check function
+// ScheduleHealthCheck registers a periodic health check function
 // The check function will be called at the specified interval
 // If interval is 0 or negative, uses default of 15 minutes
-func (h *healthPlatformImpl) RegisterCheck(checkID string, checkName string, checkFn healthplatformdef.HealthCheckFunc, interval time.Duration) error {
-	return h.checkRunner.RegisterCheck(checkID, checkName, checkrunnerdef.HealthCheckFunc(checkFn), interval)
+func (h *healthPlatformImpl) ScheduleHealthCheck(checkID string, checkName string, checkFn healthplatformdef.HealthCheckFunc, interval time.Duration) error {
+	return h.checkRunner.ScheduleHealthCheck(checkID, checkName, checkrunnerdef.HealthCheckFunc(checkFn), interval)
 }
 
-// RunCheck runs a single health check immediately
-func (h *healthPlatformImpl) RunCheck(checkID, checkName string, checkFn healthplatformdef.HealthCheckFunc) error {
-	return h.checkRunner.RunCheck(checkID, checkName, checkrunnerdef.HealthCheckFunc(checkFn))
+// RunHealthCheck runs a single health check immediately
+func (h *healthPlatformImpl) RunHealthCheck(checkID, checkName string, checkFn healthplatformdef.HealthCheckFunc) error {
+	return h.checkRunner.RunHealthCheck(checkID, checkName, checkrunnerdef.HealthCheckFunc(checkFn))
 }
 
 // ============================================================================
@@ -422,8 +424,8 @@ func (h *healthPlatformImpl) GetAllIssues() (int, map[string]*healthplatform.Iss
 	return count, result
 }
 
-// GetIssueForCheck returns the issue for a specific check (nil if no issue)
-func (h *healthPlatformImpl) GetIssueForCheck(checkID string) *healthplatform.Issue {
+// GetIssue returns the issue for a specific check (nil if no issue)
+func (h *healthPlatformImpl) GetIssue(checkID string) *healthplatform.Issue {
 	h.issuesMux.RLock()
 	defer h.issuesMux.RUnlock()
 
@@ -440,8 +442,8 @@ func (h *healthPlatformImpl) GetIssueForCheck(checkID string) *healthplatform.Is
 // Clear Methods
 // ============================================================================
 
-// ClearIssuesForCheck clears the issue for a specific check (useful when issue is resolved)
-func (h *healthPlatformImpl) ClearIssuesForCheck(checkID string) {
+// ResolveIssue clears the issue for a specific check (useful when issue is resolved)
+func (h *healthPlatformImpl) ResolveIssue(checkID string) {
 	h.issuesMux.Lock()
 
 	// Only log and update persistence if there was actually an issue to clear
@@ -468,8 +470,8 @@ func (h *healthPlatformImpl) ClearIssuesForCheck(checkID string) {
 	}
 }
 
-// ClearAllIssues clears all issues (useful for testing or when all issues are resolved)
-func (h *healthPlatformImpl) ClearAllIssues() {
+// ResolveAllIssues clears all issues (useful for testing or when all issues are resolved)
+func (h *healthPlatformImpl) ResolveAllIssues() {
 	h.issuesMux.Lock()
 
 	now := time.Now().Format(time.RFC3339)
@@ -536,13 +538,15 @@ func (h *healthPlatformImpl) storeIssue(checkID string, issue *healthplatform.Is
 	// Add timestamp to issue if present
 	if issue != nil {
 		issue.DetectedAt = now
-		// Update telemetry
-		h.metrics.issuesCounter.Add(1, checkID)
+		// Update telemetry, tagged by issue template id (matches the
+		// `issue_type` label declared on the counter).
+		h.metrics.issuesCounter.Add(1, issue.Id)
 	}
 
 	h.issues[checkID] = issue
 
-	// Update persisted issue with state tracking
+	// Update persisted issue with state tracking.
+	// IssueID is the issue id as registered in the registry (Module.IssueID()).
 	existing := h.persistedIssues[checkID]
 	if existing == nil {
 		// No previous record - new issue
@@ -560,9 +564,9 @@ func (h *healthPlatformImpl) storeIssue(checkID string, issue *healthplatform.Is
 		existing.LastSeen = now
 		existing.ResolvedAt = ""
 	} else if existing.IssueID != issue.Id {
-		// The check is reporting a different issue ID than what was previously stored.
-		// This is an internal agent bug: a given check should always report the same issue type.
-		_ = h.log.Errorf("health platform: check %s changed issue ID from %q to %q; this is an agent bug",
+		// The check is reporting a different issue id than what was previously stored.
+		// This is an internal agent bug: a given check should always report the same issue id.
+		_ = h.log.Errorf("health platform: check %s changed issue id from %q to %q; this is an agent bug",
 			checkID, existing.IssueID, issue.Id)
 		existing.IssueID = issue.Id
 		existing.State = IssueStateNew
@@ -727,7 +731,7 @@ func (h *healthPlatformImpl) startupChecks() {
 			continue
 		}
 
-		err := h.RunCheck(check.ID, check.Name, check.CheckFn)
+		err := h.RunHealthCheck(check.ID, check.Name, check.CheckFn)
 		if err != nil {
 			h.log.Warnf("Failed to run startup check %s: %v", check.Name, err)
 		}

--- a/comp/healthplatform/store/impl/store_test.go
+++ b/comp/healthplatform/store/impl/store_test.go
@@ -172,13 +172,13 @@ func TestReportIssue(t *testing.T) {
 	assert.NotNil(t, allIssues)
 	assert.Contains(t, allIssues, "logs-docker-file-permissions")
 
-	// Test GetIssueForCheck
-	issueForCheck := comp.GetIssueForCheck("logs-docker-file-permissions")
+	// Test GetIssue
+	issueForCheck := comp.GetIssue("logs-docker-file-permissions")
 	assert.NotNil(t, issueForCheck)
 	assert.Equal(t, "docker-file-tailing-disabled", issueForCheck.Id)
 
-	// Test GetIssueForCheck with non-existent check
-	nonExistentIssue := comp.GetIssueForCheck("non-existent")
+	// Test GetIssue with non-existent check
+	nonExistentIssue := comp.GetIssue("non-existent")
 	assert.Nil(t, nonExistentIssue)
 
 	// Stop the component
@@ -225,7 +225,7 @@ func TestIssueResolution(t *testing.T) {
 	newCount, _ := comp.GetAllIssues()
 	assert.Equal(t, 0, newCount)
 
-	clearedIssue := comp.GetIssueForCheck("test-check-1")
+	clearedIssue := comp.GetIssue("test-check-1")
 	assert.Nil(t, clearedIssue)
 
 	// Stop the component
@@ -273,13 +273,13 @@ func TestClearMethods(t *testing.T) {
 	count, _ := comp.GetAllIssues()
 	assert.Equal(t, 2, count)
 
-	// Test ClearIssuesForCheck
-	comp.ClearIssuesForCheck("check-1")
+	// Test ResolveIssue
+	comp.ResolveIssue("check-1")
 	count, _ = comp.GetAllIssues()
 	assert.Equal(t, 1, count)
 
-	// Test ClearAllIssues
-	comp.ClearAllIssues()
+	// Test ResolveAllIssues
+	comp.ResolveAllIssues()
 	countAfterClear, allIssuesAfterClear := comp.GetAllIssues()
 	assert.Equal(t, 0, countAfterClear)
 	assert.Len(t, allIssuesAfterClear, 0)
@@ -419,7 +419,7 @@ func TestIssueTimestamp(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify the issue got a timestamp
-	issue := comp.GetIssueForCheck("timestamp-check-1")
+	issue := comp.GetIssue("timestamp-check-1")
 	require.NotNil(t, issue)
 	assert.NotEmpty(t, issue.DetectedAt)
 
@@ -469,13 +469,13 @@ func TestComponentDisabled(t *testing.T) {
 	assert.Equal(t, 0, count)
 	assert.Empty(t, issues)
 
-	// Verify GetIssueForCheck returns nil
-	issue := provides.Comp.GetIssueForCheck("test-check")
+	// Verify GetIssue returns nil
+	issue := provides.Comp.GetIssue("test-check")
 	assert.Nil(t, issue)
 
 	// Verify clear methods work without error
-	provides.Comp.ClearIssuesForCheck("test-check")
-	provides.Comp.ClearAllIssues()
+	provides.Comp.ResolveIssue("test-check")
+	provides.Comp.ResolveAllIssues()
 }
 
 // TestGetIssuesHandlerEmpty tests the HTTP handler returns empty list when no issues

--- a/comp/healthplatform/store/mock/mock.go
+++ b/comp/healthplatform/store/mock/mock.go
@@ -59,8 +59,8 @@ func (m *mockHealthPlatform) ReportIssue(checkID string, checkName string, repor
 	return nil
 }
 
-// RegisterCheck does nothing in the mock implementation
-func (m *mockHealthPlatform) RegisterCheck(_ string, _ string, _ healthplatform.HealthCheckFunc, _ time.Duration) error {
+// ScheduleHealthCheck does nothing in the mock implementation
+func (m *mockHealthPlatform) ScheduleHealthCheck(_ string, _ string, _ healthplatform.HealthCheckFunc, _ time.Duration) error {
 	return nil
 }
 
@@ -79,8 +79,8 @@ func (m *mockHealthPlatform) GetAllIssues() (int, map[string]*healthplatformpayl
 	return count, result
 }
 
-// GetIssueForCheck returns the issue for a specific check
-func (m *mockHealthPlatform) GetIssueForCheck(checkID string) *healthplatformpayload.Issue {
+// GetIssue returns the issue for a specific check
+func (m *mockHealthPlatform) GetIssue(checkID string) *healthplatformpayload.Issue {
 	issue := m.issues[checkID]
 	if issue == nil {
 		return nil
@@ -88,12 +88,12 @@ func (m *mockHealthPlatform) GetIssueForCheck(checkID string) *healthplatformpay
 	return proto.Clone(issue).(*healthplatformpayload.Issue)
 }
 
-// ClearIssuesForCheck clears issues for a specific check
-func (m *mockHealthPlatform) ClearIssuesForCheck(checkID string) {
+// ResolveIssue clears issues for a specific check
+func (m *mockHealthPlatform) ResolveIssue(checkID string) {
 	delete(m.issues, checkID)
 }
 
-// ClearAllIssues clears all issues
-func (m *mockHealthPlatform) ClearAllIssues() {
+// ResolveAllIssues clears all issues
+func (m *mockHealthPlatform) ResolveAllIssues() {
 	m.issues = make(map[string]*healthplatformpayload.Issue)
 }

--- a/comp/healthplatform/store/noop-impl/noop.go
+++ b/comp/healthplatform/store/noop-impl/noop.go
@@ -41,8 +41,8 @@ func (n *NoopHealthPlatform) ReportIssue(_ string, _ string, _ *healthplatformpa
 	return nil
 }
 
-// RegisterCheck does nothing when the health platform is disabled.
-func (n *NoopHealthPlatform) RegisterCheck(_ string, _ string, _ healthplatform.HealthCheckFunc, _ time.Duration) error {
+// ScheduleHealthCheck does nothing when the health platform is disabled.
+func (n *NoopHealthPlatform) ScheduleHealthCheck(_ string, _ string, _ healthplatform.HealthCheckFunc, _ time.Duration) error {
 	return nil
 }
 
@@ -51,17 +51,17 @@ func (n *NoopHealthPlatform) GetAllIssues() (int, map[string]*healthplatformpayl
 	return 0, make(map[string]*healthplatformpayload.Issue)
 }
 
-// GetIssueForCheck returns nil when the health platform is disabled.
-func (n *NoopHealthPlatform) GetIssueForCheck(_ string) *healthplatformpayload.Issue {
+// GetIssue returns nil when the health platform is disabled.
+func (n *NoopHealthPlatform) GetIssue(_ string) *healthplatformpayload.Issue {
 	return nil
 }
 
-// ClearIssuesForCheck does nothing when the health platform is disabled.
-func (n *NoopHealthPlatform) ClearIssuesForCheck(_ string) {
+// ResolveIssue does nothing when the health platform is disabled.
+func (n *NoopHealthPlatform) ResolveIssue(_ string) {
 }
 
-// ClearAllIssues does nothing when the health platform is disabled.
-func (n *NoopHealthPlatform) ClearAllIssues() {
+// ResolveAllIssues does nothing when the health platform is disabled.
+func (n *NoopHealthPlatform) ResolveAllIssues() {
 }
 
 // GetIssuesHandler handles GET /health-platform/issues when disabled.

--- a/releasenotes/notes/health-platform-rename-issue-id-tag-fb0b7f34a03aa6ab.yaml
+++ b/releasenotes/notes/health-platform-rename-issue-id-tag-fb0b7f34a03aa6ab.yaml
@@ -1,0 +1,7 @@
+---
+upgrade:
+  - |
+    Health Platform: the ``health_platform.issues_detected`` telemetry counter
+    is now tagged with ``issue_type`` instead of ``health_check_id``. Update any
+    dashboards, monitors, or telemetry configuration that filtered or grouped
+    by the ``health_check_id`` tag to use ``issue_type`` instead.


### PR DESCRIPTION
### What does this PR do?

Renames the public Component methods on the healthplatform `store` and `scheduler` to remove "check" vocabulary that conflicts with integration-check terminology used elsewhere in the agent. Also renames the `health_platform.issues_detected` counter's tag from `health_check_id` to `issue_type`.

| Before | After |
| --- | --- |
| `store.Component.RegisterCheck` | `store.Component.ScheduleHealthCheck` |
| `store.Component.RunCheck` | `store.Component.RunHealthCheck` |
| `store.Component.GetIssueForCheck` | `store.Component.GetIssue` |
| `store.Component.ClearIssuesForCheck` | `store.Component.ResolveIssue` |
| `store.Component.ClearAllIssues` | `store.Component.ResolveAllIssues` |
| `scheduler.Component.RegisterCheck` | `scheduler.Component.ScheduleHealthCheck` |
| `scheduler.Component.RunCheck` | `scheduler.Component.RunHealthCheck` |
| Counter tag `health_check_id` | Counter tag `issue_type` |

The counter's value is now the issue template id (from the registry) rather than the `checkID`, which matches the new tag name. The agent-telemetry profile in `comp/core/agenttelemetry/impl/config.go` is updated to whitelist the new tag so the counter remains exported.

`ReportIssue`'s signature is intentionally unchanged in this PR — it still takes `(checkID, checkName, *IssueReport)`. The model shift (one source reporting many concurrent issues, `ReportIssue` taking only an `*IssueReport`) lands in the [next PR](https://github.com/DataDog/datadog-agent/pull/50417).

### Motivation

In datadog-agent, the word "check" overwhelmingly means **integration check** (mysql, kubernetes, …) — a periodic data collector. Until now the healthplatform's public API used the same vocabulary for self-diagnostic checks (`RegisterCheck`, `RunCheck`, `GetIssueForCheck`, `ClearIssuesForCheck`, …). Reading any of this code, you couldn't tell whether "check" meant a mysql integration check or a docker-permissions self-diagnostic. As integration-checks will soon report health issues, this naming become confusing. The new names clarify the distinction:

- `Schedule`/`RunHealthCheck` make it explicit that the operand is a *health* check, not an integration check.
- `GetIssue` / `ResolveIssue` / `ResolveAllIssues` describe the operation (issue lifecycle management) rather than the dispatcher concept.

This rename PR is intentionally limited to method names + telemetry tag so that the model-level changes that follow stay reviewable on their own.

### Describe how you validated your changes

- `codex review --base pducolin/healthplatform-refactor` — clean after two rounds (agenttelemetry profile + counter call site).
- Agent Health e2e tests run successfully 

### Additional Notes

Second PR in the healthplatform refactor stack (see details at the bottom of this PR's description):

1. ✅ Mechanical rename `core/→store/`, `checkrunner/→scheduler/` (#50407, base of this PR)
2. **(this PR)** Drop "check" terminology from the public API
3. Model shift: `ReportIssue(*IssueReport)`, unique-instance-id storage, persistence v2 (#50417)
4. Component split: new `runner/` and `egress/`, scheduler shrinks to `Schedule` only
5. Per-component tests targeting ≥85% coverage

<details>
<summary>Full refactor plan</summary>
# Healthplatform refactor: split store/runner/scheduler/egress + key issues by unique instance id

## Context

The healthplatform (`comp/healthplatform/`, brand-new in 2026) is the agent's
self-health reporting subsystem. Two design problems have emerged.

### Problem 1 — "check" terminology collides with integration checks

Across datadog-agent, "check" means **integration check** (mysql, kubernetes,
docker, …) — a periodic data collector. The healthplatform borrows the same
word for its periodic self-diagnostics (`checkrunner`, `RegisterCheck`,
`HealthCheckFunc`, `checkID`, `checkName`, `health_check_id` telemetry label,
…). Reading any of this code, you can't tell whether "check" means a mysql
integration or a docker-permissions self-diagnostic. This is misleading.

### Problem 2 — `checkID`-keyed storage forces one issue per reporter

Today the issue map is keyed by `checkID` (the reporter id), so each reporter
can hold exactly **one** active issue. `ReportIssue` even logs a "this is an
agent bug" error if a reporter changes the issue type
(`health-platform.go:562-571`). That's wrong: one source can legitimately have
many active issues — a `mysql` integration may simultaneously hit
`db-not-reachable` against `mysql-prod-1` *and* `auth-failed` against
`mysql-prod-2`.

The fix is a model shift:

| Concept              | Today                          | New                                           |
| -------------------- | ------------------------------ | --------------------------------------------- |
| Map key              | `checkID` (reporter)           | `issueId` (unique instance)                   |
| Type/template lookup | `IssueReport.IssueId`          | `IssueReport.IssueType`                       |
| Source/reporter      | `checkName` (separate arg)     | `IssueReport.Source` (field on the report)    |
| Reports per source   | 1                              | Many                                          |

`ReportIssue` then takes only an `IssueReport` (everything moves into it).

## Decisions

Confirmed with the user, in order:

- **Naming away from "check":** `Health` prefix is mandatory. Bare `Check`
  collides with integration checks; bare `Probe` collides with k8s liveness/
  readiness probes; so we keep the existing `HealthCheck` term but rename
  the *runner package*. Final vocabulary: a `HealthCheckFunc` is a function
  that probes for issues and returns reports.

- **Component split — single responsibility per component:**
  - `store` (renamed from `core/`) — pure state owner. Receives `ReportIssue` /
    `ResolveIssue`, owns the in-memory issue map + persistence + lifecycle
    state machine, exposes queries, hosts the local HTTP
    `GET /health-platform/issues` endpoint, and the flare provider. Has **no**
    dependency on the forwarder. Also owns the **internal-`IssueReport` →
    proto `Issue` translation** inside `ReportIssue`: looks up the template
    via `issues/registry.BuildIssue(report.IssueType, report.Context)`, then
    sets `Issue.Id = report.IssueId`, `Issue.Source = report.Source`, and
    appends `report.Tags`.
  - `runner` (new) — stateless. Runs a single `HealthCheckFunc` once, forwards
    each emitted `IssueReport` to the store, returns the set of issue ids it
    reported (so the scheduler can diff).
  - `scheduler` (renamed from `checkrunner/`) — schedules periodic execution.
    On each tick, calls `runner.Run(...)`, takes the returned issue ids, and
    uses its per-registration state to resolve any issue ids that disappeared.
    Public API: `Schedule(source, fn, interval)` only — no run-once method.
  - `egress` (new) — periodic backend egress driver. Holds a configurable
    ticker (default 5 min). Each tick: calls `store.GetAllIssues()`, builds
    a `HealthReport`, calls `forwarder.Send(...)`. No public API beyond fx
    wiring + lifecycle.
  - `forwarder` — stateless HTTP client. Public API: `Send(ctx, report
    *HealthReport) error`. Builds the request, POSTs to Datadog intake. This
    matches the agent's dominant forwarder convention —
    `comp/forwarder/defaultforwarder` (`Submit*`),
    `comp/forwarder/eventplatform` (`SendEventPlatformEvent`),
    `comp/forwarder/connectionsforwarder` (`SubmitConnectionChecks`),
    `comp/ndmtmp/forwarder` (embeds eventplatform) — all expose Submit/Send
    methods, with producers depending on the forwarder. The outlier is
    `comp/snmptraps/forwarder` which pulls via a listener channel.
  - `issues/registry` (promoted from package-level helper to a tiny fx
    component) — in-memory registry of templates + built-in health checks;
    self-registered by the existing `issues/{admisconfig,checkfailure,
    dockerpermissions,rofspermissions}` modules.

  Note: the store hosts the *local* read-only HTTP endpoint
  (`GET /health-platform/issues`, served by the agent's API server for
  local diagnostics and flare). The egress component drives the periodic
  *outbound* HTTP POST to the Datadog intake via the forwarder. Local read
  vs. backend write — distinct components.

- **Persistence:** no migration. The on-disk shape changes; old files are
  detected via a `version` field, logged, and ignored.

- **Scope:** full sweep — public API, internal field/var names, telemetry
  label, log messages, comments.

- **`IssueReport` shape:** define a new Go struct in
  `comp/healthplatform/store/def/issue_report.go` and **remove the
  `IssueReport` message from agent-payload entirely**. Verification (run
  during planning):
  - `dd-source/domains/evp-workers/apps/agthealth-worker/schemas/
    healthplatform.proto` mirrors the schema but `worker.ts` only imports
    `IHealthReport`, never `IIssueReport`.
  - Other `IssueReport` matches in dd-source (`cloud_platform/...`) refer to
    a different proto (`IntegrationIssueReport` in Integration Health Service
    `ihpb`) — unrelated.
  - `dd-go` has no `healthplatform` references at all.
  - `PersistedIssue` is checked separately (see next bullet).

  Cross-repo work:
  1. PR to `DataDog/agent-payload` removing the `IssueReport` message.
     Bump version.
  2. Mirror the removal in `dd-source/.../agthealth-worker/schemas/
     healthplatform.proto`.
  3. Bump agent-payload in datadog-agent's `go.mod` and switch all
     `healthplatformpayload.IssueReport` references to the new Go struct.

- **`PersistedIssue` stays in agent-payload.** It's referenced as a sub-
  message field (`persisted_issue = 13`) on `Issue`, and `Issue` IS on the
  wire (consumed by agthealth-worker via `HealthReport`). Removing it would
  require either inlining its fields into `Issue` (wire-incompatible) or
  dropping lifecycle from the wire entirely. Both are out of scope for this
  refactor.

## Architecture and dependency graph

No cycles:

```
issues/registry  ◀── store         (template lookup on ReportIssue)
store            ◀── runner        (runner forwards each emitted IssueReport)
runner           ◀── scheduler     (each tick: scheduler calls runner.Run)
store            ◀── scheduler     (resolve disappeared issue ids after diff)
store            ◀── egress        (GetAllIssues on tick)
forwarder        ◀── egress        (Send on tick)

store owns:
  - in-memory issue map + persistence
  - local HTTP GET /health-platform/issues endpoint
  - flare provider

egress owns:
  - periodic ticker that pulls store.GetAllIssues() and calls forwarder.Send

forwarder owns:
  - HTTP POST to Datadog intake (stateless; takes a HealthReport per call)

bundle.go (fx.Invoke):
  inputs: registry, runner, scheduler
  action at startup:
    - for each BuiltInHealthCheck c in registry.GetBuiltInHealthChecks():
        if c.Once { runner.Run(c.Source, c.Fn) }
        else      { scheduler.Schedule(c.Source, c.Fn, c.Interval) }
```

This eliminates today's `SetReporter` and `SetProvider` callback patterns
(both were circular-dep workarounds). Every wire is now a plain fx dep.

## New `IssueReport` Go type

Defined in `comp/healthplatform/store/def/issue_report.go`:

```go
type IssueReport struct {
    // IssueId is the unique INSTANCE id. Two calls with the same IssueId
    // update the same instance (state machine new -> ongoing). Different
    // instances of the same type get different IssueIds.
    // Examples:
    //   - "ad-template:mysql:abc123:def456"
    //   - "check-execution-failure:mysql:0123abcd"
    //   - "db-not-reachable:mysql-prod-1"
    IssueId string

    // IssueType is the template id. The issue registry uses this to fill in
    // title, severity, remediation, etc. Examples:
    //   - "ad-misconfiguration"
    //   - "check-execution-failure"
    //   - "db-not-reachable"
    IssueType string

    // Source is the reporting integration/component name (e.g. "mysql",
    // "autodiscovery", "docker"). Replaces today's separate `checkName`
    // argument to ReportIssue.
    Source string

    // Context provides template variables (e.g. {"dockerDir": "/var/lib/docker"}).
    Context map[string]string

    // Tags are appended to the template's default tags.
    Tags []string
}
```

Coupled removal: drop the `IssueReport` message from
`agent-payload/v5/healthplatform/healthplatform.proto` and from
`dd-source/.../agthealth-worker/schemas/healthplatform.proto` (the schema
mirror). `PersistedIssue` stays — it's structurally part of the wire `Issue`
type that agthealth-worker consumes via `HealthReport`.

## Naming map

| Today                                                  | After                                                              |
| ------------------------------------------------------ | ------------------------------------------------------------------ |
| `comp/healthplatform/core/`                            | `comp/healthplatform/store/`                                    |
| `comp/healthplatform/checkrunner/`                     | `comp/healthplatform/scheduler/`                                   |
| —                                                      | `comp/healthplatform/runner/` (new)                                |
| —                                                      | `comp/healthplatform/egress/` (new)                                |
| `coredef.Component` (everything)                       | `storedef.Component` (report+query only)                        |
| `checkrunnerdef.Component`                             | `schedulerdef.Component` (schedule only)                           |
| `checkrunnerdef.IssueReporter` + `SetReporter`         | dropped — runner has plain fx dep on store                         |
| `forwarderdef.IssueProvider` + `SetProvider`           | dropped — store calls forwarder.Send, forwarder is stateless       |
| `HealthCheckFunc` (returns one proto report)           | `HealthCheckFunc func() ([]*storedef.IssueReport, error)`       |
| `core.Component.RegisterCheck(checkID, checkName, …)`  | `scheduler.Component.Schedule(source, fn, interval)`               |
| `core.Component.RunCheck(checkID, checkName, fn)`      | `runner.Component.Run(source, fn)` (different component)           |
| `core.Component.ReportIssue(checkID, checkName, rep)`  | `store.Component.ReportIssue(report *IssueReport)`              |
| `core.Component.GetIssueForCheck(checkID)`             | `store.Component.GetIssue(issueId)`                             |
| `core.Component.ClearIssuesForCheck(checkID)`          | `store.Component.ResolveIssue(issueId)`                         |
| `core.Component.ClearAllIssues()`                      | `store.Component.ResolveAllIssues()`                            |
| Telemetry label `health_check_id`                      | `issue_id`                                                         |
| `BuiltInCheck` (in `issues/registry.go`)               | `BuiltInHealthCheck`                                               |
| `ADMisconfigurationCheckName` constant                 | `ADMisconfigurationSource`                                         |
| Local vars `checkID`/`checkName`                       | `issueId`/`source`                                                 |

## New component interfaces

```go
// comp/healthplatform/store/def/component.go
type Component interface {
    ReportIssue(report *IssueReport) error
    ResolveIssue(issueId string)
    ResolveAllIssues()
    GetIssue(issueId string) *healthplatformpayload.Issue
    GetAllIssues() (int, map[string]*healthplatformpayload.Issue)
}
```

```go
// comp/healthplatform/runner/def/component.go
type HealthCheckFunc func() ([]*storedef.IssueReport, error)

type Component interface {
    // Run executes fn once. Each emitted IssueReport is forwarded to the
    // store via ReportIssue. Returns the set of IssueIds that were
    // reported, so callers (the scheduler) can diff across runs.
    Run(source string, fn HealthCheckFunc) ([]string, error)
}
```

```go
// comp/healthplatform/scheduler/def/component.go
type Component interface {
    // Schedule registers fn to run every interval. The scheduler maintains
    // per-registration state to auto-resolve issue ids that disappear from a
    // subsequent run. There is intentionally no Run-once method here — call
    // runner.Run directly for that.
    Schedule(source string, fn runnerdef.HealthCheckFunc, interval time.Duration) error
}
```

```go
// comp/healthplatform/forwarder/def/component.go
type Component interface {
    // Send POSTs the given report to Datadog intake. Stateless. Called by
    // the store on its periodic tick.
    Send(ctx context.Context, report *healthplatformpayload.HealthReport) error
}
```

## File-by-file changes

### `comp/healthplatform/core/` → rename to `comp/healthplatform/store/`

- `def/issue_report.go` (new): the `IssueReport` Go struct (see "New IssueReport Go type" above).
- `def/component.go`:
  - Drop `HealthCheckFunc` alias and the `RegisterCheck`/`RunCheck` methods —
    those move to `scheduler` and `runner`.
  - Stop importing `healthplatformpayload.IssueReport`. Use the new local
    `IssueReport` struct.
  - Final shape as in "New component interfaces" above.
- `def/constants.go`:
  - `ADMisconfigurationIssueID` — keep, document as the **issue type**.
  - `ADMisconfigurationCheckName` → `ADMisconfigurationSource` (value: `"autodiscovery"`).
- `impl/health-platform.go` → `impl/store.go`:
  - Drop `CheckRunner` from `Requires`. Do **not** add a forwarder dep — egress is its own component.
  - Keep the `Provides.APIGetIssues` field, the `getIssuesHandler`, and the
    `writeJSONResponse` helper — the local HTTP endpoint stays here.
  - `issues map[string]*Issue` and `persistedIssues map[string]*PersistedIssue`
    are now keyed by **issue id** (instance), not checkID. Update comments.
  - `ReportIssue(checkID, checkName, report) error` → `ReportIssue(report *IssueReport) error`:
    validate `report != nil`, `report.IssueId != ""`, `report.IssueType != ""`.
    Translation **internal IssueReport → proto Issue** lives here:
    1. `protoIssue, err := issueRegistry.BuildIssue(report.IssueType, report.Context)` — looks up the template by type and renders title/severity/remediation/etc.
    2. `protoIssue.Id = report.IssueId` (instance id, the storage key).
    3. `protoIssue.Source = report.Source`.
    4. `protoIssue.Tags = append(protoIssue.Tags, report.Tags...)`.
    5. `protoIssue.DetectedAt = now` (existing logic in `storeIssue`).
    6. `protoIssue.PersistedIssue = persistedIssueToProto(...)` (existing logic).
    Then store under the key `report.IssueId` and update the persistence record.
    Drop the "check changed issue ID" branch (lines 562-571) — impossible now.
  - Drop `RegisterCheck`/`RunCheck` (lines 393-400).
  - `ClearIssuesForCheck` → `ResolveIssue`. `ClearAllIssues` → `ResolveAllIssues`.
    `GetIssueForCheck` → `GetIssue`.
  - Telemetry: counter label `"health_check_id"` → `"issue_id"` (line 278).
  - `start`: load persistence (version-gated, see below). No more egress
    goroutine here — that lives in the egress component now. No
    `SetReporter`/`SetProvider` calls.
  - `handleIssueStateChange` and `storeIssue`: replace `checkID`/`checkName`
    with `issueId`/`source`. Drop the changed-issue-ID branch.
- `impl/persistence.go` and `impl/persistence_noop.go`:
  - Add a `Version int` field to `PersistedState` (set to `2` going forward).
  - `loadFromDisk`: if `state.Version != 2`, log warning ("incompatible
    health-platform persistence file from older version, ignoring") and start
    fresh. No migration.
- `impl/health-platform_test.go` → `impl/store_test.go`:
  - Rewrite call sites to the new `ReportIssue(&IssueReport{...})` shape.
  - Add a test: one source can hold multiple distinct issue instances.
  - Add a test: on-disk-version mismatch is ignored cleanly.
  - (egress-tick test moves to the egress component's tests.)

### `comp/healthplatform/checkrunner/` → rename to `comp/healthplatform/scheduler/`

- `def/component.go`:
  - **Drop** `IssueReporter` and `SetReporter` (replaced by fx).
  - **Drop** `RunCheck` (now lives in `runner`).
  - `Component` shrinks to just `Schedule(source string, fn HealthCheckFunc, interval time.Duration) error`.
- `impl/check_runner.go` → `impl/scheduler.go`:
  - Rename struct `checkRunner` → `scheduler`. `Requires` is `{Lifecycle, Log,
    Runner runnerdef.Component, Store storedef.Component}`.
  - `registeredCheck` → `registeredHealthCheck` (fields: `source`, `fn`,
    `interval`, `lastIssueIds map[string]struct{}`, `stopCh`).
  - On each tick: call `runner.Run(reg.source, reg.fn)` which returns the new
    set of issue ids; for any id in `lastIssueIds` not in the new set, call
    `store.ResolveIssue(id)`; replace `lastIssueIds` with the new set.
  - Drop the `executeCheck` store-call path — the runner handles reporting
    new/ongoing; the scheduler only handles resolving disappeared ones.
- `impl/check_runner_test.go` → `impl/scheduler_test.go`: cover Schedule,
  per-tick diff/resolve, multi-issue health checks. Use mock runner + mock
  store via fx.
- `mock/mock.go`, `fx/fx.go`: update.

### `comp/healthplatform/runner/` (new)

- `def/component.go`: `HealthCheckFunc` type and `Component` interface.
- `impl/runner.go`:
  - Single struct `runner` with `Requires{Log, Store storedef.Component}`.
  - `Run(source, fn)`: call fn (with panic recovery), iterate the returned
    `[]*IssueReport`, fill in `Source` if empty, call `r.store.ReportIssue`
    for each, return the slice of `IssueId`s and the (possibly nil) error.
- `impl/runner_test.go`: covers panic recovery, error propagation, Source
  default-fill, return-value correctness.
- `fx/fx.go`, `mock/mock.go`: standard component plumbing.

### `comp/healthplatform/egress/` (new)

- `def/component.go`: empty `Component` interface (no public methods —
  egress is wired via fx and runs purely as a lifecycle-managed background
  goroutine). Exists so other code can express the dependency if needed
  (today, nobody does).
- `impl/egress.go`:
  - `Requires{Lifecycle, Log, Config, Hostname hostnameinterface.Component, Store storedef.Component, Forwarder forwarderdef.Component}`.
  - On `OnStart`: launch a goroutine on the configurable
    `health_platform.forwarder.interval` (default 5 min). Each tick:
    `count, issues := store.GetAllIssues()`; if `count == 0`, skip; else
    build a `HealthReport` (`event_type`, `emitted_at`, `host`, `service`,
    `issues`) and call `forwarder.Send(ctx, report)`.
  - On `OnStop`: cancel the goroutine.
- `impl/egress_test.go`: cover tick → store.GetAllIssues → forwarder.Send;
  empty-state skip; lifecycle start/stop.
- `fx/fx.go`, `mock/mock.go`: standard plumbing.

### `comp/healthplatform/forwarder/`

- `def/component.go`:
  - **Drop** `IssueProvider` and `SetProvider`.
  - `Component` shrinks to just `Send(ctx, *HealthReport) error`.
- `impl/forwarder.go`:
  - Drop the internal ticker and the `provider` field. Drop the
    pull-from-provider flush path.
  - Keep the HTTP client, the host-info building, and the actual POST logic.
    `Send` builds the request from the passed-in `HealthReport`.
  - Lifecycle: keep `OnStop` if needed for HTTP-client teardown; otherwise
    drop the lifecycle hook entirely (cadence now lives in egress).
- `impl/forwarder_test.go`: simpler — exercise `Send` against a test HTTP
  server.

### `comp/healthplatform/issues/`

- Promote the existing in-memory `Registry` (`issues/registry.go`) into a
  proper fx-injectable component under `comp/healthplatform/issues/registry/
  {def,fx,impl}/`. The store and the bundle's `fx.Invoke` depend on it.
  Existing `issues/{admisconfig,checkfailure,dockerpermissions,rofspermissions}`
  modules keep registering themselves into it.
- Rename `BuiltInCheck` → `BuiltInHealthCheck`. Fields `Name`/`ID`/`CheckFn` →
  `Source`/`Fn`. Accessor `GetBuiltInChecks` → `GetBuiltInHealthChecks`.
  The `ID`/`Name` distinction collapses now that health checks don't own a
  single issue id; the check's `Source` is its label, and each emitted
  `IssueReport` carries its own `IssueId`/`IssueType`.
- `dockerpermissions/check.go` → `dockerpermissions/health_check.go`. Returns
  `[]*storedef.IssueReport{ {IssueId: "docker-permissions:default",
  IssueType: "docker-permissions", Source: "docker", Context, Tags} }`.
- `rofspermissions/check.go` → `rofspermissions/health_check.go`. Same shape.
- `admisconfig/`, `checkfailure/`: just rename `BuiltInCheck` references
  (template-only modules; no health check).

### External callers

- `pkg/collector/check/stats/stats.go` (lines 323-358):
  - `reportToHealthPlatform`: build the new Go `storedef.IssueReport` with
    `IssueId: "check-execution-failure:" + string(cs.CheckID)`,
    `IssueType: "check-execution-failure"`, `Source: cs.CheckName`, plus
    today's Context and Tags. Drop the `healthplatformpayload` import.
  - `clearHealthPlatformIssue`: call
    `cs.healthPlatform.ResolveIssue("check-execution-failure:" + string(cs.CheckID))`.
- `comp/core/autodiscovery/autodiscoveryimpl/configmgr.go` (lines 431-470):
  - `reportTemplateResolutionFailure`: build issueId
    `"ad-template:" + tpl.Name + ":" + svc.GetServiceID() + ":" + tpl.Digest()`
    (today's `checkID` value, repurposed as instance id),
    `IssueType: ADMisconfigurationIssueID`, `Source: ADMisconfigurationSource`.
  - `clearTemplateResolutionFailure` / `clearTemplateResolutionFailureByID`:
    `ResolveIssue(issueId)`.
- `comp/core/autodiscovery/providers/container.go` (lines 334-347): same
  pattern, prefix issueId with `"ad-annotation:"`.
- All call sites that import `…/healthplatform/core/def`: update to
  `…/healthplatform/store/def`. The `Component` field/parameter names
  (`healthPlatform`, `HealthPlatform`) stay — the abstraction is still
  "the health platform"; consumers happen to use the store side.
- `cmd/agent/subcommands/run/command.go` (and `_windows.go`),
  `pkg/collector/runner/runner.go`, `pkg/collector/worker/worker.go`,
  `comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go`,
  `comp/core/autodiscovery/providers/types/types.go`,
  `comp/collector/collector/collectorimpl/collector.go`: import-path updates only.

### Bundle wiring (`comp/healthplatform/bundle.go`)

- Provide `store`, `runner`, `scheduler`, `egress`, `forwarder`,
  `issues/registry` modules.
- Add an `fx.Invoke(bootstrapBuiltInHealthChecks)` that takes
  `(registry, runner, scheduler)` and at startup iterates
  `registry.GetBuiltInHealthChecks()`: `Once` → `runner.Run(c.Source, c.Fn)`;
  periodic → `scheduler.Schedule(c.Source, c.Fn, c.Interval)`.
- The existing `fx-noop/` and `core/noop-impl/` move with the rename:
  `store/noop-impl/`, `scheduler/noop-impl/`, `runner/noop-impl/`,
  `egress/noop-impl/`. The
  forwarder doesn't strictly need a noop (Send becomes a no-op when health
  platform is disabled — handled by not providing the bundle at all).

## Persistence file format

```json
{
  "version": 2,
  "updated_at": "...",
  "issues": {
    "<issueId>": {
      "issue_type": "...",
      "state": "...",
      "first_seen": "...",
      "last_seen": "...",
      "resolved_at": "..."
    }
  }
}
```

`issue_type` replaces today's `issue_id` field on `PersistedIssue` (today's
stored `IssueID` *was* the type, used to rebuild from the registry).

## Verification

### Unit tests — ≥85% coverage per component

Run:
- `dda inv test --targets=./comp/healthplatform/... --coverage` (Python invoke task; produces a coverage report)
- `bazel test //comp/healthplatform/...`
- Per-component coverage gate: 85% on lines and branches. Track with `go tool cover -func=...` after the test run; flag any package below the bar.

Per-component test responsibilities (each component ships its own `*_test.go`):

**store** (`comp/healthplatform/store/impl/store_test.go`)
- `ReportIssue` happy path: valid report → issue stored under `report.IssueId`; proto fields filled (`Id`, `Source`, `Tags`, `DetectedAt`, `PersistedIssue`).
- `ReportIssue` validation: nil report → error; empty `IssueId` → error; empty `IssueType` → error; unknown `IssueType` (not in registry) → error.
- `ReportIssue` re-report (same `IssueId` twice): state machine `new → ongoing`; `LastSeen` updated; `FirstSeen` preserved.
- `ResolveIssue`: removes from active map; persisted record marked `resolved` with `ResolvedAt`.
- `ResolveIssue` on unknown id: no-op, no error.
- `ResolveAllIssues`: clears all active; all persisted records marked resolved.
- `GetIssue` / `GetAllIssues`: returns deep copies; nil for unknown id.
- **Multi-instance:** one source reports two issues with different `IssueId`s of the same `IssueType` simultaneously → both coexist.
- **Multi-type per source:** one source reports two different `IssueType`s simultaneously → both coexist (no "issue id changed" error path).
- Persistence: load → save → load round-trip preserves state.
- Version gate: file with `version: 1` (or no version) → log warning, start fresh.
- Resolved-TTL: resolved issues older than 24h pruned on save.
- HTTP endpoint: `GET /health-platform/issues` returns expected JSON envelope `{count, issues}`.
- Flare provider: `fillFlare` writes `health-platform-issues.json` only when `count > 0`.
- Telemetry: counter `health_platform.issues_detected` increments with label `issue_id`.

**runner** (`comp/healthplatform/runner/impl/runner_test.go`)
- `Run` happy path: fn returns N reports → all forwarded to mock store via `ReportIssue`; returned slice has the N issue ids in order.
- `Run` with empty result: returned slice is empty; no `ReportIssue` calls.
- `Run` with fn error: error propagated; reports already emitted before the error are still forwarded.
- `Run` with fn panic: recovered, returned as error; no partial state corruption.
- `Source` default-fill: report with empty `Source` gets `source` arg.
- Concurrency: two `Run` calls in parallel don't interfere.

**scheduler** (`comp/healthplatform/scheduler/impl/scheduler_test.go`)
- `Schedule` registers a probe; runner invoked on each tick at the configured interval.
- Per-tick diff: tick 1 emits {A, B}, tick 2 emits {A, C} → resolve B, no resolve for A or C; lastIssueIds is now {A, C}.
- Tick 2 emits empty: resolve all from tick 1.
- Multiple `Schedule` calls: each runs independently with its own state.
- Lifecycle stop cancels all per-probe goroutines.
- Default interval applied when caller passes ≤ 0.

**egress** (`comp/healthplatform/egress/impl/egress_test.go`)
- Tick fires → `store.GetAllIssues` → `forwarder.Send` with a `HealthReport` whose `Issues` matches the store snapshot.
- Empty store snapshot → `forwarder.Send` not called (no-op tick).
- `forwarder.Send` returns error → logged, next tick still fires.
- Lifecycle: `OnStart` launches goroutine, `OnStop` cancels and waits.

**forwarder** (`comp/healthplatform/forwarder/impl/forwarder_test.go`)
- `Send` POSTs the marshaled `HealthReport` to the configured URL with the correct headers (API key, content-type).
- HTTP non-2xx → returned as error.
- Network error → returned as error.
- (No more pull-from-provider tests; that path is gone.)

**issues/registry** (`comp/healthplatform/issues/registry/impl/registry_test.go`)
- `BuildIssue` happy path: known issue type + context → proto `Issue` with all template fields filled.
- `BuildIssue` unknown type → error.
- `GetBuiltInHealthChecks`: returns all registered checks; periodic vs `Once` flagged correctly.
- Module self-registration: each of `admisconfig`, `checkfailure`, `dockerpermissions`, `rofspermissions` registers its templates and (where applicable) its built-in check.

**bundle** (`comp/healthplatform/bundle_test.go`)
- Existing `TestBundleStartLifecycle` adapted: confirm fx wiring resolves with no `SetReporter`/`SetProvider` calls remaining.
- New: built-in `Once` checks fire at startup via the bootstrap `fx.Invoke`; periodic ones get scheduled.

### Other gates

1. **Lint:** `dda inv linter.go`.
2. **Manual smoke:**
   - Build: `dda inv agent.build --build-exclude=systemd`.
   - Run with `health_platform.enabled: true`, `health_platform.persist_on_kubernetes: false`.
   - Trigger an integration check failure (rename a Python integration to break it). Confirm `GET /health-platform/issues` returns the issue keyed by the new instance id and that its `source` field shows the integration name.
   - Trigger an AD template-resolution failure. Confirm both issues coexist and resolve independently when each is fixed.
   - Inspect `<run_path>/health-platform/issues.json` — verify `version: 2` and the new keying.
   - Restart the agent — confirm active issues are restored.
3. **External callers:** `dda inv test --targets=./pkg/collector/check/stats/...` and `./comp/core/autodiscovery/...`.

## Critical files

- `comp/healthplatform/store/def/component.go` — store contract.
- `comp/healthplatform/store/def/issue_report.go` — new Go `IssueReport`.
- `agent-payload/v5/healthplatform/healthplatform.proto` — remove the
  `IssueReport` message. Mirror in `dd-source/.../agthealth-worker/schemas/healthplatform.proto`.
- `comp/healthplatform/store/impl/store.go` — model shift; storage + lifecycle state machine.
- `comp/healthplatform/egress/impl/egress.go` — periodic `store.GetAllIssues` → `forwarder.Send` tick.
- `comp/healthplatform/store/impl/persistence.go` — version-gated load.
- `comp/healthplatform/runner/def/component.go` — `HealthCheckFunc` and
  `Run` signature.
- `comp/healthplatform/runner/impl/runner.go` — invokes fn, calls store,
  returns issue-id list.
- `comp/healthplatform/scheduler/def/component.go` — `Schedule` only.
- `comp/healthplatform/scheduler/impl/scheduler.go` — periodic ticker +
  per-registration diff state.
- `comp/healthplatform/forwarder/impl/forwarder.go` — stateless `Send`
  (HTTP POST to intake); cadence is driven by egress.
- `comp/healthplatform/issues/registry/` — promoted to fx component.
- `comp/healthplatform/bundle.go` — fx wiring + bootstrap `fx.Invoke`.
- `pkg/collector/check/stats/stats.go` — biggest external caller.
- `comp/core/autodiscovery/autodiscoveryimpl/configmgr.go`,
  `comp/core/autodiscovery/providers/container.go` — other external callers.

</details>