### PR TITLE
Fix `pkg/discovery/module/testutil/fake_server/.gitignore`

### DIFF
--- a/pkg/discovery/module/testutil/fake_server/.gitignore
+++ b/pkg/discovery/module/testutil/fake_server/.gitignore
@@ -1,2 +1,3 @@
 *
-! *.go
+!*.go
+!BUILD.bazel


### PR DESCRIPTION
### What does this PR do?
- drop the spurious space in `! *.go`, which silently turned the negation into a literal ` *.go` (only matches names that start with a space) - so any newly added `*.go` in this directory was silently ignored despite the rule's intent,
- un-ignore tracked `BUILD.bazel` so `.gitignore`-aware tools (`ugrep`, `ripgrep`, `fd`, ...) stop skipping it during recursive sweeps.

### Motivation
PR #32125 broadened this `.gitignore` from an explicit binary list to `*\n! *.go` to be robust against future generated binaries. Two problems crept in:
- the leading space after `!` is part of the pattern (per [`gitignore(5)`](https://git-scm.com/docs/gitignore)), so the negation never matched `foo.go`. The checked-in `fake_server.go` only stays tracked because it was added before the rule and tracked files are immune to subsequent `.gitignore` matches,
- `BUILD.bazel` was added later by PR #50363 and got swept into the broad ignore. Tools that honor `.gitignore` for tracked files (`ugrep` used by Claude Code, `ripgrep --no-ignore-vcs=false`, etc.) silently drop the file from recursive searches, which masked an `@io_bazel_rules_go` reference during a mass rewrite.

### Describe how you validated your changes
- empirical gitignore test in a scratch repo confirms `! *.go` matches only names starting with a literal space, while `!*.go` matches `foo.go` as intended,
- `grep -rl rules_go pkg/discovery/module/testutil/fake_server/` (Claude Code's `ugrep` wrapper, with `--ignore-files`) now lists the `BUILD.bazel` - before the fix it returned nothing,
- audited every other tracked, non-empty `BUILD`/`*.bzl` in the repo: this is the only file affected.

### Additional Notes
No behavioral change for the in-tree `fake_server.go` (already tracked) or for build artifacts (still globbed by `*`).