### PR TITLE
Fix flaky service collection tests with sync

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -641,48 +641,46 @@ func (c *collector) updateDiscoveredServicesMetric() {
 	c.metricDiscoveredServices.Set(float64(count))
 }
 
+// collectProcessesOnce runs a single process collection iteration: scans
+// processes, computes the diff against lastCollectedProcesses, updates the
+// cache, and returns the resulting event. The caller is responsible for
+// delivering the event (e.g. via processEventsCh or store.Notify).
+func (c *collector) collectProcessesOnce() *Event {
+	procs, err := c.processProbe.ProcessesByPID(c.clock.Now().UTC(), false)
+	if err != nil {
+		log.Errorf("Error getting processes by pid: %v", err)
+		return nil
+	}
+
+	pidToCid := c.containerProvider.GetPidToCid(cacheValidityNoRT)
+	enrichProcessesWithContainerID(procs, pidToCid)
+
+	createdProcs := processCacheDifference(procs, c.lastCollectedProcesses)
+	languages := c.detectLanguages(createdProcs)
+	wlmCreatedProcs := createdProcessesToWorkloadmetaProcesses(createdProcs, pidToCid, languages)
+
+	wlmDeletedProcs := c.findDeletedProcesses(procs)
+
+	c.mux.Lock()
+	c.lastCollectedProcesses = procs
+	c.mux.Unlock()
+
+	return &Event{
+		Type:    EventTypeProcess,
+		Created: wlmCreatedProcs,
+		Deleted: wlmDeletedProcs,
+	}
+}
+
 // collectProcesses captures all the required process data for the process check
 func (c *collector) collectProcesses(ctx context.Context, collectionTicker *clock.Ticker) {
-	// TODO: implement the full collection logic for the process collector. Once collection is done, submit events.
 	ctx, cancel := context.WithCancel(ctx)
 	defer collectionTicker.Stop()
 	defer cancel()
-	// Run collection immediately on startup, then wait for ticker to repeat
 	for {
-		// fetch process data and submit events to streaming channel for asynchronous processing
-		procs, err := c.processProbe.ProcessesByPID(c.clock.Now().UTC(), false)
-		if err != nil {
-			log.Errorf("Error getting processes by pid: %v", err)
-			return
+		if event := c.collectProcessesOnce(); event != nil {
+			c.processEventsCh <- event
 		}
-
-		// some processes are in a container so we want to store the container_id for them
-		pidToCid := c.containerProvider.GetPidToCid(cacheValidityNoRT)
-		// TODO: potentially scrub process data here instead of in the check?
-
-		// Enrich processes with container IDs before diffing so that a CID
-		// change (e.g. becoming available after a race with the container
-		// runtime) is detected by processCacheDifference.
-		enrichProcessesWithContainerID(procs, pidToCid)
-
-		// categorize the processes into events for workloadmeta
-		createdProcs := processCacheDifference(procs, c.lastCollectedProcesses)
-		languages := c.detectLanguages(createdProcs)
-		wlmCreatedProcs := createdProcessesToWorkloadmetaProcesses(createdProcs, pidToCid, languages)
-
-		wlmDeletedProcs := c.findDeletedProcesses(procs)
-
-		// send these events to the channel
-		c.processEventsCh <- &Event{
-			Type:    EventTypeProcess,
-			Created: wlmCreatedProcs,
-			Deleted: wlmDeletedProcs,
-		}
-
-		// store latest collected processes
-		c.mux.Lock()
-		c.lastCollectedProcesses = procs
-		c.mux.Unlock()
 
 		select {
 		case <-collectionTicker.C:

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -646,21 +646,28 @@ func (c *collector) updateDiscoveredServicesMetric() {
 // cache, and returns the resulting event. The caller is responsible for
 // delivering the event (e.g. via processEventsCh or store.Notify).
 func (c *collector) collectProcessesOnce() *Event {
+	// fetch process data
 	procs, err := c.processProbe.ProcessesByPID(c.clock.Now().UTC(), false)
 	if err != nil {
 		log.Errorf("Error getting processes by pid: %v", err)
 		return nil
 	}
 
+	// some processes are in a container so we want to store the container_id for them
 	pidToCid := c.containerProvider.GetPidToCid(cacheValidityNoRT)
+	// Enrich processes with container IDs before diffing so that a CID
+	// change (e.g. becoming available after a race with the container
+	// runtime) is detected by processCacheDifference.
 	enrichProcessesWithContainerID(procs, pidToCid)
 
+	// categorize the processes into events for workloadmeta
 	createdProcs := processCacheDifference(procs, c.lastCollectedProcesses)
 	languages := c.detectLanguages(createdProcs)
 	wlmCreatedProcs := createdProcessesToWorkloadmetaProcesses(createdProcs, pidToCid, languages)
 
 	wlmDeletedProcs := c.findDeletedProcesses(procs)
 
+	// store latest collected processes
 	c.mux.Lock()
 	c.lastCollectedProcesses = procs
 	c.mux.Unlock()

--- a/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
@@ -446,6 +446,33 @@ func TestServiceStoreLifetimeProcessCollectionDisabled(t *testing.T) {
 	}
 }
 
+// syncProcessCollection runs a single synchronous process collection and
+// notifies the store, bypassing the async collectProcesses goroutine.
+// This ensures lastCollectedProcesses is populated before Start() launches
+// the service collection goroutine that depends on it.
+func syncProcessCollection(c collectorTest) {
+	event := c.collector.collectProcessesOnce()
+	if event == nil {
+		return
+	}
+	events := make([]workloadmeta.CollectorEvent, 0, len(event.Created)+len(event.Deleted))
+	for _, proc := range event.Deleted {
+		events = append(events, workloadmeta.CollectorEvent{
+			Type:   workloadmeta.EventTypeUnset,
+			Entity: proc,
+			Source: workloadmeta.SourceProcessCollector,
+		})
+	}
+	for _, proc := range event.Created {
+		events = append(events, workloadmeta.CollectorEvent{
+			Type:   workloadmeta.EventTypeSet,
+			Entity: proc,
+			Source: workloadmeta.SourceProcessCollector,
+		})
+	}
+	c.mockStore.Notify(events)
+}
+
 func TestServiceStoreLifetime(t *testing.T) {
 	const collectionIntervalSeconds = 60
 	const collectionInterval = time.Duration(collectionIntervalSeconds) * time.Second
@@ -651,17 +678,13 @@ func TestServiceStoreLifetime(t *testing.T) {
 			c.probe.On("ProcessesByPID", mock.Anything, mock.Anything).Return(tc.processesToCollect, nil).Maybe()
 			c.mockContainerProvider.EXPECT().GetPidToCid(cacheValidityNoRT).Return(map[int]string{}).AnyTimes()
 
+			// Synchronously populate lastCollectedProcesses and store before
+			// Start() so the service collection goroutine sees process data
+			// on its first tick, eliminating the race between goroutines.
+			syncProcessCollection(c)
+
 			err := c.collector.Start(ctx, c.mockStore)
 			assert.NoError(t, err)
-
-			// collectProcesses runs its first iteration immediately (no tick).
-			// Wait for it to update lastCollectedProcesses before advancing
-			// the clock, so collectServicesCached reads a populated cache.
-			require.EventuallyWithT(t, func(collectT *assert.CollectT) {
-				c.collector.mux.RLock()
-				defer c.collector.mux.RUnlock()
-				assert.Len(collectT, c.collector.lastCollectedProcesses, len(tc.processesToCollect))
-			}, 2*time.Second, 10*time.Millisecond)
 
 			// Trigger service collection (service collection waits for first tick)
 			c.mockClock.Add(collectionInterval)
@@ -722,20 +745,15 @@ func TestProcessDeathRemovesServiceData(t *testing.T) {
 
 	c.collector.store = c.mockStore
 
-	c.probe.On("ProcessesByPID", mock.Anything, mock.Anything).Return(nil, nil).Times(2)
-	c.mockContainerProvider.EXPECT().GetPidToCid(cacheValidityNoRT).Return(nil).Times(2)
+	c.probe.On("ProcessesByPID", mock.Anything, mock.Anything).Return(nil, nil).Times(3)
+	c.mockContainerProvider.EXPECT().GetPidToCid(cacheValidityNoRT).Return(nil).Times(3)
+
+	// Synchronously populate lastCollectedProcesses before Start() to
+	// avoid the race between process and service collection goroutines.
+	syncProcessCollection(c)
 
 	err := c.collector.Start(ctx, c.mockStore)
 	assert.NoError(t, err)
-
-	// collectProcesses runs its first iteration immediately (no tick).
-	// Wait for it to update lastCollectedProcesses before advancing
-	// the clock, so collectServicesCached reads the correct cache.
-	require.EventuallyWithT(t, func(collectT *assert.CollectT) {
-		c.collector.mux.RLock()
-		defer c.collector.mux.RUnlock()
-		assert.Empty(collectT, c.collector.lastCollectedProcesses)
-	}, 2*time.Second, 10*time.Millisecond)
 
 	c.mockClock.Add(collectionInterval)
 

--- a/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
@@ -654,6 +654,15 @@ func TestServiceStoreLifetime(t *testing.T) {
 			err := c.collector.Start(ctx, c.mockStore)
 			assert.NoError(t, err)
 
+			// collectProcesses runs its first iteration immediately (no tick).
+			// Wait for it to update lastCollectedProcesses before advancing
+			// the clock, so collectServicesCached reads a populated cache.
+			require.EventuallyWithT(t, func(collectT *assert.CollectT) {
+				c.collector.mux.RLock()
+				defer c.collector.mux.RUnlock()
+				assert.Len(collectT, c.collector.lastCollectedProcesses, len(tc.processesToCollect))
+			}, 2*time.Second, 10*time.Millisecond)
+
 			// Trigger service collection (service collection waits for first tick)
 			c.mockClock.Add(collectionInterval)
 
@@ -718,6 +727,15 @@ func TestProcessDeathRemovesServiceData(t *testing.T) {
 
 	err := c.collector.Start(ctx, c.mockStore)
 	assert.NoError(t, err)
+
+	// collectProcesses runs its first iteration immediately (no tick).
+	// Wait for it to update lastCollectedProcesses before advancing
+	// the clock, so collectServicesCached reads the correct cache.
+	require.EventuallyWithT(t, func(collectT *assert.CollectT) {
+		c.collector.mux.RLock()
+		defer c.collector.mux.RUnlock()
+		assert.Empty(collectT, c.collector.lastCollectedProcesses)
+	}, 2*time.Second, 10*time.Millisecond)
 
 	c.mockClock.Add(collectionInterval)
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"ff733223-1521-4a51-aaf0-d5fa1de37488","source":"chat","resourceId":"cc418311-cc06-454d-950d-bbdd86db3fb7","workflowId":"90f3df02-8a91-46d3-8122-1c5ddcb78ab8","codeChangeId":"90f3df02-8a91-46d3-8122-1c5ddcb78ab8","sourceType":"slack"} -->
### What does this PR do?
Fixes a race condition in TestServiceStoreLifetime and TestProcessDeathRemovesServiceData by extracting a collectProcessesOnce() helper from the collectProcesses loop body, then calling it synchronously in tests before Start() to guarantee the process cache is populated before service collection runs.

### Motivation
The tests were flaky because collectProcesses and collectServicesCached run as independent goroutines. When the mock clock advances, both tickers fire simultaneously, and Go's scheduler picks goroutine order nondeterministically. If collectServicesCached runs before collectProcesses populates lastCollectedProcesses, service collection sees an empty cache and produces no service data — a one-shot failure since the tick is consumed.

### Changes

#### Production code ([process_collector.go](https://github.com/datadog/datadog-agent/blob/ed51e26c0c4f7326c2987931711ffd8042955411/comp/core/workloadmeta/collectors/internal/process/process_collector.go)):

Extracted collectProcessesOnce() — runs a single process scan, diffs against lastCollectedProcesses, updates the cache, and returns the event. collectProcesses() now calls collectProcessesOnce() in its loop and sends the returned event to the channel.

#### Test code ([process_service_collector_test.go](https://github.com/datadog/datadog-agent/blob/ed51e26c0c4f7326c2987931711ffd8042955411/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go)):

Added syncProcessCollection() test helper that calls collectProcessesOnce() and notifies the store synchronously.
Both flaky tests call syncProcessCollection() before Start() to eliminate the goroutine ordering race.
Updated mock expectations in TestProcessDeathRemovesServiceData from .Times(2) to .Times(3) for the additional sync call.

### Additional Notes
One minor behavior change: the original collectProcesses exited the goroutine on ProcessesByPID error. The extracted version returns nil and the loop retries on the next tick, which is more resilient to transient errors.

https://datadoghq.atlassian.net/browse/CXP-2502

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/cc418311-cc06-454d-950d-bbdd86db3fb7)

Comment @datadog to request changes