### PR TITLE
Fix flaky TestInstrumentDockerInactive by cleaning inject state between tests

### DIFF
--- a/test/new-e2e/tests/installer/unix/package_apm_inject_test.go
+++ b/test/new-e2e/tests/installer/unix/package_apm_inject_test.go
@@ -38,6 +38,12 @@ func (s *packageApmInjectSuite) SetupTest() {
 	if s.os == e2eos.Debian12 || s.os == e2eos.Ubuntu2404 {
 		flake.Mark(s.T())
 	}
+	// Purge() uses Execute (not MustExecute), so failures are silent.
+	// A stale packages.db entry causes Install() to skip PostInstall hooks
+	// (which create /etc/ld.so.preload and /etc/docker/daemon.json).
+	s.Env().RemoteHost.Execute("sudo rm -f /opt/datadog-packages/packages.db")
+	s.Env().RemoteHost.Execute("sudo rm -f /etc/ld.so.preload")
+	s.Env().RemoteHost.Execute("sudo rm -f /etc/docker/daemon.json")
 }
 
 func (s *packageApmInjectSuite) TestInstall() {


### PR DESCRIPTION
## Summary
- Clean `/opt/datadog-packages/packages.db` in `SetupTest` so each APM inject subtest starts from a known baseline
- Tests share a VM and rely on `defer Purge()` for cleanup, but `Purge()` uses `Execute` (not `MustExecute`), so failures are silent — a stale `packages.db` entry survives
- When `Install()` finds the package already registered at the same version in `packages.db`, it returns nil **without running PostInstall hooks** (`pkg/fleet/installer/installer.go:209-217`). The PostInstall hooks are what create `/etc/ld.so.preload` and `/etc/docker/daemon.json`
- Also cleans `/etc/ld.so.preload` and `/etc/docker/daemon.json` as belt-and-suspenders

## Test plan
- [x] `TestInstrumentDockerInactive` on suse_15_4_x86_64 no longer flakes (was the consistently flaky one)
- [x] All `packageApmInjectSuite` tests pass across all flavors — zero FAILs in CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)