### PR TITLE
Stop on-wire size gates from being blocking

### DIFF
--- a/tasks/static_quality_gates/gates.py
+++ b/tasks/static_quality_gates/gates.py
@@ -562,15 +562,7 @@ class StaticQualityGate:
         """
         violations = []
 
-        if measurement.on_wire_size > self.config.max_on_wire_size:
-            violations.append(
-                SizeViolation(
-                    measurement_type="wire",
-                    current_size=measurement.on_wire_size,
-                    max_size=self.config.max_on_wire_size,
-                )
-            )
-
+        # Only on-disk size can currently cause a violation
         if measurement.on_disk_size > self.config.max_on_disk_size:
             violations.append(
                 SizeViolation(

--- a/tasks/static_quality_gates/pr_comment.py
+++ b/tasks/static_quality_gates/pr_comment.py
@@ -25,14 +25,6 @@ body_collapsed_pattern = """<details>
 |--|--|--|
 """
 
-# Collapsed table pattern for on-wire sizes
-body_wire_pattern = """<details>
-<summary>On-wire sizes (compressed)</summary>
-
-||Quality gate|Change|Size (prev → **curr** → max)|
-|--|--|--|--|
-"""
-
 body_error_footer_pattern = """<details>
 <summary>Gate failure full details</summary>
 
