### PR TITLE
[Backport 7.78.x] [FA] - Mark apm_inject for Ubuntu and Debian as flaky (#50387)

### DIFF
--- a/test/new-e2e/tests/installer/unix/package_apm_inject_test.go
+++ b/test/new-e2e/tests/installer/unix/package_apm_inject_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	e2eos "github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
 	"github.com/stretchr/testify/assert"
 	"go.yaml.in/yaml/v3"
@@ -30,6 +31,12 @@ type packageApmInjectSuite struct {
 func testApmInjectAgent(os e2eos.Descriptor, arch e2eos.Architecture, method InstallMethodOption) packageSuite {
 	return &packageApmInjectSuite{
 		packageBaseSuite: newPackageSuite("apm-inject", os, arch, method),
+	}
+}
+
+func (s *packageApmInjectSuite) SetupTest() {
+	if s.os == e2eos.Debian12 || s.os == e2eos.Ubuntu2404 {
+		flake.Mark(s.T())
 	}
 }
 


### PR DESCRIPTION
Backport of #50387 to `7.78.x`.

## Why

The `new-e2e-installer` job on `7.78.x` has been timing out at the 2-hour CI limit on every run since it was introduced (8 consecutive failures). The Ubuntu 24.04 and Debian 12 APM inject tests are slow due to the `verifySharedLib` AppArmor issue, and their cumulative runtime pushes the job over the limit.

Backporting the flake marks allows CI to skip these known-flaky tests on `7.78.x` (when `SKIP_FLAKE=true` is set), unblocking the release branch pipeline while the proper fix is tracked separately.

## What

Cherry-pick of `e41246d207` from `main`.