@@ -160,9 +152,6 @@ def display_pr_comment(
     body_error = body_pattern.format("Error")
     body_error_footer = body_error_footer_pattern
 
-    # On-wire sizes table (separate collapsed section)
-    body_wire = ""
-
     with_blocking_error = False
     with_non_blocking_error = False
     significant_success_count = 0
@@ -178,9 +167,6 @@ def display_pr_comment(
         change_str, limit_bounds, is_neutral = get_change_metrics(gate.name, metric_handler, metric_type="disk")
         if change_str == "N/A":
             has_na_change = True
-
-        # Get change metrics for on-wire
-        wire_change_str, wire_limit_bounds, _ = get_change_metrics(gate.name, metric_handler, metric_type="wire")
 
         if gate.failure is None:
             if is_neutral:
@@ -199,9 +185,6 @@ def display_pr_comment(
                     body_info = "<details open>\n<summary>Successful checks</summary>\n\n" + body_pattern.format("Info")
                 body_info += f"|{SUCCESS_CHAR}|{gate_name}|{change_str}|{limit_bounds}|\n"
                 significant_success_count += 1
-
-            # All successful gates go to wire table
-            body_wire += f"|{SUCCESS_CHAR}|{gate_name}|{wire_change_str}|{wire_limit_bounds}|\n"
         else:
             # Check if this is a blocking or non-blocking failure
             status_char = FAIL_CHAR if gate.blocking else WARNING_CHAR
@@ -209,19 +192,10 @@ def display_pr_comment(
             if gate.failure == GateFailureKind.PerPRThresholdExceeded:
                 body_error += f"|{status_char}|{gate_name} (per-PR threshold)|{change_str}|{limit_bounds}|\n"
             elif gate.failure == GateFailureKind.PerPRWireThresholdExceeded:
-                body_error += (
-                    f"|{status_char}|{gate_name} (per-PR wire threshold)|{wire_change_str}|{wire_limit_bounds}|\n"
-                )
+                wire_change_str, _, _ = get_change_metrics(gate.name, metric_handler, metric_type="wire")
+                body_error += f"|{status_char}|{gate_name} (per-PR wire threshold)|{wire_change_str}| N/A |\n"
             else:
-                # This is probably way more convoluted than it should be, but the best we can do
-                # without refactoring the data structures involved
-                if gate_metrics.get("current_on_wire_size", 0) > gate_metrics.get("max_on_wire_size", float('inf')):
-                    body_error += f"|{status_char}|{gate_name} (on wire)|{wire_change_str}|{wire_limit_bounds}|\n"
-                if gate_metrics.get("current_on_disk_size", 0) > gate_metrics.get("max_on_disk_size", float('inf')):
-                    body_error += f"|{status_char}|{gate_name} (on disk)|{change_str}|{limit_bounds}|\n"
-
-            # Add to wire table for errors too
-            body_wire += f"|{status_char}|{gate_name}|{wire_change_str}|{wire_limit_bounds}|\n"
+                body_error += f"|{status_char}|{gate_name} (on disk)|{change_str}|{limit_bounds}|\n"
 
             error_message = gate.message.replace('\n', '<br>')
             note_suffix = f" ({gate.blocking_note})" if gate.blocking_note else ""
@@ -260,18 +234,11 @@ def display_pr_comment(
         success_section += body_info_collapsed
         success_section += "\n</details>\n"
 
-    # Build on-wire sizes section (collapsed)
-    wire_section = ""
-    if body_wire:
-        wire_section = body_wire_pattern
-        wire_section += body_wire
-        wire_section += "\n</details>\n"
-
     # Add retry hint if some deltas are N/A (ancestor metrics not yet available due to race condition)
     retry_hint = ""
     if has_na_change and job_url:
         retry_hint = f"SOME SIZE DELTAS ARE N/A (ANCESTOR METRICS NOT YET AVAILABLE). [RETRY JOB]({job_url})\n"
 
-    body = f"{FAIL_CHAR if evaluation.has_blocking_failures else SUCCESS_CHAR} Please find below the results from static quality gates\n{ancestor_info}{dashboard_link}{job_link}{retry_hint}{exception_banner}{final_error_body}\n\n{success_section}\n{wire_section}"
+    body = f"{FAIL_CHAR if evaluation.has_blocking_failures else SUCCESS_CHAR} Please find below the results from static quality gates\n{ancestor_info}{dashboard_link}{job_link}{retry_hint}{exception_banner}{final_error_body}\n\n{success_section}"
 
     pr_commenter(ctx, title=title, body=body, pr=pr)

--- a/tasks/unit_tests/static_quality_gates/gates_tests.py
+++ b/tasks/unit_tests/static_quality_gates/gates_tests.py
@@ -445,7 +445,8 @@ class TestStaticQualityGate(unittest.TestCase):
         measurement = ArtifactMeasurement("/path", 120 * 1024 * 1024, 150 * 1024 * 1024)
         self.mock_measurer.measure.return_value = measurement
 
-        self.assertFalse(self.gate.execute_gate(self.mock_ctx).success)
+        # on-wire gates are non-blocking
+        self.assertTrue(self.gate.execute_gate(self.mock_ctx).success)
 
     def test_execute_gate_on_disk_violation(self):
         # Mock measurement exceeding disk limit (250MB > 200MB limit)
@@ -466,14 +467,11 @@ class TestStaticQualityGate(unittest.TestCase):
         violations = self.gate._check_size_limits(measurement)
         self.assertEqual(len(violations), 0)
 
-    def test_check_size_limits_on_wire_violation(self):
+    def test_check_size_limits_on_wire_causes_no_violation(self):
         measurement = ArtifactMeasurement("/path", 120 * 1024 * 1024, 150 * 1024 * 1024)
         violations = self.gate._check_size_limits(measurement)
 
-        self.assertEqual(len(violations), 1)
-        self.assertEqual(violations[0].measurement_type, "wire")
-        self.assertEqual(violations[0].current_size, 120 * 1024 * 1024)
-        self.assertEqual(violations[0].max_size, 100 * 1024 * 1024)
+        self.assertEqual(len(violations), 0)
 
     def test_check_size_limits_on_disk_violation(self):
         measurement = ArtifactMeasurement("/path", 80 * 1024 * 1024, 250 * 1024 * 1024)

--- a/tasks/unit_tests/static_quality_gates/pr_comment_tests.py
+++ b/tasks/unit_tests/static_quality_gates/pr_comment_tests.py
@@ -237,8 +237,6 @@ class TestQualityGatesPrMessage(unittest.TestCase):
         self.assertIn('Successful checks', body)
         self.assertIn('gateA', body)
         self.assertIn('gateB', body)
-        # Check on-wire section is present
-        self.assertIn('On-wire sizes (compressed)', body)
         # Check dashboard link is present
         self.assertIn('Static Quality Gates Dashboard', body)
         # Check PR was passed to pr_commenter
@@ -295,8 +293,6 @@ class TestQualityGatesPrMessage(unittest.TestCase):
         # Check that gates are in the collapsed section
         self.assertIn('gateA', body)
         self.assertIn('gateB', body)
-        # Check on-wire section is present
-        self.assertIn('On-wire sizes (compressed)', body)
 
     @patch.dict(
         'os.environ',
@@ -393,8 +389,6 @@ class TestQualityGatesPrMessage(unittest.TestCase):
         self.assertIn('gateB', body)
         self.assertIn('Gate failure full details', body)
         self.assertIn('Static quality gates prevent the PR to merge!', body)
-        # Check on-wire section is present
-        self.assertIn('On-wire sizes (compressed)', body)
         # Check dashboard link is present
         self.assertIn('Static Quality Gates Dashboard', body)
 
@@ -448,8 +442,6 @@ class TestQualityGatesPrMessage(unittest.TestCase):
         # Check new columns are present
         self.assertIn('Change', body)
         self.assertIn('Size (prev', body)
-        # Check on-wire section is present
-        self.assertIn('On-wire sizes (compressed)', body)
 
     @patch.dict(
         'os.environ',
@@ -485,103 +477,6 @@ class TestQualityGatesPrMessage(unittest.TestCase):
         call_args = pr_commenter_mock.call_args
         body = call_args[1]['body']
         self.assertIn('N/A', body)
-
-    @patch.dict(
-        'os.environ',
-        {
-            'CI_COMMIT_REF_NAME': 'pikachu',
-            'CI_COMMIT_BRANCH': 'sequoia',
-        },
-    )
-    @patch("tasks.static_quality_gates.pr_comment.pr_commenter")
-    def test_wire_table_separate(self, pr_commenter_mock):
-        """Test that on-wire sizes appear in a separate collapsed section."""
-        from invoke import MockContext
-
-        c = MockContext()
-        gate_metric_handler = GateMetricHandler("main", "dev")
-        gate_metric_handler.metrics["gateA"] = {
-            "current_on_disk_size": 100 * 1024 * 1024,
-            "max_on_disk_size": 150 * 1024 * 1024,
-            "relative_on_disk_size": 5 * 1024 * 1024,
-            "current_on_wire_size": 50 * 1024 * 1024,
-            "max_on_wire_size": 75 * 1024 * 1024,
-            "relative_on_wire_size": 2 * 1024 * 1024,
-        }
-        mock_pr = MagicMock()
-        mock_pr.number = 12345
-        display_pr_comment(
-            c,
-            GateEvaluationResult(
-                verdicts=[GateVerdict(name='gateA', failure=None)],
-            ),
-            gate_metric_handler,
-            "value",
-            mock_pr,
-        )
-        pr_commenter_mock.assert_called_once()
-        call_args = pr_commenter_mock.call_args
-        body = call_args[1]['body']
-        # Check on-wire section is present and collapsed
-        self.assertIn('On-wire sizes (compressed)', body)
-        self.assertIn('<details>', body)
-        # Check gateA appears in wire section
-        wire_section_start = body.find('On-wire sizes (compressed)')
-        self.assertIn('gateA', body[wire_section_start:])
-
-    @patch("tasks.static_quality_gates.pr_comment.pr_commenter")
-    def test_error_on_wire_displays_uncollapsed_on_error_section(self, pr_commenter_mock):
-        """Test that when only the on-wire size is violating a specific gate
-        (and not the on-disk size for that same gate),
-        The uncollapsed error actually shows the data for the on-wire size violation (only)."""
-        from invoke import MockContext
-
-        c = MockContext()
-        gate_metric_handler = GateMetricHandler("main", "dev")
-
-        # current-on-disk < max-on-disk and current-on-wire > max-on-wire
-        gate_metric_handler.metrics["gateA"] = {
-            "current_on_disk_size": 95 * 1024 * 1024,
-            "max_on_disk_size": 100 * 1024 * 1024,
-            "relative_on_disk_size": 5 * 1024 * 1024,
-            "current_on_wire_size": 50 * 1024 * 1024,
-            "max_on_wire_size": 49 * 1024 * 1024,
-            "relative_on_wire_size": 2 * 1024 * 1024,
-        }
-
-        mock_pr = MagicMock()
-        mock_pr.number = 12345
-        display_pr_comment(
-            c,
-            GateEvaluationResult(
-                verdicts=[
-                    GateVerdict(
-                        name='gateA', failure=GateFailureKind.AbsoluteLimitExceeded, blocking=True, message='some_msg_A'
-                    ),
-                ],
-                has_blocking_failures=True,
-            ),
-            gate_metric_handler,
-            "value",
-            mock_pr,
-        )
-        pr_commenter_mock.assert_called_once()
-        call_args = pr_commenter_mock.call_args
-        body = call_args[1]['body']
-        expected = "\n".join(
-            [
-                "||Quality gate|Change|Size (prev → **curr** → max)|",
-                "|--|--|--|--|",
-                "|❌|gateA (on wire)|+2.0 MiB (4.17% increase)|48.000 → **50.000** → 49.000|",
-                "<details>",
-                "<summary>Gate failure full details</summary>",
-                "",
-                "|Quality gate|Error type|Error message|",
-                "|----|---|--------|",
-                "|gateA|AbsoluteLimitExceeded|some_msg_A|",
-            ]
-        )
-        self.assertIn(expected.strip(), body)
 
 
 class TestNonBlockingPrComment(unittest.TestCase):

--- a/tasks/unit_tests/static_quality_gates/tasks_tests.py
+++ b/tasks/unit_tests/static_quality_gates/tasks_tests.py
@@ -269,7 +269,7 @@ class TestQualityGatesIntegration(unittest.TestCase):
             mock_pr_commenter.assert_called_once()
 
     @patch.dict('os.environ', _PR_ENV_VARS, clear=True)
-    def test_gate_fails_absolute_wire_limit(self):
+    def test_gate_absolute_wire_limit_does_not_block(self):
         gate_scenarios = [
             GateScenario(
                 name=_DEB_GATE,
@@ -303,10 +303,9 @@ class TestQualityGatesIntegration(unittest.TestCase):
             patch("tasks.static_quality_gates.pr_comment.pr_commenter") as mock_pr_commenter,
         ):
             ctx = MockContext(
-                run={"datadog-ci tag --level job --tags static_quality_gates:\"failure\"": Result("Done")}
+                run={"datadog-ci tag --level job --tags static_quality_gates:\"success\"": Result("Done")}
             )
-            with self.assertRaises(Exit):
-                parse_and_trigger_gates(ctx, config_path)
+            parse_and_trigger_gates(ctx, config_path)
             mock_send_metrics.assert_called_once()
             mock_generate_reports.assert_called_once()
             mock_pr_commenter.assert_called_once()


### PR DESCRIPTION
### What does this PR do?

It stops on-wire gates from causing PRs to be blocked from merging, and removes references to them on the PR comments.

### Motivation

See [ABLD-450](https://datadoghq.atlassian.net/browse/ABLD-450) and linked RFC to understand why we're no longer blocking on on-wire gates.

### Describe how you validated your changes

Tests. On-wire table gone from the PR comment.

### Additional Notes


[ABLD-450]: https://datadoghq.atlassian.net/browse/ABLD-450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