### PR TITLE
pkg/dyninst: Add a looping mode to the dyninst sample program

### DIFF
--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -13,11 +13,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1406 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0xd0e76a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0ed4a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1407 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0xd0e7a5", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0ed85", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -33,11 +33,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1245 EventRootType Probe[main.testAny]
-              InjectionPoints: [{PC: "0xd08bea", Frameless: false}]
+              InjectionPoints: [{PC: "0xd08cea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1246 EventRootType Probe[main.testAny]Return
-              InjectionPoints: [{PC: "0xd08c25", Frameless: false}]
+              InjectionPoints: [{PC: "0xd08d25", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -59,11 +59,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1248 EventRootType Probe[main.testAnyPtr]
-              InjectionPoints: [{PC: "0xd08c8a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd08d8a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1249 EventRootType Probe[main.testAnyPtr]Return
-              InjectionPoints: [{PC: "0xd08cbd", Frameless: false}]
+              InjectionPoints: [{PC: "0xd08dbd", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -84,11 +84,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1377 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0xd0d18e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0d34e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1378 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0xd0d242", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0d402", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -110,7 +110,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1193 EventRootType Probe[main.testArrayEmptyStructs]
-              InjectionPoints: [{PC: "0xd03e20", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03f20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -132,7 +132,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1189 EventRootType Probe[main.testArrayOfArrays]
-              InjectionPoints: [{PC: "0xd03da0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03ea0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -154,7 +154,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1191 EventRootType Probe[main.testArrayOfArraysOfArrays]
-              InjectionPoints: [{PC: "0xd03de0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03ee0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -176,7 +176,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1257 EventRootType Probe[main.testArrayOfMaps]
-              InjectionPoints: [{PC: "0xd09420", Frameless: true}]
+              InjectionPoints: [{PC: "0xd095e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -198,7 +198,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1190 EventRootType Probe[main.testArrayOfStrings]
-              InjectionPoints: [{PC: "0xd03dc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03ec0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -219,7 +219,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1192 EventRootType Probe[main.testArrayOfStructs]
-              InjectionPoints: [{PC: "0xd03e00", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03f00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -241,11 +241,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1279 EventRootType Probe[main.testAtomicAdd]
-              InjectionPoints: [{PC: "0xd0b140", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0b300", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1280 EventRootType Probe[main.testAtomicAdd]Return
-              InjectionPoints: [{PC: "0xd0b152", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0b312", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -267,11 +267,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1211 EventRootType Probe[main.testBigStruct]
-              InjectionPoints: [{PC: "0xd04520", Frameless: true}]
+              InjectionPoints: [{PC: "0xd04620", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1212 EventRootType Probe[main.testBigStruct]Return
-              InjectionPoints: [{PC: "0xd0453e", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0463e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -293,7 +293,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1178 EventRootType Probe[main.testBoolArray]
-              InjectionPoints: [{PC: "0xd03c40", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03d40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -315,7 +315,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1175 EventRootType Probe[main.testByteArray]
-              InjectionPoints: [{PC: "0xd03be0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03ce0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -342,11 +342,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1425 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xd0eba0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f180", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1426 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0xd0ebc2", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f1a2", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -366,15 +366,15 @@ Probes:
             - Kind: Line
               Type: 1486 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xd0840e"
+                - PC: "0xd0850e"
                   Frameless: false
-                - PC: "0xd08491"
+                - PC: "0xd08591"
                   Frameless: false
-                - PC: "0xd085d2"
+                - PC: "0xd086d2"
                   Frameless: false
-                - PC: "0xd0865c"
+                - PC: "0xd0875c"
                   Frameless: false
-                - PC: "0xd0872f"
+                - PC: "0xd0882f"
                   Frameless: false
               Condition: null
     - id: testCaptureExprLineCond
@@ -396,15 +396,15 @@ Probes:
             - Kind: Line
               Type: 1487 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xd0840e"
+                - PC: "0xd0850e"
                   Frameless: false
-                - PC: "0xd08491"
+                - PC: "0xd08591"
                   Frameless: false
-                - PC: "0xd085d2"
+                - PC: "0xd086d2"
                   Frameless: false
-                - PC: "0xd0865c"
+                - PC: "0xd0875c"
                   Frameless: false
-                - PC: "0xd0872f"
+                - PC: "0xd0882f"
                   Frameless: false
               Condition:
                 Type: 5 BaseType bool
@@ -440,15 +440,15 @@ Probes:
             - Kind: Line
               Type: 1488 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xd0840e"
+                - PC: "0xd0850e"
                   Frameless: false
-                - PC: "0xd08491"
+                - PC: "0xd08591"
                   Frameless: false
-                - PC: "0xd085d2"
+                - PC: "0xd086d2"
                   Frameless: false
-                - PC: "0xd0865c"
+                - PC: "0xd0875c"
                   Frameless: false
-                - PC: "0xd0872f"
+                - PC: "0xd0882f"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -476,7 +476,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1276 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0xd0ada0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0af60", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -495,7 +495,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1277 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0xd0ada0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0af60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -521,7 +521,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1433 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0xd0ecc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f2a0", Frameless: true}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -557,7 +557,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1281 EventRootType Probe[main.testChannel]
-              InjectionPoints: [{PC: "0xd0b160", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0b320", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -587,7 +587,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1275 EventRootType Probe[main.testCombinedByte]
-              InjectionPoints: [{PC: "0xd0ad60", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0af20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{w}, {x}, {y}'
@@ -616,11 +616,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1342 EventRootType Probe[main.testConflictingReturn]
-              InjectionPoints: [{PC: "0xd0c3ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c5ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1343 EventRootType Probe[main.testConflictingReturn]Return
-              InjectionPoints: [{PC: "0xd0c4b4", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c674", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -642,7 +642,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1289 EventRootType Probe[main.testCycle]
-              InjectionPoints: [{PC: "0xd0b540", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0b700", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{t}'
@@ -664,7 +664,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1218 EventRootType Probe[main.testDeepMap1]
-              InjectionPoints: [{PC: "0xd04a20", Frameless: true}]
+              InjectionPoints: [{PC: "0xd04b20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -686,7 +686,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1219 EventRootType Probe[main.testDeepMap7]
-              InjectionPoints: [{PC: "0xd04a40", Frameless: true}]
+              InjectionPoints: [{PC: "0xd04b40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -708,7 +708,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1214 EventRootType Probe[main.testDeepPtr1]
-              InjectionPoints: [{PC: "0xd04700", Frameless: true}]
+              InjectionPoints: [{PC: "0xd04800", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -730,7 +730,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1215 EventRootType Probe[main.testDeepPtr7]
-              InjectionPoints: [{PC: "0xd04720", Frameless: true}]
+              InjectionPoints: [{PC: "0xd04820", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -752,7 +752,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1216 EventRootType Probe[main.testDeepSlice1]
-              InjectionPoints: [{PC: "0xd048a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd049a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -774,7 +774,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1217 EventRootType Probe[main.testDeepSlice7]
-              InjectionPoints: [{PC: "0xd048c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd049c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -796,7 +796,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1394 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0xd0e280", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0e440", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -823,7 +823,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1397 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0xd0e2e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0e4a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -851,7 +851,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1420 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0xd0e8a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0ee80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -873,7 +873,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1434 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0xd0ed20", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f300", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -894,7 +894,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1435 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0xd0ed40", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f320", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -916,7 +916,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1247 EventRootType Probe[main.testError]
-              InjectionPoints: [{PC: "0xd08c60", Frameless: true}]
+              InjectionPoints: [{PC: "0xd08d60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -950,7 +950,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1213 EventRootType Probe[main.testErrorAtLine]Line
-              InjectionPoints: [{PC: "0xd045bb", Frameless: false}]
+              InjectionPoints: [{PC: "0xd046bb", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}, err={err}
@@ -978,11 +978,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1229 EventRootType Probe[main.testEsotericHeap]
-              InjectionPoints: [{PC: "0xd06eea", Frameless: false}]
+              InjectionPoints: [{PC: "0xd06fea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1230 EventRootType Probe[main.testEsotericHeap]Return
-              InjectionPoints: [{PC: "0xd06f2c", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0702c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1004,11 +1004,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1227 EventRootType Probe[main.testEsotericStack]
-              InjectionPoints: [{PC: "0xd06dce", Frameless: false}]
+              InjectionPoints: [{PC: "0xd06ece", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1228 EventRootType Probe[main.testEsotericStack]Return
-              InjectionPoints: [{PC: "0xd06e5b", Frameless: false}]
+              InjectionPoints: [{PC: "0xd06f5b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1030,11 +1030,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1239 EventRootType Probe[main.testFrameless]
-              InjectionPoints: [{PC: "0xd088c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd089c0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1240 EventRootType Probe[main.testFrameless]Return
-              InjectionPoints: [{PC: "0xd088c5", Frameless: true}]
+              InjectionPoints: [{PC: "0xd089c5", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1056,11 +1056,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1241 EventRootType Probe[main.testFramelessArray]
-              InjectionPoints: [{PC: "0xd088e4", Frameless: false}]
+              InjectionPoints: [{PC: "0xd089e4", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1242 EventRootType Probe[main.testFramelessArray]Return
-              InjectionPoints: [{PC: "0xd0891d", Frameless: false}]
+              InjectionPoints: [{PC: "0xd08a1d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1085,7 +1085,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1243 EventRootType Probe[main.testFramelessArray]Line
-              InjectionPoints: [{PC: "0xd088e8", Frameless: false}]
+              InjectionPoints: [{PC: "0xd089e8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1107,11 +1107,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1472 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0xd11940", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11f20", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1473 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xd11947", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11f27", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1125,11 +1125,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1474 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0xd11964", Frameless: false}]
+              InjectionPoints: [{PC: "0xd11f44", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1475 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0xd119b1", Frameless: false}]
+              InjectionPoints: [{PC: "0xd11f91", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1152,11 +1152,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1468 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0xd118aa", Frameless: false}]
+              InjectionPoints: [{PC: "0xd11e8a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1469 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0xd118b9", Frameless: false}]
+              InjectionPoints: [{PC: "0xd11e99", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1170,11 +1170,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1470 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0xd118ea", Frameless: false}]
+              InjectionPoints: [{PC: "0xd11eca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1471 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0xd11902", Frameless: false}]
+              InjectionPoints: [{PC: "0xd11ee2", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1197,14 +1197,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1476 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0xd119c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11fa0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1477 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0xd119e0"
+                - PC: "0xd11fc0"
                   Frameless: true
-                - PC: "0xd119e3"
+                - PC: "0xd11fc3"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1219,14 +1219,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1478 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0xd11a0a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd11fea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1479 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0xd11a6b"
+                - PC: "0xd1204b"
                   Frameless: false
-                - PC: "0xd11a73"
+                - PC: "0xd12053"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1253,7 +1253,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1480 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0xd119c5", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11fa5", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1265,7 +1265,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1481 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0xd11a1f", Frameless: false}]
+              InjectionPoints: [{PC: "0xd11fff", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1286,11 +1286,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1456 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0xd11560", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11b40", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1457 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0xd11570", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11b50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1304,11 +1304,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1458 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0xd11600", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11be0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1459 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0xd11608", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11be8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1332,11 +1332,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1444 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0xd110ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xd116ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1445 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xd111d4", Frameless: false}]
+              InjectionPoints: [{PC: "0xd117b4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1378,11 +1378,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1448 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xd1122a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd1180a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1449 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xd11239", Frameless: false}]
+              InjectionPoints: [{PC: "0xd11819", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1405,11 +1405,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1482 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0xd11ac0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd120a0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1483 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0xd11ac6", Frameless: true}]
+              InjectionPoints: [{PC: "0xd120a6", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1423,11 +1423,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1484 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0xd11b4a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd1212a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1485 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0xd11b6d", Frameless: false}]
+              InjectionPoints: [{PC: "0xd1214d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1450,11 +1450,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1440 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0xd11040", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11620", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1441 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xd11043", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11623", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1468,11 +1468,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1442 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0xd11060", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11640", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1443 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xd1106b", Frameless: true}]
+              InjectionPoints: [{PC: "0xd1164b", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1495,11 +1495,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1460 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0xd116c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11ca0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1461 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0xd116c7", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11ca7", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1513,11 +1513,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1462 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0xd1176a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd11d4a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1463 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0xd11796", Frameless: false}]
+              InjectionPoints: [{PC: "0xd11d76", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1540,11 +1540,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1450 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0xd11500", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11ae0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1451 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xd11503", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11ae3", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1558,11 +1558,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1452 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0xd11520", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11b00", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1453 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0xd11523", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11b03", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1576,11 +1576,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1454 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0xd11540", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11b20", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1455 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0xd11543", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11b23", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1603,11 +1603,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1464 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0xd11860", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11e40", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1465 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0xd11867", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11e47", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1621,11 +1621,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1466 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xd11880", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11e60", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1467 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xd1188e", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11e6e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1648,11 +1648,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1436 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0xd11000", Frameless: true}]
+              InjectionPoints: [{PC: "0xd115e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1437 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xd11003", Frameless: true}]
+              InjectionPoints: [{PC: "0xd115e3", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1666,11 +1666,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1438 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0xd11020", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11600", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1439 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xd1102b", Frameless: true}]
+              InjectionPoints: [{PC: "0xd1160b", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1693,11 +1693,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1231 EventRootType Probe[main.testInlinedBA]
-              InjectionPoints: [{PC: "0xd085aa", Frameless: false}]
+              InjectionPoints: [{PC: "0xd086aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1232 EventRootType Probe[main.testInlinedBA]Return
-              InjectionPoints: [{PC: "0xd0860e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0870e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1724,11 +1724,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1233 EventRootType Probe[main.testInlinedBB]
-              InjectionPoints: [{PC: "0xd0864e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0874e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1234 EventRootType Probe[main.testInlinedBB]Return
-              InjectionPoints: [{PC: "0xd086de", Frameless: false}]
+              InjectionPoints: [{PC: "0xd087de", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}'
@@ -1755,11 +1755,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1235 EventRootType Probe[main.testInlinedBBA]
-              InjectionPoints: [{PC: "0xd0872a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0882a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1236 EventRootType Probe[main.testInlinedBBA]Return
-              InjectionPoints: [{PC: "0xd0876b", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0886b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1781,7 +1781,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1492 EventRootType Probe[main.testInlinedBBB]
-              InjectionPoints: [{PC: "0xd086a6", Frameless: false}]
+              InjectionPoints: [{PC: "0xd087a6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBBB
@@ -1799,11 +1799,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1237 EventRootType Probe[main.testInlinedBC]
-              InjectionPoints: [{PC: "0xd087ae", Frameless: false}]
+              InjectionPoints: [{PC: "0xd088ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1238 EventRootType Probe[main.testInlinedBC]Return
-              InjectionPoints: [{PC: "0xd0889e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0899e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBC
@@ -1821,7 +1821,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1493 EventRootType Probe[main.testInlinedBCA]
-              InjectionPoints: [{PC: "0xd087b3", Frameless: false}]
+              InjectionPoints: [{PC: "0xd088b3", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1842,7 +1842,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1494 EventRootType Probe[main.testInlinedBCA]Line
-              InjectionPoints: [{PC: "0xd087b3", Frameless: false}]
+              InjectionPoints: [{PC: "0xd088b3", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1860,7 +1860,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1495 EventRootType Probe[main.testInlinedBCB]
-              InjectionPoints: [{PC: "0xd08866", Frameless: false}]
+              InjectionPoints: [{PC: "0xd08966", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1881,7 +1881,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1496 EventRootType Probe[main.testInlinedBCB]Line
-              InjectionPoints: [{PC: "0xd08866", Frameless: false}]
+              InjectionPoints: [{PC: "0xd08966", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1902,7 +1902,7 @@ Probes:
               InjectionPoints:
                 - PC: "0x51e6d2"
                   Frameless: true
-                - PC: "0xd09290"
+                - PC: "0xd094bd"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1923,20 +1923,20 @@ Probes:
             - Kind: Entry
               Type: 1489 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
-                - PC: "0xd0840a"
+                - PC: "0xd0850a"
                   Frameless: false
-                - PC: "0xd08491"
+                - PC: "0xd08591"
                   Frameless: false
-                - PC: "0xd085d2"
+                - PC: "0xd086d2"
                   Frameless: false
-                - PC: "0xd0865c"
+                - PC: "0xd0875c"
                   Frameless: false
-                - PC: "0xd0872f"
+                - PC: "0xd0882f"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1490 EventRootType Probe[main.testInlinedPrint]Return
-              InjectionPoints: [{PC: "0xd0844a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0854a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1962,15 +1962,15 @@ Probes:
             - Kind: Line
               Type: 1491 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xd0840e"
+                - PC: "0xd0850e"
                   Frameless: false
-                - PC: "0xd08491"
+                - PC: "0xd08591"
                   Frameless: false
-                - PC: "0xd085d2"
+                - PC: "0xd086d2"
                   Frameless: false
-                - PC: "0xd0865c"
+                - PC: "0xd0875c"
                   Frameless: false
-                - PC: "0xd0872f"
+                - PC: "0xd0882f"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1993,7 +1993,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1497 EventRootType Probe[main.testInlinedSq]
-              InjectionPoints: [{PC: "0xd088c1", Frameless: true}]
+              InjectionPoints: [{PC: "0xd089c1", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2018,7 +2018,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1498 EventRootType Probe[main.testInlinedSq]Line
-              InjectionPoints: [{PC: "0xd088c1", Frameless: true}]
+              InjectionPoints: [{PC: "0xd089c1", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2042,9 +2042,9 @@ Probes:
             - Kind: Entry
               Type: 1499 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
-                - PC: "0xd08905"
+                - PC: "0xd08a05"
                   Frameless: false
-                - PC: "0xd089a5"
+                - PC: "0xd08aa5"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2067,7 +2067,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1181 EventRootType Probe[main.testInt16Array]
-              InjectionPoints: [{PC: "0xd03ca0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03da0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2089,7 +2089,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1182 EventRootType Probe[main.testInt32Array]
-              InjectionPoints: [{PC: "0xd03cc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03dc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2111,7 +2111,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1183 EventRootType Probe[main.testInt64Array]
-              InjectionPoints: [{PC: "0xd03ce0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03de0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2133,7 +2133,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1180 EventRootType Probe[main.testInt8Array]
-              InjectionPoints: [{PC: "0xd03c80", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03d80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2155,7 +2155,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1179 EventRootType Probe[main.testIntArray]
-              InjectionPoints: [{PC: "0xd03c60", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03d60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2177,7 +2177,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1244 EventRootType Probe[main.testInterface]
-              InjectionPoints: [{PC: "0xd08bc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd08cc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -2198,11 +2198,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1375 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0xd0d00e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0d1ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1376 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xd0d153", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0d313", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2224,7 +2224,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1283 EventRootType Probe[main.testLinkedList]
-              InjectionPoints: [{PC: "0xd0b360", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0b520", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -2249,7 +2249,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1222 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0xd04aba", Frameless: false}]
+              InjectionPoints: [{PC: "0xd04bba", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2271,7 +2271,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1223 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0xd04b6d", Frameless: false}]
+              InjectionPoints: [{PC: "0xd04c6d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2293,7 +2293,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1224 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0xd04c34", Frameless: false}]
+              InjectionPoints: [{PC: "0xd04d34", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2336,11 +2336,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1381 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0xd0d4b3", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0d673", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1382 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0xd0d6c2", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0d882", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2403,7 +2403,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1225 EventRootType Probe[main.testManyPointers]
-              InjectionPoints: [{PC: "0xd05120", Frameless: true}]
+              InjectionPoints: [{PC: "0xd05220", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2427,7 +2427,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1226 EventRootType Probe[main.testManyStrings]
-              InjectionPoints: [{PC: "0xd06b00", Frameless: true}]
+              InjectionPoints: [{PC: "0xd06c00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{ss}'
@@ -2449,7 +2449,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1255 EventRootType Probe[main.testMapArrayToArray]
-              InjectionPoints: [{PC: "0xd093e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd095a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2471,7 +2471,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1262 EventRootType Probe[main.testMapEmbeddedMaps]
-              InjectionPoints: [{PC: "0xd094a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd09660", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2493,7 +2493,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1272 EventRootType Probe[main.testMapEmptyKey]
-              InjectionPoints: [{PC: "0xd095e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd097a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2515,7 +2515,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1274 EventRootType Probe[main.testMapEmptyKeyAndValue]
-              InjectionPoints: [{PC: "0xd09620", Frameless: true}]
+              InjectionPoints: [{PC: "0xd097e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2537,7 +2537,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1273 EventRootType Probe[main.testMapEmptyValue]
-              InjectionPoints: [{PC: "0xd09600", Frameless: true}]
+              InjectionPoints: [{PC: "0xd097c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2559,7 +2559,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1259 EventRootType Probe[main.testMapIntToInt]
-              InjectionPoints: [{PC: "0xd09460", Frameless: true}]
+              InjectionPoints: [{PC: "0xd09620", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2581,7 +2581,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1271 EventRootType Probe[main.testMapLargeKeyLargeValue]
-              InjectionPoints: [{PC: "0xd095c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd09780", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2603,7 +2603,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1270 EventRootType Probe[main.testMapLargeKeySmallValue]
-              InjectionPoints: [{PC: "0xd095a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd09760", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2627,7 +2627,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1260 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0xd09480", Frameless: true}]
+              InjectionPoints: [{PC: "0xd09640", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2651,7 +2651,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1261 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0xd09480", Frameless: true}]
+              InjectionPoints: [{PC: "0xd09640", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2673,7 +2673,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1269 EventRootType Probe[main.testMapSmallKeyLargeValue]
-              InjectionPoints: [{PC: "0xd09580", Frameless: true}]
+              InjectionPoints: [{PC: "0xd09740", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2695,7 +2695,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1268 EventRootType Probe[main.testMapSmallKeySmallValue]
-              InjectionPoints: [{PC: "0xd09560", Frameless: true}]
+              InjectionPoints: [{PC: "0xd09720", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2717,7 +2717,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1253 EventRootType Probe[main.testMapStringToInt]
-              InjectionPoints: [{PC: "0xd093a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd09560", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2739,7 +2739,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1254 EventRootType Probe[main.testMapStringToSlice]
-              InjectionPoints: [{PC: "0xd093c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd09580", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2761,7 +2761,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1252 EventRootType Probe[main.testMapStringToStruct]
-              InjectionPoints: [{PC: "0xd09380", Frameless: true}]
+              InjectionPoints: [{PC: "0xd09540", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2783,7 +2783,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1263 EventRootType Probe[main.testMapWithLinkedList]
-              InjectionPoints: [{PC: "0xd094c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd09680", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2805,7 +2805,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1266 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-              InjectionPoints: [{PC: "0xd09520", Frameless: true}]
+              InjectionPoints: [{PC: "0xd096e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2827,7 +2827,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1267 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-              InjectionPoints: [{PC: "0xd09540", Frameless: true}]
+              InjectionPoints: [{PC: "0xd09700", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2849,7 +2849,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1264 EventRootType Probe[main.testMapWithSmallValue]
-              InjectionPoints: [{PC: "0xd094e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd096a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2873,7 +2873,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1265 EventRootType Probe[main.testMapWithSmallValueMassive]
-              InjectionPoints: [{PC: "0xd09500", Frameless: true}]
+              InjectionPoints: [{PC: "0xd096c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2895,7 +2895,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1417 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xd0e860", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0ee40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2918,7 +2918,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1418 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xd0e860", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0ee40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2965,11 +2965,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1383 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0xd0d753", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0d913", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1384 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0xd0d98b", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0db4b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -3035,11 +3035,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1387 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0xd0dace", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0dc8e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1388 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0xd0db96", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0dd56", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3070,11 +3070,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1379 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0xd0d26e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0d42e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1380 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0xd0d48a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0d64a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3100,11 +3100,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1320 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xd0c22e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c3ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1321 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0c2cf", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c48f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3140,7 +3140,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1278 EventRootType Probe[main.testMultipleSimpleParams]
-              InjectionPoints: [{PC: "0xd0af20", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0b0e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -3181,11 +3181,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1314 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xd0c18a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c34a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1315 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0c1f5", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c3b5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3209,11 +3209,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1316 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xd0c18a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c34a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1317 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0c1f5", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c3b5", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
       version: 0
@@ -3232,11 +3232,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1322 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xd0c22e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c3ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1323 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0c2cf", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c48f", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
       version: 0
@@ -3256,11 +3256,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1324 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xd0c22e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c3ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1325 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0c2cf", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c48f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r1={result} r2={result2}
@@ -3293,11 +3293,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1318 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xd0c18a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c34a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1319 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0c1f5", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c3b5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Parameter {i} * 2 = result {result}
@@ -3325,7 +3325,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1429 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xd0eca0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f280", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3350,7 +3350,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1430 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xd0eca0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f280", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3381,7 +3381,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1431 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xd0eca0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f280", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3406,7 +3406,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1432 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xd0eca0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f280", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3433,7 +3433,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1288 EventRootType Probe[main.testNilPointer]
-              InjectionPoints: [{PC: "0xd0b500", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0b6c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}, {a}'
@@ -3460,7 +3460,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1401 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0xd0e360", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0e520", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3487,7 +3487,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1398 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0xd0e300", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0e4c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3522,7 +3522,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1400 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0xd0e340", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0e500", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3554,7 +3554,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1416 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0xd0e840", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0ee20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3576,7 +3576,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1284 EventRootType Probe[main.testPointerLoop]
-              InjectionPoints: [{PC: "0xd0b380", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0b540", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3598,7 +3598,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1258 EventRootType Probe[main.testPointerToMap]
-              InjectionPoints: [{PC: "0xd09440", Frameless: true}]
+              InjectionPoints: [{PC: "0xd09600", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3620,7 +3620,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1282 EventRootType Probe[main.testPointerToSimpleStruct]
-              InjectionPoints: [{PC: "0xd0b340", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0b500", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3644,11 +3644,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1290 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xd0ba4a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0bc0a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1291 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xd0ba9b", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0bc5b", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
       version: 0
@@ -3668,11 +3668,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1334 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xd0c30e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c4ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1335 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0c3ae", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c56e", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3715,11 +3715,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1300 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xd0bb6e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0bd2e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1301 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xd0bc24", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0bde4", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3759,11 +3759,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1292 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xd0ba4a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0bc0a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1293 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xd0ba9b", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0bc5b", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3806,11 +3806,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1302 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xd0bb6e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0bd2e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1303 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xd0bc24", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0bde4", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3852,11 +3852,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1336 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xd0c30e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c4ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1337 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0c3ae", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c56e", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
       version: 0
@@ -3873,11 +3873,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1338 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xd0c30e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c4ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1339 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0c3ae", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c56e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r0={@return.r0}
@@ -3899,11 +3899,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1294 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xd0ba4a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0bc0a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1295 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xd0ba9b", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0bc5b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: result={@return}
@@ -3926,18 +3926,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1310 EventRootType Probe[main.testReturnsAny]
-              InjectionPoints: [{PC: "0xd0be0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0bfce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1311 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
-                - PC: "0xd0bec4"
+                - PC: "0xd0c084"
                   Frameless: false
-                - PC: "0xd0beff"
+                - PC: "0xd0c0bf"
                   Frameless: false
-                - PC: "0xd0bfc2"
+                - PC: "0xd0c182"
                   Frameless: false
-                - PC: "0xd0bfcc"
+                - PC: "0xd0c18c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3965,18 +3965,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1308 EventRootType Probe[main.testReturnsAnyAndError]
-              InjectionPoints: [{PC: "0xd0bcae", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0be6e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1309 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
-                - PC: "0xd0bd18"
+                - PC: "0xd0bed8"
                   Frameless: false
-                - PC: "0xd0bd53"
+                - PC: "0xd0bf13"
                   Frameless: false
-                - PC: "0xd0bd87"
+                - PC: "0xd0bf47"
                   Frameless: false
-                - PC: "0xd0bdb9"
+                - PC: "0xd0bf79"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4003,11 +4003,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1353 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0xd0caaa", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0cc6a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1354 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0xd0cb0d", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0cccd", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -4024,11 +4024,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1355 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0xd0cb2a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0ccea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1356 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0xd0cb6b", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0cd2b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -4045,11 +4045,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1357 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0xd0cb8a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0cd4a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1358 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0xd0cbc6", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0cd86", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4066,11 +4066,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1361 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0xd0cc6e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0ce2e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1362 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0xd0ccea", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0ceaa", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4087,11 +4087,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1373 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0xd0cfaa", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0d16a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1374 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0xd0cff0", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0d1b0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4108,11 +4108,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1349 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0xd0c96a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0cb2a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1350 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0xd0c9c6", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0cb86", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4130,14 +4130,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1306 EventRootType Probe[main.testReturnsError]
-              InjectionPoints: [{PC: "0xd0bc4a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0be0a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1307 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
-                - PC: "0xd0bc7a"
+                - PC: "0xd0be3a"
                   Frameless: false
-                - PC: "0xd0bc85"
+                - PC: "0xd0be45"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4159,11 +4159,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1296 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xd0ba4a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0bc0a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1297 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xd0ba9b", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0bc5b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4184,11 +4184,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1304 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xd0bb6e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0bd2e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1305 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xd0bc24", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0bde4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4209,11 +4209,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1298 EventRootType Probe[main.testReturnsIntPointer]
-              InjectionPoints: [{PC: "0xd0baca", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0bc8a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1299 EventRootType Probe[main.testReturnsIntPointer]Return
-              InjectionPoints: [{PC: "0xd0bb3b", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0bcfb", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4235,14 +4235,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1312 EventRootType Probe[main.testReturnsInterface]
-              InjectionPoints: [{PC: "0xd0c00e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c1ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1313 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
-                - PC: "0xd0c0f1"
+                - PC: "0xd0c2b1"
                   Frameless: false
-                - PC: "0xd0c0fb"
+                - PC: "0xd0c2bb"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4264,11 +4264,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1351 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0xd0c9ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0cbae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1352 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0xd0ca73", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0cc33", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4285,11 +4285,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1347 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0xd0c86e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0ca2e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1348 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0xd0c945", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0cb05", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4306,11 +4306,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1365 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0xd0cdca", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0cf8a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1366 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0xd0ce2c", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0cfec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4327,11 +4327,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1359 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0xd0cbea", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0cdaa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1360 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0xd0cc38", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0cdf8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4348,11 +4348,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1371 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0xd0cf2a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0d0ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1372 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0xd0cf76", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0d136", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
@@ -4372,7 +4372,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1344 EventRootType Probe[main.testReturnsNamedDeferLine]Line
-              InjectionPoints: [{PC: "0xd0c5ef", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c7af", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4393,11 +4393,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1369 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0xd0ceca", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0d08a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1370 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0xd0cf0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0d0ce", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4414,11 +4414,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1345 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0xd0c7ea", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c9aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1346 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0xd0c851", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0ca11", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4435,11 +4435,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1367 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0xd0ce4a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0d00a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1368 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0xd0cead", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0d06d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4456,11 +4456,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1363 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0xd0cd0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0cece", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1364 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0xd0cd94", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0cf54", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4478,7 +4478,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1176 EventRootType Probe[main.testRuneArray]
-              InjectionPoints: [{PC: "0xd03c00", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03d00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4513,11 +4513,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1326 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xd0c22e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c3ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1327 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0c2cf", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c48f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -4563,7 +4563,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1197 EventRootType Probe[main.testSingleBool]
-              InjectionPoints: [{PC: "0xd04220", Frameless: true}]
+              InjectionPoints: [{PC: "0xd04320", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4585,7 +4585,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1195 EventRootType Probe[main.testSingleByte]
-              InjectionPoints: [{PC: "0xd041e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd042e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4607,7 +4607,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1208 EventRootType Probe[main.testSingleFloat32]
-              InjectionPoints: [{PC: "0xd04380", Frameless: true}]
+              InjectionPoints: [{PC: "0xd04480", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4625,7 +4625,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1209 EventRootType Probe[main.testSingleFloat64]
-              InjectionPoints: [{PC: "0xd043a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd044a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4643,7 +4643,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1198 EventRootType Probe[main.testSingleInt]
-              InjectionPoints: [{PC: "0xd04240", Frameless: true}]
+              InjectionPoints: [{PC: "0xd04340", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4665,7 +4665,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1200 EventRootType Probe[main.testSingleInt16]
-              InjectionPoints: [{PC: "0xd04280", Frameless: true}]
+              InjectionPoints: [{PC: "0xd04380", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}
@@ -4688,7 +4688,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1201 EventRootType Probe[main.testSingleInt32]
-              InjectionPoints: [{PC: "0xd042a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd043a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4710,7 +4710,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1202 EventRootType Probe[main.testSingleInt64]
-              InjectionPoints: [{PC: "0xd042c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd043c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4739,7 +4739,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1199 EventRootType Probe[main.testSingleInt8]
-              InjectionPoints: [{PC: "0xd04260", Frameless: true}]
+              InjectionPoints: [{PC: "0xd04360", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}{x}{x}
@@ -4770,7 +4770,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1196 EventRootType Probe[main.testSingleRune]
-              InjectionPoints: [{PC: "0xd04200", Frameless: true}]
+              InjectionPoints: [{PC: "0xd04300", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4792,7 +4792,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1408 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0xd0e7c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0eda0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4814,7 +4814,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1203 EventRootType Probe[main.testSingleUint]
-              InjectionPoints: [{PC: "0xd042e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd043e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4836,7 +4836,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1205 EventRootType Probe[main.testSingleUint16]
-              InjectionPoints: [{PC: "0xd04320", Frameless: true}]
+              InjectionPoints: [{PC: "0xd04420", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4858,7 +4858,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1206 EventRootType Probe[main.testSingleUint32]
-              InjectionPoints: [{PC: "0xd04340", Frameless: true}]
+              InjectionPoints: [{PC: "0xd04440", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4880,7 +4880,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1207 EventRootType Probe[main.testSingleUint64]
-              InjectionPoints: [{PC: "0xd04360", Frameless: true}]
+              InjectionPoints: [{PC: "0xd04460", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4902,7 +4902,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1204 EventRootType Probe[main.testSingleUint8]
-              InjectionPoints: [{PC: "0xd04300", Frameless: true}]
+              InjectionPoints: [{PC: "0xd04400", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4924,7 +4924,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1404 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0xd0e3a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0e560", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -4946,7 +4946,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1395 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0xd0e2a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0e460", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -4968,7 +4968,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1256 EventRootType Probe[main.testSmallMap]
-              InjectionPoints: [{PC: "0xd09400", Frameless: true}]
+              InjectionPoints: [{PC: "0xd095c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -4989,11 +4989,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1340 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xd0c30e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c4ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1341 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0c3ae", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c56e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -5014,11 +5014,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1385 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0xd0da2a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0dbea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1386 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0xd0da9c", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0dc5c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5040,7 +5040,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1177 EventRootType Probe[main.testStringArray]
-              InjectionPoints: [{PC: "0xd03c20", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03d20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5062,7 +5062,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1287 EventRootType Probe[main.testStringPointer]
-              InjectionPoints: [{PC: "0xd0b4c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0b680", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}'
@@ -5084,7 +5084,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1399 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0xd0e320", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0e4e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5106,7 +5106,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1220 EventRootType Probe[main.testStringType1]
-              InjectionPoints: [{PC: "0xd04a60", Frameless: true}]
+              InjectionPoints: [{PC: "0xd04b60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5128,7 +5128,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1221 EventRootType Probe[main.testStringType2]
-              InjectionPoints: [{PC: "0xd04a80", Frameless: true}]
+              InjectionPoints: [{PC: "0xd04b80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5150,11 +5150,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1427 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xd0eba0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f180", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1428 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0xd0ebc2", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f1a2", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5181,7 +5181,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1396 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0xd0e2c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0e480", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5208,7 +5208,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1250 EventRootType Probe[main.testStructWithAny]
-              InjectionPoints: [{PC: "0xd08ce0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd08de0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5229,11 +5229,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1389 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0xd0dbce", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0dd8e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1390 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0xd0dc7a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0de3a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5255,11 +5255,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1423 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0xd0ea60", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f040", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1424 EventRootType Probe[main.testStructWithCyclicMaps]Return
-              InjectionPoints: [{PC: "0xd0ea7e", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f05e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5280,7 +5280,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1422 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0xd0ea40", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f020", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5307,7 +5307,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1251 EventRootType Probe[main.testStructWithMap]
-              InjectionPoints: [{PC: "0xd09360", Frameless: true}]
+              InjectionPoints: [{PC: "0xd09520", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s} {@duration}'
@@ -5340,7 +5340,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1405 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0xd0e3c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0e580", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5380,7 +5380,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1421 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0xd0e8c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0eea0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5413,11 +5413,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1328 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xd0c22e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c3ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1329 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0c2cf", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c48f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{nonexistentVariable}'
@@ -5438,11 +5438,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1330 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xd0c22e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c3ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1331 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0c2cf", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c48f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{unsupportedExpression}'
@@ -5465,11 +5465,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1332 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xd0c22e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c3ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1333 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0c2cf", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c48f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -5501,7 +5501,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1409 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0xd0e7e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0edc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5533,11 +5533,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1410 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xd0e800", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0ede0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1411 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0xd0e81e", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0edfe", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5567,11 +5567,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1412 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xd0e800", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0ede0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1413 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0xd0e81e", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0edfe", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5603,7 +5603,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1414 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xd0e820", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0ee00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5633,7 +5633,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1415 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xd0e820", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0ee00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5665,7 +5665,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1210 EventRootType Probe[main.testTypeAlias]
-              InjectionPoints: [{PC: "0xd043c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd044c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5687,7 +5687,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1186 EventRootType Probe[main.testUint16Array]
-              InjectionPoints: [{PC: "0xd03d40", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03e40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5709,7 +5709,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1187 EventRootType Probe[main.testUint32Array]
-              InjectionPoints: [{PC: "0xd03d60", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03e60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5731,7 +5731,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1188 EventRootType Probe[main.testUint64Array]
-              InjectionPoints: [{PC: "0xd03d80", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03e80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5753,7 +5753,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1185 EventRootType Probe[main.testUint8Array]
-              InjectionPoints: [{PC: "0xd03d20", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03e20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5775,7 +5775,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1184 EventRootType Probe[main.testUintArray]
-              InjectionPoints: [{PC: "0xd03d00", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03e00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5797,7 +5797,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1286 EventRootType Probe[main.testUintPointer]
-              InjectionPoints: [{PC: "0xd0b3e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0b5a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5819,7 +5819,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1393 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0xd0e260", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0e420", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5841,7 +5841,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1419 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0xd0e880", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0ee60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5863,7 +5863,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1285 EventRootType Probe[main.testUnsafePointer]
-              InjectionPoints: [{PC: "0xd0b3a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0b560", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5885,7 +5885,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1194 EventRootType Probe[main.testVeryLargeArray]
-              InjectionPoints: [{PC: "0xd03e60", Frameless: true}]
+              InjectionPoints: [{PC: "0xd03f60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5907,7 +5907,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1402 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xd0e380", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0e540", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5929,7 +5929,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1403 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xd0e380", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0e540", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5952,14 +5952,14 @@ Probes:
             - Kind: Entry
               Type: 1500 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
-                - PC: "0xd08aea"
+                - PC: "0xd08bea"
                   Frameless: false
-                - PC: "0xd11c63"
+                - PC: "0xd12243"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1501 EventRootType Probe[main.firstBehavior.DoSomething]Return
-              InjectionPoints: [{PC: "0xd08b30", Frameless: false}]
+              InjectionPoints: [{PC: "0xd08c30", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testWhollyInlinedSubroutine
@@ -5981,11 +5981,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1391 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0xd0dcae", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0de6e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1392 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xd0dd2c", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0deec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -6002,481 +6002,481 @@ Probes:
 Subprograms:
     - ID: 1
       Name: main.testByteArray
-      OutOfLinePCRanges: [0xd03be0..0xd03be1]
+      OutOfLinePCRanges: [0xd03ce0..0xd03ce1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 103 ArrayType [2]uint8
           Locations:
-            - Range: 0xd03be0..0xd03be1
+            - Range: 0xd03ce0..0xd03ce1
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 2
       Name: main.testRuneArray
-      OutOfLinePCRanges: [0xd03c00..0xd03c01]
+      OutOfLinePCRanges: [0xd03d00..0xd03d01]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 104 ArrayType [2]int32
           Locations:
-            - Range: 0xd03c00..0xd03c01
+            - Range: 0xd03d00..0xd03d01
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 3
       Name: main.testStringArray
-      OutOfLinePCRanges: [0xd03c20..0xd03c21]
+      OutOfLinePCRanges: [0xd03d20..0xd03d21]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 105 ArrayType [2]string
           Locations:
-            - Range: 0xd03c20..0xd03c21
+            - Range: 0xd03d20..0xd03d21
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 4
       Name: main.testBoolArray
-      OutOfLinePCRanges: [0xd03c40..0xd03c41]
+      OutOfLinePCRanges: [0xd03d40..0xd03d41]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 106 ArrayType [2]bool
           Locations:
-            - Range: 0xd03c40..0xd03c41
+            - Range: 0xd03d40..0xd03d41
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 5
       Name: main.testIntArray
-      OutOfLinePCRanges: [0xd03c60..0xd03c61]
+      OutOfLinePCRanges: [0xd03d60..0xd03d61]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 107 ArrayType [2]int
           Locations:
-            - Range: 0xd03c60..0xd03c61
+            - Range: 0xd03d60..0xd03d61
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 6
       Name: main.testInt8Array
-      OutOfLinePCRanges: [0xd03c80..0xd03c81]
+      OutOfLinePCRanges: [0xd03d80..0xd03d81]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 108 ArrayType [2]int8
           Locations:
-            - Range: 0xd03c80..0xd03c81
+            - Range: 0xd03d80..0xd03d81
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 7
       Name: main.testInt16Array
-      OutOfLinePCRanges: [0xd03ca0..0xd03ca1]
+      OutOfLinePCRanges: [0xd03da0..0xd03da1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 109 ArrayType [2]int16
           Locations:
-            - Range: 0xd03ca0..0xd03ca1
+            - Range: 0xd03da0..0xd03da1
               Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 8
       Name: main.testInt32Array
-      OutOfLinePCRanges: [0xd03cc0..0xd03cc1]
+      OutOfLinePCRanges: [0xd03dc0..0xd03dc1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 104 ArrayType [2]int32
           Locations:
-            - Range: 0xd03cc0..0xd03cc1
+            - Range: 0xd03dc0..0xd03dc1
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 9
       Name: main.testInt64Array
-      OutOfLinePCRanges: [0xd03ce0..0xd03ce1]
+      OutOfLinePCRanges: [0xd03de0..0xd03de1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 110 ArrayType [2]int64
           Locations:
-            - Range: 0xd03ce0..0xd03ce1
+            - Range: 0xd03de0..0xd03de1
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 10
       Name: main.testUintArray
-      OutOfLinePCRanges: [0xd03d00..0xd03d01]
+      OutOfLinePCRanges: [0xd03e00..0xd03e01]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 111 ArrayType [2]uint
           Locations:
-            - Range: 0xd03d00..0xd03d01
+            - Range: 0xd03e00..0xd03e01
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 11
       Name: main.testUint8Array
-      OutOfLinePCRanges: [0xd03d20..0xd03d21]
+      OutOfLinePCRanges: [0xd03e20..0xd03e21]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 103 ArrayType [2]uint8
           Locations:
-            - Range: 0xd03d20..0xd03d21
+            - Range: 0xd03e20..0xd03e21
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 12
       Name: main.testUint16Array
-      OutOfLinePCRanges: [0xd03d40..0xd03d41]
+      OutOfLinePCRanges: [0xd03e40..0xd03e41]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 112 ArrayType [2]uint16
           Locations:
-            - Range: 0xd03d40..0xd03d41
+            - Range: 0xd03e40..0xd03e41
               Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 13
       Name: main.testUint32Array
-      OutOfLinePCRanges: [0xd03d60..0xd03d61]
+      OutOfLinePCRanges: [0xd03e60..0xd03e61]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 113 ArrayType [2]uint32
           Locations:
-            - Range: 0xd03d60..0xd03d61
+            - Range: 0xd03e60..0xd03e61
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 14
       Name: main.testUint64Array
-      OutOfLinePCRanges: [0xd03d80..0xd03d81]
+      OutOfLinePCRanges: [0xd03e80..0xd03e81]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 53 ArrayType [2]uint64
           Locations:
-            - Range: 0xd03d80..0xd03d81
+            - Range: 0xd03e80..0xd03e81
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 15
       Name: main.testArrayOfArrays
-      OutOfLinePCRanges: [0xd03da0..0xd03da1]
+      OutOfLinePCRanges: [0xd03ea0..0xd03ea1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 114 ArrayType [2][2]int
           Locations:
-            - Range: 0xd03da0..0xd03da1
+            - Range: 0xd03ea0..0xd03ea1
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 16
       Name: main.testArrayOfStrings
-      OutOfLinePCRanges: [0xd03dc0..0xd03dc1]
+      OutOfLinePCRanges: [0xd03ec0..0xd03ec1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 105 ArrayType [2]string
           Locations:
-            - Range: 0xd03dc0..0xd03dc1
+            - Range: 0xd03ec0..0xd03ec1
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 17
       Name: main.testArrayOfArraysOfArrays
-      OutOfLinePCRanges: [0xd03de0..0xd03de1]
+      OutOfLinePCRanges: [0xd03ee0..0xd03ee1]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 115 ArrayType [2][2][2]int
           Locations:
-            - Range: 0xd03de0..0xd03de1
+            - Range: 0xd03ee0..0xd03ee1
               Pieces: [{Size: 64, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 18
       Name: main.testArrayOfStructs
-      OutOfLinePCRanges: [0xd03e00..0xd03e01]
+      OutOfLinePCRanges: [0xd03f00..0xd03f01]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 116 ArrayType [2]main.nestedStruct
           Locations:
-            - Range: 0xd03e00..0xd03e01
+            - Range: 0xd03f00..0xd03f01
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 19
       Name: main.testArrayEmptyStructs
-      OutOfLinePCRanges: [0xd03e20..0xd03e21]
+      OutOfLinePCRanges: [0xd03f20..0xd03f21]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 118 ArrayType [2]struct {}
           Locations:
-            - Range: 0xd03e20..0xd03e21
+            - Range: 0xd03f20..0xd03f21
               Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 20
       Name: main.testVeryLargeArray
-      OutOfLinePCRanges: [0xd03e60..0xd03e61]
+      OutOfLinePCRanges: [0xd03f60..0xd03f61]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 120 ArrayType [100]uint
           Locations:
-            - Range: 0xd03e60..0xd03e61
+            - Range: 0xd03f60..0xd03f61
               Pieces: [{Size: 800, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 21
       Name: main.testSingleByte
-      OutOfLinePCRanges: [0xd041e0..0xd041e1]
+      OutOfLinePCRanges: [0xd042e0..0xd042e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xd041e0..0xd041e1
+            - Range: 0xd042e0..0xd042e1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 22
       Name: main.testSingleRune
-      OutOfLinePCRanges: [0xd04200..0xd04201]
+      OutOfLinePCRanges: [0xd04300..0xd04301]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType int32
           Locations:
-            - Range: 0xd04200..0xd04201
+            - Range: 0xd04300..0xd04301
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 23
       Name: main.testSingleBool
-      OutOfLinePCRanges: [0xd04220..0xd04221]
+      OutOfLinePCRanges: [0xd04320..0xd04321]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xd04220..0xd04221
+            - Range: 0xd04320..0xd04321
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 24
       Name: main.testSingleInt
-      OutOfLinePCRanges: [0xd04240..0xd04241]
+      OutOfLinePCRanges: [0xd04340..0xd04341]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd04240..0xd04241
+            - Range: 0xd04340..0xd04341
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 25
       Name: main.testSingleInt8
-      OutOfLinePCRanges: [0xd04260..0xd04261]
+      OutOfLinePCRanges: [0xd04360..0xd04361]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 BaseType int8
           Locations:
-            - Range: 0xd04260..0xd04261
+            - Range: 0xd04360..0xd04361
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 26
       Name: main.testSingleInt16
-      OutOfLinePCRanges: [0xd04280..0xd04281]
+      OutOfLinePCRanges: [0xd04380..0xd04381]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 98 BaseType int16
           Locations:
-            - Range: 0xd04280..0xd04281
+            - Range: 0xd04380..0xd04381
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 27
       Name: main.testSingleInt32
-      OutOfLinePCRanges: [0xd042a0..0xd042a1]
+      OutOfLinePCRanges: [0xd043a0..0xd043a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType int32
           Locations:
-            - Range: 0xd042a0..0xd042a1
+            - Range: 0xd043a0..0xd043a1
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 28
       Name: main.testSingleInt64
-      OutOfLinePCRanges: [0xd042c0..0xd042c1]
+      OutOfLinePCRanges: [0xd043c0..0xd043c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 BaseType int64
           Locations:
-            - Range: 0xd042c0..0xd042c1
+            - Range: 0xd043c0..0xd043c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 29
       Name: main.testSingleUint
-      OutOfLinePCRanges: [0xd042e0..0xd042e1]
+      OutOfLinePCRanges: [0xd043e0..0xd043e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 BaseType uint
           Locations:
-            - Range: 0xd042e0..0xd042e1
+            - Range: 0xd043e0..0xd043e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 30
       Name: main.testSingleUint8
-      OutOfLinePCRanges: [0xd04300..0xd04301]
+      OutOfLinePCRanges: [0xd04400..0xd04401]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xd04300..0xd04301
+            - Range: 0xd04400..0xd04401
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 31
       Name: main.testSingleUint16
-      OutOfLinePCRanges: [0xd04320..0xd04321]
+      OutOfLinePCRanges: [0xd04420..0xd04421]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint16
           Locations:
-            - Range: 0xd04320..0xd04321
+            - Range: 0xd04420..0xd04421
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 32
       Name: main.testSingleUint32
-      OutOfLinePCRanges: [0xd04340..0xd04341]
+      OutOfLinePCRanges: [0xd04440..0xd04441]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint32
           Locations:
-            - Range: 0xd04340..0xd04341
+            - Range: 0xd04440..0xd04441
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 33
       Name: main.testSingleUint64
-      OutOfLinePCRanges: [0xd04360..0xd04361]
+      OutOfLinePCRanges: [0xd04460..0xd04461]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 BaseType uint64
           Locations:
-            - Range: 0xd04360..0xd04361
+            - Range: 0xd04460..0xd04461
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 34
       Name: main.testSingleFloat32
-      OutOfLinePCRanges: [0xd04380..0xd04381]
+      OutOfLinePCRanges: [0xd04480..0xd04481]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType float32
           Locations:
-            - Range: 0xd04380..0xd04381
+            - Range: 0xd04480..0xd04481
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 35
       Name: main.testSingleFloat64
-      OutOfLinePCRanges: [0xd043a0..0xd043a1]
+      OutOfLinePCRanges: [0xd044a0..0xd044a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 18 BaseType float64
           Locations:
-            - Range: 0xd043a0..0xd043a1
+            - Range: 0xd044a0..0xd044a1
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 36
       Name: main.testTypeAlias
-      OutOfLinePCRanges: [0xd043c0..0xd043c1]
+      OutOfLinePCRanges: [0xd044c0..0xd044c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 121 BaseType main.typeAlias
           Locations:
-            - Range: 0xd043c0..0xd043c1
+            - Range: 0xd044c0..0xd044c1
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 37
       Name: main.testBigStruct
-      OutOfLinePCRanges: [0xd04520..0xd0453f]
+      OutOfLinePCRanges: [0xd04620..0xd0463f]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 122 StructureType main.bigStruct
           Locations:
-            - Range: 0xd04520..0xd0453f
+            - Range: 0xd04620..0xd0463f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6495,48 +6495,48 @@ Subprograms:
       DictRegister: null
     - ID: 38
       Name: main.testErrorAtLine
-      OutOfLinePCRanges: [0xd04580..0xd04692]
+      OutOfLinePCRanges: [0xd04680..0xd04792]
       InlinePCRanges: []
       Variables:
         - Name: shouldErr
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xd04580..0xd04598
+            - Range: 0xd04680..0xd04698
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType int
-          Locations: [{Range: 0xd04580..0xd04692, Pieces: []}]
+          Locations: [{Range: 0xd04680..0xd04792, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 10 BaseType int
-          Locations: [{Range: 0xd04580..0xd04692, Pieces: []}]
+          Locations: [{Range: 0xd04680..0xd04792, Pieces: []}]
           Role: Local
           DictIndex: -1
         - Name: err
           Type: 19 GoInterfaceType error
           Locations:
-            - Range: 0xd045a9..0xd045c5
+            - Range: 0xd046a9..0xd046c5
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
-            - Range: 0xd045c5..0xd045fe
+            - Range: 0xd046c5..0xd046fe
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xd045fe..0xd04605
+            - Range: 0xd046fe..0xd04705
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -80}
                 - Size: 8
                   Op: {CfaOffset: -72}
-            - Range: 0xd04605..0xd04692
+            - Range: 0xd04705..0xd04792
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -80}
@@ -6547,39 +6547,39 @@ Subprograms:
       DictRegister: null
     - ID: 39
       Name: main.testDeepPtr1
-      OutOfLinePCRanges: [0xd04700..0xd04701]
+      OutOfLinePCRanges: [0xd04800..0xd04801]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 126 StructureType main.deepPtr1
           Locations:
-            - Range: 0xd04700..0xd04701
+            - Range: 0xd04800..0xd04801
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 40
       Name: main.testDeepPtr7
-      OutOfLinePCRanges: [0xd04720..0xd04721]
+      OutOfLinePCRanges: [0xd04820..0xd04821]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 129 PointerType *main.deepPtr7
           Locations:
-            - Range: 0xd04720..0xd04721
+            - Range: 0xd04820..0xd04821
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 41
       Name: main.testDeepSlice1
-      OutOfLinePCRanges: [0xd048a0..0xd048a1]
+      OutOfLinePCRanges: [0xd049a0..0xd049a1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 131 StructureType main.deepSlice1
           Locations:
-            - Range: 0xd048a0..0xd048a1
+            - Range: 0xd049a0..0xd049a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6592,142 +6592,142 @@ Subprograms:
       DictRegister: null
     - ID: 42
       Name: main.testDeepSlice7
-      OutOfLinePCRanges: [0xd048c0..0xd048c1]
+      OutOfLinePCRanges: [0xd049c0..0xd049c1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 135 PointerType *main.deepSlice7
           Locations:
-            - Range: 0xd048c0..0xd048c1
+            - Range: 0xd049c0..0xd049c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 43
       Name: main.testDeepMap1
-      OutOfLinePCRanges: [0xd04a20..0xd04a21]
+      OutOfLinePCRanges: [0xd04b20..0xd04b21]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 137 StructureType main.deepMap1
           Locations:
-            - Range: 0xd04a20..0xd04a21
+            - Range: 0xd04b20..0xd04b21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 44
       Name: main.testDeepMap7
-      OutOfLinePCRanges: [0xd04a40..0xd04a41]
+      OutOfLinePCRanges: [0xd04b40..0xd04b41]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 145 PointerType *main.deepMap7
           Locations:
-            - Range: 0xd04a40..0xd04a41
+            - Range: 0xd04b40..0xd04b41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 45
       Name: main.testStringType1
-      OutOfLinePCRanges: [0xd04a60..0xd04a61]
+      OutOfLinePCRanges: [0xd04b60..0xd04b61]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 147 PointerType *main.stringType1
           Locations:
-            - Range: 0xd04a60..0xd04a61
+            - Range: 0xd04b60..0xd04b61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 46
       Name: main.testStringType2
-      OutOfLinePCRanges: [0xd04a80..0xd04a81]
+      OutOfLinePCRanges: [0xd04b80..0xd04b81]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 149 PointerType **main.stringType2
           Locations:
-            - Range: 0xd04a80..0xd04a81
+            - Range: 0xd04b80..0xd04b81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 47
       Name: main.testLongFunctionWithChangingState
-      OutOfLinePCRanges: [0xd04aa0..0xd04cea]
+      OutOfLinePCRanges: [0xd04ba0..0xd04dea]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd04b84..0xd04ba5
+            - Range: 0xd04c84..0xd04ca5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd04c58..0xd04c6f
+            - Range: 0xd04d58..0xd04d6f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: aPerArch
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd04b6d..0xd04b70
+            - Range: 0xd04c6d..0xd04c70
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd04b70..0xd04ba5
+            - Range: 0xd04c70..0xd04ca5
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd04ba5..0xd04c4b
+            - Range: 0xd04ca5..0xd04d4b
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0xd04c4b..0xd04c58
+            - Range: 0xd04d4b..0xd04d58
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0xd04c58..0xd04cea
+            - Range: 0xd04d58..0xd04dea
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
           Role: Local
           DictIndex: -1
         - Name: b
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd04b6a..0xd04b70
+            - Range: 0xd04c6a..0xd04c70
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd04b70..0xd04b70
+            - Range: 0xd04c70..0xd04c70
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd04b70..0xd04ba5
+            - Range: 0xd04c70..0xd04ca5
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd04ba5..0xd04c4b
+            - Range: 0xd04ca5..0xd04d4b
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0xd04c4b..0xd04c50
+            - Range: 0xd04d4b..0xd04d50
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0xd04c50..0xd04c58
+            - Range: 0xd04d50..0xd04d58
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
-            - Range: 0xd04c58..0xd04c6f
+            - Range: 0xd04d58..0xd04d6f
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
-            - Range: 0xd04c6f..0xd04cea
+            - Range: 0xd04d6f..0xd04dea
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 48
       Name: main.testManyPointers
-      OutOfLinePCRanges: [0xd05120..0xd05121]
+      OutOfLinePCRanges: [0xd05220..0xd05221]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 151 StructureType main.manyPointers
           Locations:
-            - Range: 0xd05120..0xd05121
+            - Range: 0xd05220..0xd05221
               Pieces: [{Size: 560, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 49
       Name: main.testManyStrings
-      OutOfLinePCRanges: [0xd06b00..0xd06b01]
+      OutOfLinePCRanges: [0xd06c00..0xd06c01]
       InlinePCRanges: []
       Variables:
         - Name: ss
           Type: 154 GoSliceHeaderType []string
           Locations:
-            - Range: 0xd06b00..0xd06b01
+            - Range: 0xd06c00..0xd06c01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6740,13 +6740,13 @@ Subprograms:
       DictRegister: null
     - ID: 50
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0xd06dc0..0xd06ec5]
+      OutOfLinePCRanges: [0xd06ec0..0xd06fc5]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 155 StructureType main.esotericStack
           Locations:
-            - Range: 0xd06dc0..0xd06e13
+            - Range: 0xd06ec0..0xd06f13
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -6766,7 +6766,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xd06e13..0xd06e18
+            - Range: 0xd06f13..0xd06f18
               Pieces:
                 - Size: 4
                   Op: null
@@ -6786,7 +6786,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xd06e18..0xd06e1d
+            - Range: 0xd06f18..0xd06f1d
               Pieces:
                 - Size: 4
                   Op: null
@@ -6811,155 +6811,155 @@ Subprograms:
       DictRegister: null
     - ID: 51
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0xd06ee0..0xd06f43]
+      OutOfLinePCRanges: [0xd06fe0..0xd07043]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 159 PointerType *main.esotericHeap
           Locations:
-            - Range: 0xd06ee0..0xd06f0d
+            - Range: 0xd06fe0..0xd0700d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 52
       Name: main.testInlinedBA
-      OutOfLinePCRanges: [0xd085a0..0xd08628]
+      OutOfLinePCRanges: [0xd086a0..0xd08728]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd085a0..0xd085b5
+            - Range: 0xd086a0..0xd086b5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 53
       Name: main.testInlinedBB
-      OutOfLinePCRanges: [0xd08640..0xd08705]
+      OutOfLinePCRanges: [0xd08740..0xd08805]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd08640..0xd08656
+            - Range: 0xd08740..0xd08756
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: "y"
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd08640..0xd08667
+            - Range: 0xd08740..0xd08767
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: z
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd08656..0xd08667
+            - Range: 0xd08756..0xd08767
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd08667..0xd08705
+            - Range: 0xd08767..0xd08805
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 54
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0xd08720..0xd08782]
+      OutOfLinePCRanges: [0xd08820..0xd08882]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd08720..0xd0873a
+            - Range: 0xd08820..0xd0883a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 55
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0xd087a0..0xd088ae]
+      OutOfLinePCRanges: [0xd088a0..0xd089ae]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd087fb..0xd08805
+            - Range: 0xd088fb..0xd08905
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xd08805..0xd08820
+            - Range: 0xd08905..0xd08920
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xd08820..0xd08834
+            - Range: 0xd08920..0xd08934
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: i
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd087f6..0xd08800
+            - Range: 0xd088f6..0xd08900
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xd08800..0xd08820
+            - Range: 0xd08900..0xd08920
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xd08820..0xd0882f
+            - Range: 0xd08920..0xd0892f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 56
       Name: main.testFrameless
-      OutOfLinePCRanges: [0xd088c0..0xd088c6]
+      OutOfLinePCRanges: [0xd089c0..0xd089c6]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd088c0..0xd088c5
+            - Range: 0xd089c0..0xd089c5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd088c0..0xd088c5
+            - Range: 0xd089c0..0xd089c5
               Pieces: []
-            - Range: 0xd088c5..0xd088c6
+            - Range: 0xd089c5..0xd089c6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 57
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0xd088e0..0xd08923]
+      OutOfLinePCRanges: [0xd089e0..0xd08a23]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 161 ArrayType [5]int
           Locations:
-            - Range: 0xd088e0..0xd08923
+            - Range: 0xd089e0..0xd08a23
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd088e0..0xd0891d
+            - Range: 0xd089e0..0xd08a1d
               Pieces: []
-            - Range: 0xd0891d..0xd0891e
+            - Range: 0xd08a1d..0xd08a1e
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0891e..0xd08923
+            - Range: 0xd08a1e..0xd08a23
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 58
       Name: main.testInterface
-      OutOfLinePCRanges: [0xd08bc0..0xd08bc1]
+      OutOfLinePCRanges: [0xd08cc0..0xd08cc1]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 162 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xd08bc0..0xd08bc1
+            - Range: 0xd08cc0..0xd08cc1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6970,19 +6970,19 @@ Subprograms:
       DictRegister: null
     - ID: 59
       Name: main.testAny
-      OutOfLinePCRanges: [0xd08be0..0xd08c46]
+      OutOfLinePCRanges: [0xd08ce0..0xd08d46]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd08be0..0xd08c09
+            - Range: 0xd08ce0..0xd08d09
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd08c09..0xd08c0e
+            - Range: 0xd08d09..0xd08d0e
               Pieces:
                 - Size: 8
                   Op: null
@@ -6993,28 +6993,28 @@ Subprograms:
         - Name: ~r0
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0xd08be0..0xd08c25
+            - Range: 0xd08ce0..0xd08d25
               Pieces: []
-            - Range: 0xd08c25..0xd08c26
+            - Range: 0xd08d25..0xd08d26
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd08c26..0xd08c46
+            - Range: 0xd08d26..0xd08d46
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 60
       Name: main.testError
-      OutOfLinePCRanges: [0xd08c60..0xd08c61]
+      OutOfLinePCRanges: [0xd08d60..0xd08d61]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 19 GoInterfaceType error
           Locations:
-            - Range: 0xd08c60..0xd08c61
+            - Range: 0xd08d60..0xd08d61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7025,41 +7025,41 @@ Subprograms:
       DictRegister: null
     - ID: 61
       Name: main.testAnyPtr
-      OutOfLinePCRanges: [0xd08c80..0xd08cd4]
+      OutOfLinePCRanges: [0xd08d80..0xd08dd4]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 163 PointerType *interface {}
           Locations:
-            - Range: 0xd08c80..0xd08ca6
+            - Range: 0xd08d80..0xd08da6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0xd08c80..0xd08cbd
+            - Range: 0xd08d80..0xd08dbd
               Pieces: []
-            - Range: 0xd08cbd..0xd08cbe
+            - Range: 0xd08dbd..0xd08dbe
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd08cbe..0xd08cd4
+            - Range: 0xd08dbe..0xd08dd4
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 62
       Name: main.testStructWithAny
-      OutOfLinePCRanges: [0xd08ce0..0xd08ce1]
+      OutOfLinePCRanges: [0xd08de0..0xd08de1]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 164 StructureType main.structWithAny
           Locations:
-            - Range: 0xd08ce0..0xd08ce1
+            - Range: 0xd08de0..0xd08de1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7070,346 +7070,346 @@ Subprograms:
       DictRegister: null
     - ID: 63
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0xd09360..0xd09361]
+      OutOfLinePCRanges: [0xd09520..0xd09521]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 165 StructureType main.structWithMap
-          Locations:
-            - Range: 0xd09360..0xd09361
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 64
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0xd09380..0xd09381]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 171 GoMapType map[string]main.nestedStruct
-          Locations:
-            - Range: 0xd09380..0xd09381
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 65
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0xd093a0..0xd093a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 176 GoMapType map[string]int
-          Locations:
-            - Range: 0xd093a0..0xd093a1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 66
-      Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0xd093c0..0xd093c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 181 GoMapType map[string][]string
-          Locations:
-            - Range: 0xd093c0..0xd093c1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 67
-      Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0xd093e0..0xd093e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 186 GoMapType map[[4]string][2]int
-          Locations:
-            - Range: 0xd093e0..0xd093e1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 68
-      Name: main.testSmallMap
-      OutOfLinePCRanges: [0xd09400..0xd09401]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 176 GoMapType map[string]int
-          Locations:
-            - Range: 0xd09400..0xd09401
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 69
-      Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0xd09420..0xd09421]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 191 ArrayType [2]map[string]int
-          Locations:
-            - Range: 0xd09420..0xd09421
-              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 70
-      Name: main.testPointerToMap
-      OutOfLinePCRanges: [0xd09440..0xd09441]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 192 PointerType *map[string]int
-          Locations:
-            - Range: 0xd09440..0xd09441
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 71
-      Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0xd09460..0xd09461]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 166 GoMapType map[int]int
-          Locations:
-            - Range: 0xd09460..0xd09461
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 72
-      Name: main.testMapMassive
-      OutOfLinePCRanges: [0xd09480..0xd09481]
-      InlinePCRanges: []
-      Variables:
-        - Name: redactMyEntries
-          Type: 193 GoMapType map[string][]main.structWithMap
-          Locations:
-            - Range: 0xd09480..0xd09481
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 73
-      Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0xd094a0..0xd094a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 193 GoMapType map[string][]main.structWithMap
-          Locations:
-            - Range: 0xd094a0..0xd094a1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 74
-      Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0xd094c0..0xd094c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 198 GoMapType map[bool]main.node
-          Locations:
-            - Range: 0xd094c0..0xd094c1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 75
-      Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0xd094e0..0xd094e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 203 GoMapType map[int]uint8
-          Locations:
-            - Range: 0xd094e0..0xd094e1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 76
-      Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0xd09500..0xd09501]
-      InlinePCRanges: []
-      Variables:
-        - Name: redactMyEntries
-          Type: 203 GoMapType map[int]uint8
-          Locations:
-            - Range: 0xd09500..0xd09501
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 77
-      Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0xd09520..0xd09521]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 208 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xd09520..0xd09521
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 78
-      Name: main.testMapWithSmallKeyAndValueMassive
+    - ID: 64
+      Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0xd09540..0xd09541]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 208 GoMapType map[uint8]uint8
+          Type: 171 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0xd09540..0xd09541
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 79
-      Name: main.testMapSmallKeySmallValue
+    - ID: 65
+      Name: main.testMapStringToInt
       OutOfLinePCRanges: [0xd09560..0xd09561]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 208 GoMapType map[uint8]uint8
+          Type: 176 GoMapType map[string]int
           Locations:
             - Range: 0xd09560..0xd09561
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 80
-      Name: main.testMapSmallKeyLargeValue
+    - ID: 66
+      Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0xd09580..0xd09581]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 213 GoMapType map[uint8][4]int
+          Type: 181 GoMapType map[string][]string
           Locations:
             - Range: 0xd09580..0xd09581
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 81
-      Name: main.testMapLargeKeySmallValue
+    - ID: 67
+      Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0xd095a0..0xd095a1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 218 GoMapType map[[4]int]uint8
+          Type: 186 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0xd095a0..0xd095a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 82
-      Name: main.testMapLargeKeyLargeValue
+    - ID: 68
+      Name: main.testSmallMap
       OutOfLinePCRanges: [0xd095c0..0xd095c1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 223 GoMapType map[[4]int][4]int
+          Type: 176 GoMapType map[string]int
           Locations:
             - Range: 0xd095c0..0xd095c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 83
-      Name: main.testMapEmptyKey
+    - ID: 69
+      Name: main.testArrayOfMaps
       OutOfLinePCRanges: [0xd095e0..0xd095e1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 228 GoMapType map[struct {}]int
+          Type: 191 ArrayType [2]map[string]int
           Locations:
             - Range: 0xd095e0..0xd095e1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 84
-      Name: main.testMapEmptyValue
+    - ID: 70
+      Name: main.testPointerToMap
       OutOfLinePCRanges: [0xd09600..0xd09601]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 233 GoMapType map[int]struct {}
+          Type: 192 PointerType *map[string]int
           Locations:
             - Range: 0xd09600..0xd09601
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 85
-      Name: main.testMapEmptyKeyAndValue
+    - ID: 71
+      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0xd09620..0xd09621]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 238 GoMapType map[struct {}]struct {}
+          Type: 166 GoMapType map[int]int
           Locations:
             - Range: 0xd09620..0xd09621
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 72
+      Name: main.testMapMassive
+      OutOfLinePCRanges: [0xd09640..0xd09641]
+      InlinePCRanges: []
+      Variables:
+        - Name: redactMyEntries
+          Type: 193 GoMapType map[string][]main.structWithMap
+          Locations:
+            - Range: 0xd09640..0xd09641
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 73
+      Name: main.testMapEmbeddedMaps
+      OutOfLinePCRanges: [0xd09660..0xd09661]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 193 GoMapType map[string][]main.structWithMap
+          Locations:
+            - Range: 0xd09660..0xd09661
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 74
+      Name: main.testMapWithLinkedList
+      OutOfLinePCRanges: [0xd09680..0xd09681]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 198 GoMapType map[bool]main.node
+          Locations:
+            - Range: 0xd09680..0xd09681
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 75
+      Name: main.testMapWithSmallValue
+      OutOfLinePCRanges: [0xd096a0..0xd096a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 203 GoMapType map[int]uint8
+          Locations:
+            - Range: 0xd096a0..0xd096a1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 76
+      Name: main.testMapWithSmallValueMassive
+      OutOfLinePCRanges: [0xd096c0..0xd096c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: redactMyEntries
+          Type: 203 GoMapType map[int]uint8
+          Locations:
+            - Range: 0xd096c0..0xd096c1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 77
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0xd096e0..0xd096e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 208 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xd096e0..0xd096e1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 78
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0xd09700..0xd09701]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 208 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xd09700..0xd09701
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 79
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0xd09720..0xd09721]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 208 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xd09720..0xd09721
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 80
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0xd09740..0xd09741]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 213 GoMapType map[uint8][4]int
+          Locations:
+            - Range: 0xd09740..0xd09741
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 81
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0xd09760..0xd09761]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 218 GoMapType map[[4]int]uint8
+          Locations:
+            - Range: 0xd09760..0xd09761
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 82
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0xd09780..0xd09781]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 223 GoMapType map[[4]int][4]int
+          Locations:
+            - Range: 0xd09780..0xd09781
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 83
+      Name: main.testMapEmptyKey
+      OutOfLinePCRanges: [0xd097a0..0xd097a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 228 GoMapType map[struct {}]int
+          Locations:
+            - Range: 0xd097a0..0xd097a1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 84
+      Name: main.testMapEmptyValue
+      OutOfLinePCRanges: [0xd097c0..0xd097c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 233 GoMapType map[int]struct {}
+          Locations:
+            - Range: 0xd097c0..0xd097c1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 85
+      Name: main.testMapEmptyKeyAndValue
+      OutOfLinePCRanges: [0xd097e0..0xd097e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 238 GoMapType map[struct {}]struct {}
+          Locations:
+            - Range: 0xd097e0..0xd097e1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 86
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0xd0ad60..0xd0ad61]
+      OutOfLinePCRanges: [0xd0af20..0xd0af21]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xd0ad60..0xd0ad61
+            - Range: 0xd0af20..0xd0af21
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xd0ad60..0xd0ad61
+            - Range: 0xd0af20..0xd0af21
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: "y"
           Type: 17 BaseType float32
           Locations:
-            - Range: 0xd0ad60..0xd0ad61
+            - Range: 0xd0af20..0xd0af21
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 87
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0xd0ada0..0xd0ada1]
+      OutOfLinePCRanges: [0xd0af60..0xd0af61]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xd0ada0..0xd0ada1
+            - Range: 0xd0af60..0xd0af61
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0xd0ada0..0xd0ada1
+            - Range: 0xd0af60..0xd0af61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -7420,48 +7420,48 @@ Subprograms:
         - Name: "y"
           Type: 17 BaseType float32
           Locations:
-            - Range: 0xd0ada0..0xd0ada1
+            - Range: 0xd0af60..0xd0af61
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 88
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0xd0af20..0xd0af21]
+      OutOfLinePCRanges: [0xd0b0e0..0xd0b0e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xd0af20..0xd0af21
+            - Range: 0xd0b0e0..0xd0b0e1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xd0af20..0xd0af21
+            - Range: 0xd0b0e0..0xd0b0e1
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 13 BaseType int32
           Locations:
-            - Range: 0xd0af20..0xd0af21
+            - Range: 0xd0b0e0..0xd0b0e1
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 16 BaseType uint
           Locations:
-            - Range: 0xd0af20..0xd0af21
+            - Range: 0xd0b0e0..0xd0b0e1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0xd0af20..0xd0af21
+            - Range: 0xd0b0e0..0xd0b0e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7472,61 +7472,61 @@ Subprograms:
       DictRegister: null
     - ID: 89
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0xd0b140..0xd0b153]
+      OutOfLinePCRanges: [0xd0b300..0xd0b313]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 BaseType uint64
           Locations:
-            - Range: 0xd0b140..0xd0b152
+            - Range: 0xd0b300..0xd0b312
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 11 BaseType uint64
           Locations:
-            - Range: 0xd0b140..0xd0b152
+            - Range: 0xd0b300..0xd0b312
               Pieces: []
-            - Range: 0xd0b152..0xd0b153
+            - Range: 0xd0b312..0xd0b313
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 90
       Name: main.testChannel
-      OutOfLinePCRanges: [0xd0b160..0xd0b161]
+      OutOfLinePCRanges: [0xd0b320..0xd0b321]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 243 GoChannelType chan bool
           Locations:
-            - Range: 0xd0b160..0xd0b161
+            - Range: 0xd0b320..0xd0b321
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 91
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xd0b340..0xd0b341]
+      OutOfLinePCRanges: [0xd0b500..0xd0b501]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 244 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xd0b340..0xd0b341
+            - Range: 0xd0b500..0xd0b501
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 92
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0xd0b360..0xd0b361]
+      OutOfLinePCRanges: [0xd0b520..0xd0b521]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 246 StructureType main.node
           Locations:
-            - Range: 0xd0b360..0xd0b361
+            - Range: 0xd0b520..0xd0b521
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7537,273 +7537,273 @@ Subprograms:
       DictRegister: null
     - ID: 93
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xd0b380..0xd0b381]
+      OutOfLinePCRanges: [0xd0b540..0xd0b541]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 247 PointerType *main.node
-          Locations:
-            - Range: 0xd0b380..0xd0b381
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 94
-      Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xd0b3a0..0xd0b3a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 20 VoidPointerType unsafe.Pointer
-          Locations:
-            - Range: 0xd0b3a0..0xd0b3a1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 95
-      Name: main.testUintPointer
-      OutOfLinePCRanges: [0xd0b3e0..0xd0b3e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 101 PointerType *uint
-          Locations:
-            - Range: 0xd0b3e0..0xd0b3e1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 96
-      Name: main.testStringPointer
-      OutOfLinePCRanges: [0xd0b4c0..0xd0b4c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: z
-          Type: 89 PointerType *string
-          Locations:
-            - Range: 0xd0b4c0..0xd0b4c1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 97
-      Name: main.testNilPointer
-      OutOfLinePCRanges: [0xd0b500..0xd0b501]
-      InlinePCRanges: []
-      Variables:
-        - Name: z
-          Type: 6 PointerType *bool
-          Locations:
-            - Range: 0xd0b500..0xd0b501
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: a
-          Type: 16 BaseType uint
-          Locations:
-            - Range: 0xd0b500..0xd0b501
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 98
-      Name: main.testCycle
-      OutOfLinePCRanges: [0xd0b540..0xd0b541]
-      InlinePCRanges: []
-      Variables:
-        - Name: t
-          Type: 248 PointerType *main.t
           Locations:
             - Range: 0xd0b540..0xd0b541
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 94
+      Name: main.testUnsafePointer
+      OutOfLinePCRanges: [0xd0b560..0xd0b561]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 20 VoidPointerType unsafe.Pointer
+          Locations:
+            - Range: 0xd0b560..0xd0b561
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 95
+      Name: main.testUintPointer
+      OutOfLinePCRanges: [0xd0b5a0..0xd0b5a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 101 PointerType *uint
+          Locations:
+            - Range: 0xd0b5a0..0xd0b5a1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 96
+      Name: main.testStringPointer
+      OutOfLinePCRanges: [0xd0b680..0xd0b681]
+      InlinePCRanges: []
+      Variables:
+        - Name: z
+          Type: 89 PointerType *string
+          Locations:
+            - Range: 0xd0b680..0xd0b681
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 97
+      Name: main.testNilPointer
+      OutOfLinePCRanges: [0xd0b6c0..0xd0b6c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: z
+          Type: 6 PointerType *bool
+          Locations:
+            - Range: 0xd0b6c0..0xd0b6c1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 16 BaseType uint
+          Locations:
+            - Range: 0xd0b6c0..0xd0b6c1
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 98
+      Name: main.testCycle
+      OutOfLinePCRanges: [0xd0b700..0xd0b701]
+      InlinePCRanges: []
+      Variables:
+        - Name: t
+          Type: 248 PointerType *main.t
+          Locations:
+            - Range: 0xd0b700..0xd0b701
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 99
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0xd0ba40..0xd0bab2]
+      OutOfLinePCRanges: [0xd0bc00..0xd0bc72]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0ba40..0xd0ba52
+            - Range: 0xd0bc00..0xd0bc12
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0ba40..0xd0ba9b
+            - Range: 0xd0bc00..0xd0bc5b
               Pieces: []
-            - Range: 0xd0ba9b..0xd0ba9c
+            - Range: 0xd0bc5b..0xd0bc5c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0ba9c..0xd0bab2
+            - Range: 0xd0bc5c..0xd0bc72
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0ba52..0xd0ba65
+            - Range: 0xd0bc12..0xd0bc25
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0ba65..0xd0bab2
+            - Range: 0xd0bc25..0xd0bc72
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 100
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0xd0bac0..0xd0bb55]
+      OutOfLinePCRanges: [0xd0bc80..0xd0bd15]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0bac0..0xd0bada
+            - Range: 0xd0bc80..0xd0bc9a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0bada..0xd0bb55
+            - Range: 0xd0bc9a..0xd0bd15
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 94 PointerType *int
           Locations:
-            - Range: 0xd0bac0..0xd0bb3b
+            - Range: 0xd0bc80..0xd0bcfb
               Pieces: []
-            - Range: 0xd0bb3b..0xd0bb3c
+            - Range: 0xd0bcfb..0xd0bcfc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0bb3c..0xd0bb55
+            - Range: 0xd0bcfc..0xd0bd15
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: '&result'
           Type: 94 PointerType *int
           Locations:
-            - Range: 0xd0badf..0xd0bafc
+            - Range: 0xd0bc9f..0xd0bcbc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0bafc..0xd0bb55
+            - Range: 0xd0bcbc..0xd0bd15
               Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 101
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0xd0bb60..0xd0bc3e]
+      OutOfLinePCRanges: [0xd0bd20..0xd0bdfe]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0bb60..0xd0bbc2
+            - Range: 0xd0bd20..0xd0bd82
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0bb60..0xd0bc24
+            - Range: 0xd0bd20..0xd0bde4
               Pieces: []
-            - Range: 0xd0bc24..0xd0bc25
+            - Range: 0xd0bde4..0xd0bde5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0bc25..0xd0bc3e
+            - Range: 0xd0bde5..0xd0bdfe
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0bb60..0xd0bc3e, Pieces: []}]
+          Locations: [{Range: 0xd0bd20..0xd0bdfe, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: resultInt
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0bb76..0xd0bbc7
+            - Range: 0xd0bd36..0xd0bd87
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd0bbc7..0xd0bc3e
+            - Range: 0xd0bd87..0xd0bdfe
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
           Role: Local
           DictIndex: -1
         - Name: resultFloat
           Type: 18 BaseType float64
           Locations:
-            - Range: 0xd0bb8f..0xd0bbc7
+            - Range: 0xd0bd4f..0xd0bd87
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
-            - Range: 0xd0bbc7..0xd0bc3e
+            - Range: 0xd0bd87..0xd0bdfe
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 102
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0xd0bc40..0xd0bc9b]
+      OutOfLinePCRanges: [0xd0be00..0xd0be5b]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xd0bc40..0xd0bc59
+            - Range: 0xd0be00..0xd0be19
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 19 GoInterfaceType error
           Locations:
-            - Range: 0xd0bc40..0xd0bc7a
+            - Range: 0xd0be00..0xd0be3a
               Pieces: []
-            - Range: 0xd0bc7a..0xd0bc7b
+            - Range: 0xd0be3a..0xd0be3b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0bc7b..0xd0bc85
+            - Range: 0xd0be3b..0xd0be45
               Pieces: []
-            - Range: 0xd0bc85..0xd0bc86
+            - Range: 0xd0be45..0xd0be46
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0bc86..0xd0bc9b
+            - Range: 0xd0be46..0xd0be5b
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 103
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0xd0bca0..0xd0bde6]
+      OutOfLinePCRanges: [0xd0be60..0xd0bfa6]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd0bca0..0xd0bcf1
+            - Range: 0xd0be60..0xd0beb1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0bcf1..0xd0bcf4
+            - Range: 0xd0beb1..0xd0beb4
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0bd37..0xd0bd45
+            - Range: 0xd0bef7..0xd0bf05
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0bd60..0xd0bd65
+            - Range: 0xd0bf20..0xd0bf25
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0bd94..0xd0bd99
+            - Range: 0xd0bf54..0xd0bf59
               Pieces:
                 - Size: 8
                   Op: null
@@ -7814,117 +7814,117 @@ Subprograms:
         - Name: failed
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xd0bca0..0xd0bcef
+            - Range: 0xd0be60..0xd0beaf
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd0bca0..0xd0bd18
+            - Range: 0xd0be60..0xd0bed8
               Pieces: []
-            - Range: 0xd0bd18..0xd0bd19
+            - Range: 0xd0bed8..0xd0bed9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0bd19..0xd0bd53
+            - Range: 0xd0bed9..0xd0bf13
               Pieces: []
-            - Range: 0xd0bd53..0xd0bd54
+            - Range: 0xd0bf13..0xd0bf14
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0bd54..0xd0bd87
+            - Range: 0xd0bf14..0xd0bf47
               Pieces: []
-            - Range: 0xd0bd87..0xd0bd88
+            - Range: 0xd0bf47..0xd0bf48
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0bd88..0xd0bdb9
+            - Range: 0xd0bf48..0xd0bf79
               Pieces: []
-            - Range: 0xd0bdb9..0xd0bdba
+            - Range: 0xd0bf79..0xd0bf7a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0bdba..0xd0bde6
+            - Range: 0xd0bf7a..0xd0bfa6
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 19 GoInterfaceType error
           Locations:
-            - Range: 0xd0bca0..0xd0bd18
+            - Range: 0xd0be60..0xd0bed8
               Pieces: []
-            - Range: 0xd0bd18..0xd0bd19
+            - Range: 0xd0bed8..0xd0bed9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd0bd19..0xd0bd53
+            - Range: 0xd0bed9..0xd0bf13
               Pieces: []
-            - Range: 0xd0bd53..0xd0bd54
+            - Range: 0xd0bf13..0xd0bf14
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd0bd54..0xd0bd87
+            - Range: 0xd0bf14..0xd0bf47
               Pieces: []
-            - Range: 0xd0bd87..0xd0bd88
+            - Range: 0xd0bf47..0xd0bf48
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd0bd88..0xd0bdb9
+            - Range: 0xd0bf48..0xd0bf79
               Pieces: []
-            - Range: 0xd0bdb9..0xd0bdba
+            - Range: 0xd0bf79..0xd0bf7a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd0bdba..0xd0bde6
+            - Range: 0xd0bf7a..0xd0bfa6
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0bd37..0xd0bd40
+            - Range: 0xd0bef7..0xd0bf00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 104
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0xd0be00..0xd0bff4]
+      OutOfLinePCRanges: [0xd0bfc0..0xd0c1b4]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd0be00..0xd0be5f
+            - Range: 0xd0bfc0..0xd0c01f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0be5f..0xd0be62
+            - Range: 0xd0c01f..0xd0c022
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd0be62..0xd0bff4
+            - Range: 0xd0c022..0xd0c1b4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -7935,1128 +7935,1128 @@ Subprograms:
         - Name: ~r0
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd0be00..0xd0bec4
+            - Range: 0xd0bfc0..0xd0c084
               Pieces: []
-            - Range: 0xd0bec4..0xd0bec5
+            - Range: 0xd0c084..0xd0c085
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0bec5..0xd0beff
+            - Range: 0xd0c085..0xd0c0bf
               Pieces: []
-            - Range: 0xd0beff..0xd0bf00
+            - Range: 0xd0c0bf..0xd0c0c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0bf00..0xd0bfc2
+            - Range: 0xd0c0c0..0xd0c182
               Pieces: []
-            - Range: 0xd0bfc2..0xd0bfc3
+            - Range: 0xd0c182..0xd0c183
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0bfc3..0xd0bfcc
+            - Range: 0xd0c183..0xd0c18c
               Pieces: []
-            - Range: 0xd0bfcc..0xd0bfcd
+            - Range: 0xd0c18c..0xd0c18d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0bfcd..0xd0bff4
+            - Range: 0xd0c18d..0xd0c1b4
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0beea..0xd0bef0
+            - Range: 0xd0c0aa..0xd0c0b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: '&result'
           Type: 94 PointerType *int
           Locations:
-            - Range: 0xd0bea5..0xd0bec4
+            - Range: 0xd0c065..0xd0c084
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 105
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0xd0c000..0xd0c165]
+      OutOfLinePCRanges: [0xd0c1c0..0xd0c325]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd0c000..0xd0c040
+            - Range: 0xd0c1c0..0xd0c200
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0c040..0xd0c0a5
+            - Range: 0xd0c200..0xd0c265
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xd0c0a5..0xd0c101
+            - Range: 0xd0c265..0xd0c2c1
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xd0c101..0xd0c121
+            - Range: 0xd0c2c1..0xd0c2e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd0c121..0xd0c128
+            - Range: 0xd0c2e1..0xd0c2e8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd0c128..0xd0c165
+            - Range: 0xd0c2e8..0xd0c325
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 162 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xd0c000..0xd0c0f1
+            - Range: 0xd0c1c0..0xd0c2b1
               Pieces: []
-            - Range: 0xd0c0f1..0xd0c0f2
+            - Range: 0xd0c2b1..0xd0c2b2
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0c0f2..0xd0c0fb
+            - Range: 0xd0c2b2..0xd0c2bb
               Pieces: []
-            - Range: 0xd0c0fb..0xd0c0fc
+            - Range: 0xd0c2bb..0xd0c2bc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0c0fc..0xd0c165
+            - Range: 0xd0c2bc..0xd0c325
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 162 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xd0c000..0xd0c040
+            - Range: 0xd0c1c0..0xd0c200
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0c040..0xd0c095
+            - Range: 0xd0c200..0xd0c255
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd0c095..0xd0c0a5
+            - Range: 0xd0c255..0xd0c265
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd0c0a5..0xd0c0f7
+            - Range: 0xd0c265..0xd0c2b7
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd0c0f7..0xd0c0f9
+            - Range: 0xd0c2b7..0xd0c2b9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd0c0f9..0xd0c0fb
+            - Range: 0xd0c2b9..0xd0c2bb
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xd0c0fb..0xd0c165
+            - Range: 0xd0c2bb..0xd0c325
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 106
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0xd0c180..0xd0c20f]
+      OutOfLinePCRanges: [0xd0c340..0xd0c3cf]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0c180..0xd0c191
+            - Range: 0xd0c340..0xd0c351
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0c180..0xd0c1f5
+            - Range: 0xd0c340..0xd0c3b5
               Pieces: []
-            - Range: 0xd0c1f5..0xd0c1f6
+            - Range: 0xd0c3b5..0xd0c3b6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0c1f6..0xd0c20f
+            - Range: 0xd0c3b6..0xd0c3cf
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 107
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0xd0c220..0xd0c2e9]
+      OutOfLinePCRanges: [0xd0c3e0..0xd0c4a9]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0c220..0xd0c273
+            - Range: 0xd0c3e0..0xd0c433
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0c220..0xd0c2cf
+            - Range: 0xd0c3e0..0xd0c48f
               Pieces: []
-            - Range: 0xd0c2cf..0xd0c2d0
+            - Range: 0xd0c48f..0xd0c490
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0c2d0..0xd0c2e9
+            - Range: 0xd0c490..0xd0c4a9
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0c220..0xd0c2cf
+            - Range: 0xd0c3e0..0xd0c48f
               Pieces: []
-            - Range: 0xd0c2cf..0xd0c2d0
+            - Range: 0xd0c48f..0xd0c490
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0c2d0..0xd0c2e9
+            - Range: 0xd0c490..0xd0c4a9
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 108
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0xd0c300..0xd0c3c8]
+      OutOfLinePCRanges: [0xd0c4c0..0xd0c588]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0c300..0xd0c345
+            - Range: 0xd0c4c0..0xd0c505
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0c345..0xd0c3c8
+            - Range: 0xd0c505..0xd0c588
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0c300..0xd0c3ae
+            - Range: 0xd0c4c0..0xd0c56e
               Pieces: []
-            - Range: 0xd0c3ae..0xd0c3af
+            - Range: 0xd0c56e..0xd0c56f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0c3af..0xd0c3c8
+            - Range: 0xd0c56f..0xd0c588
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0c300..0xd0c3ae
+            - Range: 0xd0c4c0..0xd0c56e
               Pieces: []
-            - Range: 0xd0c3ae..0xd0c3af
+            - Range: 0xd0c56e..0xd0c56f
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0c3af..0xd0c3c8
+            - Range: 0xd0c56f..0xd0c588
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0c300..0xd0c3ae
+            - Range: 0xd0c4c0..0xd0c56e
               Pieces: []
-            - Range: 0xd0c3ae..0xd0c3af
+            - Range: 0xd0c56e..0xd0c56f
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd0c3af..0xd0c3c8
+            - Range: 0xd0c56f..0xd0c588
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 109
       Name: main.testConflictingReturn
-      OutOfLinePCRanges: [0xd0c3e0..0xd0c4cf]
+      OutOfLinePCRanges: [0xd0c5a0..0xd0c68f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0c3e0..0xd0c425
+            - Range: 0xd0c5a0..0xd0c5e5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0c425..0xd0c4cf
+            - Range: 0xd0c5e5..0xd0c68f
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0c3e0..0xd0c4b4
+            - Range: 0xd0c5a0..0xd0c674
               Pieces: []
-            - Range: 0xd0c4b4..0xd0c4b5
+            - Range: 0xd0c674..0xd0c675
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0c4b5..0xd0c4cf
+            - Range: 0xd0c675..0xd0c68f
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: r0
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0xd0c3e0..0xd0c4b4
+            - Range: 0xd0c5a0..0xd0c674
               Pieces: []
-            - Range: 0xd0c4b4..0xd0c4b5
+            - Range: 0xd0c674..0xd0c675
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xd0c4b5..0xd0c4cf
+            - Range: 0xd0c675..0xd0c68f
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 110
       Name: main.testReturnsNamedDeferLine
-      OutOfLinePCRanges: [0xd0c4e0..0xd0c6ef]
+      OutOfLinePCRanges: [0xd0c6a0..0xd0c8af]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0c4e0..0xd0c566
+            - Range: 0xd0c6a0..0xd0c726
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0c566..0xd0c6ef
+            - Range: 0xd0c726..0xd0c8af
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0xd0c517..0xd0c6ef
+            - Range: 0xd0c6d7..0xd0c8af
               Pieces: [{Size: 16, Op: {CfaOffset: -128}}]
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0xd0c51d..0xd0c6ef
+            - Range: 0xd0c6dd..0xd0c8af
               Pieces: [{Size: 16, Op: {CfaOffset: -144}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 111
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0xd0c7e0..0xd0c85e]
+      OutOfLinePCRanges: [0xd0c9a0..0xd0ca1e]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 15 BaseType int8
           Locations:
-            - Range: 0xd0c7e0..0xd0c851
+            - Range: 0xd0c9a0..0xd0ca11
               Pieces: []
-            - Range: 0xd0c851..0xd0c852
+            - Range: 0xd0ca11..0xd0ca12
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0c852..0xd0c85e
+            - Range: 0xd0ca12..0xd0ca1e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 98 BaseType int16
           Locations:
-            - Range: 0xd0c7e0..0xd0c851
+            - Range: 0xd0c9a0..0xd0ca11
               Pieces: []
-            - Range: 0xd0c851..0xd0c852
+            - Range: 0xd0ca11..0xd0ca12
               Pieces: [{Size: 2, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0c852..0xd0c85e
+            - Range: 0xd0ca12..0xd0ca1e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 13 BaseType int32
           Locations:
-            - Range: 0xd0c7e0..0xd0c851
+            - Range: 0xd0c9a0..0xd0ca11
               Pieces: []
-            - Range: 0xd0c851..0xd0c852
+            - Range: 0xd0ca11..0xd0ca12
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd0c852..0xd0c85e
+            - Range: 0xd0ca12..0xd0ca1e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 14 BaseType int64
           Locations:
-            - Range: 0xd0c7e0..0xd0c851
+            - Range: 0xd0c9a0..0xd0ca11
               Pieces: []
-            - Range: 0xd0c851..0xd0c852
+            - Range: 0xd0ca11..0xd0ca12
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xd0c852..0xd0c85e
+            - Range: 0xd0ca12..0xd0ca1e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xd0c7e0..0xd0c851
+            - Range: 0xd0c9a0..0xd0ca11
               Pieces: []
-            - Range: 0xd0c851..0xd0c852
+            - Range: 0xd0ca11..0xd0ca12
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xd0c852..0xd0c85e
+            - Range: 0xd0ca12..0xd0ca1e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 8 BaseType uint16
           Locations:
-            - Range: 0xd0c7e0..0xd0c851
+            - Range: 0xd0c9a0..0xd0ca11
               Pieces: []
-            - Range: 0xd0c851..0xd0c852
+            - Range: 0xd0ca11..0xd0ca12
               Pieces: [{Size: 2, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xd0c852..0xd0c85e
+            - Range: 0xd0ca12..0xd0ca1e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 3 BaseType uint32
           Locations:
-            - Range: 0xd0c7e0..0xd0c851
+            - Range: 0xd0c9a0..0xd0ca11
               Pieces: []
-            - Range: 0xd0c851..0xd0c852
+            - Range: 0xd0ca11..0xd0ca12
               Pieces: [{Size: 4, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xd0c852..0xd0c85e
+            - Range: 0xd0ca12..0xd0ca1e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 11 BaseType uint64
           Locations:
-            - Range: 0xd0c7e0..0xd0c851
+            - Range: 0xd0c9a0..0xd0ca11
               Pieces: []
-            - Range: 0xd0c851..0xd0c852
+            - Range: 0xd0ca11..0xd0ca12
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xd0c852..0xd0c85e
+            - Range: 0xd0ca12..0xd0ca1e
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 112
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0xd0c860..0xd0c955]
+      OutOfLinePCRanges: [0xd0ca20..0xd0cb15]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0c860..0xd0c955, Pieces: []}]
+          Locations: [{Range: 0xd0ca20..0xd0cb15, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0c860..0xd0c955, Pieces: []}]
+          Locations: [{Range: 0xd0ca20..0xd0cb15, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0c860..0xd0c955, Pieces: []}]
+          Locations: [{Range: 0xd0ca20..0xd0cb15, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0c860..0xd0c955, Pieces: []}]
+          Locations: [{Range: 0xd0ca20..0xd0cb15, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0c860..0xd0c955, Pieces: []}]
+          Locations: [{Range: 0xd0ca20..0xd0cb15, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0c860..0xd0c955, Pieces: []}]
+          Locations: [{Range: 0xd0ca20..0xd0cb15, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0c860..0xd0c955, Pieces: []}]
+          Locations: [{Range: 0xd0ca20..0xd0cb15, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0c860..0xd0c955, Pieces: []}]
+          Locations: [{Range: 0xd0ca20..0xd0cb15, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0c860..0xd0c955, Pieces: []}]
+          Locations: [{Range: 0xd0ca20..0xd0cb15, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r9
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0c860..0xd0c955, Pieces: []}]
+          Locations: [{Range: 0xd0ca20..0xd0cb15, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r10
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0c860..0xd0c955, Pieces: []}]
+          Locations: [{Range: 0xd0ca20..0xd0cb15, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r11
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0c860..0xd0c955, Pieces: []}]
+          Locations: [{Range: 0xd0ca20..0xd0cb15, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r12
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0c860..0xd0c955, Pieces: []}]
+          Locations: [{Range: 0xd0ca20..0xd0cb15, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r13
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0c860..0xd0c955, Pieces: []}]
+          Locations: [{Range: 0xd0ca20..0xd0cb15, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r14
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0c860..0xd0c955, Pieces: []}]
+          Locations: [{Range: 0xd0ca20..0xd0cb15, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: onlyOnAmd64_16
           Type: 18 BaseType float64
           Locations:
-            - Range: 0xd0c860..0xd0c945
+            - Range: 0xd0ca20..0xd0cb05
               Pieces: []
-            - Range: 0xd0c945..0xd0c946
+            - Range: 0xd0cb05..0xd0cb06
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xd0c946..0xd0c955
+            - Range: 0xd0cb06..0xd0cb15
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: bothArmAndAmd64
           Type: 18 BaseType float64
           Locations:
-            - Range: 0xd0c860..0xd0c945
+            - Range: 0xd0ca20..0xd0cb05
               Pieces: []
-            - Range: 0xd0c945..0xd0c946
+            - Range: 0xd0cb05..0xd0cb06
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xd0c946..0xd0c955
+            - Range: 0xd0cb06..0xd0cb15
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 113
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0xd0c960..0xd0c9d3]
+      OutOfLinePCRanges: [0xd0cb20..0xd0cb93]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 90 BaseType complex64
-          Locations: [{Range: 0xd0c960..0xd0c9d3, Pieces: []}]
+          Locations: [{Range: 0xd0cb20..0xd0cb93, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 91 BaseType complex128
-          Locations: [{Range: 0xd0c960..0xd0c9d3, Pieces: []}]
+          Locations: [{Range: 0xd0cb20..0xd0cb93, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 114
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0xd0c9e0..0xd0ca85]
+      OutOfLinePCRanges: [0xd0cba0..0xd0cc45]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xd0c9e0..0xd0ca73
+            - Range: 0xd0cba0..0xd0cc33
               Pieces: []
-            - Range: 0xd0ca73..0xd0ca74
+            - Range: 0xd0cc33..0xd0cc34
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
-            - Range: 0xd0ca74..0xd0ca85
+            - Range: 0xd0cc34..0xd0cc45
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 115
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0xd0caa0..0xd0cb1a]
+      OutOfLinePCRanges: [0xd0cc60..0xd0ccda]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0xd0caa0..0xd0cb0d
+            - Range: 0xd0cc60..0xd0cccd
               Pieces: []
-            - Range: 0xd0cb0d..0xd0cb0e
+            - Range: 0xd0cccd..0xd0ccce
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xd0cb0e..0xd0cb1a
+            - Range: 0xd0ccce..0xd0ccda
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 116
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0xd0cb20..0xd0cb78]
+      OutOfLinePCRanges: [0xd0cce0..0xd0cd38]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 252 ArrayType [1]int
           Locations:
-            - Range: 0xd0cb20..0xd0cb6b
+            - Range: 0xd0cce0..0xd0cd2b
               Pieces: []
-            - Range: 0xd0cb6b..0xd0cb6c
+            - Range: 0xd0cd2b..0xd0cd2c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0cb6c..0xd0cb78
+            - Range: 0xd0cd2c..0xd0cd38
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 117
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0xd0cb80..0xd0cbd3]
+      OutOfLinePCRanges: [0xd0cd40..0xd0cd93]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 253 ArrayType [0]int
           Locations:
-            - Range: 0xd0cb80..0xd0cbc6
+            - Range: 0xd0cd40..0xd0cd86
               Pieces: []
-            - Range: 0xd0cbc6..0xd0cbc7
+            - Range: 0xd0cd86..0xd0cd87
               Pieces: []
-            - Range: 0xd0cbc7..0xd0cbd3
+            - Range: 0xd0cd87..0xd0cd93
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 118
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0xd0cbe0..0xd0cc47]
+      OutOfLinePCRanges: [0xd0cda0..0xd0ce07]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 254 StructureType main.mixedStruct
-          Locations: [{Range: 0xd0cbe0..0xd0cc47, Pieces: []}]
+          Locations: [{Range: 0xd0cda0..0xd0ce07, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 119
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0xd0cc60..0xd0ccfa]
+      OutOfLinePCRanges: [0xd0ce20..0xd0ceba]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0cc60..0xd0ccea
+            - Range: 0xd0ce20..0xd0ceaa
               Pieces: []
-            - Range: 0xd0ccea..0xd0cceb
+            - Range: 0xd0ceaa..0xd0ceab
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0cceb..0xd0ccfa
+            - Range: 0xd0ceab..0xd0ceba
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0cc60..0xd0ccea
+            - Range: 0xd0ce20..0xd0ceaa
               Pieces: []
-            - Range: 0xd0ccea..0xd0cceb
+            - Range: 0xd0ceaa..0xd0ceab
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0cceb..0xd0ccfa
+            - Range: 0xd0ceab..0xd0ceba
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0cc60..0xd0ccea
+            - Range: 0xd0ce20..0xd0ceaa
               Pieces: []
-            - Range: 0xd0ccea..0xd0cceb
+            - Range: 0xd0ceaa..0xd0ceab
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd0cceb..0xd0ccfa
+            - Range: 0xd0ceab..0xd0ceba
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0cc60..0xd0ccea
+            - Range: 0xd0ce20..0xd0ceaa
               Pieces: []
-            - Range: 0xd0ccea..0xd0cceb
+            - Range: 0xd0ceaa..0xd0ceab
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xd0cceb..0xd0ccfa
+            - Range: 0xd0ceab..0xd0ceba
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0cc60..0xd0ccea
+            - Range: 0xd0ce20..0xd0ceaa
               Pieces: []
-            - Range: 0xd0ccea..0xd0cceb
+            - Range: 0xd0ceaa..0xd0ceab
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xd0cceb..0xd0ccfa
+            - Range: 0xd0ceab..0xd0ceba
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0cc60..0xd0ccea
+            - Range: 0xd0ce20..0xd0ceaa
               Pieces: []
-            - Range: 0xd0ccea..0xd0cceb
+            - Range: 0xd0ceaa..0xd0ceab
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xd0cceb..0xd0ccfa
+            - Range: 0xd0ceab..0xd0ceba
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0cc60..0xd0ccea
+            - Range: 0xd0ce20..0xd0ceaa
               Pieces: []
-            - Range: 0xd0ccea..0xd0cceb
+            - Range: 0xd0ceaa..0xd0ceab
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xd0cceb..0xd0ccfa
+            - Range: 0xd0ceab..0xd0ceba
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0cc60..0xd0ccea
+            - Range: 0xd0ce20..0xd0ceaa
               Pieces: []
-            - Range: 0xd0ccea..0xd0cceb
+            - Range: 0xd0ceaa..0xd0ceab
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xd0cceb..0xd0ccfa
+            - Range: 0xd0ceab..0xd0ceba
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0xd0cc60..0xd0ccea
+            - Range: 0xd0ce20..0xd0ceaa
               Pieces: []
-            - Range: 0xd0ccea..0xd0cceb
+            - Range: 0xd0ceaa..0xd0ceab
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xd0cceb..0xd0ccfa
+            - Range: 0xd0ceab..0xd0ceba
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 120
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0xd0cd00..0xd0cda5]
+      OutOfLinePCRanges: [0xd0cec0..0xd0cf65]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 255 StructureType main.wideStruct
           Locations:
-            - Range: 0xd0cd00..0xd0cd94
+            - Range: 0xd0cec0..0xd0cf54
               Pieces: []
-            - Range: 0xd0cd94..0xd0cd95
+            - Range: 0xd0cf54..0xd0cf55
               Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
-            - Range: 0xd0cd95..0xd0cda5
+            - Range: 0xd0cf55..0xd0cf65
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 121
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0xd0cdc0..0xd0ce39]
+      OutOfLinePCRanges: [0xd0cf80..0xd0cff9]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0cdc0..0xd0ce2c
+            - Range: 0xd0cf80..0xd0cfec
               Pieces: []
-            - Range: 0xd0ce2c..0xd0ce2d
+            - Range: 0xd0cfec..0xd0cfed
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0ce2d..0xd0ce39
+            - Range: 0xd0cfed..0xd0cff9
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0cdc0..0xd0ce39, Pieces: []}]
+          Locations: [{Range: 0xd0cf80..0xd0cff9, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0cdc0..0xd0ce2c
+            - Range: 0xd0cf80..0xd0cfec
               Pieces: []
-            - Range: 0xd0ce2c..0xd0ce2d
+            - Range: 0xd0cfec..0xd0cfed
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0ce2d..0xd0ce39
+            - Range: 0xd0cfed..0xd0cff9
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0cdc0..0xd0ce39, Pieces: []}]
+          Locations: [{Range: 0xd0cf80..0xd0cff9, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0xd0cdc0..0xd0ce2c
+            - Range: 0xd0cf80..0xd0cfec
               Pieces: []
-            - Range: 0xd0ce2c..0xd0ce2d
+            - Range: 0xd0cfec..0xd0cfed
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd0ce2d..0xd0ce39
+            - Range: 0xd0cfed..0xd0cff9
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 122
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0xd0ce40..0xd0ceba]
+      OutOfLinePCRanges: [0xd0d000..0xd0d07a]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 256 StructureType main.structWithArray
           Locations:
-            - Range: 0xd0ce40..0xd0cead
+            - Range: 0xd0d000..0xd0d06d
               Pieces: []
-            - Range: 0xd0cead..0xd0ceae
+            - Range: 0xd0d06d..0xd0d06e
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xd0ceae..0xd0ceba
+            - Range: 0xd0d06e..0xd0d07a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 123
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0xd0cec0..0xd0cf1b]
+      OutOfLinePCRanges: [0xd0d080..0xd0d0db]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0cec0..0xd0cf1b, Pieces: []}]
+          Locations: [{Range: 0xd0d080..0xd0d0db, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 124
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0xd0cf20..0xd0cf87]
+      OutOfLinePCRanges: [0xd0d0e0..0xd0d147]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float32
-          Locations: [{Range: 0xd0cf20..0xd0cf87, Pieces: []}]
+          Locations: [{Range: 0xd0d0e0..0xd0d147, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0cf20..0xd0cf87, Pieces: []}]
+          Locations: [{Range: 0xd0d0e0..0xd0d147, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 125
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0xd0cfa0..0xd0cffd]
+      OutOfLinePCRanges: [0xd0d160..0xd0d1bd]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xd0cfa0..0xd0cff0
+            - Range: 0xd0d160..0xd0d1b0
               Pieces: []
-            - Range: 0xd0cff0..0xd0cff1
+            - Range: 0xd0d1b0..0xd0d1b1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0cff1..0xd0cffd
+            - Range: 0xd0d1b1..0xd0d1bd
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 2 BaseType uintptr
           Locations:
-            - Range: 0xd0cfa0..0xd0cff0
+            - Range: 0xd0d160..0xd0d1b0
               Pieces: []
-            - Range: 0xd0cff0..0xd0cff1
+            - Range: 0xd0d1b0..0xd0d1b1
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0cff1..0xd0cffd
+            - Range: 0xd0d1b1..0xd0d1bd
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 126
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0xd0d000..0xd0d165]
+      OutOfLinePCRanges: [0xd0d1c0..0xd0d325]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xd0d000..0xd0d165
+            - Range: 0xd0d1c0..0xd0d325
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xd0d000..0xd0d153
+            - Range: 0xd0d1c0..0xd0d313
               Pieces: []
-            - Range: 0xd0d153..0xd0d154
+            - Range: 0xd0d313..0xd0d314
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
-            - Range: 0xd0d154..0xd0d165
+            - Range: 0xd0d314..0xd0d325
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 127
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0xd0d180..0xd0d252]
+      OutOfLinePCRanges: [0xd0d340..0xd0d412]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0xd0d180..0xd0d252
+            - Range: 0xd0d340..0xd0d412
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0xd0d180..0xd0d242
+            - Range: 0xd0d340..0xd0d402
               Pieces: []
-            - Range: 0xd0d242..0xd0d243
+            - Range: 0xd0d402..0xd0d403
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xd0d243..0xd0d252
+            - Range: 0xd0d403..0xd0d412
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 128
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0xd0d260..0xd0d49a]
+      OutOfLinePCRanges: [0xd0d420..0xd0d65a]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xd0d260..0xd0d49a
+            - Range: 0xd0d420..0xd0d65a
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s2
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xd0d260..0xd0d49a
+            - Range: 0xd0d420..0xd0d65a
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xd0d260..0xd0d48a
+            - Range: 0xd0d420..0xd0d64a
               Pieces: []
-            - Range: 0xd0d48a..0xd0d48b
+            - Range: 0xd0d64a..0xd0d64b
               Pieces: [{Size: 80, Op: {CfaOffset: 160}}]
-            - Range: 0xd0d48b..0xd0d49a
+            - Range: 0xd0d64b..0xd0d65a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 129
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0xd0d4a0..0xd0d72f]
+      OutOfLinePCRanges: [0xd0d660..0xd0d8ef]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0d4a0..0xd0d550
+            - Range: 0xd0d660..0xd0d710
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0d550..0xd0d72f
+            - Range: 0xd0d710..0xd0d8ef
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0d4a0..0xd0d550
+            - Range: 0xd0d660..0xd0d710
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0d550..0xd0d72f
+            - Range: 0xd0d710..0xd0d8ef
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0d4a0..0xd0d550
+            - Range: 0xd0d660..0xd0d710
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd0d550..0xd0d72f
+            - Range: 0xd0d710..0xd0d8ef
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0d4a0..0xd0d510
+            - Range: 0xd0d660..0xd0d6d0
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xd0d510..0xd0d72f
+            - Range: 0xd0d6d0..0xd0d8ef
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0d4a0..0xd0d550
+            - Range: 0xd0d660..0xd0d710
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xd0d550..0xd0d72f
+            - Range: 0xd0d710..0xd0d8ef
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0d4a0..0xd0d550
+            - Range: 0xd0d660..0xd0d710
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xd0d550..0xd0d72f
+            - Range: 0xd0d710..0xd0d8ef
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0d4a0..0xd0d550
+            - Range: 0xd0d660..0xd0d710
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xd0d550..0xd0d72f
+            - Range: 0xd0d710..0xd0d8ef
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0d4a0..0xd0d550
+            - Range: 0xd0d660..0xd0d710
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xd0d550..0xd0d72f
+            - Range: 0xd0d710..0xd0d8ef
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
         - Name: i
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0d4a0..0xd0d550
+            - Range: 0xd0d660..0xd0d710
               Pieces: [{Size: 8, Op: {RegNo: 11, Shift: 0}}]
-            - Range: 0xd0d550..0xd0d72f
+            - Range: 0xd0d710..0xd0d8ef
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 107 ArrayType [2]int
           Locations:
-            - Range: 0xd0d4a0..0xd0d6c2
+            - Range: 0xd0d660..0xd0d882
               Pieces: []
-            - Range: 0xd0d6c2..0xd0d6c3
+            - Range: 0xd0d882..0xd0d883
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xd0d6c3..0xd0d72f
+            - Range: 0xd0d883..0xd0d8ef
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 130
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0xd0d740..0xd0da0c]
+      OutOfLinePCRanges: [0xd0d900..0xd0dbcc]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0d740..0xd0d7eb
+            - Range: 0xd0d900..0xd0d9ab
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0d7eb..0xd0da0c
+            - Range: 0xd0d9ab..0xd0dbcc
               Pieces: [{Size: 8, Op: {CfaOffset: 96}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0d740..0xd0d7eb
+            - Range: 0xd0d900..0xd0d9ab
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0d7eb..0xd0da0c
+            - Range: 0xd0d9ab..0xd0dbcc
               Pieces: [{Size: 8, Op: {CfaOffset: 104}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0d740..0xd0d7eb
+            - Range: 0xd0d900..0xd0d9ab
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd0d7eb..0xd0da0c
+            - Range: 0xd0d9ab..0xd0dbcc
               Pieces: [{Size: 8, Op: {CfaOffset: 112}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0d740..0xd0d7a2
+            - Range: 0xd0d900..0xd0d962
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xd0d7a2..0xd0da0c
+            - Range: 0xd0d962..0xd0dbcc
               Pieces: [{Size: 8, Op: {CfaOffset: 120}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0d740..0xd0d7eb
+            - Range: 0xd0d900..0xd0d9ab
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xd0d7eb..0xd0da0c
+            - Range: 0xd0d9ab..0xd0dbcc
               Pieces: [{Size: 8, Op: {CfaOffset: 128}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0d740..0xd0d7eb
+            - Range: 0xd0d900..0xd0d9ab
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xd0d7eb..0xd0da0c
+            - Range: 0xd0d9ab..0xd0dbcc
               Pieces: [{Size: 8, Op: {CfaOffset: 136}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0d740..0xd0d7eb
+            - Range: 0xd0d900..0xd0d9ab
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xd0d7eb..0xd0da0c
+            - Range: 0xd0d9ab..0xd0dbcc
               Pieces: [{Size: 8, Op: {CfaOffset: 144}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0d740..0xd0d7eb
+            - Range: 0xd0d900..0xd0d9ab
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xd0d7eb..0xd0da0c
+            - Range: 0xd0d9ab..0xd0dbcc
               Pieces: [{Size: 8, Op: {CfaOffset: 152}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0xd0d740..0xd0da0c
+            - Range: 0xd0d900..0xd0dbcc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -9067,200 +9067,200 @@ Subprograms:
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xd0d740..0xd0d98b
+            - Range: 0xd0d900..0xd0db4b
               Pieces: []
-            - Range: 0xd0d98b..0xd0d98c
+            - Range: 0xd0db4b..0xd0db4c
               Pieces: [{Size: 80, Op: {CfaOffset: 16}}]
-            - Range: 0xd0d98c..0xd0da0c
+            - Range: 0xd0db4c..0xd0dbcc
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 131
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0xd0da20..0xd0daac]
+      OutOfLinePCRanges: [0xd0dbe0..0xd0dc6c]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 161 ArrayType [5]int
           Locations:
-            - Range: 0xd0da20..0xd0daac
+            - Range: 0xd0dbe0..0xd0dc6c
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0da20..0xd0da9c
+            - Range: 0xd0dbe0..0xd0dc5c
               Pieces: []
-            - Range: 0xd0da9c..0xd0da9d
+            - Range: 0xd0dc5c..0xd0dc5d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0da9d..0xd0daac
+            - Range: 0xd0dc5d..0xd0dc6c
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0da20..0xd0da9c
+            - Range: 0xd0dbe0..0xd0dc5c
               Pieces: []
-            - Range: 0xd0da9c..0xd0da9d
+            - Range: 0xd0dc5c..0xd0dc5d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0da9d..0xd0daac
+            - Range: 0xd0dc5d..0xd0dc6c
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0da20..0xd0da9c
+            - Range: 0xd0dbe0..0xd0dc5c
               Pieces: []
-            - Range: 0xd0da9c..0xd0da9d
+            - Range: 0xd0dc5c..0xd0dc5d
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd0da9d..0xd0daac
+            - Range: 0xd0dc5d..0xd0dc6c
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 132
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0xd0dac0..0xd0dbaa]
+      OutOfLinePCRanges: [0xd0dc80..0xd0dd6a]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 107 ArrayType [2]int
           Locations:
-            - Range: 0xd0dac0..0xd0dbaa
+            - Range: 0xd0dc80..0xd0dd6a
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0xd0dac0..0xd0dbaa
+            - Range: 0xd0dc80..0xd0dd6a
               Pieces: [{Size: 24, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0dac0..0xd0db96
+            - Range: 0xd0dc80..0xd0dd56
               Pieces: []
-            - Range: 0xd0db96..0xd0db97
+            - Range: 0xd0dd56..0xd0dd57
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0db97..0xd0dbaa
+            - Range: 0xd0dd57..0xd0dd6a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 107 ArrayType [2]int
           Locations:
-            - Range: 0xd0dac0..0xd0db96
+            - Range: 0xd0dc80..0xd0dd56
               Pieces: []
-            - Range: 0xd0db96..0xd0db97
+            - Range: 0xd0dd56..0xd0dd57
               Pieces: [{Size: 16, Op: {CfaOffset: 40}}]
-            - Range: 0xd0db97..0xd0dbaa
+            - Range: 0xd0dd57..0xd0dd6a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 133
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0xd0dbc0..0xd0dc8b]
+      OutOfLinePCRanges: [0xd0dd80..0xd0de4b]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 256 StructureType main.structWithArray
           Locations:
-            - Range: 0xd0dbc0..0xd0dc8b
+            - Range: 0xd0dd80..0xd0de4b
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0dbc0..0xd0dc7a
+            - Range: 0xd0dd80..0xd0de3a
               Pieces: []
-            - Range: 0xd0dc7a..0xd0dc7b
+            - Range: 0xd0de3a..0xd0de3b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0dc7b..0xd0dc8b
+            - Range: 0xd0de3b..0xd0de4b
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 256 StructureType main.structWithArray
           Locations:
-            - Range: 0xd0dbc0..0xd0dc7a
+            - Range: 0xd0dd80..0xd0de3a
               Pieces: []
-            - Range: 0xd0dc7a..0xd0dc7b
+            - Range: 0xd0de3a..0xd0de3b
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xd0dc7b..0xd0dc8b
+            - Range: 0xd0de3b..0xd0de4b
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0dc46..0xd0dc8b
+            - Range: 0xd0de06..0xd0de4b
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 134
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0xd0dca0..0xd0dd46]
+      OutOfLinePCRanges: [0xd0de60..0xd0df06]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 253 ArrayType [0]int
-          Locations: [{Range: 0xd0dca0..0xd0dd46, Pieces: []}]
+          Locations: [{Range: 0xd0de60..0xd0df06, Pieces: []}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0dca0..0xd0dce5
+            - Range: 0xd0de60..0xd0dea5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0dce5..0xd0dd07
+            - Range: 0xd0dea5..0xd0dec7
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xd0dd07..0xd0dd22
+            - Range: 0xd0dec7..0xd0dee2
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xd0dd22..0xd0dd46
+            - Range: 0xd0dee2..0xd0df06
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0dca0..0xd0dd2c
+            - Range: 0xd0de60..0xd0deec
               Pieces: []
-            - Range: 0xd0dd2c..0xd0dd2d
+            - Range: 0xd0deec..0xd0deed
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0dd2d..0xd0dd46
+            - Range: 0xd0deed..0xd0df06
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 253 ArrayType [0]int
           Locations:
-            - Range: 0xd0dca0..0xd0dd2c
+            - Range: 0xd0de60..0xd0deec
               Pieces: []
-            - Range: 0xd0dd2c..0xd0dd2d
+            - Range: 0xd0deec..0xd0deed
               Pieces: []
-            - Range: 0xd0dd2d..0xd0dd46
+            - Range: 0xd0deed..0xd0df06
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 135
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0xd0e260..0xd0e261]
+      OutOfLinePCRanges: [0xd0e420..0xd0e421]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd0e260..0xd0e261
+            - Range: 0xd0e420..0xd0e421
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9273,13 +9273,13 @@ Subprograms:
       DictRegister: null
     - ID: 136
       Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xd0e280..0xd0e281]
+      OutOfLinePCRanges: [0xd0e440..0xd0e441]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd0e280..0xd0e281
+            - Range: 0xd0e440..0xd0e441
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9292,13 +9292,13 @@ Subprograms:
       DictRegister: null
     - ID: 137
       Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xd0e2a0..0xd0e2a1]
+      OutOfLinePCRanges: [0xd0e460..0xd0e461]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 258 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0xd0e2a0..0xd0e2a1
+            - Range: 0xd0e460..0xd0e461
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9311,13 +9311,13 @@ Subprograms:
       DictRegister: null
     - ID: 138
       Name: main.testStructSlice
-      OutOfLinePCRanges: [0xd0e2c0..0xd0e2c1]
+      OutOfLinePCRanges: [0xd0e480..0xd0e481]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 260 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xd0e2c0..0xd0e2c1
+            - Range: 0xd0e480..0xd0e481
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9330,20 +9330,20 @@ Subprograms:
         - Name: a
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0e2c0..0xd0e2c1
+            - Range: 0xd0e480..0xd0e481
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 139
       Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xd0e2e0..0xd0e2e1]
+      OutOfLinePCRanges: [0xd0e4a0..0xd0e4a1]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 260 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xd0e2e0..0xd0e2e1
+            - Range: 0xd0e4a0..0xd0e4a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9356,20 +9356,20 @@ Subprograms:
         - Name: a
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0e2e0..0xd0e2e1
+            - Range: 0xd0e4a0..0xd0e4a1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 140
       Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xd0e300..0xd0e301]
+      OutOfLinePCRanges: [0xd0e4c0..0xd0e4c1]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 260 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xd0e300..0xd0e301
+            - Range: 0xd0e4c0..0xd0e4c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9382,20 +9382,20 @@ Subprograms:
         - Name: a
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0e300..0xd0e301
+            - Range: 0xd0e4c0..0xd0e4c1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 141
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0xd0e320..0xd0e321]
+      OutOfLinePCRanges: [0xd0e4e0..0xd0e4e1]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 154 GoSliceHeaderType []string
           Locations:
-            - Range: 0xd0e320..0xd0e321
+            - Range: 0xd0e4e0..0xd0e4e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9408,20 +9408,20 @@ Subprograms:
       DictRegister: null
     - ID: 142
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xd0e340..0xd0e341]
+      OutOfLinePCRanges: [0xd0e500..0xd0e501]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 15 BaseType int8
           Locations:
-            - Range: 0xd0e340..0xd0e341
+            - Range: 0xd0e500..0xd0e501
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 263 GoSliceHeaderType []bool
           Locations:
-            - Range: 0xd0e340..0xd0e341
+            - Range: 0xd0e500..0xd0e501
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9434,20 +9434,20 @@ Subprograms:
         - Name: x
           Type: 16 BaseType uint
           Locations:
-            - Range: 0xd0e340..0xd0e341
+            - Range: 0xd0e500..0xd0e501
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 143
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0xd0e360..0xd0e361]
+      OutOfLinePCRanges: [0xd0e520..0xd0e521]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 264 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0xd0e360..0xd0e361
+            - Range: 0xd0e520..0xd0e521
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9460,13 +9460,13 @@ Subprograms:
       DictRegister: null
     - ID: 144
       Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0xd0e380..0xd0e381]
+      OutOfLinePCRanges: [0xd0e540..0xd0e541]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd0e380..0xd0e381
+            - Range: 0xd0e540..0xd0e541
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9479,13 +9479,13 @@ Subprograms:
       DictRegister: null
     - ID: 145
       Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0xd0e3a0..0xd0e3a1]
+      OutOfLinePCRanges: [0xd0e560..0xd0e561]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 265 GoSliceHeaderType []struct {}
           Locations:
-            - Range: 0xd0e3a0..0xd0e3a1
+            - Range: 0xd0e560..0xd0e561
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9498,13 +9498,13 @@ Subprograms:
       DictRegister: null
     - ID: 146
       Name: main.testSubslices
-      OutOfLinePCRanges: [0xd0e3c0..0xd0e3c1]
+      OutOfLinePCRanges: [0xd0e580..0xd0e581]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd0e3c0..0xd0e3c1
+            - Range: 0xd0e580..0xd0e581
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9517,7 +9517,7 @@ Subprograms:
         - Name: bs
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd0e3c0..0xd0e3c1
+            - Range: 0xd0e580..0xd0e581
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -9530,7 +9530,7 @@ Subprograms:
         - Name: cs
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd0e3c0..0xd0e3c1
+            - Range: 0xd0e580..0xd0e581
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -9543,34 +9543,34 @@ Subprograms:
       DictRegister: null
     - ID: 147
       Name: main.stackC
-      OutOfLinePCRanges: [0xd0e760..0xd0e7b2]
+      OutOfLinePCRanges: [0xd0ed40..0xd0ed92]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0xd0e760..0xd0e7a5
+            - Range: 0xd0ed40..0xd0ed85
               Pieces: []
-            - Range: 0xd0e7a5..0xd0e7a6
+            - Range: 0xd0ed85..0xd0ed86
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0e7a6..0xd0e7b2
+            - Range: 0xd0ed86..0xd0ed92
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 148
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xd0e7c0..0xd0e7c1]
+      OutOfLinePCRanges: [0xd0eda0..0xd0eda1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0xd0e7c0..0xd0e7c1
+            - Range: 0xd0eda0..0xd0eda1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9581,13 +9581,13 @@ Subprograms:
       DictRegister: null
     - ID: 149
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xd0e7e0..0xd0e7e1]
+      OutOfLinePCRanges: [0xd0edc0..0xd0edc1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0xd0e7e0..0xd0e7e1
+            - Range: 0xd0edc0..0xd0edc1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9598,7 +9598,7 @@ Subprograms:
         - Name: "y"
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0xd0e7e0..0xd0e7e1
+            - Range: 0xd0edc0..0xd0edc1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9609,7 +9609,7 @@ Subprograms:
         - Name: z
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0xd0e7e0..0xd0e7e1
+            - Range: 0xd0edc0..0xd0edc1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9620,13 +9620,13 @@ Subprograms:
       DictRegister: null
     - ID: 150
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xd0e800..0xd0e81f]
+      OutOfLinePCRanges: [0xd0ede0..0xd0edff]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 267 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xd0e800..0xd0e81f
+            - Range: 0xd0ede0..0xd0edff
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9645,39 +9645,39 @@ Subprograms:
       DictRegister: null
     - ID: 151
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xd0e820..0xd0e821]
+      OutOfLinePCRanges: [0xd0ee00..0xd0ee01]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 268 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xd0e820..0xd0e821
+            - Range: 0xd0ee00..0xd0ee01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 152
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xd0e840..0xd0e841]
+      OutOfLinePCRanges: [0xd0ee20..0xd0ee21]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 269 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xd0e840..0xd0e841
+            - Range: 0xd0ee20..0xd0ee21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 153
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0xd0e860..0xd0e861]
+      OutOfLinePCRanges: [0xd0ee40..0xd0ee41]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0xd0e860..0xd0e861
+            - Range: 0xd0ee40..0xd0ee41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9688,13 +9688,13 @@ Subprograms:
       DictRegister: null
     - ID: 154
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xd0e880..0xd0e881]
+      OutOfLinePCRanges: [0xd0ee60..0xd0ee61]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0xd0e880..0xd0e881
+            - Range: 0xd0ee60..0xd0ee61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9705,13 +9705,13 @@ Subprograms:
       DictRegister: null
     - ID: 155
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0xd0e8a0..0xd0e8a1]
+      OutOfLinePCRanges: [0xd0ee80..0xd0ee81]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0xd0e8a0..0xd0e8a1
+            - Range: 0xd0ee80..0xd0ee81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9722,13 +9722,13 @@ Subprograms:
       DictRegister: null
     - ID: 156
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0xd0e8c0..0xd0e8c1]
+      OutOfLinePCRanges: [0xd0eea0..0xd0eea1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0xd0e8c0..0xd0e8c1
+            - Range: 0xd0eea0..0xd0eea1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9739,7 +9739,7 @@ Subprograms:
         - Name: b
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0xd0e8c0..0xd0e8c1
+            - Range: 0xd0eea0..0xd0eea1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9750,7 +9750,7 @@ Subprograms:
         - Name: c
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0xd0e8c0..0xd0e8c1
+            - Range: 0xd0eea0..0xd0eea1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9761,26 +9761,26 @@ Subprograms:
       DictRegister: null
     - ID: 157
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0xd0ea40..0xd0ea41]
+      OutOfLinePCRanges: [0xd0f020..0xd0f021]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 271 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0xd0ea40..0xd0ea41
+            - Range: 0xd0f020..0xd0f021
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 158
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0xd0ea60..0xd0ea7f]
+      OutOfLinePCRanges: [0xd0f040..0xd0f05f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 284 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0xd0ea60..0xd0ea7f
+            - Range: 0xd0f040..0xd0f05f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9799,13 +9799,13 @@ Subprograms:
       DictRegister: null
     - ID: 159
       Name: main.testStruct
-      OutOfLinePCRanges: [0xd0eba0..0xd0ebc3]
+      OutOfLinePCRanges: [0xd0f180..0xd0f1a3]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 315 StructureType main.aStruct
           Locations:
-            - Range: 0xd0eba0..0xd0ebc3
+            - Range: 0xd0f180..0xd0f1a3
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -9826,91 +9826,91 @@ Subprograms:
       DictRegister: null
     - ID: 160
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0xd0eca0..0xd0eca1]
+      OutOfLinePCRanges: [0xd0f280..0xd0f281]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 316 PointerType *main.anotherStruct
           Locations:
-            - Range: 0xd0eca0..0xd0eca1
+            - Range: 0xd0f280..0xd0f281
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 161
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0xd0ecc0..0xd0ecc1]
+      OutOfLinePCRanges: [0xd0f2a0..0xd0f2a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 318 StructureType main.tenStrings
           Locations:
-            - Range: 0xd0ecc0..0xd0ecc1
+            - Range: 0xd0f2a0..0xd0f2a1
               Pieces: [{Size: 160, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 162
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xd0ed20..0xd0ed21]
+      OutOfLinePCRanges: [0xd0f300..0xd0f301]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 319 StructureType main.emptyStruct
-          Locations: [{Range: 0xd0ed20..0xd0ed21, Pieces: []}]
+          Locations: [{Range: 0xd0f300..0xd0f301, Pieces: []}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 163
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xd0ed40..0xd0ed41]
+      OutOfLinePCRanges: [0xd0f320..0xd0f321]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 320 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xd0ed40..0xd0ed41
+            - Range: 0xd0f320..0xd0f321
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 164
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0xd11000..0xd11004]
+      OutOfLinePCRanges: [0xd115e0..0xd115e4]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0xd11000..0xd11004
+            - Range: 0xd115e0..0xd115e4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 322 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xd11000..0xd11003
+            - Range: 0xd115e0..0xd115e3
               Pieces: []
-            - Range: 0xd11003..0xd11004
+            - Range: 0xd115e3..0xd115e4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 165
       Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0xd11020..0xd1102c]
+      OutOfLinePCRanges: [0xd11600..0xd1160c]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd11020..0xd1102b
+            - Range: 0xd11600..0xd1160b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xd1102b..0xd1102c
+            - Range: 0xd1160b..0xd1160c
               Pieces:
                 - Size: 8
                   Op: null
@@ -9921,9 +9921,9 @@ Subprograms:
         - Name: ~r0
           Type: 324 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xd11020..0xd1102b
+            - Range: 0xd11600..0xd1160b
               Pieces: []
-            - Range: 0xd1102b..0xd1102c
+            - Range: 0xd1160b..0xd1160c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9934,41 +9934,41 @@ Subprograms:
       DictRegister: 0
     - ID: 166
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0xd11040..0xd11044]
+      OutOfLinePCRanges: [0xd11620..0xd11624]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 322 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xd11040..0xd11044
+            - Range: 0xd11620..0xd11624
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0xd11040..0xd11043
+            - Range: 0xd11620..0xd11623
               Pieces: []
-            - Range: 0xd11043..0xd11044
+            - Range: 0xd11623..0xd11624
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 167
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0xd11060..0xd1106c]
+      OutOfLinePCRanges: [0xd11640..0xd1164c]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 324 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xd11060..0xd1106b
+            - Range: 0xd11640..0xd1164b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xd1106b..0xd1106c
+            - Range: 0xd1164b..0xd1164c
               Pieces:
                 - Size: 8
                   Op: null
@@ -9979,9 +9979,9 @@ Subprograms:
         - Name: ~r0
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd11060..0xd1106b
+            - Range: 0xd11640..0xd1164b
               Pieces: []
-            - Range: 0xd1106b..0xd1106c
+            - Range: 0xd1164b..0xd1164c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9992,13 +9992,13 @@ Subprograms:
       DictRegister: 0
     - ID: 168
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0xd110e0..0xd11216]
+      OutOfLinePCRanges: [0xd116c0..0xd117f6]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 325 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xd110e0..0xd11113
+            - Range: 0xd116c0..0xd116f3
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10006,7 +10006,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd11113..0xd1111b
+            - Range: 0xd116f3..0xd116fb
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -10014,7 +10014,7 @@ Subprograms:
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: null
-            - Range: 0xd1111b..0xd11216
+            - Range: 0xd116fb..0xd117f6
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -10027,18 +10027,18 @@ Subprograms:
         - Name: pred
           Type: 327 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0xd110e0..0xd1111b
+            - Range: 0xd116c0..0xd116fb
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xd1111b..0xd11216
+            - Range: 0xd116fb..0xd117f6
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 325 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xd110e0..0xd111d4
+            - Range: 0xd116c0..0xd117b4
               Pieces: []
-            - Range: 0xd111d4..0xd111d5
+            - Range: 0xd117b4..0xd117b5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10046,14 +10046,14 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xd111d5..0xd11216
+            - Range: 0xd117b5..0xd117f6
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
           Type: 325 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xd1111b..0xd11139
+            - Range: 0xd116fb..0xd11719
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10061,7 +10061,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xd11139..0xd11141
+            - Range: 0xd11719..0xd11721
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10069,7 +10069,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xd11141..0xd11149
+            - Range: 0xd11721..0xd11729
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10077,7 +10077,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xd11149..0xd11149
+            - Range: 0xd11729..0xd11729
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10085,7 +10085,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xd11149..0xd11173
+            - Range: 0xd11729..0xd11753
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
@@ -10093,7 +10093,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd11173..0xd111cb
+            - Range: 0xd11753..0xd117ab
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10101,7 +10101,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xd111cb..0xd11216
+            - Range: 0xd117ab..0xd117f6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
@@ -10114,132 +10114,132 @@ Subprograms:
         - Name: item
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0xd11166..0xd11173
+            - Range: 0xd11746..0xd11753
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd11173..0xd111cb
+            - Range: 0xd11753..0xd117ab
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
     - ID: 169
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xd11220..0xd11264]
+      OutOfLinePCRanges: [0xd11800..0xd11844]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 322 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xd11220..0xd11239
+            - Range: 0xd11800..0xd11819
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
           Type: 328 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0xd11220..0xd11239
+            - Range: 0xd11800..0xd11819
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 324 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xd11220..0xd11239
+            - Range: 0xd11800..0xd11819
               Pieces: []
-            - Range: 0xd11239..0xd1123a
+            - Range: 0xd11819..0xd1181a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd1123a..0xd11264
+            - Range: 0xd1181a..0xd11844
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
     - ID: 170
       Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0xd11500..0xd11504]
+      OutOfLinePCRanges: [0xd11ae0..0xd11ae4]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 326 PointerType *go.shape.int
           Locations:
-            - Range: 0xd11500..0xd11504
+            - Range: 0xd11ae0..0xd11ae4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 326 PointerType *go.shape.int
           Locations:
-            - Range: 0xd11500..0xd11503
+            - Range: 0xd11ae0..0xd11ae3
               Pieces: []
-            - Range: 0xd11503..0xd11504
+            - Range: 0xd11ae3..0xd11ae4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 171
       Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0xd11520..0xd11524]
+      OutOfLinePCRanges: [0xd11b00..0xd11b04]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 329 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0xd11520..0xd11524
+            - Range: 0xd11b00..0xd11b04
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 329 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0xd11520..0xd11523
+            - Range: 0xd11b00..0xd11b03
               Pieces: []
-            - Range: 0xd11523..0xd11524
+            - Range: 0xd11b03..0xd11b04
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 172
       Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0xd11540..0xd11544]
+      OutOfLinePCRanges: [0xd11b20..0xd11b24]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 331 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0xd11540..0xd11544
+            - Range: 0xd11b20..0xd11b24
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 331 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0xd11540..0xd11543
+            - Range: 0xd11b20..0xd11b23
               Pieces: []
-            - Range: 0xd11543..0xd11544
+            - Range: 0xd11b23..0xd11b24
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 173
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0xd11560..0xd11571]
+      OutOfLinePCRanges: [0xd11b40..0xd11b51]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 333 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0xd11560..0xd11571
+            - Range: 0xd11b40..0xd11b51
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd11560..0xd11570
+            - Range: 0xd11b40..0xd11b50
               Pieces: []
-            - Range: 0xd11570..0xd11571
+            - Range: 0xd11b50..0xd11b51
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10250,69 +10250,69 @@ Subprograms:
       DictRegister: 0
     - ID: 174
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0xd11600..0xd11609]
+      OutOfLinePCRanges: [0xd11be0..0xd11be9]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 335 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0xd11600..0xd11609
+            - Range: 0xd11be0..0xd11be9
               Pieces: [{Size: 136, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0xd11600..0xd11608
+            - Range: 0xd11be0..0xd11be8
               Pieces: []
-            - Range: 0xd11608..0xd11609
+            - Range: 0xd11be8..0xd11be9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 175
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0xd116c0..0xd116c8]
+      OutOfLinePCRanges: [0xd11ca0..0xd11ca8]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 336 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0xd116c0..0xd116c8
+            - Range: 0xd11ca0..0xd11ca8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0xd116c0..0xd116c8
+            - Range: 0xd11ca0..0xd11ca8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
           Type: 338 BaseType go.shape.bool
           Locations:
-            - Range: 0xd116c0..0xd116c8
+            - Range: 0xd11ca0..0xd11ca8
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
     - ID: 176
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0xd11760..0xd117d1]
+      OutOfLinePCRanges: [0xd11d40..0xd11db1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 339 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0xd11760..0xd117d1
+            - Range: 0xd11d40..0xd11db1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd11760..0xd117d1
+            - Range: 0xd11d40..0xd11db1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10323,20 +10323,20 @@ Subprograms:
         - Name: v
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0xd11760..0xd117d1
+            - Range: 0xd11d40..0xd11db1
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
     - ID: 177
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0xd11860..0xd11868]
+      OutOfLinePCRanges: [0xd11e40..0xd11e48]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd11860..0xd11868
+            - Range: 0xd11e40..0xd11e48
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10347,25 +10347,25 @@ Subprograms:
         - Name: b
           Type: 338 BaseType go.shape.bool
           Locations:
-            - Range: 0xd11860..0xd11868
+            - Range: 0xd11e40..0xd11e48
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 338 BaseType go.shape.bool
           Locations:
-            - Range: 0xd11860..0xd11867
+            - Range: 0xd11e40..0xd11e47
               Pieces: []
-            - Range: 0xd11867..0xd11868
+            - Range: 0xd11e47..0xd11e48
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd11860..0xd11867
+            - Range: 0xd11e40..0xd11e47
               Pieces: []
-            - Range: 0xd11867..0xd11868
+            - Range: 0xd11e47..0xd11e48
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10376,26 +10376,26 @@ Subprograms:
       DictRegister: 0
     - ID: 178
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xd11880..0xd1188f]
+      OutOfLinePCRanges: [0xd11e60..0xd11e6f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0xd11880..0xd1188e
+            - Range: 0xd11e60..0xd11e6e
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd11880..0xd1188b
+            - Range: 0xd11e60..0xd11e6b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd1188b..0xd1188f
+            - Range: 0xd11e6b..0xd11e6f
               Pieces:
                 - Size: 8
                   Op: null
@@ -10406,9 +10406,9 @@ Subprograms:
         - Name: ~r0
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd11880..0xd1188e
+            - Range: 0xd11e60..0xd11e6e
               Pieces: []
-            - Range: 0xd1188e..0xd1188f
+            - Range: 0xd11e6e..0xd11e6f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10419,56 +10419,56 @@ Subprograms:
         - Name: ~r1
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0xd11880..0xd1188e
+            - Range: 0xd11e60..0xd11e6e
               Pieces: []
-            - Range: 0xd1188e..0xd1188f
+            - Range: 0xd11e6e..0xd11e6f
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 179
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0xd118a0..0xd118da]
+      OutOfLinePCRanges: [0xd11e80..0xd11eba]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 341 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0xd118a0..0xd118b9
+            - Range: 0xd11e80..0xd11e99
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0xd118a0..0xd118b9
+            - Range: 0xd11e80..0xd11e99
               Pieces: []
-            - Range: 0xd118b9..0xd118ba
+            - Range: 0xd11e99..0xd11e9a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd118ba..0xd118da
+            - Range: 0xd11e9a..0xd11eba
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 180
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0xd118e0..0xd1192d]
+      OutOfLinePCRanges: [0xd11ec0..0xd11f0d]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 342 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0xd118e0..0xd118ff
+            - Range: 0xd11ec0..0xd11edf
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xd118ff..0xd11902
+            - Range: 0xd11edf..0xd11ee2
               Pieces:
                 - Size: 8
                   Op: null
@@ -10479,37 +10479,37 @@ Subprograms:
         - Name: ~r0
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0xd118e0..0xd11902
+            - Range: 0xd11ec0..0xd11ee2
               Pieces: []
-            - Range: 0xd11902..0xd11903
+            - Range: 0xd11ee2..0xd11ee3
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd11903..0xd1192d
+            - Range: 0xd11ee3..0xd11f0d
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 181
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0xd11940..0xd11948]
+      OutOfLinePCRanges: [0xd11f20..0xd11f28]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 343 PointerType *go.shape.string
           Locations:
-            - Range: 0xd11940..0xd11947
+            - Range: 0xd11f20..0xd11f27
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd11940..0xd11947
+            - Range: 0xd11f20..0xd11f27
               Pieces: []
-            - Range: 0xd11947..0xd11948
+            - Range: 0xd11f27..0xd11f28
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10520,22 +10520,22 @@ Subprograms:
       DictRegister: 0
     - ID: 182
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0xd11960..0xd119b7]
+      OutOfLinePCRanges: [0xd11f40..0xd11f97]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 344 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xd11960..0xd1199d
+            - Range: 0xd11f40..0xd11f7d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 345 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xd11960..0xd119b1
+            - Range: 0xd11f40..0xd11f91
               Pieces: []
-            - Range: 0xd119b1..0xd119b2
+            - Range: 0xd11f91..0xd11f92
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10549,20 +10549,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xd119b2..0xd119b7
+            - Range: 0xd11f92..0xd11f97
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 183
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0xd119c0..0xd119e4]
+      OutOfLinePCRanges: [0xd11fa0..0xd11fc4]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 325 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xd119c0..0xd119e4
+            - Range: 0xd11fa0..0xd11fc4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10575,33 +10575,33 @@ Subprograms:
         - Name: needle
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0xd119c0..0xd119e4
+            - Range: 0xd11fa0..0xd11fc4
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xd119c0..0xd119e0
+            - Range: 0xd11fa0..0xd11fc0
               Pieces: []
-            - Range: 0xd119e0..0xd119e1
+            - Range: 0xd11fc0..0xd11fc1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd119e1..0xd119e3
+            - Range: 0xd11fc1..0xd11fc3
               Pieces: []
-            - Range: 0xd119e3..0xd119e4
+            - Range: 0xd11fc3..0xd11fc4
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 184
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0xd11a00..0xd11abf]
+      OutOfLinePCRanges: [0xd11fe0..0xd1209f]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 346 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0xd11a00..0xd11a1d
+            - Range: 0xd11fe0..0xd11ffd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10609,7 +10609,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd11a1d..0xd11a1f
+            - Range: 0xd11ffd..0xd11fff
               Pieces:
                 - Size: 8
                   Op: null
@@ -10622,13 +10622,13 @@ Subprograms:
         - Name: needle
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd11a00..0xd11a4c
+            - Range: 0xd11fe0..0xd1202c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xd11a4c..0xd11abf
+            - Range: 0xd1202c..0xd1209f
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
@@ -10639,28 +10639,28 @@ Subprograms:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xd11a00..0xd11a6b
+            - Range: 0xd11fe0..0xd1204b
               Pieces: []
-            - Range: 0xd11a6b..0xd11a6c
+            - Range: 0xd1204b..0xd1204c
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd11a6c..0xd11a73
+            - Range: 0xd1204c..0xd12053
               Pieces: []
-            - Range: 0xd11a73..0xd11a74
+            - Range: 0xd12053..0xd12054
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd11a74..0xd11abf
+            - Range: 0xd12054..0xd1209f
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd11a2f..0xd11a41
+            - Range: 0xd1200f..0xd12021
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xd11a41..0xd11a4c
+            - Range: 0xd12021..0xd1202c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10671,54 +10671,54 @@ Subprograms:
       DictRegister: 0
     - ID: 185
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0xd11ac0..0xd11ac7]
+      OutOfLinePCRanges: [0xd120a0..0xd120a7]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 347 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0xd11ac0..0xd11ac6
+            - Range: 0xd120a0..0xd120a6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0xd11ac0..0xd11ac7
+            - Range: 0xd120a0..0xd120a7
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xd11ac0..0xd11ac6
+            - Range: 0xd120a0..0xd120a6
               Pieces: []
-            - Range: 0xd11ac6..0xd11ac7
+            - Range: 0xd120a6..0xd120a7
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 3
     - ID: 186
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0xd11b40..0xd11bac]
+      OutOfLinePCRanges: [0xd12120..0xd1218c]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 348 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0xd11b40..0xd11b60
+            - Range: 0xd12120..0xd12140
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd11b60..0xd11b68
+            - Range: 0xd12140..0xd12148
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd11b68..0xd11b6d
+            - Range: 0xd12148..0xd1214d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10729,7 +10729,7 @@ Subprograms:
         - Name: value
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd11b40..0xd11b6d
+            - Range: 0xd12120..0xd1214d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -10740,11 +10740,11 @@ Subprograms:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xd11b40..0xd11b6d
+            - Range: 0xd12120..0xd1214d
               Pieces: []
-            - Range: 0xd11b6d..0xd11b6e
+            - Range: 0xd1214d..0xd1214e
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd11b6e..0xd11bac
+            - Range: 0xd1214e..0xd1218c
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10882,31 +10882,31 @@ Subprograms:
       DictRegister: 0
     - ID: 188
       Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0xd08400..0xd08462]
+      OutOfLinePCRanges: [0xd08500..0xd08562]
       InlinePCRanges:
-        - Ranges: [0xd08491..0xd084cd]
-          RootRanges: [0xd08480..0xd084f1]
-        - Ranges: [0xd085d2..0xd0860e]
-          RootRanges: [0xd085a0..0xd08628]
-        - Ranges: [0xd0865c..0xd08698]
-          RootRanges: [0xd08640..0xd08705]
-        - Ranges: [0xd0872f..0xd0876b]
-          RootRanges: [0xd08720..0xd08782]
+        - Ranges: [0xd08591..0xd085cd]
+          RootRanges: [0xd08580..0xd085f1]
+        - Ranges: [0xd086d2..0xd0870e]
+          RootRanges: [0xd086a0..0xd08728]
+        - Ranges: [0xd0875c..0xd08798]
+          RootRanges: [0xd08740..0xd08805]
+        - Ranges: [0xd0882f..0xd0886b]
+          RootRanges: [0xd08820..0xd08882]
       Variables:
         - Name: x
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd08400..0xd08419
+            - Range: 0xd08500..0xd08519
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd08491..0xd0849c
+            - Range: 0xd08591..0xd0859c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd085d2..0xd085dd
+            - Range: 0xd086d2..0xd086dd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd08656..0xd08667
+            - Range: 0xd08756..0xd08767
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd08667..0xd08705
+            - Range: 0xd08767..0xd08805
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xd08720..0xd0873a
+            - Range: 0xd08820..0xd0883a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10915,37 +10915,37 @@ Subprograms:
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xd086a6..0xd086de]
-          RootRanges: [0xd08640..0xd08705]
+        - Ranges: [0xd087a6..0xd087de]
+          RootRanges: [0xd08740..0xd08805]
       Variables: []
       DictRegister: null
     - ID: 190
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xd087b3..0xd087f1]
-          RootRanges: [0xd087a0..0xd088ae]
+        - Ranges: [0xd088b3..0xd088f1]
+          RootRanges: [0xd088a0..0xd089ae]
       Variables: []
       DictRegister: null
     - ID: 191
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xd08866..0xd0889e]
-          RootRanges: [0xd087a0..0xd088ae]
+        - Ranges: [0xd08966..0xd0899e]
+          RootRanges: [0xd088a0..0xd089ae]
       Variables: []
       DictRegister: null
     - ID: 192
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xd088c1..0xd088c5]
-          RootRanges: [0xd088c0..0xd088c6]
+        - Ranges: [0xd089c1..0xd089c5]
+          RootRanges: [0xd089c0..0xd089c6]
       Variables:
         - Name: x
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd088c0..0xd088c5
+            - Range: 0xd089c0..0xd089c5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10954,38 +10954,38 @@ Subprograms:
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xd08905..0xd0891d]
-          RootRanges: [0xd088e0..0xd08923]
-        - Ranges: [0xd089a5..0xd089c3]
-          RootRanges: [0xd08940..0xd08ac5]
+        - Ranges: [0xd08a05..0xd08a1d]
+          RootRanges: [0xd089e0..0xd08a23]
+        - Ranges: [0xd08aa5..0xd08ac3]
+          RootRanges: [0xd08a40..0xd08bc5]
       Variables:
         - Name: a
           Type: 161 ArrayType [5]int
           Locations:
-            - Range: 0xd088ed..0xd08923
+            - Range: 0xd089ed..0xd08a23
               Pieces: [{Size: 40, Op: {CfaOffset: -56}}]
-            - Range: 0xd0898c..0xd08ac5
+            - Range: 0xd08a8c..0xd08bc5
               Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 194
       Name: main.firstBehavior.DoSomething
-      OutOfLinePCRanges: [0xd08ae0..0xd08b51]
+      OutOfLinePCRanges: [0xd08be0..0xd08c51]
       InlinePCRanges:
-        - Ranges: [0xd11c63..0xd11ca5]
-          RootRanges: [0xd11c40..0xd11cd6]
+        - Ranges: [0xd12243..0xd12285]
+          RootRanges: [0xd12220..0xd122b6]
       Variables:
         - Name: b
           Type: 353 StructureType main.firstBehavior
           Locations:
-            - Range: 0xd08ae0..0xd08b08
+            - Range: 0xd08be0..0xd08c08
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd08b08..0xd08b0d
+            - Range: 0xd08c08..0xd08c0d
               Pieces:
                 - Size: 8
                   Op: null
@@ -10996,15 +10996,15 @@ Subprograms:
         - Name: ~r0
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0xd08ae0..0xd08b30
+            - Range: 0xd08be0..0xd08c30
               Pieces: []
-            - Range: 0xd08b30..0xd08b31
+            - Range: 0xd08c30..0xd08c31
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd08b31..0xd08b51
+            - Range: 0xd08c31..0xd08c51
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11013,8 +11013,8 @@ Subprograms:
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xd09290..0xd09297]
-          RootRanges: [0xd09140..0xd092e5]
+        - Ranges: [0xd094bd..0xd094c4]
+          RootRanges: [0xd09420..0xd0950b]
         - Ranges: [0x51e6d2..0x51e6d6, 0x51e6d7..0x51e6de]
           RootRanges: [0x51e6c0..0x51e6df]
       Variables: []
@@ -11187,7 +11187,7 @@ Types:
       ID: 40
       Name: '*[]runtime.ancestorInfo'
       ByteSize: 8
-      GoRuntimeType: 458304
+      GoRuntimeType: 458496
       GoKind: 22
       Pointee: 41 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
@@ -11290,7 +11290,7 @@ Types:
       ID: 6
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 365504
+      GoRuntimeType: 365632
       GoKind: 22
       Pointee: 5 BaseType bool
     - __kind: PointerType
@@ -11820,7 +11820,7 @@ Types:
       ID: 100
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 364416
+      GoRuntimeType: 364544
       GoKind: 22
       Pointee: 19 GoInterfaceType error
     - __kind: PointerType
@@ -11841,14 +11841,14 @@ Types:
       ID: 102
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 365376
+      GoRuntimeType: 365504
       GoKind: 22
       Pointee: 17 BaseType float32
     - __kind: PointerType
       ID: 92
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 365440
+      GoRuntimeType: 365568
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
@@ -12842,42 +12842,42 @@ Types:
       ID: 94
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 365056
+      GoRuntimeType: 365184
       GoKind: 22
       Pointee: 10 BaseType int
     - __kind: PointerType
       ID: 97
       Name: '*int16'
       ByteSize: 8
-      GoRuntimeType: 364672
+      GoRuntimeType: 364800
       GoKind: 22
       Pointee: 98 BaseType int16
     - __kind: PointerType
       ID: 21
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 364800
+      GoRuntimeType: 364928
       GoKind: 22
       Pointee: 13 BaseType int32
     - __kind: PointerType
       ID: 93
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 364928
+      GoRuntimeType: 365056
       GoKind: 22
       Pointee: 14 BaseType int64
     - __kind: PointerType
       ID: 99
       Name: '*int8'
       ByteSize: 8
-      GoRuntimeType: 364544
+      GoRuntimeType: 364672
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
       ID: 163
       Name: '*interface {}'
       ByteSize: 8
-      GoRuntimeType: 365632
+      GoRuntimeType: 365760
       GoKind: 22
       Pointee: 157 GoEmptyInterfaceType interface {}
     - __kind: PointerType
@@ -12891,7 +12891,7 @@ Types:
       ID: 904
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
-      GoRuntimeType: 832544
+      GoRuntimeType: 832928
       GoKind: 22
       Pointee: 905 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
@@ -12916,12 +12916,12 @@ Types:
       GoKind: 22
       Pointee: 797 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 526
+      ID: 529
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
-      GoRuntimeType: 831392
+      GoRuntimeType: 831776
       GoKind: 22
-      Pointee: 527 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 530 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
       ID: 950
       Name: '*io.PipeWriter'
@@ -13730,12 +13730,12 @@ Types:
       GoKind: 22
       Pointee: 503 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 528
+      ID: 531
       Name: '*reflect.ValueError'
       ByteSize: 8
-      GoRuntimeType: 832160
+      GoRuntimeType: 832544
       GoKind: 22
-      Pointee: 529 UnresolvedPointeeType reflect.ValueError
+      Pointee: 532 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
       ID: 621
       Name: '*regexp/syntax.Error'
@@ -13747,21 +13747,21 @@ Types:
       ID: 731
       Name: '*runtime.PanicNilError'
       ByteSize: 8
-      GoRuntimeType: 989696
+      GoRuntimeType: 989952
       GoKind: 22
       Pointee: 732 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
       ID: 736
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
-      GoRuntimeType: 991616
+      GoRuntimeType: 991872
       GoKind: 22
       Pointee: 737 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 27
       Name: '*runtime._defer'
       ByteSize: 8
-      GoRuntimeType: 365696
+      GoRuntimeType: 365824
       GoKind: 22
       Pointee: 28 UnresolvedPointeeType runtime._defer
     - __kind: PointerType
@@ -13775,21 +13775,21 @@ Types:
       ID: 733
       Name: '*runtime.boundsError'
       ByteSize: 8
-      GoRuntimeType: 989824
+      GoRuntimeType: 990080
       GoKind: 22
       Pointee: 734 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 61
       Name: '*runtime.cgoCallers'
       ByteSize: 8
-      GoRuntimeType: 366336
+      GoRuntimeType: 366464
       GoKind: 22
       Pointee: 62 UnresolvedPointeeType runtime.cgoCallers
     - __kind: PointerType
       ID: 48
       Name: '*runtime.coro'
       ByteSize: 8
-      GoRuntimeType: 366400
+      GoRuntimeType: 366528
       GoKind: 22
       Pointee: 49 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
@@ -13803,7 +13803,7 @@ Types:
       ID: 730
       Name: '*runtime.errorString'
       ByteSize: 8
-      GoRuntimeType: 989440
+      GoRuntimeType: 989696
       GoKind: 22
       Pointee: 711 GoStringHeaderType runtime.errorString
     - __kind: PointerType
@@ -13815,28 +13815,28 @@ Types:
       ID: 54
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 830624
+      GoRuntimeType: 831008
       GoKind: 22
       Pointee: 23 StructureType runtime.g
     - __kind: PointerType
       ID: 29
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 990976
+      GoRuntimeType: 991232
       GoKind: 22
       Pointee: 30 StructureType runtime.m
     - __kind: PointerType
       ID: 143
       Name: '*runtime.mapextra'
       ByteSize: 8
-      GoRuntimeType: 368384
+      GoRuntimeType: 368512
       GoKind: 22
       Pointee: 144 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 735
       Name: '*runtime.plainError'
       ByteSize: 8
-      GoRuntimeType: 991360
+      GoRuntimeType: 991616
       GoKind: 22
       Pointee: 714 GoStringHeaderType runtime.plainError
     - __kind: PointerType
@@ -13848,7 +13848,7 @@ Types:
       ID: 42
       Name: '*runtime.sudog'
       ByteSize: 8
-      GoRuntimeType: 367104
+      GoRuntimeType: 367232
       GoKind: 22
       Pointee: 43 UnresolvedPointeeType runtime.sudog
     - __kind: PointerType
@@ -13862,7 +13862,7 @@ Types:
       ID: 73
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1435584
+      GoRuntimeType: 1435968
       GoKind: 22
       Pointee: 74 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
@@ -13876,7 +13876,7 @@ Types:
       ID: 89
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 364480
+      GoRuntimeType: 364608
       GoKind: 22
       Pointee: 12 GoStringHeaderType string
     - __kind: PointerType
@@ -13935,21 +13935,21 @@ Types:
       ID: 860
       Name: '*time.Location'
       ByteSize: 8
-      GoRuntimeType: 1441152
+      GoRuntimeType: 1432128
       GoKind: 22
       Pointee: 861 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 531
+      ID: 527
       Name: '*time.ParseError'
       ByteSize: 8
-      GoRuntimeType: 833312
+      GoRuntimeType: 829184
       GoKind: 22
-      Pointee: 532 UnresolvedPointeeType time.ParseError
+      Pointee: 528 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 530
+      ID: 526
       Name: '*time.fileSizeError'
       ByteSize: 8
-      GoRuntimeType: 833216
+      GoRuntimeType: 829088
       GoKind: 22
       Pointee: 453 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
@@ -13961,42 +13961,42 @@ Types:
       ID: 101
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 365120
+      GoRuntimeType: 365248
       GoKind: 22
       Pointee: 16 BaseType uint
     - __kind: PointerType
       ID: 96
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 364736
+      GoRuntimeType: 364864
       GoKind: 22
       Pointee: 8 BaseType uint16
     - __kind: PointerType
       ID: 22
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 364864
+      GoRuntimeType: 364992
       GoKind: 22
       Pointee: 3 BaseType uint32
     - __kind: PointerType
       ID: 95
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 364992
+      GoRuntimeType: 365120
       GoKind: 22
       Pointee: 11 BaseType uint64
     - __kind: PointerType
       ID: 7
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 364608
+      GoRuntimeType: 364736
       GoKind: 22
       Pointee: 4 BaseType uint8
     - __kind: PointerType
       ID: 9
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 365184
+      GoRuntimeType: 365312
       GoKind: 22
       Pointee: 2 BaseType uintptr
     - __kind: PointerType
@@ -23133,7 +23133,7 @@ Types:
       ID: 86
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 642368
+      GoRuntimeType: 643712
       GoKind: 17
       Count: 10
       HasCount: true
@@ -23160,7 +23160,7 @@ Types:
       ID: 72
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 642080
+      GoRuntimeType: 643424
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23185,7 +23185,7 @@ Types:
       ID: 78
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 642272
+      GoRuntimeType: 643616
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23327,7 +23327,7 @@ Types:
       ID: 64
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 641888
+      GoRuntimeType: 643232
       GoKind: 17
       Count: 32
       HasCount: true
@@ -23345,7 +23345,7 @@ Types:
       ID: 52
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 641600
+      GoRuntimeType: 642944
       GoKind: 17
       Count: 3
       HasCount: true
@@ -23415,7 +23415,7 @@ Types:
       ID: 79
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 642176
+      GoRuntimeType: 643520
       GoKind: 17
       Count: 8
       HasCount: true
@@ -23680,7 +23680,7 @@ Types:
       ID: 263
       Name: '[]bool'
       ByteSize: 24
-      GoRuntimeType: 456512
+      GoRuntimeType: 456704
       GoKind: 23
       RawFields:
         - Name: array
@@ -23865,7 +23865,7 @@ Types:
       ID: 883
       Name: '[]float64'
       ByteSize: 24
-      GoRuntimeType: 456384
+      GoRuntimeType: 456576
       GoKind: 23
       RawFields:
         - Name: array
@@ -23956,7 +23956,7 @@ Types:
       ID: 1144
       Name: '[]interface {}'
       ByteSize: 24
-      GoRuntimeType: 456832
+      GoRuntimeType: 457024
       GoKind: 23
       RawFields:
         - Name: array
@@ -24098,7 +24098,7 @@ Types:
       ID: 154
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 456640
+      GoRuntimeType: 456832
       GoKind: 23
       RawFields:
         - Name: array
@@ -24143,7 +24143,7 @@ Types:
       ID: 257
       Name: '[]uint'
       ByteSize: 24
-      GoRuntimeType: 456128
+      GoRuntimeType: 456320
       GoKind: 23
       RawFields:
         - Name: array
@@ -24166,7 +24166,7 @@ Types:
       ID: 264
       Name: '[]uint16'
       ByteSize: 24
-      GoRuntimeType: 455488
+      GoRuntimeType: 455680
       GoKind: 23
       RawFields:
         - Name: array
@@ -24189,7 +24189,7 @@ Types:
       ID: 39
       Name: '[]uint8'
       ByteSize: 24
-      GoRuntimeType: 455360
+      GoRuntimeType: 455552
       GoKind: 23
       RawFields:
         - Name: array
@@ -24212,7 +24212,7 @@ Types:
       ID: 44
       Name: '[]uintptr'
       ByteSize: 24
-      GoRuntimeType: 456192
+      GoRuntimeType: 456384
       GoKind: 23
       RawFields:
         - Name: array
@@ -25326,7 +25326,7 @@ Types:
       ID: 19
       Name: error
       ByteSize: 16
-      GoRuntimeType: 989312
+      GoRuntimeType: 989568
       GoKind: 20
       RawFields:
         - Name: tab
@@ -25377,7 +25377,7 @@ Types:
       ID: 68
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 781472
+      GoRuntimeType: 781760
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 352
@@ -27507,7 +27507,7 @@ Types:
       ID: 157
       Name: interface {}
       ByteSize: 16
-      GoRuntimeType: 781184
+      GoRuntimeType: 781472
       GoKind: 20
       RawFields:
         - Name: _type
@@ -27557,11 +27557,11 @@ Types:
     - __kind: StructureType
       ID: 797
       Name: internal/poll.errNetClosing
-      GoRuntimeType: 1300352
+      GoRuntimeType: 1300672
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 527
+      ID: 530
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -29552,7 +29552,7 @@ Types:
       GoRuntimeType: 771392
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 529
+      ID: 532
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -29618,7 +29618,7 @@ Types:
       ID: 793
       Name: runtime.errorAddressString
       ByteSize: 24
-      GoRuntimeType: 1635904
+      GoRuntimeType: 1636096
       GoKind: 25
       RawFields:
         - Name: msg
@@ -29835,7 +29835,7 @@ Types:
       ID: 31
       Name: runtime.gobuf
       ByteSize: 56
-      GoRuntimeType: 1842208
+      GoRuntimeType: 1842496
       GoKind: 25
       RawFields:
         - Name: sp
@@ -29863,7 +29863,7 @@ Types:
       ID: 47
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1295392
+      GoRuntimeType: 1295712
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -29876,7 +29876,7 @@ Types:
       ID: 55
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1634944
+      GoRuntimeType: 1635136
       GoKind: 25
       RawFields:
         - Name: stack
@@ -29895,13 +29895,13 @@ Types:
       ID: 32
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 764192
+      GoRuntimeType: 764480
       GoKind: 12
     - __kind: StructureType
       ID: 87
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1295232
+      GoRuntimeType: 1295552
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -29914,7 +29914,7 @@ Types:
       ID: 75
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 1790464
+      GoRuntimeType: 1790720
       GoKind: 25
       RawFields:
         - Name: fn
@@ -29939,7 +29939,7 @@ Types:
       ID: 88
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 764096
+      GoRuntimeType: 764384
       GoKind: 2
     - __kind: StructureType
       ID: 30
@@ -30165,7 +30165,7 @@ Types:
       ID: 65
       Name: runtime.mLockProfile
       ByteSize: 64
-      GoRuntimeType: 1790208
+      GoRuntimeType: 1790464
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -30190,7 +30190,7 @@ Types:
       ID: 82
       Name: runtime.mOS
       ByteSize: 8
-      GoRuntimeType: 1435968
+      GoRuntimeType: 1436352
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -30206,7 +30206,7 @@ Types:
       ID: 70
       Name: runtime.mTraceState
       ByteSize: 32
-      GoRuntimeType: 1435776
+      GoRuntimeType: 1436160
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -30226,7 +30226,7 @@ Types:
       ID: 38
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 763808
+      GoRuntimeType: 764096
       GoKind: 12
     - __kind: StructureType
       ID: 63
@@ -30239,7 +30239,7 @@ Types:
       ID: 77
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1295072
+      GoRuntimeType: 1295392
       GoKind: 25
       RawFields:
         - Name: entries
@@ -30252,7 +30252,7 @@ Types:
       ID: 80
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1635712
+      GoRuntimeType: 1635904
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -30290,13 +30290,13 @@ Types:
       ID: 59
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 764000
+      GoRuntimeType: 764288
       GoKind: 12
     - __kind: ArrayType
       ID: 56
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 830240
+      GoRuntimeType: 830624
       GoKind: 17
       Count: 2
       HasCount: true
@@ -30305,7 +30305,7 @@ Types:
       ID: 24
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1293472
+      GoRuntimeType: 1293792
       GoKind: 25
       RawFields:
         - Name: lo
@@ -30342,7 +30342,7 @@ Types:
       ID: 51
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1294432
+      GoRuntimeType: 1294752
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -30539,14 +30539,14 @@ Types:
       ID: 988
       Name: time.Duration
       ByteSize: 8
-      GoRuntimeType: 1791232
+      GoRuntimeType: 1788416
       GoKind: 6
     - __kind: UnresolvedPointeeType
       ID: 861
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 532
+      ID: 528
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
@@ -30569,7 +30569,7 @@ Types:
       ID: 453
       Name: time.fileSizeError
       ByteSize: 16
-      GoRuntimeType: 764576
+      GoRuntimeType: 763328
       GoKind: 24
       RawFields:
         - Name: str
@@ -30776,10 +30776,10 @@ Issues:
       issue:
         Kind: 7
         Message: return value selector (e.g., @return.r0) must be used for multi-value returns
-GoModuledataInfo: {FirstModuledataAddr: "0x176c760", TypesOffset: 296}
+GoModuledataInfo: {FirstModuledataAddr: "0x176d760", TypesOffset: 296}
 GoMapHashInfo:
-    UseAeshashAddr: "0x184598b"
-    AeskeyschedAddr: "0x1846b20"
+    UseAeshashAddr: "0x184698b"
+    AeskeyschedAddr: "0x1847b20"
 CommonTypes:
     G: 23 StructureType runtime.g
     M: 30 StructureType runtime.m

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -13,11 +13,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1581 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0xcdfbaa", Frameless: false}]
+              InjectionPoints: [{PC: "0xce018a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1582 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0xcdfbe5", Frameless: false}]
+              InjectionPoints: [{PC: "0xce01c5", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -33,11 +33,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1420 EventRootType Probe[main.testAny]
-              InjectionPoints: [{PC: "0xcd9f0a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcda00a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1421 EventRootType Probe[main.testAny]Return
-              InjectionPoints: [{PC: "0xcd9f45", Frameless: false}]
+              InjectionPoints: [{PC: "0xcda045", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -59,11 +59,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1423 EventRootType Probe[main.testAnyPtr]
-              InjectionPoints: [{PC: "0xcd9faa", Frameless: false}]
+              InjectionPoints: [{PC: "0xcda0aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1424 EventRootType Probe[main.testAnyPtr]Return
-              InjectionPoints: [{PC: "0xcd9fdd", Frameless: false}]
+              InjectionPoints: [{PC: "0xcda0dd", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -84,11 +84,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1552 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0xcde5ce", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde78e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1553 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0xcde682", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde842", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -110,7 +110,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1368 EventRootType Probe[main.testArrayEmptyStructs]
-              InjectionPoints: [{PC: "0xcd5140", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5240", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -132,7 +132,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1364 EventRootType Probe[main.testArrayOfArrays]
-              InjectionPoints: [{PC: "0xcd50c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd51c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -154,7 +154,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1366 EventRootType Probe[main.testArrayOfArraysOfArrays]
-              InjectionPoints: [{PC: "0xcd5100", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5200", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -176,7 +176,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1432 EventRootType Probe[main.testArrayOfMaps]
-              InjectionPoints: [{PC: "0xcda740", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda900", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -198,7 +198,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1365 EventRootType Probe[main.testArrayOfStrings]
-              InjectionPoints: [{PC: "0xcd50e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd51e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -219,7 +219,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1367 EventRootType Probe[main.testArrayOfStructs]
-              InjectionPoints: [{PC: "0xcd5120", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5220", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -241,11 +241,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1454 EventRootType Probe[main.testAtomicAdd]
-              InjectionPoints: [{PC: "0xcdc620", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc7e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1455 EventRootType Probe[main.testAtomicAdd]Return
-              InjectionPoints: [{PC: "0xcdc632", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc7f2", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -267,11 +267,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1386 EventRootType Probe[main.testBigStruct]
-              InjectionPoints: [{PC: "0xcd5840", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5940", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1387 EventRootType Probe[main.testBigStruct]Return
-              InjectionPoints: [{PC: "0xcd585e", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd595e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -293,7 +293,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1353 EventRootType Probe[main.testBoolArray]
-              InjectionPoints: [{PC: "0xcd4f60", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5060", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -315,7 +315,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1350 EventRootType Probe[main.testByteArray]
-              InjectionPoints: [{PC: "0xcd4f00", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5000", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -342,11 +342,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1600 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xcdffe0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce05c0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1601 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0xce0002", Frameless: true}]
+              InjectionPoints: [{PC: "0xce05e2", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -366,15 +366,15 @@ Probes:
             - Kind: Line
               Type: 1661 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xcd972e"
+                - PC: "0xcd982e"
                   Frameless: false
-                - PC: "0xcd97b1"
+                - PC: "0xcd98b1"
                   Frameless: false
-                - PC: "0xcd98f2"
+                - PC: "0xcd99f2"
                   Frameless: false
-                - PC: "0xcd997c"
+                - PC: "0xcd9a7c"
                   Frameless: false
-                - PC: "0xcd9a4f"
+                - PC: "0xcd9b4f"
                   Frameless: false
               Condition: null
     - id: testCaptureExprLineCond
@@ -396,15 +396,15 @@ Probes:
             - Kind: Line
               Type: 1662 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xcd972e"
+                - PC: "0xcd982e"
                   Frameless: false
-                - PC: "0xcd97b1"
+                - PC: "0xcd98b1"
                   Frameless: false
-                - PC: "0xcd98f2"
+                - PC: "0xcd99f2"
                   Frameless: false
-                - PC: "0xcd997c"
+                - PC: "0xcd9a7c"
                   Frameless: false
-                - PC: "0xcd9a4f"
+                - PC: "0xcd9b4f"
                   Frameless: false
               Condition:
                 Type: 5 BaseType bool
@@ -440,15 +440,15 @@ Probes:
             - Kind: Line
               Type: 1663 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xcd972e"
+                - PC: "0xcd982e"
                   Frameless: false
-                - PC: "0xcd97b1"
+                - PC: "0xcd98b1"
                   Frameless: false
-                - PC: "0xcd98f2"
+                - PC: "0xcd99f2"
                   Frameless: false
-                - PC: "0xcd997c"
+                - PC: "0xcd9a7c"
                   Frameless: false
-                - PC: "0xcd9a4f"
+                - PC: "0xcd9b4f"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -476,7 +476,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1451 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0xcdc280", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc440", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -495,7 +495,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1452 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0xcdc280", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc440", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -521,7 +521,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1608 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0xce0100", Frameless: true}]
+              InjectionPoints: [{PC: "0xce06e0", Frameless: true}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -557,7 +557,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1456 EventRootType Probe[main.testChannel]
-              InjectionPoints: [{PC: "0xcdc640", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc800", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -587,7 +587,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1450 EventRootType Probe[main.testCombinedByte]
-              InjectionPoints: [{PC: "0xcdc240", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc400", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{w}, {x}, {y}'
@@ -616,11 +616,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1517 EventRootType Probe[main.testConflictingReturn]
-              InjectionPoints: [{PC: "0xcdd80e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd9ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1518 EventRootType Probe[main.testConflictingReturn]Return
-              InjectionPoints: [{PC: "0xcdd8d1", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdda91", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -642,7 +642,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1464 EventRootType Probe[main.testCycle]
-              InjectionPoints: [{PC: "0xcdca20", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdcbe0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{t}'
@@ -664,7 +664,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1393 EventRootType Probe[main.testDeepMap1]
-              InjectionPoints: [{PC: "0xcd5d40", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5e40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -686,7 +686,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1394 EventRootType Probe[main.testDeepMap7]
-              InjectionPoints: [{PC: "0xcd5d60", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5e60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -708,7 +708,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1389 EventRootType Probe[main.testDeepPtr1]
-              InjectionPoints: [{PC: "0xcd5a20", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5b20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -730,7 +730,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1390 EventRootType Probe[main.testDeepPtr7]
-              InjectionPoints: [{PC: "0xcd5a40", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5b40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -752,7 +752,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1391 EventRootType Probe[main.testDeepSlice1]
-              InjectionPoints: [{PC: "0xcd5bc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5cc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -774,7 +774,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1392 EventRootType Probe[main.testDeepSlice7]
-              InjectionPoints: [{PC: "0xcd5be0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5ce0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -796,7 +796,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1569 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0xcdf6c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf880", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -823,7 +823,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1572 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0xcdf720", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf8e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -851,7 +851,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1595 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0xcdfce0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce02c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -873,7 +873,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1609 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0xce0160", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0740", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -894,7 +894,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1610 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0xce0180", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0760", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -916,7 +916,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1422 EventRootType Probe[main.testError]
-              InjectionPoints: [{PC: "0xcd9f80", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda080", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -950,7 +950,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1388 EventRootType Probe[main.testErrorAtLine]Line
-              InjectionPoints: [{PC: "0xcd58db", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd59db", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}, err={err}
@@ -978,11 +978,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1404 EventRootType Probe[main.testEsotericHeap]
-              InjectionPoints: [{PC: "0xcd820a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd830a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1405 EventRootType Probe[main.testEsotericHeap]Return
-              InjectionPoints: [{PC: "0xcd824c", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd834c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1004,11 +1004,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1402 EventRootType Probe[main.testEsotericStack]
-              InjectionPoints: [{PC: "0xcd80ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd81ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1403 EventRootType Probe[main.testEsotericStack]Return
-              InjectionPoints: [{PC: "0xcd817b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd827b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1030,11 +1030,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1414 EventRootType Probe[main.testFrameless]
-              InjectionPoints: [{PC: "0xcd9be0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9ce0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1415 EventRootType Probe[main.testFrameless]Return
-              InjectionPoints: [{PC: "0xcd9be5", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9ce5", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1056,11 +1056,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1416 EventRootType Probe[main.testFramelessArray]
-              InjectionPoints: [{PC: "0xcd9c04", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd9d04", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1417 EventRootType Probe[main.testFramelessArray]Return
-              InjectionPoints: [{PC: "0xcd9c3d", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd9d3d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1085,7 +1085,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1418 EventRootType Probe[main.testFramelessArray]Line
-              InjectionPoints: [{PC: "0xcd9c08", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd9d08", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1107,11 +1107,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1647 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0xce2d80", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3360", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1648 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce2d87", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3367", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1125,11 +1125,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1649 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0xce2da4", Frameless: false}]
+              InjectionPoints: [{PC: "0xce3384", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1650 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0xce2df1", Frameless: false}]
+              InjectionPoints: [{PC: "0xce33d1", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1152,11 +1152,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1643 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0xce2cea", Frameless: false}]
+              InjectionPoints: [{PC: "0xce32ca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1644 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0xce2cf9", Frameless: false}]
+              InjectionPoints: [{PC: "0xce32d9", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1170,11 +1170,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1645 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0xce2d2a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce330a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1646 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0xce2d42", Frameless: false}]
+              InjectionPoints: [{PC: "0xce3322", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1197,14 +1197,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1651 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0xce2e00", Frameless: true}]
+              InjectionPoints: [{PC: "0xce33e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1652 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0xce2e20"
+                - PC: "0xce3400"
                   Frameless: true
-                - PC: "0xce2e23"
+                - PC: "0xce3403"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1219,14 +1219,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1653 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0xce2e4a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce342a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1654 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0xce2eab"
+                - PC: "0xce348b"
                   Frameless: false
-                - PC: "0xce2eb3"
+                - PC: "0xce3493"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1253,7 +1253,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1655 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0xce2e05", Frameless: true}]
+              InjectionPoints: [{PC: "0xce33e5", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1265,7 +1265,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1656 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0xce2e5f", Frameless: false}]
+              InjectionPoints: [{PC: "0xce343f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1286,11 +1286,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1631 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0xce29a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2f80", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1632 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0xce29b0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2f90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1304,11 +1304,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1633 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0xce2a40", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3020", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1634 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0xce2a48", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3028", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1332,11 +1332,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1619 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0xce252e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2b0e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1620 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce2614", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2bf4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1378,11 +1378,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1623 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xce266a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2c4a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1624 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce2679", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2c59", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1405,11 +1405,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1657 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0xce2f00", Frameless: true}]
+              InjectionPoints: [{PC: "0xce34e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1658 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0xce2f06", Frameless: true}]
+              InjectionPoints: [{PC: "0xce34e6", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1423,11 +1423,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1659 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0xce2f8a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce356a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1660 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0xce2fad", Frameless: false}]
+              InjectionPoints: [{PC: "0xce358d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1450,11 +1450,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1615 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0xce2480", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2a60", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1616 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce2483", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2a63", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1468,11 +1468,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1617 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0xce24a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2a80", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1618 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce24ab", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2a8b", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1495,11 +1495,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1635 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0xce2b00", Frameless: true}]
+              InjectionPoints: [{PC: "0xce30e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1636 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0xce2b07", Frameless: true}]
+              InjectionPoints: [{PC: "0xce30e7", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1513,11 +1513,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1637 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0xce2baa", Frameless: false}]
+              InjectionPoints: [{PC: "0xce318a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1638 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0xce2bd6", Frameless: false}]
+              InjectionPoints: [{PC: "0xce31b6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1540,11 +1540,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1625 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0xce2940", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2f20", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1626 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce2943", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2f23", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1558,11 +1558,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1627 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0xce2960", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2f40", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1628 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0xce2963", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2f43", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1576,11 +1576,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1629 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0xce2980", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2f60", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1630 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0xce2983", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2f63", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1603,11 +1603,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1639 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0xce2ca0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3280", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1640 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0xce2ca7", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3287", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1621,11 +1621,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1641 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xce2cc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce32a0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1642 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce2cce", Frameless: true}]
+              InjectionPoints: [{PC: "0xce32ae", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1648,11 +1648,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1611 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0xce2440", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2a20", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1612 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce2443", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2a23", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1666,11 +1666,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1613 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0xce2460", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2a40", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1614 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce246b", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2a4b", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1693,11 +1693,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1406 EventRootType Probe[main.testInlinedBA]
-              InjectionPoints: [{PC: "0xcd98ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd99ca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1407 EventRootType Probe[main.testInlinedBA]Return
-              InjectionPoints: [{PC: "0xcd992e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd9a2e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1724,11 +1724,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1408 EventRootType Probe[main.testInlinedBB]
-              InjectionPoints: [{PC: "0xcd996e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd9a6e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1409 EventRootType Probe[main.testInlinedBB]Return
-              InjectionPoints: [{PC: "0xcd99fe", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd9afe", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}'
@@ -1755,11 +1755,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1410 EventRootType Probe[main.testInlinedBBA]
-              InjectionPoints: [{PC: "0xcd9a4a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd9b4a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1411 EventRootType Probe[main.testInlinedBBA]Return
-              InjectionPoints: [{PC: "0xcd9a8b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd9b8b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1781,7 +1781,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1667 EventRootType Probe[main.testInlinedBBB]
-              InjectionPoints: [{PC: "0xcd99c6", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd9ac6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBBB
@@ -1799,11 +1799,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1412 EventRootType Probe[main.testInlinedBC]
-              InjectionPoints: [{PC: "0xcd9ace", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd9bce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1413 EventRootType Probe[main.testInlinedBC]Return
-              InjectionPoints: [{PC: "0xcd9bbe", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd9cbe", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBC
@@ -1821,7 +1821,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1668 EventRootType Probe[main.testInlinedBCA]
-              InjectionPoints: [{PC: "0xcd9ad3", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd9bd3", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1842,7 +1842,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1669 EventRootType Probe[main.testInlinedBCA]Line
-              InjectionPoints: [{PC: "0xcd9ad3", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd9bd3", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1860,7 +1860,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1670 EventRootType Probe[main.testInlinedBCB]
-              InjectionPoints: [{PC: "0xcd9b86", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd9c86", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1881,7 +1881,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1671 EventRootType Probe[main.testInlinedBCB]Line
-              InjectionPoints: [{PC: "0xcd9b86", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd9c86", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1902,7 +1902,7 @@ Probes:
               InjectionPoints:
                 - PC: "0x5230a1"
                   Frameless: true
-                - PC: "0xcda5b0"
+                - PC: "0xcda7dd"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1923,20 +1923,20 @@ Probes:
             - Kind: Entry
               Type: 1664 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
-                - PC: "0xcd972a"
+                - PC: "0xcd982a"
                   Frameless: false
-                - PC: "0xcd97b1"
+                - PC: "0xcd98b1"
                   Frameless: false
-                - PC: "0xcd98f2"
+                - PC: "0xcd99f2"
                   Frameless: false
-                - PC: "0xcd997c"
+                - PC: "0xcd9a7c"
                   Frameless: false
-                - PC: "0xcd9a4f"
+                - PC: "0xcd9b4f"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1665 EventRootType Probe[main.testInlinedPrint]Return
-              InjectionPoints: [{PC: "0xcd976a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd986a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1962,15 +1962,15 @@ Probes:
             - Kind: Line
               Type: 1666 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xcd972e"
+                - PC: "0xcd982e"
                   Frameless: false
-                - PC: "0xcd97b1"
+                - PC: "0xcd98b1"
                   Frameless: false
-                - PC: "0xcd98f2"
+                - PC: "0xcd99f2"
                   Frameless: false
-                - PC: "0xcd997c"
+                - PC: "0xcd9a7c"
                   Frameless: false
-                - PC: "0xcd9a4f"
+                - PC: "0xcd9b4f"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1993,7 +1993,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1672 EventRootType Probe[main.testInlinedSq]
-              InjectionPoints: [{PC: "0xcd9be1", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9ce1", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2018,7 +2018,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1673 EventRootType Probe[main.testInlinedSq]Line
-              InjectionPoints: [{PC: "0xcd9be1", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9ce1", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2042,9 +2042,9 @@ Probes:
             - Kind: Entry
               Type: 1674 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
-                - PC: "0xcd9c25"
+                - PC: "0xcd9d25"
                   Frameless: false
-                - PC: "0xcd9cc5"
+                - PC: "0xcd9dc5"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2067,7 +2067,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1356 EventRootType Probe[main.testInt16Array]
-              InjectionPoints: [{PC: "0xcd4fc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd50c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2089,7 +2089,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1357 EventRootType Probe[main.testInt32Array]
-              InjectionPoints: [{PC: "0xcd4fe0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd50e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2111,7 +2111,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1358 EventRootType Probe[main.testInt64Array]
-              InjectionPoints: [{PC: "0xcd5000", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5100", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2133,7 +2133,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1355 EventRootType Probe[main.testInt8Array]
-              InjectionPoints: [{PC: "0xcd4fa0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd50a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2155,7 +2155,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1354 EventRootType Probe[main.testIntArray]
-              InjectionPoints: [{PC: "0xcd4f80", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5080", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2177,7 +2177,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1419 EventRootType Probe[main.testInterface]
-              InjectionPoints: [{PC: "0xcd9ee0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9fe0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -2198,11 +2198,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1550 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0xcde42e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde5ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1551 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xcde593", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde753", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2224,7 +2224,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1458 EventRootType Probe[main.testLinkedList]
-              InjectionPoints: [{PC: "0xcdc840", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdca00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -2249,7 +2249,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1397 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0xcd5dda", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd5eda", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2271,7 +2271,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1398 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0xcd5e8d", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd5f8d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2293,7 +2293,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1399 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0xcd5f54", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd6054", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2336,11 +2336,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1556 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0xcde8f3", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdeab3", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1557 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0xcdeb02", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdecc2", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2403,7 +2403,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1400 EventRootType Probe[main.testManyPointers]
-              InjectionPoints: [{PC: "0xcd6440", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd6540", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2427,7 +2427,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1401 EventRootType Probe[main.testManyStrings]
-              InjectionPoints: [{PC: "0xcd7e20", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd7f20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{ss}'
@@ -2449,7 +2449,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1430 EventRootType Probe[main.testMapArrayToArray]
-              InjectionPoints: [{PC: "0xcda700", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda8c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2471,7 +2471,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1437 EventRootType Probe[main.testMapEmbeddedMaps]
-              InjectionPoints: [{PC: "0xcda7c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda980", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2493,7 +2493,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1447 EventRootType Probe[main.testMapEmptyKey]
-              InjectionPoints: [{PC: "0xcda900", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdaac0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2515,7 +2515,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1449 EventRootType Probe[main.testMapEmptyKeyAndValue]
-              InjectionPoints: [{PC: "0xcda940", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdab00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2537,7 +2537,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1448 EventRootType Probe[main.testMapEmptyValue]
-              InjectionPoints: [{PC: "0xcda920", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdaae0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2559,7 +2559,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1434 EventRootType Probe[main.testMapIntToInt]
-              InjectionPoints: [{PC: "0xcda780", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda940", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2581,7 +2581,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1446 EventRootType Probe[main.testMapLargeKeyLargeValue]
-              InjectionPoints: [{PC: "0xcda8e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdaaa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2603,7 +2603,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1445 EventRootType Probe[main.testMapLargeKeySmallValue]
-              InjectionPoints: [{PC: "0xcda8c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdaa80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2627,7 +2627,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1435 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0xcda7a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda960", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2651,7 +2651,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1436 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0xcda7a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda960", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2673,7 +2673,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1444 EventRootType Probe[main.testMapSmallKeyLargeValue]
-              InjectionPoints: [{PC: "0xcda8a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdaa60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2695,7 +2695,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1443 EventRootType Probe[main.testMapSmallKeySmallValue]
-              InjectionPoints: [{PC: "0xcda880", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdaa40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2717,7 +2717,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1428 EventRootType Probe[main.testMapStringToInt]
-              InjectionPoints: [{PC: "0xcda6c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda880", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2739,7 +2739,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1429 EventRootType Probe[main.testMapStringToSlice]
-              InjectionPoints: [{PC: "0xcda6e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda8a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2761,7 +2761,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1427 EventRootType Probe[main.testMapStringToStruct]
-              InjectionPoints: [{PC: "0xcda6a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda860", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2783,7 +2783,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1438 EventRootType Probe[main.testMapWithLinkedList]
-              InjectionPoints: [{PC: "0xcda7e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda9a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2805,7 +2805,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1441 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-              InjectionPoints: [{PC: "0xcda840", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdaa00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2827,7 +2827,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1442 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-              InjectionPoints: [{PC: "0xcda860", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdaa20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2849,7 +2849,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1439 EventRootType Probe[main.testMapWithSmallValue]
-              InjectionPoints: [{PC: "0xcda800", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda9c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2873,7 +2873,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1440 EventRootType Probe[main.testMapWithSmallValueMassive]
-              InjectionPoints: [{PC: "0xcda820", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda9e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2895,7 +2895,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1592 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xcdfca0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0280", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2918,7 +2918,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1593 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xcdfca0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0280", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2965,11 +2965,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1558 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0xcdeb93", Frameless: false}]
+              InjectionPoints: [{PC: "0xcded53", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1559 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0xcdedcb", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdef8b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -3035,11 +3035,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1562 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0xcdef0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdf0ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1563 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0xcdefde", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdf19e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3070,11 +3070,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1554 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0xcde6ae", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde86e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1555 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0xcde8ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdea8a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3100,11 +3100,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1495 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcdd64e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd80e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1496 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdd6ef", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd8af", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3140,7 +3140,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1453 EventRootType Probe[main.testMultipleSimpleParams]
-              InjectionPoints: [{PC: "0xcdc400", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc5c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -3181,11 +3181,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1489 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xcdd5aa", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd76a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1490 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdd615", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd7d5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3209,11 +3209,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1491 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xcdd5aa", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd76a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1492 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdd615", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd7d5", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
       version: 0
@@ -3232,11 +3232,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1497 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcdd64e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd80e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1498 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdd6ef", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd8af", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
       version: 0
@@ -3256,11 +3256,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1499 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcdd64e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd80e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1500 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdd6ef", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd8af", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r1={result} r2={result2}
@@ -3293,11 +3293,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1493 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xcdd5aa", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd76a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1494 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdd615", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd7d5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Parameter {i} * 2 = result {result}
@@ -3325,7 +3325,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1604 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xce00e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce06c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3350,7 +3350,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1605 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xce00e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce06c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3381,7 +3381,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1606 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xce00e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce06c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3406,7 +3406,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1607 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xce00e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce06c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3433,7 +3433,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1463 EventRootType Probe[main.testNilPointer]
-              InjectionPoints: [{PC: "0xcdc9e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdcba0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}, {a}'
@@ -3460,7 +3460,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1576 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0xcdf7a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf960", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3487,7 +3487,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1573 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0xcdf740", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf900", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3522,7 +3522,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1575 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0xcdf780", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf940", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3554,7 +3554,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1591 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0xcdfc80", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0260", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3576,7 +3576,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1459 EventRootType Probe[main.testPointerLoop]
-              InjectionPoints: [{PC: "0xcdc860", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdca20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3598,7 +3598,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1433 EventRootType Probe[main.testPointerToMap]
-              InjectionPoints: [{PC: "0xcda760", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda920", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3620,7 +3620,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1457 EventRootType Probe[main.testPointerToSimpleStruct]
-              InjectionPoints: [{PC: "0xcdc820", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc9e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3644,11 +3644,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1465 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xcdce8a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd04a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1466 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xcdcedb", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd09b", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
       version: 0
@@ -3668,11 +3668,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1509 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xcdd72e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd8ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1510 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdd7cb", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd98b", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3715,11 +3715,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1475 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xcdcfae", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd16e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1476 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xcdd064", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd224", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3759,11 +3759,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1467 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xcdce8a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd04a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1468 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xcdcedb", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd09b", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3806,11 +3806,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1477 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xcdcfae", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd16e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1478 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xcdd064", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd224", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3852,11 +3852,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1511 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xcdd72e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd8ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1512 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdd7cb", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd98b", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
       version: 0
@@ -3873,11 +3873,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1513 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xcdd72e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd8ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1514 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdd7cb", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd98b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r0={@return.r0}
@@ -3899,11 +3899,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1469 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xcdce8a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd04a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1470 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xcdcedb", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd09b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: result={@return}
@@ -3926,18 +3926,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1485 EventRootType Probe[main.testReturnsAny]
-              InjectionPoints: [{PC: "0xcdd24e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd40e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1486 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
-                - PC: "0xcdd304"
+                - PC: "0xcdd4c4"
                   Frameless: false
-                - PC: "0xcdd33f"
+                - PC: "0xcdd4ff"
                   Frameless: false
-                - PC: "0xcdd402"
+                - PC: "0xcdd5c2"
                   Frameless: false
-                - PC: "0xcdd40c"
+                - PC: "0xcdd5cc"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3965,18 +3965,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1483 EventRootType Probe[main.testReturnsAnyAndError]
-              InjectionPoints: [{PC: "0xcdd0ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd2ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1484 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
-                - PC: "0xcdd144"
+                - PC: "0xcdd304"
                   Frameless: false
-                - PC: "0xcdd193"
+                - PC: "0xcdd353"
                   Frameless: false
-                - PC: "0xcdd1c7"
+                - PC: "0xcdd387"
                   Frameless: false
-                - PC: "0xcdd1f9"
+                - PC: "0xcdd3b9"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4003,11 +4003,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1528 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0xcddeca", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde08a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1529 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0xcddf2d", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde0ed", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -4024,11 +4024,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1530 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0xcddf4a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde10a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1531 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0xcddf8b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde14b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -4045,11 +4045,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1532 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0xcddfaa", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde16a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1533 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0xcddfe6", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde1a6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4066,11 +4066,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1536 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0xcde08e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde24e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1537 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0xcde10a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde2ca", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4087,11 +4087,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1548 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0xcde3ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde58a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1549 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0xcde410", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde5d0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4108,11 +4108,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1524 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0xcddd8a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcddf4a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1525 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0xcddde6", Frameless: false}]
+              InjectionPoints: [{PC: "0xcddfa6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4130,14 +4130,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1481 EventRootType Probe[main.testReturnsError]
-              InjectionPoints: [{PC: "0xcdd08a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd24a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1482 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
-                - PC: "0xcdd0ba"
+                - PC: "0xcdd27a"
                   Frameless: false
-                - PC: "0xcdd0c5"
+                - PC: "0xcdd285"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4159,11 +4159,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1471 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xcdce8a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd04a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1472 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xcdcedb", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd09b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4184,11 +4184,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1479 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xcdcfae", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd16e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1480 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xcdd064", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd224", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4209,11 +4209,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1473 EventRootType Probe[main.testReturnsIntPointer]
-              InjectionPoints: [{PC: "0xcdcf0a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd0ca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1474 EventRootType Probe[main.testReturnsIntPointer]Return
-              InjectionPoints: [{PC: "0xcdcf74", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd134", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4235,14 +4235,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1487 EventRootType Probe[main.testReturnsInterface]
-              InjectionPoints: [{PC: "0xcdd44e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd60e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1488 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
-                - PC: "0xcdd52f"
+                - PC: "0xcdd6ef"
                   Frameless: false
-                - PC: "0xcdd539"
+                - PC: "0xcdd6f9"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4264,11 +4264,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1526 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0xcdde0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcddfce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1527 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0xcdde93", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde053", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4285,11 +4285,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1522 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0xcddc8e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdde4e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1523 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0xcddd67", Frameless: false}]
+              InjectionPoints: [{PC: "0xcddf27", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4306,11 +4306,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1540 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0xcde1ea", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde3aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1541 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0xcde24c", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde40c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4327,11 +4327,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1534 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0xcde00a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde1ca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1535 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0xcde058", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde218", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4348,11 +4348,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1546 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0xcde34a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde50a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1547 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0xcde396", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde556", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
@@ -4372,7 +4372,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1519 EventRootType Probe[main.testReturnsNamedDeferLine]Line
-              InjectionPoints: [{PC: "0xcdda0f", Frameless: false}]
+              InjectionPoints: [{PC: "0xcddbcf", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4393,11 +4393,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1544 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0xcde2ea", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde4aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1545 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0xcde32e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde4ee", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4414,11 +4414,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1520 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0xcddc0a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdddca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1521 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0xcddc71", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdde31", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4435,11 +4435,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1542 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0xcde26a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde42a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1543 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0xcde2cd", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde48d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4456,11 +4456,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1538 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0xcde12e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde2ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1539 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0xcde1b4", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde374", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4478,7 +4478,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1351 EventRootType Probe[main.testRuneArray]
-              InjectionPoints: [{PC: "0xcd4f20", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5020", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4513,11 +4513,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1501 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcdd64e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd80e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1502 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdd6ef", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd8af", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -4563,7 +4563,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1372 EventRootType Probe[main.testSingleBool]
-              InjectionPoints: [{PC: "0xcd5540", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5640", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4585,7 +4585,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1370 EventRootType Probe[main.testSingleByte]
-              InjectionPoints: [{PC: "0xcd5500", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5600", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4607,7 +4607,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1383 EventRootType Probe[main.testSingleFloat32]
-              InjectionPoints: [{PC: "0xcd56a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd57a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4625,7 +4625,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1384 EventRootType Probe[main.testSingleFloat64]
-              InjectionPoints: [{PC: "0xcd56c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd57c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4643,7 +4643,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1373 EventRootType Probe[main.testSingleInt]
-              InjectionPoints: [{PC: "0xcd5560", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5660", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4665,7 +4665,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1375 EventRootType Probe[main.testSingleInt16]
-              InjectionPoints: [{PC: "0xcd55a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd56a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}
@@ -4688,7 +4688,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1376 EventRootType Probe[main.testSingleInt32]
-              InjectionPoints: [{PC: "0xcd55c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd56c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4710,7 +4710,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1377 EventRootType Probe[main.testSingleInt64]
-              InjectionPoints: [{PC: "0xcd55e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd56e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4739,7 +4739,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1374 EventRootType Probe[main.testSingleInt8]
-              InjectionPoints: [{PC: "0xcd5580", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5680", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}{x}{x}
@@ -4770,7 +4770,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1371 EventRootType Probe[main.testSingleRune]
-              InjectionPoints: [{PC: "0xcd5520", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5620", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4792,7 +4792,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1583 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0xcdfc00", Frameless: true}]
+              InjectionPoints: [{PC: "0xce01e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4814,7 +4814,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1378 EventRootType Probe[main.testSingleUint]
-              InjectionPoints: [{PC: "0xcd5600", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5700", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4836,7 +4836,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1380 EventRootType Probe[main.testSingleUint16]
-              InjectionPoints: [{PC: "0xcd5640", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5740", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4858,7 +4858,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1381 EventRootType Probe[main.testSingleUint32]
-              InjectionPoints: [{PC: "0xcd5660", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5760", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4880,7 +4880,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1382 EventRootType Probe[main.testSingleUint64]
-              InjectionPoints: [{PC: "0xcd5680", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5780", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4902,7 +4902,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1379 EventRootType Probe[main.testSingleUint8]
-              InjectionPoints: [{PC: "0xcd5620", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5720", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4924,7 +4924,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1579 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0xcdf7e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf9a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -4946,7 +4946,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1570 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0xcdf6e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf8a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -4968,7 +4968,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1431 EventRootType Probe[main.testSmallMap]
-              InjectionPoints: [{PC: "0xcda720", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda8e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -4989,11 +4989,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1515 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xcdd72e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd8ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1516 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdd7cb", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd98b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -5014,11 +5014,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1560 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0xcdee6a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdf02a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1561 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0xcdeedc", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdf09c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5040,7 +5040,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1352 EventRootType Probe[main.testStringArray]
-              InjectionPoints: [{PC: "0xcd4f40", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5040", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5062,7 +5062,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1462 EventRootType Probe[main.testStringPointer]
-              InjectionPoints: [{PC: "0xcdc9a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdcb60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}'
@@ -5084,7 +5084,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1574 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0xcdf760", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf920", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5106,7 +5106,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1395 EventRootType Probe[main.testStringType1]
-              InjectionPoints: [{PC: "0xcd5d80", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5e80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5128,7 +5128,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1396 EventRootType Probe[main.testStringType2]
-              InjectionPoints: [{PC: "0xcd5da0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5ea0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5150,11 +5150,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1602 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xcdffe0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce05c0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1603 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0xce0002", Frameless: true}]
+              InjectionPoints: [{PC: "0xce05e2", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5181,7 +5181,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1571 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0xcdf700", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf8c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5208,7 +5208,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1425 EventRootType Probe[main.testStructWithAny]
-              InjectionPoints: [{PC: "0xcda000", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda100", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5229,11 +5229,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1564 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0xcdf00e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdf1ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1565 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0xcdf0ba", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdf27a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5255,11 +5255,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1598 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0xcdfea0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0480", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1599 EventRootType Probe[main.testStructWithCyclicMaps]Return
-              InjectionPoints: [{PC: "0xcdfebe", Frameless: true}]
+              InjectionPoints: [{PC: "0xce049e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5280,7 +5280,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1597 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0xcdfe80", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0460", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5307,7 +5307,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1426 EventRootType Probe[main.testStructWithMap]
-              InjectionPoints: [{PC: "0xcda680", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda840", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s} {@duration}'
@@ -5340,7 +5340,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1580 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0xcdf800", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf9c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5380,7 +5380,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1596 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0xcdfd00", Frameless: true}]
+              InjectionPoints: [{PC: "0xce02e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5413,11 +5413,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1503 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcdd64e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd80e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1504 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdd6ef", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd8af", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{nonexistentVariable}'
@@ -5438,11 +5438,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1505 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcdd64e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd80e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1506 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdd6ef", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd8af", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{unsupportedExpression}'
@@ -5465,11 +5465,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1507 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcdd64e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd80e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1508 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdd6ef", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd8af", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -5501,7 +5501,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1584 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0xcdfc20", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0200", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5533,11 +5533,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1585 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xcdfc40", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0220", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1586 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0xcdfc5e", Frameless: true}]
+              InjectionPoints: [{PC: "0xce023e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5567,11 +5567,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1587 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xcdfc40", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0220", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1588 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0xcdfc5e", Frameless: true}]
+              InjectionPoints: [{PC: "0xce023e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5603,7 +5603,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1589 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xcdfc60", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0240", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5633,7 +5633,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1590 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xcdfc60", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0240", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5665,7 +5665,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1385 EventRootType Probe[main.testTypeAlias]
-              InjectionPoints: [{PC: "0xcd56e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd57e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5687,7 +5687,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1361 EventRootType Probe[main.testUint16Array]
-              InjectionPoints: [{PC: "0xcd5060", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5160", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5709,7 +5709,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1362 EventRootType Probe[main.testUint32Array]
-              InjectionPoints: [{PC: "0xcd5080", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5180", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5731,7 +5731,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1363 EventRootType Probe[main.testUint64Array]
-              InjectionPoints: [{PC: "0xcd50a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd51a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5753,7 +5753,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1360 EventRootType Probe[main.testUint8Array]
-              InjectionPoints: [{PC: "0xcd5040", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5140", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5775,7 +5775,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1359 EventRootType Probe[main.testUintArray]
-              InjectionPoints: [{PC: "0xcd5020", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5120", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5797,7 +5797,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1461 EventRootType Probe[main.testUintPointer]
-              InjectionPoints: [{PC: "0xcdc8c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdca80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5819,7 +5819,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1568 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0xcdf6a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf860", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5841,7 +5841,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1594 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0xcdfcc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce02a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5863,7 +5863,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1460 EventRootType Probe[main.testUnsafePointer]
-              InjectionPoints: [{PC: "0xcdc880", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdca40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5885,7 +5885,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1369 EventRootType Probe[main.testVeryLargeArray]
-              InjectionPoints: [{PC: "0xcd5180", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd5280", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5907,7 +5907,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1577 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xcdf7c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf980", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5929,7 +5929,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1578 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xcdf7c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf980", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5952,14 +5952,14 @@ Probes:
             - Kind: Entry
               Type: 1675 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
-                - PC: "0xcd9e0a"
+                - PC: "0xcd9f0a"
                   Frameless: false
-                - PC: "0xce30a3"
+                - PC: "0xce3683"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1676 EventRootType Probe[main.firstBehavior.DoSomething]Return
-              InjectionPoints: [{PC: "0xcd9e50", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd9f50", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testWhollyInlinedSubroutine
@@ -5981,11 +5981,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1566 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0xcdf0ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdf2ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1567 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xcdf16c", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdf32c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -6002,481 +6002,481 @@ Probes:
 Subprograms:
     - ID: 1
       Name: main.testByteArray
-      OutOfLinePCRanges: [0xcd4f00..0xcd4f01]
+      OutOfLinePCRanges: [0xcd5000..0xcd5001]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 108 ArrayType [2]uint8
           Locations:
-            - Range: 0xcd4f00..0xcd4f01
+            - Range: 0xcd5000..0xcd5001
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 2
       Name: main.testRuneArray
-      OutOfLinePCRanges: [0xcd4f20..0xcd4f21]
+      OutOfLinePCRanges: [0xcd5020..0xcd5021]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 109 ArrayType [2]int32
           Locations:
-            - Range: 0xcd4f20..0xcd4f21
+            - Range: 0xcd5020..0xcd5021
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 3
       Name: main.testStringArray
-      OutOfLinePCRanges: [0xcd4f40..0xcd4f41]
+      OutOfLinePCRanges: [0xcd5040..0xcd5041]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 110 ArrayType [2]string
           Locations:
-            - Range: 0xcd4f40..0xcd4f41
+            - Range: 0xcd5040..0xcd5041
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 4
       Name: main.testBoolArray
-      OutOfLinePCRanges: [0xcd4f60..0xcd4f61]
+      OutOfLinePCRanges: [0xcd5060..0xcd5061]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 111 ArrayType [2]bool
           Locations:
-            - Range: 0xcd4f60..0xcd4f61
+            - Range: 0xcd5060..0xcd5061
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 5
       Name: main.testIntArray
-      OutOfLinePCRanges: [0xcd4f80..0xcd4f81]
+      OutOfLinePCRanges: [0xcd5080..0xcd5081]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 112 ArrayType [2]int
           Locations:
-            - Range: 0xcd4f80..0xcd4f81
+            - Range: 0xcd5080..0xcd5081
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 6
       Name: main.testInt8Array
-      OutOfLinePCRanges: [0xcd4fa0..0xcd4fa1]
+      OutOfLinePCRanges: [0xcd50a0..0xcd50a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 113 ArrayType [2]int8
           Locations:
-            - Range: 0xcd4fa0..0xcd4fa1
+            - Range: 0xcd50a0..0xcd50a1
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 7
       Name: main.testInt16Array
-      OutOfLinePCRanges: [0xcd4fc0..0xcd4fc1]
+      OutOfLinePCRanges: [0xcd50c0..0xcd50c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 114 ArrayType [2]int16
           Locations:
-            - Range: 0xcd4fc0..0xcd4fc1
+            - Range: 0xcd50c0..0xcd50c1
               Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 8
       Name: main.testInt32Array
-      OutOfLinePCRanges: [0xcd4fe0..0xcd4fe1]
+      OutOfLinePCRanges: [0xcd50e0..0xcd50e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 109 ArrayType [2]int32
           Locations:
-            - Range: 0xcd4fe0..0xcd4fe1
+            - Range: 0xcd50e0..0xcd50e1
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 9
       Name: main.testInt64Array
-      OutOfLinePCRanges: [0xcd5000..0xcd5001]
+      OutOfLinePCRanges: [0xcd5100..0xcd5101]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 115 ArrayType [2]int64
           Locations:
-            - Range: 0xcd5000..0xcd5001
+            - Range: 0xcd5100..0xcd5101
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 10
       Name: main.testUintArray
-      OutOfLinePCRanges: [0xcd5020..0xcd5021]
+      OutOfLinePCRanges: [0xcd5120..0xcd5121]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 116 ArrayType [2]uint
           Locations:
-            - Range: 0xcd5020..0xcd5021
+            - Range: 0xcd5120..0xcd5121
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 11
       Name: main.testUint8Array
-      OutOfLinePCRanges: [0xcd5040..0xcd5041]
+      OutOfLinePCRanges: [0xcd5140..0xcd5141]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 108 ArrayType [2]uint8
           Locations:
-            - Range: 0xcd5040..0xcd5041
+            - Range: 0xcd5140..0xcd5141
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 12
       Name: main.testUint16Array
-      OutOfLinePCRanges: [0xcd5060..0xcd5061]
+      OutOfLinePCRanges: [0xcd5160..0xcd5161]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 117 ArrayType [2]uint16
           Locations:
-            - Range: 0xcd5060..0xcd5061
+            - Range: 0xcd5160..0xcd5161
               Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 13
       Name: main.testUint32Array
-      OutOfLinePCRanges: [0xcd5080..0xcd5081]
+      OutOfLinePCRanges: [0xcd5180..0xcd5181]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 118 ArrayType [2]uint32
           Locations:
-            - Range: 0xcd5080..0xcd5081
+            - Range: 0xcd5180..0xcd5181
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 14
       Name: main.testUint64Array
-      OutOfLinePCRanges: [0xcd50a0..0xcd50a1]
+      OutOfLinePCRanges: [0xcd51a0..0xcd51a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 55 ArrayType [2]uint64
           Locations:
-            - Range: 0xcd50a0..0xcd50a1
+            - Range: 0xcd51a0..0xcd51a1
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 15
       Name: main.testArrayOfArrays
-      OutOfLinePCRanges: [0xcd50c0..0xcd50c1]
+      OutOfLinePCRanges: [0xcd51c0..0xcd51c1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 119 ArrayType [2][2]int
           Locations:
-            - Range: 0xcd50c0..0xcd50c1
+            - Range: 0xcd51c0..0xcd51c1
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 16
       Name: main.testArrayOfStrings
-      OutOfLinePCRanges: [0xcd50e0..0xcd50e1]
+      OutOfLinePCRanges: [0xcd51e0..0xcd51e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 110 ArrayType [2]string
           Locations:
-            - Range: 0xcd50e0..0xcd50e1
+            - Range: 0xcd51e0..0xcd51e1
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 17
       Name: main.testArrayOfArraysOfArrays
-      OutOfLinePCRanges: [0xcd5100..0xcd5101]
+      OutOfLinePCRanges: [0xcd5200..0xcd5201]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 120 ArrayType [2][2][2]int
           Locations:
-            - Range: 0xcd5100..0xcd5101
+            - Range: 0xcd5200..0xcd5201
               Pieces: [{Size: 64, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 18
       Name: main.testArrayOfStructs
-      OutOfLinePCRanges: [0xcd5120..0xcd5121]
+      OutOfLinePCRanges: [0xcd5220..0xcd5221]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 121 ArrayType [2]main.nestedStruct
           Locations:
-            - Range: 0xcd5120..0xcd5121
+            - Range: 0xcd5220..0xcd5221
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 19
       Name: main.testArrayEmptyStructs
-      OutOfLinePCRanges: [0xcd5140..0xcd5141]
+      OutOfLinePCRanges: [0xcd5240..0xcd5241]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 123 ArrayType [2]struct {}
           Locations:
-            - Range: 0xcd5140..0xcd5141
+            - Range: 0xcd5240..0xcd5241
               Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 20
       Name: main.testVeryLargeArray
-      OutOfLinePCRanges: [0xcd5180..0xcd5181]
+      OutOfLinePCRanges: [0xcd5280..0xcd5281]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 125 ArrayType [100]uint
           Locations:
-            - Range: 0xcd5180..0xcd5181
+            - Range: 0xcd5280..0xcd5281
               Pieces: [{Size: 800, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 21
       Name: main.testSingleByte
-      OutOfLinePCRanges: [0xcd5500..0xcd5501]
+      OutOfLinePCRanges: [0xcd5600..0xcd5601]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xcd5500..0xcd5501
+            - Range: 0xcd5600..0xcd5601
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 22
       Name: main.testSingleRune
-      OutOfLinePCRanges: [0xcd5520..0xcd5521]
+      OutOfLinePCRanges: [0xcd5620..0xcd5621]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 BaseType int32
           Locations:
-            - Range: 0xcd5520..0xcd5521
+            - Range: 0xcd5620..0xcd5621
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 23
       Name: main.testSingleBool
-      OutOfLinePCRanges: [0xcd5540..0xcd5541]
+      OutOfLinePCRanges: [0xcd5640..0xcd5641]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xcd5540..0xcd5541
+            - Range: 0xcd5640..0xcd5641
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 24
       Name: main.testSingleInt
-      OutOfLinePCRanges: [0xcd5560..0xcd5561]
+      OutOfLinePCRanges: [0xcd5660..0xcd5661]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcd5560..0xcd5561
+            - Range: 0xcd5660..0xcd5661
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 25
       Name: main.testSingleInt8
-      OutOfLinePCRanges: [0xcd5580..0xcd5581]
+      OutOfLinePCRanges: [0xcd5680..0xcd5681]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 BaseType int8
           Locations:
-            - Range: 0xcd5580..0xcd5581
+            - Range: 0xcd5680..0xcd5681
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 26
       Name: main.testSingleInt16
-      OutOfLinePCRanges: [0xcd55a0..0xcd55a1]
+      OutOfLinePCRanges: [0xcd56a0..0xcd56a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 103 BaseType int16
           Locations:
-            - Range: 0xcd55a0..0xcd55a1
+            - Range: 0xcd56a0..0xcd56a1
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 27
       Name: main.testSingleInt32
-      OutOfLinePCRanges: [0xcd55c0..0xcd55c1]
+      OutOfLinePCRanges: [0xcd56c0..0xcd56c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 BaseType int32
           Locations:
-            - Range: 0xcd55c0..0xcd55c1
+            - Range: 0xcd56c0..0xcd56c1
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 28
       Name: main.testSingleInt64
-      OutOfLinePCRanges: [0xcd55e0..0xcd55e1]
+      OutOfLinePCRanges: [0xcd56e0..0xcd56e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType int64
           Locations:
-            - Range: 0xcd55e0..0xcd55e1
+            - Range: 0xcd56e0..0xcd56e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 29
       Name: main.testSingleUint
-      OutOfLinePCRanges: [0xcd5600..0xcd5601]
+      OutOfLinePCRanges: [0xcd5700..0xcd5701]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType uint
           Locations:
-            - Range: 0xcd5600..0xcd5601
+            - Range: 0xcd5700..0xcd5701
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 30
       Name: main.testSingleUint8
-      OutOfLinePCRanges: [0xcd5620..0xcd5621]
+      OutOfLinePCRanges: [0xcd5720..0xcd5721]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xcd5620..0xcd5621
+            - Range: 0xcd5720..0xcd5721
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 31
       Name: main.testSingleUint16
-      OutOfLinePCRanges: [0xcd5640..0xcd5641]
+      OutOfLinePCRanges: [0xcd5740..0xcd5741]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType uint16
           Locations:
-            - Range: 0xcd5640..0xcd5641
+            - Range: 0xcd5740..0xcd5741
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 32
       Name: main.testSingleUint32
-      OutOfLinePCRanges: [0xcd5660..0xcd5661]
+      OutOfLinePCRanges: [0xcd5760..0xcd5761]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint32
           Locations:
-            - Range: 0xcd5660..0xcd5661
+            - Range: 0xcd5760..0xcd5761
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 33
       Name: main.testSingleUint64
-      OutOfLinePCRanges: [0xcd5680..0xcd5681]
+      OutOfLinePCRanges: [0xcd5780..0xcd5781]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0xcd5680..0xcd5681
+            - Range: 0xcd5780..0xcd5781
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 34
       Name: main.testSingleFloat32
-      OutOfLinePCRanges: [0xcd56a0..0xcd56a1]
+      OutOfLinePCRanges: [0xcd57a0..0xcd57a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 18 BaseType float32
           Locations:
-            - Range: 0xcd56a0..0xcd56a1
+            - Range: 0xcd57a0..0xcd57a1
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 35
       Name: main.testSingleFloat64
-      OutOfLinePCRanges: [0xcd56c0..0xcd56c1]
+      OutOfLinePCRanges: [0xcd57c0..0xcd57c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 19 BaseType float64
           Locations:
-            - Range: 0xcd56c0..0xcd56c1
+            - Range: 0xcd57c0..0xcd57c1
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 36
       Name: main.testTypeAlias
-      OutOfLinePCRanges: [0xcd56e0..0xcd56e1]
+      OutOfLinePCRanges: [0xcd57e0..0xcd57e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 126 BaseType main.typeAlias
           Locations:
-            - Range: 0xcd56e0..0xcd56e1
+            - Range: 0xcd57e0..0xcd57e1
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 37
       Name: main.testBigStruct
-      OutOfLinePCRanges: [0xcd5840..0xcd585f]
+      OutOfLinePCRanges: [0xcd5940..0xcd595f]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 127 StructureType main.bigStruct
           Locations:
-            - Range: 0xcd5840..0xcd585f
+            - Range: 0xcd5940..0xcd595f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6495,48 +6495,48 @@ Subprograms:
       DictRegister: null
     - ID: 38
       Name: main.testErrorAtLine
-      OutOfLinePCRanges: [0xcd58a0..0xcd59b2]
+      OutOfLinePCRanges: [0xcd59a0..0xcd5ab2]
       InlinePCRanges: []
       Variables:
         - Name: shouldErr
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xcd58a0..0xcd58b8
+            - Range: 0xcd59a0..0xcd59b8
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
-          Locations: [{Range: 0xcd58a0..0xcd59b2, Pieces: []}]
+          Locations: [{Range: 0xcd59a0..0xcd5ab2, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 8 BaseType int
-          Locations: [{Range: 0xcd58a0..0xcd59b2, Pieces: []}]
+          Locations: [{Range: 0xcd59a0..0xcd5ab2, Pieces: []}]
           Role: Local
           DictIndex: -1
         - Name: err
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0xcd58c9..0xcd58e5
+            - Range: 0xcd59c9..0xcd59e5
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
-            - Range: 0xcd58e5..0xcd5908
+            - Range: 0xcd59e5..0xcd5a08
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcd5908..0xcd591e
+            - Range: 0xcd5a08..0xcd5a1e
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -80}
                 - Size: 8
                   Op: {CfaOffset: -72}
-            - Range: 0xcd591e..0xcd59b2
+            - Range: 0xcd5a1e..0xcd5ab2
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -80}
@@ -6547,39 +6547,39 @@ Subprograms:
       DictRegister: null
     - ID: 39
       Name: main.testDeepPtr1
-      OutOfLinePCRanges: [0xcd5a20..0xcd5a21]
+      OutOfLinePCRanges: [0xcd5b20..0xcd5b21]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 131 StructureType main.deepPtr1
           Locations:
-            - Range: 0xcd5a20..0xcd5a21
+            - Range: 0xcd5b20..0xcd5b21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 40
       Name: main.testDeepPtr7
-      OutOfLinePCRanges: [0xcd5a40..0xcd5a41]
+      OutOfLinePCRanges: [0xcd5b40..0xcd5b41]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 134 PointerType *main.deepPtr7
           Locations:
-            - Range: 0xcd5a40..0xcd5a41
+            - Range: 0xcd5b40..0xcd5b41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 41
       Name: main.testDeepSlice1
-      OutOfLinePCRanges: [0xcd5bc0..0xcd5bc1]
+      OutOfLinePCRanges: [0xcd5cc0..0xcd5cc1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 136 StructureType main.deepSlice1
           Locations:
-            - Range: 0xcd5bc0..0xcd5bc1
+            - Range: 0xcd5cc0..0xcd5cc1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6592,142 +6592,142 @@ Subprograms:
       DictRegister: null
     - ID: 42
       Name: main.testDeepSlice7
-      OutOfLinePCRanges: [0xcd5be0..0xcd5be1]
+      OutOfLinePCRanges: [0xcd5ce0..0xcd5ce1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 140 PointerType *main.deepSlice7
           Locations:
-            - Range: 0xcd5be0..0xcd5be1
+            - Range: 0xcd5ce0..0xcd5ce1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 43
       Name: main.testDeepMap1
-      OutOfLinePCRanges: [0xcd5d40..0xcd5d41]
+      OutOfLinePCRanges: [0xcd5e40..0xcd5e41]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 142 StructureType main.deepMap1
           Locations:
-            - Range: 0xcd5d40..0xcd5d41
+            - Range: 0xcd5e40..0xcd5e41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 44
       Name: main.testDeepMap7
-      OutOfLinePCRanges: [0xcd5d60..0xcd5d61]
+      OutOfLinePCRanges: [0xcd5e60..0xcd5e61]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 148 PointerType *main.deepMap7
           Locations:
-            - Range: 0xcd5d60..0xcd5d61
+            - Range: 0xcd5e60..0xcd5e61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 45
       Name: main.testStringType1
-      OutOfLinePCRanges: [0xcd5d80..0xcd5d81]
+      OutOfLinePCRanges: [0xcd5e80..0xcd5e81]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 150 PointerType *main.stringType1
           Locations:
-            - Range: 0xcd5d80..0xcd5d81
+            - Range: 0xcd5e80..0xcd5e81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 46
       Name: main.testStringType2
-      OutOfLinePCRanges: [0xcd5da0..0xcd5da1]
+      OutOfLinePCRanges: [0xcd5ea0..0xcd5ea1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 152 PointerType **main.stringType2
           Locations:
-            - Range: 0xcd5da0..0xcd5da1
+            - Range: 0xcd5ea0..0xcd5ea1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 47
       Name: main.testLongFunctionWithChangingState
-      OutOfLinePCRanges: [0xcd5dc0..0xcd600a]
+      OutOfLinePCRanges: [0xcd5ec0..0xcd610a]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcd5ea4..0xcd5ec5
+            - Range: 0xcd5fa4..0xcd5fc5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd5f78..0xcd5f8f
+            - Range: 0xcd6078..0xcd608f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: aPerArch
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcd5e8d..0xcd5e90
+            - Range: 0xcd5f8d..0xcd5f90
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcd5e90..0xcd5ec5
+            - Range: 0xcd5f90..0xcd5fc5
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcd5ec5..0xcd5f6b
+            - Range: 0xcd5fc5..0xcd606b
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0xcd5f6b..0xcd5f78
+            - Range: 0xcd606b..0xcd6078
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0xcd5f78..0xcd600a
+            - Range: 0xcd6078..0xcd610a
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
           Role: Local
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcd5e8a..0xcd5e90
+            - Range: 0xcd5f8a..0xcd5f90
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcd5e90..0xcd5e90
+            - Range: 0xcd5f90..0xcd5f90
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcd5e90..0xcd5ec5
+            - Range: 0xcd5f90..0xcd5fc5
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcd5ec5..0xcd5f6b
+            - Range: 0xcd5fc5..0xcd606b
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0xcd5f6b..0xcd5f70
+            - Range: 0xcd606b..0xcd6070
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0xcd5f70..0xcd5f78
+            - Range: 0xcd6070..0xcd6078
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
-            - Range: 0xcd5f78..0xcd5f8f
+            - Range: 0xcd6078..0xcd608f
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
-            - Range: 0xcd5f8f..0xcd600a
+            - Range: 0xcd608f..0xcd610a
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 48
       Name: main.testManyPointers
-      OutOfLinePCRanges: [0xcd6440..0xcd6441]
+      OutOfLinePCRanges: [0xcd6540..0xcd6541]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 154 StructureType main.manyPointers
           Locations:
-            - Range: 0xcd6440..0xcd6441
+            - Range: 0xcd6540..0xcd6541
               Pieces: [{Size: 560, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 49
       Name: main.testManyStrings
-      OutOfLinePCRanges: [0xcd7e20..0xcd7e21]
+      OutOfLinePCRanges: [0xcd7f20..0xcd7f21]
       InlinePCRanges: []
       Variables:
         - Name: ss
           Type: 157 GoSliceHeaderType []string
           Locations:
-            - Range: 0xcd7e20..0xcd7e21
+            - Range: 0xcd7f20..0xcd7f21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6740,13 +6740,13 @@ Subprograms:
       DictRegister: null
     - ID: 50
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0xcd80e0..0xcd81e5]
+      OutOfLinePCRanges: [0xcd81e0..0xcd82e5]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 158 StructureType main.esotericStack
           Locations:
-            - Range: 0xcd80e0..0xcd8133
+            - Range: 0xcd81e0..0xcd8233
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -6766,7 +6766,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xcd8133..0xcd8138
+            - Range: 0xcd8233..0xcd8238
               Pieces:
                 - Size: 4
                   Op: null
@@ -6786,7 +6786,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xcd8138..0xcd813d
+            - Range: 0xcd8238..0xcd823d
               Pieces:
                 - Size: 4
                   Op: null
@@ -6811,155 +6811,155 @@ Subprograms:
       DictRegister: null
     - ID: 51
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0xcd8200..0xcd8263]
+      OutOfLinePCRanges: [0xcd8300..0xcd8363]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 162 PointerType *main.esotericHeap
           Locations:
-            - Range: 0xcd8200..0xcd822d
+            - Range: 0xcd8300..0xcd832d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 52
       Name: main.testInlinedBA
-      OutOfLinePCRanges: [0xcd98c0..0xcd9948]
+      OutOfLinePCRanges: [0xcd99c0..0xcd9a48]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcd98c0..0xcd98d5
+            - Range: 0xcd99c0..0xcd99d5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 53
       Name: main.testInlinedBB
-      OutOfLinePCRanges: [0xcd9960..0xcd9a25]
+      OutOfLinePCRanges: [0xcd9a60..0xcd9b25]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcd9960..0xcd9976
+            - Range: 0xcd9a60..0xcd9a76
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: "y"
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcd9960..0xcd9987
+            - Range: 0xcd9a60..0xcd9a87
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: z
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcd9976..0xcd9987
+            - Range: 0xcd9a76..0xcd9a87
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd9987..0xcd9a25
+            - Range: 0xcd9a87..0xcd9b25
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 54
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0xcd9a40..0xcd9aa2]
+      OutOfLinePCRanges: [0xcd9b40..0xcd9ba2]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcd9a40..0xcd9a5a
+            - Range: 0xcd9b40..0xcd9b5a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 55
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0xcd9ac0..0xcd9bce]
+      OutOfLinePCRanges: [0xcd9bc0..0xcd9cce]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcd9b1b..0xcd9b25
+            - Range: 0xcd9c1b..0xcd9c25
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xcd9b25..0xcd9b40
+            - Range: 0xcd9c25..0xcd9c40
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xcd9b40..0xcd9b54
+            - Range: 0xcd9c40..0xcd9c54
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcd9b16..0xcd9b20
+            - Range: 0xcd9c16..0xcd9c20
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xcd9b20..0xcd9b40
+            - Range: 0xcd9c20..0xcd9c40
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xcd9b40..0xcd9b4f
+            - Range: 0xcd9c40..0xcd9c4f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 56
       Name: main.testFrameless
-      OutOfLinePCRanges: [0xcd9be0..0xcd9be6]
+      OutOfLinePCRanges: [0xcd9ce0..0xcd9ce6]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcd9be0..0xcd9be5
+            - Range: 0xcd9ce0..0xcd9ce5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcd9be0..0xcd9be5
+            - Range: 0xcd9ce0..0xcd9ce5
               Pieces: []
-            - Range: 0xcd9be5..0xcd9be6
+            - Range: 0xcd9ce5..0xcd9ce6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 57
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0xcd9c00..0xcd9c43]
+      OutOfLinePCRanges: [0xcd9d00..0xcd9d43]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 164 ArrayType [5]int
           Locations:
-            - Range: 0xcd9c00..0xcd9c43
+            - Range: 0xcd9d00..0xcd9d43
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcd9c00..0xcd9c3d
+            - Range: 0xcd9d00..0xcd9d3d
               Pieces: []
-            - Range: 0xcd9c3d..0xcd9c3e
+            - Range: 0xcd9d3d..0xcd9d3e
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd9c3e..0xcd9c43
+            - Range: 0xcd9d3e..0xcd9d43
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 58
       Name: main.testInterface
-      OutOfLinePCRanges: [0xcd9ee0..0xcd9ee1]
+      OutOfLinePCRanges: [0xcd9fe0..0xcd9fe1]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 165 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcd9ee0..0xcd9ee1
+            - Range: 0xcd9fe0..0xcd9fe1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6970,19 +6970,19 @@ Subprograms:
       DictRegister: null
     - ID: 59
       Name: main.testAny
-      OutOfLinePCRanges: [0xcd9f00..0xcd9f66]
+      OutOfLinePCRanges: [0xcda000..0xcda066]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 160 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcd9f00..0xcd9f29
+            - Range: 0xcda000..0xcda029
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd9f29..0xcd9f2e
+            - Range: 0xcda029..0xcda02e
               Pieces:
                 - Size: 8
                   Op: null
@@ -6993,28 +6993,28 @@ Subprograms:
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcd9f00..0xcd9f45
+            - Range: 0xcda000..0xcda045
               Pieces: []
-            - Range: 0xcd9f45..0xcd9f46
+            - Range: 0xcda045..0xcda046
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd9f46..0xcd9f66
+            - Range: 0xcda046..0xcda066
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 60
       Name: main.testError
-      OutOfLinePCRanges: [0xcd9f80..0xcd9f81]
+      OutOfLinePCRanges: [0xcda080..0xcda081]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0xcd9f80..0xcd9f81
+            - Range: 0xcda080..0xcda081
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7025,41 +7025,41 @@ Subprograms:
       DictRegister: null
     - ID: 61
       Name: main.testAnyPtr
-      OutOfLinePCRanges: [0xcd9fa0..0xcd9ff4]
+      OutOfLinePCRanges: [0xcda0a0..0xcda0f4]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 166 PointerType *interface {}
           Locations:
-            - Range: 0xcd9fa0..0xcd9fc6
+            - Range: 0xcda0a0..0xcda0c6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcd9fa0..0xcd9fdd
+            - Range: 0xcda0a0..0xcda0dd
               Pieces: []
-            - Range: 0xcd9fdd..0xcd9fde
+            - Range: 0xcda0dd..0xcda0de
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd9fde..0xcd9ff4
+            - Range: 0xcda0de..0xcda0f4
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 62
       Name: main.testStructWithAny
-      OutOfLinePCRanges: [0xcda000..0xcda001]
+      OutOfLinePCRanges: [0xcda100..0xcda101]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 167 StructureType main.structWithAny
           Locations:
-            - Range: 0xcda000..0xcda001
+            - Range: 0xcda100..0xcda101
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7070,346 +7070,346 @@ Subprograms:
       DictRegister: null
     - ID: 63
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0xcda680..0xcda681]
+      OutOfLinePCRanges: [0xcda840..0xcda841]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 168 StructureType main.structWithMap
-          Locations:
-            - Range: 0xcda680..0xcda681
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 64
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0xcda6a0..0xcda6a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 174 GoMapType map[string]main.nestedStruct
-          Locations:
-            - Range: 0xcda6a0..0xcda6a1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 65
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0xcda6c0..0xcda6c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 179 GoMapType map[string]int
-          Locations:
-            - Range: 0xcda6c0..0xcda6c1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 66
-      Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0xcda6e0..0xcda6e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 184 GoMapType map[string][]string
-          Locations:
-            - Range: 0xcda6e0..0xcda6e1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 67
-      Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0xcda700..0xcda701]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 189 GoMapType map[[4]string][2]int
-          Locations:
-            - Range: 0xcda700..0xcda701
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 68
-      Name: main.testSmallMap
-      OutOfLinePCRanges: [0xcda720..0xcda721]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 179 GoMapType map[string]int
-          Locations:
-            - Range: 0xcda720..0xcda721
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 69
-      Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0xcda740..0xcda741]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 194 ArrayType [2]map[string]int
-          Locations:
-            - Range: 0xcda740..0xcda741
-              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 70
-      Name: main.testPointerToMap
-      OutOfLinePCRanges: [0xcda760..0xcda761]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 195 PointerType *map[string]int
-          Locations:
-            - Range: 0xcda760..0xcda761
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 71
-      Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0xcda780..0xcda781]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 169 GoMapType map[int]int
-          Locations:
-            - Range: 0xcda780..0xcda781
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 72
-      Name: main.testMapMassive
-      OutOfLinePCRanges: [0xcda7a0..0xcda7a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: redactMyEntries
-          Type: 196 GoMapType map[string][]main.structWithMap
-          Locations:
-            - Range: 0xcda7a0..0xcda7a1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 73
-      Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0xcda7c0..0xcda7c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 196 GoMapType map[string][]main.structWithMap
-          Locations:
-            - Range: 0xcda7c0..0xcda7c1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 74
-      Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0xcda7e0..0xcda7e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 201 GoMapType map[bool]main.node
-          Locations:
-            - Range: 0xcda7e0..0xcda7e1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 75
-      Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0xcda800..0xcda801]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 206 GoMapType map[int]uint8
-          Locations:
-            - Range: 0xcda800..0xcda801
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 76
-      Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0xcda820..0xcda821]
-      InlinePCRanges: []
-      Variables:
-        - Name: redactMyEntries
-          Type: 206 GoMapType map[int]uint8
-          Locations:
-            - Range: 0xcda820..0xcda821
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 77
-      Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0xcda840..0xcda841]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 211 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xcda840..0xcda841
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 78
-      Name: main.testMapWithSmallKeyAndValueMassive
+    - ID: 64
+      Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0xcda860..0xcda861]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 211 GoMapType map[uint8]uint8
+          Type: 174 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0xcda860..0xcda861
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 79
-      Name: main.testMapSmallKeySmallValue
+    - ID: 65
+      Name: main.testMapStringToInt
       OutOfLinePCRanges: [0xcda880..0xcda881]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 211 GoMapType map[uint8]uint8
+          Type: 179 GoMapType map[string]int
           Locations:
             - Range: 0xcda880..0xcda881
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 80
-      Name: main.testMapSmallKeyLargeValue
+    - ID: 66
+      Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0xcda8a0..0xcda8a1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 216 GoMapType map[uint8][4]int
+          Type: 184 GoMapType map[string][]string
           Locations:
             - Range: 0xcda8a0..0xcda8a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 81
-      Name: main.testMapLargeKeySmallValue
+    - ID: 67
+      Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0xcda8c0..0xcda8c1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 221 GoMapType map[[4]int]uint8
+          Type: 189 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0xcda8c0..0xcda8c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 82
-      Name: main.testMapLargeKeyLargeValue
+    - ID: 68
+      Name: main.testSmallMap
       OutOfLinePCRanges: [0xcda8e0..0xcda8e1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 226 GoMapType map[[4]int][4]int
+          Type: 179 GoMapType map[string]int
           Locations:
             - Range: 0xcda8e0..0xcda8e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 83
-      Name: main.testMapEmptyKey
+    - ID: 69
+      Name: main.testArrayOfMaps
       OutOfLinePCRanges: [0xcda900..0xcda901]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 231 GoMapType map[struct {}]int
+          Type: 194 ArrayType [2]map[string]int
           Locations:
             - Range: 0xcda900..0xcda901
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 84
-      Name: main.testMapEmptyValue
+    - ID: 70
+      Name: main.testPointerToMap
       OutOfLinePCRanges: [0xcda920..0xcda921]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 236 GoMapType map[int]struct {}
+          Type: 195 PointerType *map[string]int
           Locations:
             - Range: 0xcda920..0xcda921
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 85
-      Name: main.testMapEmptyKeyAndValue
+    - ID: 71
+      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0xcda940..0xcda941]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 241 GoMapType map[struct {}]struct {}
+          Type: 169 GoMapType map[int]int
           Locations:
             - Range: 0xcda940..0xcda941
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 72
+      Name: main.testMapMassive
+      OutOfLinePCRanges: [0xcda960..0xcda961]
+      InlinePCRanges: []
+      Variables:
+        - Name: redactMyEntries
+          Type: 196 GoMapType map[string][]main.structWithMap
+          Locations:
+            - Range: 0xcda960..0xcda961
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 73
+      Name: main.testMapEmbeddedMaps
+      OutOfLinePCRanges: [0xcda980..0xcda981]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 196 GoMapType map[string][]main.structWithMap
+          Locations:
+            - Range: 0xcda980..0xcda981
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 74
+      Name: main.testMapWithLinkedList
+      OutOfLinePCRanges: [0xcda9a0..0xcda9a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 201 GoMapType map[bool]main.node
+          Locations:
+            - Range: 0xcda9a0..0xcda9a1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 75
+      Name: main.testMapWithSmallValue
+      OutOfLinePCRanges: [0xcda9c0..0xcda9c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 206 GoMapType map[int]uint8
+          Locations:
+            - Range: 0xcda9c0..0xcda9c1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 76
+      Name: main.testMapWithSmallValueMassive
+      OutOfLinePCRanges: [0xcda9e0..0xcda9e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: redactMyEntries
+          Type: 206 GoMapType map[int]uint8
+          Locations:
+            - Range: 0xcda9e0..0xcda9e1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 77
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0xcdaa00..0xcdaa01]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 211 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xcdaa00..0xcdaa01
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 78
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0xcdaa20..0xcdaa21]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 211 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xcdaa20..0xcdaa21
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 79
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0xcdaa40..0xcdaa41]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 211 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xcdaa40..0xcdaa41
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 80
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0xcdaa60..0xcdaa61]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 216 GoMapType map[uint8][4]int
+          Locations:
+            - Range: 0xcdaa60..0xcdaa61
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 81
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0xcdaa80..0xcdaa81]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 221 GoMapType map[[4]int]uint8
+          Locations:
+            - Range: 0xcdaa80..0xcdaa81
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 82
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0xcdaaa0..0xcdaaa1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 226 GoMapType map[[4]int][4]int
+          Locations:
+            - Range: 0xcdaaa0..0xcdaaa1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 83
+      Name: main.testMapEmptyKey
+      OutOfLinePCRanges: [0xcdaac0..0xcdaac1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 231 GoMapType map[struct {}]int
+          Locations:
+            - Range: 0xcdaac0..0xcdaac1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 84
+      Name: main.testMapEmptyValue
+      OutOfLinePCRanges: [0xcdaae0..0xcdaae1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 236 GoMapType map[int]struct {}
+          Locations:
+            - Range: 0xcdaae0..0xcdaae1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 85
+      Name: main.testMapEmptyKeyAndValue
+      OutOfLinePCRanges: [0xcdab00..0xcdab01]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 241 GoMapType map[struct {}]struct {}
+          Locations:
+            - Range: 0xcdab00..0xcdab01
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 86
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0xcdc240..0xcdc241]
+      OutOfLinePCRanges: [0xcdc400..0xcdc401]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xcdc240..0xcdc241
+            - Range: 0xcdc400..0xcdc401
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xcdc240..0xcdc241
+            - Range: 0xcdc400..0xcdc401
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: "y"
           Type: 18 BaseType float32
           Locations:
-            - Range: 0xcdc240..0xcdc241
+            - Range: 0xcdc400..0xcdc401
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 87
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0xcdc280..0xcdc281]
+      OutOfLinePCRanges: [0xcdc440..0xcdc441]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xcdc280..0xcdc281
+            - Range: 0xcdc440..0xcdc441
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcdc280..0xcdc281
+            - Range: 0xcdc440..0xcdc441
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -7420,48 +7420,48 @@ Subprograms:
         - Name: "y"
           Type: 18 BaseType float32
           Locations:
-            - Range: 0xcdc280..0xcdc281
+            - Range: 0xcdc440..0xcdc441
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 88
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0xcdc400..0xcdc401]
+      OutOfLinePCRanges: [0xcdc5c0..0xcdc5c1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xcdc400..0xcdc401
+            - Range: 0xcdc5c0..0xcdc5c1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xcdc400..0xcdc401
+            - Range: 0xcdc5c0..0xcdc5c1
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 11 BaseType int32
           Locations:
-            - Range: 0xcdc400..0xcdc401
+            - Range: 0xcdc5c0..0xcdc5c1
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 17 BaseType uint
           Locations:
-            - Range: 0xcdc400..0xcdc401
+            - Range: 0xcdc5c0..0xcdc5c1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcdc400..0xcdc401
+            - Range: 0xcdc5c0..0xcdc5c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7472,61 +7472,61 @@ Subprograms:
       DictRegister: null
     - ID: 89
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0xcdc620..0xcdc633]
+      OutOfLinePCRanges: [0xcdc7e0..0xcdc7f3]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0xcdc620..0xcdc632
+            - Range: 0xcdc7e0..0xcdc7f2
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0xcdc620..0xcdc632
+            - Range: 0xcdc7e0..0xcdc7f2
               Pieces: []
-            - Range: 0xcdc632..0xcdc633
+            - Range: 0xcdc7f2..0xcdc7f3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 90
       Name: main.testChannel
-      OutOfLinePCRanges: [0xcdc640..0xcdc641]
+      OutOfLinePCRanges: [0xcdc800..0xcdc801]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 246 GoChannelType chan bool
           Locations:
-            - Range: 0xcdc640..0xcdc641
+            - Range: 0xcdc800..0xcdc801
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 91
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xcdc820..0xcdc821]
+      OutOfLinePCRanges: [0xcdc9e0..0xcdc9e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 247 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xcdc820..0xcdc821
+            - Range: 0xcdc9e0..0xcdc9e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 92
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0xcdc840..0xcdc841]
+      OutOfLinePCRanges: [0xcdca00..0xcdca01]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 249 StructureType main.node
           Locations:
-            - Range: 0xcdc840..0xcdc841
+            - Range: 0xcdca00..0xcdca01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7537,273 +7537,273 @@ Subprograms:
       DictRegister: null
     - ID: 93
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xcdc860..0xcdc861]
+      OutOfLinePCRanges: [0xcdca20..0xcdca21]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 250 PointerType *main.node
-          Locations:
-            - Range: 0xcdc860..0xcdc861
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 94
-      Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xcdc880..0xcdc881]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 15 VoidPointerType unsafe.Pointer
-          Locations:
-            - Range: 0xcdc880..0xcdc881
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 95
-      Name: main.testUintPointer
-      OutOfLinePCRanges: [0xcdc8c0..0xcdc8c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 106 PointerType *uint
-          Locations:
-            - Range: 0xcdc8c0..0xcdc8c1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 96
-      Name: main.testStringPointer
-      OutOfLinePCRanges: [0xcdc9a0..0xcdc9a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: z
-          Type: 94 PointerType *string
-          Locations:
-            - Range: 0xcdc9a0..0xcdc9a1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 97
-      Name: main.testNilPointer
-      OutOfLinePCRanges: [0xcdc9e0..0xcdc9e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: z
-          Type: 12 PointerType *bool
-          Locations:
-            - Range: 0xcdc9e0..0xcdc9e1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: a
-          Type: 17 BaseType uint
-          Locations:
-            - Range: 0xcdc9e0..0xcdc9e1
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 98
-      Name: main.testCycle
-      OutOfLinePCRanges: [0xcdca20..0xcdca21]
-      InlinePCRanges: []
-      Variables:
-        - Name: t
-          Type: 251 PointerType *main.t
           Locations:
             - Range: 0xcdca20..0xcdca21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 94
+      Name: main.testUnsafePointer
+      OutOfLinePCRanges: [0xcdca40..0xcdca41]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 15 VoidPointerType unsafe.Pointer
+          Locations:
+            - Range: 0xcdca40..0xcdca41
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 95
+      Name: main.testUintPointer
+      OutOfLinePCRanges: [0xcdca80..0xcdca81]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 106 PointerType *uint
+          Locations:
+            - Range: 0xcdca80..0xcdca81
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 96
+      Name: main.testStringPointer
+      OutOfLinePCRanges: [0xcdcb60..0xcdcb61]
+      InlinePCRanges: []
+      Variables:
+        - Name: z
+          Type: 94 PointerType *string
+          Locations:
+            - Range: 0xcdcb60..0xcdcb61
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 97
+      Name: main.testNilPointer
+      OutOfLinePCRanges: [0xcdcba0..0xcdcba1]
+      InlinePCRanges: []
+      Variables:
+        - Name: z
+          Type: 12 PointerType *bool
+          Locations:
+            - Range: 0xcdcba0..0xcdcba1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 17 BaseType uint
+          Locations:
+            - Range: 0xcdcba0..0xcdcba1
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 98
+      Name: main.testCycle
+      OutOfLinePCRanges: [0xcdcbe0..0xcdcbe1]
+      InlinePCRanges: []
+      Variables:
+        - Name: t
+          Type: 251 PointerType *main.t
+          Locations:
+            - Range: 0xcdcbe0..0xcdcbe1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 99
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0xcdce80..0xcdcef2]
+      OutOfLinePCRanges: [0xcdd040..0xcdd0b2]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdce80..0xcdce92
+            - Range: 0xcdd040..0xcdd052
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdce80..0xcdcedb
+            - Range: 0xcdd040..0xcdd09b
               Pieces: []
-            - Range: 0xcdcedb..0xcdcedc
+            - Range: 0xcdd09b..0xcdd09c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdcedc..0xcdcef2
+            - Range: 0xcdd09c..0xcdd0b2
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdce92..0xcdcea5
+            - Range: 0xcdd052..0xcdd065
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdcea5..0xcdcef2
+            - Range: 0xcdd065..0xcdd0b2
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 100
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0xcdcf00..0xcdcf8f]
+      OutOfLinePCRanges: [0xcdd0c0..0xcdd14f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdcf00..0xcdcf1a
+            - Range: 0xcdd0c0..0xcdd0da
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdcf1a..0xcdcf8f
+            - Range: 0xcdd0da..0xcdd14f
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 99 PointerType *int
           Locations:
-            - Range: 0xcdcf00..0xcdcf74
+            - Range: 0xcdd0c0..0xcdd134
               Pieces: []
-            - Range: 0xcdcf74..0xcdcf75
+            - Range: 0xcdd134..0xcdd135
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdcf75..0xcdcf8f
+            - Range: 0xcdd135..0xcdd14f
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: '&result'
           Type: 99 PointerType *int
           Locations:
-            - Range: 0xcdcf1f..0xcdcf39
+            - Range: 0xcdd0df..0xcdd0f9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdcf39..0xcdcf8f
+            - Range: 0xcdd0f9..0xcdd14f
               Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 101
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0xcdcfa0..0xcdd07e]
+      OutOfLinePCRanges: [0xcdd160..0xcdd23e]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdcfa0..0xcdd002
+            - Range: 0xcdd160..0xcdd1c2
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdcfa0..0xcdd064
+            - Range: 0xcdd160..0xcdd224
               Pieces: []
-            - Range: 0xcdd064..0xcdd065
+            - Range: 0xcdd224..0xcdd225
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd065..0xcdd07e
+            - Range: 0xcdd225..0xcdd23e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcdcfa0..0xcdd07e, Pieces: []}]
+          Locations: [{Range: 0xcdd160..0xcdd23e, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: resultInt
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdcfb6..0xcdd007
+            - Range: 0xcdd176..0xcdd1c7
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcdd007..0xcdd07e
+            - Range: 0xcdd1c7..0xcdd23e
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
           Role: Local
           DictIndex: -1
         - Name: resultFloat
           Type: 19 BaseType float64
           Locations:
-            - Range: 0xcdcfcf..0xcdd007
+            - Range: 0xcdd18f..0xcdd1c7
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
-            - Range: 0xcdd007..0xcdd07e
+            - Range: 0xcdd1c7..0xcdd23e
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 102
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0xcdd080..0xcdd0db]
+      OutOfLinePCRanges: [0xcdd240..0xcdd29b]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xcdd080..0xcdd099
+            - Range: 0xcdd240..0xcdd259
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0xcdd080..0xcdd0ba
+            - Range: 0xcdd240..0xcdd27a
               Pieces: []
-            - Range: 0xcdd0ba..0xcdd0bb
+            - Range: 0xcdd27a..0xcdd27b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd0bb..0xcdd0c5
+            - Range: 0xcdd27b..0xcdd285
               Pieces: []
-            - Range: 0xcdd0c5..0xcdd0c6
+            - Range: 0xcdd285..0xcdd286
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd0c6..0xcdd0db
+            - Range: 0xcdd286..0xcdd29b
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 103
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0xcdd0e0..0xcdd226]
+      OutOfLinePCRanges: [0xcdd2a0..0xcdd3e6]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 160 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcdd0e0..0xcdd12b
+            - Range: 0xcdd2a0..0xcdd2eb
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd12b..0xcdd136
+            - Range: 0xcdd2eb..0xcdd2f6
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd167..0xcdd16a
+            - Range: 0xcdd327..0xcdd32a
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd1a0..0xcdd1a5
+            - Range: 0xcdd360..0xcdd365
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd1d4..0xcdd1d9
+            - Range: 0xcdd394..0xcdd399
               Pieces:
                 - Size: 8
                   Op: null
@@ -7814,128 +7814,14 @@ Subprograms:
         - Name: failed
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xcdd0e0..0xcdd123
+            - Range: 0xcdd2a0..0xcdd2e3
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 160 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcdd0e0..0xcdd144
-              Pieces: []
-            - Range: 0xcdd144..0xcdd145
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd145..0xcdd193
-              Pieces: []
-            - Range: 0xcdd193..0xcdd194
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd194..0xcdd1c7
-              Pieces: []
-            - Range: 0xcdd1c7..0xcdd1c8
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd1c8..0xcdd1f9
-              Pieces: []
-            - Range: 0xcdd1f9..0xcdd1fa
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd1fa..0xcdd226
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-        - Name: ~r1
-          Type: 14 GoInterfaceType error
-          Locations:
-            - Range: 0xcdd0e0..0xcdd144
-              Pieces: []
-            - Range: 0xcdd144..0xcdd145
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcdd145..0xcdd193
-              Pieces: []
-            - Range: 0xcdd193..0xcdd194
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcdd194..0xcdd1c7
-              Pieces: []
-            - Range: 0xcdd1c7..0xcdd1c8
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcdd1c8..0xcdd1f9
-              Pieces: []
-            - Range: 0xcdd1f9..0xcdd1fa
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcdd1fa..0xcdd226
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-        - Name: val
-          Type: 8 BaseType int
-          Locations:
-            - Range: 0xcdd12b..0xcdd131
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Local
-          DictIndex: -1
-      DictRegister: null
-    - ID: 104
-      Name: main.testReturnsAny
-      OutOfLinePCRanges: [0xcdd240..0xcdd434]
-      InlinePCRanges: []
-      Variables:
-        - Name: v
-          Type: 160 GoEmptyInterfaceType interface {}
-          Locations:
-            - Range: 0xcdd240..0xcdd28b
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd28b..0xcdd292
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 0}
-                - Size: 8
-                  Op: {CfaOffset: 8}
-            - Range: 0xcdd292..0xcdd434
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 0}
-                - Size: 8
-                  Op: {CfaOffset: 8}
-          Role: Parameter
-          DictIndex: -1
-        - Name: ~r0
-          Type: 160 GoEmptyInterfaceType interface {}
-          Locations:
-            - Range: 0xcdd240..0xcdd304
+            - Range: 0xcdd2a0..0xcdd304
               Pieces: []
             - Range: 0xcdd304..0xcdd305
               Pieces:
@@ -7943,1120 +7829,1234 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd305..0xcdd33f
+            - Range: 0xcdd305..0xcdd353
               Pieces: []
-            - Range: 0xcdd33f..0xcdd340
+            - Range: 0xcdd353..0xcdd354
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd340..0xcdd402
+            - Range: 0xcdd354..0xcdd387
               Pieces: []
-            - Range: 0xcdd402..0xcdd403
+            - Range: 0xcdd387..0xcdd388
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd403..0xcdd40c
+            - Range: 0xcdd388..0xcdd3b9
               Pieces: []
-            - Range: 0xcdd40c..0xcdd40d
+            - Range: 0xcdd3b9..0xcdd3ba
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd40d..0xcdd434
+            - Range: 0xcdd3ba..0xcdd3e6
+              Pieces: []
+          Role: Return
+          DictIndex: -1
+        - Name: ~r1
+          Type: 14 GoInterfaceType error
+          Locations:
+            - Range: 0xcdd2a0..0xcdd304
+              Pieces: []
+            - Range: 0xcdd304..0xcdd305
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+            - Range: 0xcdd305..0xcdd353
+              Pieces: []
+            - Range: 0xcdd353..0xcdd354
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+            - Range: 0xcdd354..0xcdd387
+              Pieces: []
+            - Range: 0xcdd387..0xcdd388
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+            - Range: 0xcdd388..0xcdd3b9
+              Pieces: []
+            - Range: 0xcdd3b9..0xcdd3ba
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+            - Range: 0xcdd3ba..0xcdd3e6
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdd32a..0xcdd330
+            - Range: 0xcdd2eb..0xcdd2f1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Local
+          DictIndex: -1
+      DictRegister: null
+    - ID: 104
+      Name: main.testReturnsAny
+      OutOfLinePCRanges: [0xcdd400..0xcdd5f4]
+      InlinePCRanges: []
+      Variables:
+        - Name: v
+          Type: 160 GoEmptyInterfaceType interface {}
+          Locations:
+            - Range: 0xcdd400..0xcdd44b
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcdd44b..0xcdd452
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 0}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+            - Range: 0xcdd452..0xcdd5f4
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 0}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+          Role: Parameter
+          DictIndex: -1
+        - Name: ~r0
+          Type: 160 GoEmptyInterfaceType interface {}
+          Locations:
+            - Range: 0xcdd400..0xcdd4c4
+              Pieces: []
+            - Range: 0xcdd4c4..0xcdd4c5
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcdd4c5..0xcdd4ff
+              Pieces: []
+            - Range: 0xcdd4ff..0xcdd500
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcdd500..0xcdd5c2
+              Pieces: []
+            - Range: 0xcdd5c2..0xcdd5c3
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcdd5c3..0xcdd5cc
+              Pieces: []
+            - Range: 0xcdd5cc..0xcdd5cd
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcdd5cd..0xcdd5f4
+              Pieces: []
+          Role: Return
+          DictIndex: -1
+        - Name: val
+          Type: 8 BaseType int
+          Locations:
+            - Range: 0xcdd4ea..0xcdd4f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: '&result'
           Type: 99 PointerType *int
           Locations:
-            - Range: 0xcdd2e5..0xcdd304
+            - Range: 0xcdd4a5..0xcdd4c4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 105
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0xcdd440..0xcdd59d]
+      OutOfLinePCRanges: [0xcdd600..0xcdd75d]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 160 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcdd440..0xcdd480
+            - Range: 0xcdd600..0xcdd640
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd480..0xcdd4ce
+            - Range: 0xcdd640..0xcdd68e
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcdd4ce..0xcdd53f
+            - Range: 0xcdd68e..0xcdd6ff
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcdd53f..0xcdd55f
+            - Range: 0xcdd6ff..0xcdd71f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcdd55f..0xcdd566
+            - Range: 0xcdd71f..0xcdd726
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcdd566..0xcdd59d
+            - Range: 0xcdd726..0xcdd75d
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 165 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcdd440..0xcdd52f
+            - Range: 0xcdd600..0xcdd6ef
               Pieces: []
-            - Range: 0xcdd52f..0xcdd530
+            - Range: 0xcdd6ef..0xcdd6f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd530..0xcdd539
+            - Range: 0xcdd6f0..0xcdd6f9
               Pieces: []
-            - Range: 0xcdd539..0xcdd53a
+            - Range: 0xcdd6f9..0xcdd6fa
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd53a..0xcdd59d
+            - Range: 0xcdd6fa..0xcdd75d
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 165 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcdd440..0xcdd480
+            - Range: 0xcdd600..0xcdd640
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd480..0xcdd4ce
+            - Range: 0xcdd640..0xcdd68e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcdd4ce..0xcdd4d5
+            - Range: 0xcdd68e..0xcdd695
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcdd4d5..0xcdd535
+            - Range: 0xcdd695..0xcdd6f5
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcdd535..0xcdd537
+            - Range: 0xcdd6f5..0xcdd6f7
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcdd537..0xcdd539
+            - Range: 0xcdd6f7..0xcdd6f9
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcdd539..0xcdd59d
+            - Range: 0xcdd6f9..0xcdd75d
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 106
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0xcdd5a0..0xcdd62f]
+      OutOfLinePCRanges: [0xcdd760..0xcdd7ef]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdd5a0..0xcdd5b1
+            - Range: 0xcdd760..0xcdd771
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdd5a0..0xcdd615
+            - Range: 0xcdd760..0xcdd7d5
               Pieces: []
-            - Range: 0xcdd615..0xcdd616
+            - Range: 0xcdd7d5..0xcdd7d6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd616..0xcdd62f
+            - Range: 0xcdd7d6..0xcdd7ef
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 107
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0xcdd640..0xcdd709]
+      OutOfLinePCRanges: [0xcdd800..0xcdd8c9]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdd640..0xcdd693
+            - Range: 0xcdd800..0xcdd853
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdd640..0xcdd6ef
+            - Range: 0xcdd800..0xcdd8af
               Pieces: []
-            - Range: 0xcdd6ef..0xcdd6f0
+            - Range: 0xcdd8af..0xcdd8b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd6f0..0xcdd709
+            - Range: 0xcdd8b0..0xcdd8c9
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdd640..0xcdd6ef
+            - Range: 0xcdd800..0xcdd8af
               Pieces: []
-            - Range: 0xcdd6ef..0xcdd6f0
+            - Range: 0xcdd8af..0xcdd8b0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcdd6f0..0xcdd709
+            - Range: 0xcdd8b0..0xcdd8c9
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 108
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0xcdd720..0xcdd7e5]
+      OutOfLinePCRanges: [0xcdd8e0..0xcdd9a5]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdd720..0xcdd765
+            - Range: 0xcdd8e0..0xcdd925
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd765..0xcdd7e5
+            - Range: 0xcdd925..0xcdd9a5
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdd720..0xcdd7cb
+            - Range: 0xcdd8e0..0xcdd98b
               Pieces: []
-            - Range: 0xcdd7cb..0xcdd7cc
+            - Range: 0xcdd98b..0xcdd98c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd7cc..0xcdd7e5
+            - Range: 0xcdd98c..0xcdd9a5
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdd720..0xcdd7cb
+            - Range: 0xcdd8e0..0xcdd98b
               Pieces: []
-            - Range: 0xcdd7cb..0xcdd7cc
+            - Range: 0xcdd98b..0xcdd98c
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcdd7cc..0xcdd7e5
+            - Range: 0xcdd98c..0xcdd9a5
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdd720..0xcdd7cb
+            - Range: 0xcdd8e0..0xcdd98b
               Pieces: []
-            - Range: 0xcdd7cb..0xcdd7cc
+            - Range: 0xcdd98b..0xcdd98c
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcdd7cc..0xcdd7e5
+            - Range: 0xcdd98c..0xcdd9a5
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 109
       Name: main.testConflictingReturn
-      OutOfLinePCRanges: [0xcdd800..0xcdd8ef]
+      OutOfLinePCRanges: [0xcdd9c0..0xcddaaf]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdd800..0xcdd845
+            - Range: 0xcdd9c0..0xcdda05
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd845..0xcdd8ef
+            - Range: 0xcdda05..0xcddaaf
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdd800..0xcdd8d1
+            - Range: 0xcdd9c0..0xcdda91
               Pieces: []
-            - Range: 0xcdd8d1..0xcdd8d2
+            - Range: 0xcdda91..0xcdda92
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd8d2..0xcdd8ef
+            - Range: 0xcdda92..0xcddaaf
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcdd800..0xcdd8d1
+            - Range: 0xcdd9c0..0xcdda91
               Pieces: []
-            - Range: 0xcdd8d1..0xcdd8d2
+            - Range: 0xcdda91..0xcdda92
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcdd8d2..0xcdd8ef
+            - Range: 0xcdda92..0xcddaaf
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 110
       Name: main.testReturnsNamedDeferLine
-      OutOfLinePCRanges: [0xcdd900..0xcddb0f]
+      OutOfLinePCRanges: [0xcddac0..0xcddccf]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdd900..0xcdd986
+            - Range: 0xcddac0..0xcddb46
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd986..0xcddb0f
+            - Range: 0xcddb46..0xcddccf
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcdd937..0xcddb0f
+            - Range: 0xcddaf7..0xcddccf
               Pieces: [{Size: 16, Op: {CfaOffset: -128}}]
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcdd93d..0xcddb0f
+            - Range: 0xcddafd..0xcddccf
               Pieces: [{Size: 16, Op: {CfaOffset: -144}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 111
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0xcddc00..0xcddc7e]
+      OutOfLinePCRanges: [0xcdddc0..0xcdde3e]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 16 BaseType int8
           Locations:
-            - Range: 0xcddc00..0xcddc71
+            - Range: 0xcdddc0..0xcdde31
               Pieces: []
-            - Range: 0xcddc71..0xcddc72
+            - Range: 0xcdde31..0xcdde32
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcddc72..0xcddc7e
+            - Range: 0xcdde32..0xcdde3e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 103 BaseType int16
           Locations:
-            - Range: 0xcddc00..0xcddc71
+            - Range: 0xcdddc0..0xcdde31
               Pieces: []
-            - Range: 0xcddc71..0xcddc72
+            - Range: 0xcdde31..0xcdde32
               Pieces: [{Size: 2, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcddc72..0xcddc7e
+            - Range: 0xcdde32..0xcdde3e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 11 BaseType int32
           Locations:
-            - Range: 0xcddc00..0xcddc71
+            - Range: 0xcdddc0..0xcdde31
               Pieces: []
-            - Range: 0xcddc71..0xcddc72
+            - Range: 0xcdde31..0xcdde32
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcddc72..0xcddc7e
+            - Range: 0xcdde32..0xcdde3e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 13 BaseType int64
           Locations:
-            - Range: 0xcddc00..0xcddc71
+            - Range: 0xcdddc0..0xcdde31
               Pieces: []
-            - Range: 0xcddc71..0xcddc72
+            - Range: 0xcdde31..0xcdde32
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcddc72..0xcddc7e
+            - Range: 0xcdde32..0xcdde3e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xcddc00..0xcddc71
+            - Range: 0xcdddc0..0xcdde31
               Pieces: []
-            - Range: 0xcddc71..0xcddc72
+            - Range: 0xcdde31..0xcdde32
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcddc72..0xcddc7e
+            - Range: 0xcdde32..0xcdde3e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 7 BaseType uint16
           Locations:
-            - Range: 0xcddc00..0xcddc71
+            - Range: 0xcdddc0..0xcdde31
               Pieces: []
-            - Range: 0xcddc71..0xcddc72
+            - Range: 0xcdde31..0xcdde32
               Pieces: [{Size: 2, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcddc72..0xcddc7e
+            - Range: 0xcdde32..0xcdde3e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 3 BaseType uint32
           Locations:
-            - Range: 0xcddc00..0xcddc71
+            - Range: 0xcdddc0..0xcdde31
               Pieces: []
-            - Range: 0xcddc71..0xcddc72
+            - Range: 0xcdde31..0xcdde32
               Pieces: [{Size: 4, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcddc72..0xcddc7e
+            - Range: 0xcdde32..0xcdde3e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0xcddc00..0xcddc71
+            - Range: 0xcdddc0..0xcdde31
               Pieces: []
-            - Range: 0xcddc71..0xcddc72
+            - Range: 0xcdde31..0xcdde32
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcddc72..0xcddc7e
+            - Range: 0xcdde32..0xcdde3e
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 112
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0xcddc80..0xcddd77]
+      OutOfLinePCRanges: [0xcdde40..0xcddf37]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcddc80..0xcddd77, Pieces: []}]
+          Locations: [{Range: 0xcdde40..0xcddf37, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcddc80..0xcddd77, Pieces: []}]
+          Locations: [{Range: 0xcdde40..0xcddf37, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcddc80..0xcddd77, Pieces: []}]
+          Locations: [{Range: 0xcdde40..0xcddf37, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcddc80..0xcddd77, Pieces: []}]
+          Locations: [{Range: 0xcdde40..0xcddf37, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcddc80..0xcddd77, Pieces: []}]
+          Locations: [{Range: 0xcdde40..0xcddf37, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcddc80..0xcddd77, Pieces: []}]
+          Locations: [{Range: 0xcdde40..0xcddf37, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcddc80..0xcddd77, Pieces: []}]
+          Locations: [{Range: 0xcdde40..0xcddf37, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcddc80..0xcddd77, Pieces: []}]
+          Locations: [{Range: 0xcdde40..0xcddf37, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcddc80..0xcddd77, Pieces: []}]
+          Locations: [{Range: 0xcdde40..0xcddf37, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r9
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcddc80..0xcddd77, Pieces: []}]
+          Locations: [{Range: 0xcdde40..0xcddf37, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r10
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcddc80..0xcddd77, Pieces: []}]
+          Locations: [{Range: 0xcdde40..0xcddf37, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r11
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcddc80..0xcddd77, Pieces: []}]
+          Locations: [{Range: 0xcdde40..0xcddf37, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r12
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcddc80..0xcddd77, Pieces: []}]
+          Locations: [{Range: 0xcdde40..0xcddf37, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r13
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcddc80..0xcddd77, Pieces: []}]
+          Locations: [{Range: 0xcdde40..0xcddf37, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r14
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcddc80..0xcddd77, Pieces: []}]
+          Locations: [{Range: 0xcdde40..0xcddf37, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: onlyOnAmd64_16
           Type: 19 BaseType float64
           Locations:
-            - Range: 0xcddc80..0xcddd67
+            - Range: 0xcdde40..0xcddf27
               Pieces: []
-            - Range: 0xcddd67..0xcddd68
+            - Range: 0xcddf27..0xcddf28
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xcddd68..0xcddd77
+            - Range: 0xcddf28..0xcddf37
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: bothArmAndAmd64
           Type: 19 BaseType float64
           Locations:
-            - Range: 0xcddc80..0xcddd67
+            - Range: 0xcdde40..0xcddf27
               Pieces: []
-            - Range: 0xcddd67..0xcddd68
+            - Range: 0xcddf27..0xcddf28
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcddd68..0xcddd77
+            - Range: 0xcddf28..0xcddf37
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 113
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0xcddd80..0xcdddf3]
+      OutOfLinePCRanges: [0xcddf40..0xcddfb3]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 95 BaseType complex64
-          Locations: [{Range: 0xcddd80..0xcdddf3, Pieces: []}]
+          Locations: [{Range: 0xcddf40..0xcddfb3, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 96 BaseType complex128
-          Locations: [{Range: 0xcddd80..0xcdddf3, Pieces: []}]
+          Locations: [{Range: 0xcddf40..0xcddfb3, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 114
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0xcdde00..0xcddea5]
+      OutOfLinePCRanges: [0xcddfc0..0xcde065]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 253 StructureType main.largeStruct
           Locations:
-            - Range: 0xcdde00..0xcdde93
+            - Range: 0xcddfc0..0xcde053
               Pieces: []
-            - Range: 0xcdde93..0xcdde94
+            - Range: 0xcde053..0xcde054
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
-            - Range: 0xcdde94..0xcddea5
+            - Range: 0xcde054..0xcde065
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 115
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0xcddec0..0xcddf3a]
+      OutOfLinePCRanges: [0xcde080..0xcde0fa]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 254 ArrayType [3]int
           Locations:
-            - Range: 0xcddec0..0xcddf2d
+            - Range: 0xcde080..0xcde0ed
               Pieces: []
-            - Range: 0xcddf2d..0xcddf2e
+            - Range: 0xcde0ed..0xcde0ee
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xcddf2e..0xcddf3a
+            - Range: 0xcde0ee..0xcde0fa
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 116
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0xcddf40..0xcddf98]
+      OutOfLinePCRanges: [0xcde100..0xcde158]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 255 ArrayType [1]int
           Locations:
-            - Range: 0xcddf40..0xcddf8b
+            - Range: 0xcde100..0xcde14b
               Pieces: []
-            - Range: 0xcddf8b..0xcddf8c
+            - Range: 0xcde14b..0xcde14c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcddf8c..0xcddf98
+            - Range: 0xcde14c..0xcde158
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 117
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0xcddfa0..0xcddff3]
+      OutOfLinePCRanges: [0xcde160..0xcde1b3]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 256 ArrayType [0]int
           Locations:
-            - Range: 0xcddfa0..0xcddfe6
+            - Range: 0xcde160..0xcde1a6
               Pieces: []
-            - Range: 0xcddfe6..0xcddfe7
+            - Range: 0xcde1a6..0xcde1a7
               Pieces: []
-            - Range: 0xcddfe7..0xcddff3
+            - Range: 0xcde1a7..0xcde1b3
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 118
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0xcde000..0xcde067]
+      OutOfLinePCRanges: [0xcde1c0..0xcde227]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 257 StructureType main.mixedStruct
-          Locations: [{Range: 0xcde000..0xcde067, Pieces: []}]
+          Locations: [{Range: 0xcde1c0..0xcde227, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 119
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0xcde080..0xcde11a]
+      OutOfLinePCRanges: [0xcde240..0xcde2da]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde080..0xcde10a
+            - Range: 0xcde240..0xcde2ca
               Pieces: []
-            - Range: 0xcde10a..0xcde10b
+            - Range: 0xcde2ca..0xcde2cb
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcde10b..0xcde11a
+            - Range: 0xcde2cb..0xcde2da
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde080..0xcde10a
+            - Range: 0xcde240..0xcde2ca
               Pieces: []
-            - Range: 0xcde10a..0xcde10b
+            - Range: 0xcde2ca..0xcde2cb
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcde10b..0xcde11a
+            - Range: 0xcde2cb..0xcde2da
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde080..0xcde10a
+            - Range: 0xcde240..0xcde2ca
               Pieces: []
-            - Range: 0xcde10a..0xcde10b
+            - Range: 0xcde2ca..0xcde2cb
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcde10b..0xcde11a
+            - Range: 0xcde2cb..0xcde2da
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde080..0xcde10a
+            - Range: 0xcde240..0xcde2ca
               Pieces: []
-            - Range: 0xcde10a..0xcde10b
+            - Range: 0xcde2ca..0xcde2cb
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcde10b..0xcde11a
+            - Range: 0xcde2cb..0xcde2da
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde080..0xcde10a
+            - Range: 0xcde240..0xcde2ca
               Pieces: []
-            - Range: 0xcde10a..0xcde10b
+            - Range: 0xcde2ca..0xcde2cb
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcde10b..0xcde11a
+            - Range: 0xcde2cb..0xcde2da
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde080..0xcde10a
+            - Range: 0xcde240..0xcde2ca
               Pieces: []
-            - Range: 0xcde10a..0xcde10b
+            - Range: 0xcde2ca..0xcde2cb
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcde10b..0xcde11a
+            - Range: 0xcde2cb..0xcde2da
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde080..0xcde10a
+            - Range: 0xcde240..0xcde2ca
               Pieces: []
-            - Range: 0xcde10a..0xcde10b
+            - Range: 0xcde2ca..0xcde2cb
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcde10b..0xcde11a
+            - Range: 0xcde2cb..0xcde2da
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde080..0xcde10a
+            - Range: 0xcde240..0xcde2ca
               Pieces: []
-            - Range: 0xcde10a..0xcde10b
+            - Range: 0xcde2ca..0xcde2cb
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcde10b..0xcde11a
+            - Range: 0xcde2cb..0xcde2da
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcde080..0xcde10a
+            - Range: 0xcde240..0xcde2ca
               Pieces: []
-            - Range: 0xcde10a..0xcde10b
+            - Range: 0xcde2ca..0xcde2cb
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xcde10b..0xcde11a
+            - Range: 0xcde2cb..0xcde2da
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 120
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0xcde120..0xcde1c5]
+      OutOfLinePCRanges: [0xcde2e0..0xcde385]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 258 StructureType main.wideStruct
           Locations:
-            - Range: 0xcde120..0xcde1b4
+            - Range: 0xcde2e0..0xcde374
               Pieces: []
-            - Range: 0xcde1b4..0xcde1b5
+            - Range: 0xcde374..0xcde375
               Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
-            - Range: 0xcde1b5..0xcde1c5
+            - Range: 0xcde375..0xcde385
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 121
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0xcde1e0..0xcde259]
+      OutOfLinePCRanges: [0xcde3a0..0xcde419]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde1e0..0xcde24c
+            - Range: 0xcde3a0..0xcde40c
               Pieces: []
-            - Range: 0xcde24c..0xcde24d
+            - Range: 0xcde40c..0xcde40d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcde24d..0xcde259
+            - Range: 0xcde40d..0xcde419
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcde1e0..0xcde259, Pieces: []}]
+          Locations: [{Range: 0xcde3a0..0xcde419, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde1e0..0xcde24c
+            - Range: 0xcde3a0..0xcde40c
               Pieces: []
-            - Range: 0xcde24c..0xcde24d
+            - Range: 0xcde40c..0xcde40d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcde24d..0xcde259
+            - Range: 0xcde40d..0xcde419
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcde1e0..0xcde259, Pieces: []}]
+          Locations: [{Range: 0xcde3a0..0xcde419, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcde1e0..0xcde24c
+            - Range: 0xcde3a0..0xcde40c
               Pieces: []
-            - Range: 0xcde24c..0xcde24d
+            - Range: 0xcde40c..0xcde40d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcde24d..0xcde259
+            - Range: 0xcde40d..0xcde419
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 122
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0xcde260..0xcde2da]
+      OutOfLinePCRanges: [0xcde420..0xcde49a]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 259 StructureType main.structWithArray
           Locations:
-            - Range: 0xcde260..0xcde2cd
+            - Range: 0xcde420..0xcde48d
               Pieces: []
-            - Range: 0xcde2cd..0xcde2ce
+            - Range: 0xcde48d..0xcde48e
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xcde2ce..0xcde2da
+            - Range: 0xcde48e..0xcde49a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 123
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0xcde2e0..0xcde33b]
+      OutOfLinePCRanges: [0xcde4a0..0xcde4fb]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcde2e0..0xcde33b, Pieces: []}]
+          Locations: [{Range: 0xcde4a0..0xcde4fb, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 124
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0xcde340..0xcde3a7]
+      OutOfLinePCRanges: [0xcde500..0xcde567]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float32
-          Locations: [{Range: 0xcde340..0xcde3a7, Pieces: []}]
+          Locations: [{Range: 0xcde500..0xcde567, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcde340..0xcde3a7, Pieces: []}]
+          Locations: [{Range: 0xcde500..0xcde567, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 125
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0xcde3c0..0xcde41d]
+      OutOfLinePCRanges: [0xcde580..0xcde5dd]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xcde3c0..0xcde410
+            - Range: 0xcde580..0xcde5d0
               Pieces: []
-            - Range: 0xcde410..0xcde411
+            - Range: 0xcde5d0..0xcde5d1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcde411..0xcde41d
+            - Range: 0xcde5d1..0xcde5dd
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 2 BaseType uintptr
           Locations:
-            - Range: 0xcde3c0..0xcde410
+            - Range: 0xcde580..0xcde5d0
               Pieces: []
-            - Range: 0xcde410..0xcde411
+            - Range: 0xcde5d0..0xcde5d1
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcde411..0xcde41d
+            - Range: 0xcde5d1..0xcde5dd
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 126
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0xcde420..0xcde5a5]
+      OutOfLinePCRanges: [0xcde5e0..0xcde765]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 253 StructureType main.largeStruct
           Locations:
-            - Range: 0xcde420..0xcde5a5
+            - Range: 0xcde5e0..0xcde765
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 253 StructureType main.largeStruct
           Locations:
-            - Range: 0xcde420..0xcde593
+            - Range: 0xcde5e0..0xcde753
               Pieces: []
-            - Range: 0xcde593..0xcde594
+            - Range: 0xcde753..0xcde754
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
-            - Range: 0xcde594..0xcde5a5
+            - Range: 0xcde754..0xcde765
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 127
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0xcde5c0..0xcde692]
+      OutOfLinePCRanges: [0xcde780..0xcde852]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 254 ArrayType [3]int
           Locations:
-            - Range: 0xcde5c0..0xcde692
+            - Range: 0xcde780..0xcde852
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 254 ArrayType [3]int
           Locations:
-            - Range: 0xcde5c0..0xcde682
+            - Range: 0xcde780..0xcde842
               Pieces: []
-            - Range: 0xcde682..0xcde683
+            - Range: 0xcde842..0xcde843
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xcde683..0xcde692
+            - Range: 0xcde843..0xcde852
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 128
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0xcde6a0..0xcde8da]
+      OutOfLinePCRanges: [0xcde860..0xcdea9a]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 253 StructureType main.largeStruct
           Locations:
-            - Range: 0xcde6a0..0xcde8da
+            - Range: 0xcde860..0xcdea9a
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s2
           Type: 253 StructureType main.largeStruct
           Locations:
-            - Range: 0xcde6a0..0xcde8da
+            - Range: 0xcde860..0xcdea9a
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 253 StructureType main.largeStruct
           Locations:
-            - Range: 0xcde6a0..0xcde8ca
+            - Range: 0xcde860..0xcdea8a
               Pieces: []
-            - Range: 0xcde8ca..0xcde8cb
+            - Range: 0xcdea8a..0xcdea8b
               Pieces: [{Size: 80, Op: {CfaOffset: 160}}]
-            - Range: 0xcde8cb..0xcde8da
+            - Range: 0xcdea8b..0xcdea9a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 129
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0xcde8e0..0xcdeb6f]
+      OutOfLinePCRanges: [0xcdeaa0..0xcded2f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde8e0..0xcde990
+            - Range: 0xcdeaa0..0xcdeb50
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcde990..0xcdeb6f
+            - Range: 0xcdeb50..0xcded2f
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde8e0..0xcde990
+            - Range: 0xcdeaa0..0xcdeb50
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcde990..0xcdeb6f
+            - Range: 0xcdeb50..0xcded2f
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde8e0..0xcde97a
+            - Range: 0xcdeaa0..0xcdeb3a
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcde97a..0xcdeb6f
+            - Range: 0xcdeb3a..0xcded2f
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde8e0..0xcde950
+            - Range: 0xcdeaa0..0xcdeb10
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcde950..0xcdeb6f
+            - Range: 0xcdeb10..0xcded2f
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde8e0..0xcde990
+            - Range: 0xcdeaa0..0xcdeb50
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcde990..0xcdeb6f
+            - Range: 0xcdeb50..0xcded2f
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde8e0..0xcde990
+            - Range: 0xcdeaa0..0xcdeb50
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcde990..0xcdeb6f
+            - Range: 0xcdeb50..0xcded2f
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde8e0..0xcde990
+            - Range: 0xcdeaa0..0xcdeb50
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcde990..0xcdeb6f
+            - Range: 0xcdeb50..0xcded2f
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde8e0..0xcde990
+            - Range: 0xcdeaa0..0xcdeb50
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcde990..0xcdeb6f
+            - Range: 0xcdeb50..0xcded2f
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde8e0..0xcde990
+            - Range: 0xcdeaa0..0xcdeb50
               Pieces: [{Size: 8, Op: {RegNo: 11, Shift: 0}}]
-            - Range: 0xcde990..0xcdeb6f
+            - Range: 0xcdeb50..0xcded2f
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 112 ArrayType [2]int
           Locations:
-            - Range: 0xcde8e0..0xcdeb02
+            - Range: 0xcdeaa0..0xcdecc2
               Pieces: []
-            - Range: 0xcdeb02..0xcdeb03
+            - Range: 0xcdecc2..0xcdecc3
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xcdeb03..0xcdeb6f
+            - Range: 0xcdecc3..0xcded2f
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 130
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0xcdeb80..0xcdee4c]
+      OutOfLinePCRanges: [0xcded40..0xcdf00c]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdeb80..0xcdec2b
+            - Range: 0xcded40..0xcdedeb
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdec2b..0xcdee4c
+            - Range: 0xcdedeb..0xcdf00c
               Pieces: [{Size: 8, Op: {CfaOffset: 96}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdeb80..0xcdec2b
+            - Range: 0xcded40..0xcdedeb
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcdec2b..0xcdee4c
+            - Range: 0xcdedeb..0xcdf00c
               Pieces: [{Size: 8, Op: {CfaOffset: 104}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdeb80..0xcdec15
+            - Range: 0xcded40..0xcdedd5
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcdec15..0xcdee4c
+            - Range: 0xcdedd5..0xcdf00c
               Pieces: [{Size: 8, Op: {CfaOffset: 112}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdeb80..0xcdebe2
+            - Range: 0xcded40..0xcdeda2
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcdebe2..0xcdee4c
+            - Range: 0xcdeda2..0xcdf00c
               Pieces: [{Size: 8, Op: {CfaOffset: 120}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdeb80..0xcdec2b
+            - Range: 0xcded40..0xcdedeb
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcdec2b..0xcdee4c
+            - Range: 0xcdedeb..0xcdf00c
               Pieces: [{Size: 8, Op: {CfaOffset: 128}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdeb80..0xcdec2b
+            - Range: 0xcded40..0xcdedeb
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcdec2b..0xcdee4c
+            - Range: 0xcdedeb..0xcdf00c
               Pieces: [{Size: 8, Op: {CfaOffset: 136}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdeb80..0xcdec2b
+            - Range: 0xcded40..0xcdedeb
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcdec2b..0xcdee4c
+            - Range: 0xcdedeb..0xcdf00c
               Pieces: [{Size: 8, Op: {CfaOffset: 144}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdeb80..0xcdec2b
+            - Range: 0xcded40..0xcdedeb
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcdec2b..0xcdee4c
+            - Range: 0xcdedeb..0xcdf00c
               Pieces: [{Size: 8, Op: {CfaOffset: 152}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcdeb80..0xcdee4c
+            - Range: 0xcded40..0xcdf00c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -9067,200 +9067,200 @@ Subprograms:
         - Name: ~r0
           Type: 253 StructureType main.largeStruct
           Locations:
-            - Range: 0xcdeb80..0xcdedcb
+            - Range: 0xcded40..0xcdef8b
               Pieces: []
-            - Range: 0xcdedcb..0xcdedcc
+            - Range: 0xcdef8b..0xcdef8c
               Pieces: [{Size: 80, Op: {CfaOffset: 16}}]
-            - Range: 0xcdedcc..0xcdee4c
+            - Range: 0xcdef8c..0xcdf00c
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 131
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0xcdee60..0xcdeeec]
+      OutOfLinePCRanges: [0xcdf020..0xcdf0ac]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 164 ArrayType [5]int
           Locations:
-            - Range: 0xcdee60..0xcdeeec
+            - Range: 0xcdf020..0xcdf0ac
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdee60..0xcdeedc
+            - Range: 0xcdf020..0xcdf09c
               Pieces: []
-            - Range: 0xcdeedc..0xcdeedd
+            - Range: 0xcdf09c..0xcdf09d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdeedd..0xcdeeec
+            - Range: 0xcdf09d..0xcdf0ac
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdee60..0xcdeedc
+            - Range: 0xcdf020..0xcdf09c
               Pieces: []
-            - Range: 0xcdeedc..0xcdeedd
+            - Range: 0xcdf09c..0xcdf09d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcdeedd..0xcdeeec
+            - Range: 0xcdf09d..0xcdf0ac
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdee60..0xcdeedc
+            - Range: 0xcdf020..0xcdf09c
               Pieces: []
-            - Range: 0xcdeedc..0xcdeedd
+            - Range: 0xcdf09c..0xcdf09d
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcdeedd..0xcdeeec
+            - Range: 0xcdf09d..0xcdf0ac
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 132
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0xcdef00..0xcdefee]
+      OutOfLinePCRanges: [0xcdf0c0..0xcdf1ae]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 112 ArrayType [2]int
           Locations:
-            - Range: 0xcdef00..0xcdefee
+            - Range: 0xcdf0c0..0xcdf1ae
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 254 ArrayType [3]int
           Locations:
-            - Range: 0xcdef00..0xcdefee
+            - Range: 0xcdf0c0..0xcdf1ae
               Pieces: [{Size: 24, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdef00..0xcdefde
+            - Range: 0xcdf0c0..0xcdf19e
               Pieces: []
-            - Range: 0xcdefde..0xcdefdf
+            - Range: 0xcdf19e..0xcdf19f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdefdf..0xcdefee
+            - Range: 0xcdf19f..0xcdf1ae
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 112 ArrayType [2]int
           Locations:
-            - Range: 0xcdef00..0xcdefde
+            - Range: 0xcdf0c0..0xcdf19e
               Pieces: []
-            - Range: 0xcdefde..0xcdefdf
+            - Range: 0xcdf19e..0xcdf19f
               Pieces: [{Size: 16, Op: {CfaOffset: 40}}]
-            - Range: 0xcdefdf..0xcdefee
+            - Range: 0xcdf19f..0xcdf1ae
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 133
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0xcdf000..0xcdf0cb]
+      OutOfLinePCRanges: [0xcdf1c0..0xcdf28b]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 259 StructureType main.structWithArray
           Locations:
-            - Range: 0xcdf000..0xcdf0cb
+            - Range: 0xcdf1c0..0xcdf28b
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdf000..0xcdf0ba
+            - Range: 0xcdf1c0..0xcdf27a
               Pieces: []
-            - Range: 0xcdf0ba..0xcdf0bb
+            - Range: 0xcdf27a..0xcdf27b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdf0bb..0xcdf0cb
+            - Range: 0xcdf27b..0xcdf28b
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 259 StructureType main.structWithArray
           Locations:
-            - Range: 0xcdf000..0xcdf0ba
+            - Range: 0xcdf1c0..0xcdf27a
               Pieces: []
-            - Range: 0xcdf0ba..0xcdf0bb
+            - Range: 0xcdf27a..0xcdf27b
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xcdf0bb..0xcdf0cb
+            - Range: 0xcdf27b..0xcdf28b
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdf086..0xcdf0cb
+            - Range: 0xcdf246..0xcdf28b
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 134
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0xcdf0e0..0xcdf186]
+      OutOfLinePCRanges: [0xcdf2a0..0xcdf346]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 256 ArrayType [0]int
-          Locations: [{Range: 0xcdf0e0..0xcdf186, Pieces: []}]
+          Locations: [{Range: 0xcdf2a0..0xcdf346, Pieces: []}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdf0e0..0xcdf125
+            - Range: 0xcdf2a0..0xcdf2e5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdf125..0xcdf147
+            - Range: 0xcdf2e5..0xcdf307
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xcdf147..0xcdf15a
+            - Range: 0xcdf307..0xcdf31a
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xcdf15a..0xcdf186
+            - Range: 0xcdf31a..0xcdf346
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdf0e0..0xcdf16c
+            - Range: 0xcdf2a0..0xcdf32c
               Pieces: []
-            - Range: 0xcdf16c..0xcdf16d
+            - Range: 0xcdf32c..0xcdf32d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdf16d..0xcdf186
+            - Range: 0xcdf32d..0xcdf346
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 256 ArrayType [0]int
           Locations:
-            - Range: 0xcdf0e0..0xcdf16c
+            - Range: 0xcdf2a0..0xcdf32c
               Pieces: []
-            - Range: 0xcdf16c..0xcdf16d
+            - Range: 0xcdf32c..0xcdf32d
               Pieces: []
-            - Range: 0xcdf16d..0xcdf186
+            - Range: 0xcdf32d..0xcdf346
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 135
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0xcdf6a0..0xcdf6a1]
+      OutOfLinePCRanges: [0xcdf860..0xcdf861]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 260 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcdf6a0..0xcdf6a1
+            - Range: 0xcdf860..0xcdf861
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9273,13 +9273,13 @@ Subprograms:
       DictRegister: null
     - ID: 136
       Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xcdf6c0..0xcdf6c1]
+      OutOfLinePCRanges: [0xcdf880..0xcdf881]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 260 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcdf6c0..0xcdf6c1
+            - Range: 0xcdf880..0xcdf881
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9292,13 +9292,13 @@ Subprograms:
       DictRegister: null
     - ID: 137
       Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xcdf6e0..0xcdf6e1]
+      OutOfLinePCRanges: [0xcdf8a0..0xcdf8a1]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 261 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0xcdf6e0..0xcdf6e1
+            - Range: 0xcdf8a0..0xcdf8a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9311,13 +9311,13 @@ Subprograms:
       DictRegister: null
     - ID: 138
       Name: main.testStructSlice
-      OutOfLinePCRanges: [0xcdf700..0xcdf701]
+      OutOfLinePCRanges: [0xcdf8c0..0xcdf8c1]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 263 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xcdf700..0xcdf701
+            - Range: 0xcdf8c0..0xcdf8c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9330,20 +9330,20 @@ Subprograms:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdf700..0xcdf701
+            - Range: 0xcdf8c0..0xcdf8c1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 139
       Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xcdf720..0xcdf721]
+      OutOfLinePCRanges: [0xcdf8e0..0xcdf8e1]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 263 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xcdf720..0xcdf721
+            - Range: 0xcdf8e0..0xcdf8e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9356,20 +9356,20 @@ Subprograms:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdf720..0xcdf721
+            - Range: 0xcdf8e0..0xcdf8e1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 140
       Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xcdf740..0xcdf741]
+      OutOfLinePCRanges: [0xcdf900..0xcdf901]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 263 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xcdf740..0xcdf741
+            - Range: 0xcdf900..0xcdf901
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9382,20 +9382,20 @@ Subprograms:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdf740..0xcdf741
+            - Range: 0xcdf900..0xcdf901
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 141
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0xcdf760..0xcdf761]
+      OutOfLinePCRanges: [0xcdf920..0xcdf921]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 157 GoSliceHeaderType []string
           Locations:
-            - Range: 0xcdf760..0xcdf761
+            - Range: 0xcdf920..0xcdf921
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9408,20 +9408,20 @@ Subprograms:
       DictRegister: null
     - ID: 142
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xcdf780..0xcdf781]
+      OutOfLinePCRanges: [0xcdf940..0xcdf941]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 16 BaseType int8
           Locations:
-            - Range: 0xcdf780..0xcdf781
+            - Range: 0xcdf940..0xcdf941
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 266 GoSliceHeaderType []bool
           Locations:
-            - Range: 0xcdf780..0xcdf781
+            - Range: 0xcdf940..0xcdf941
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9434,20 +9434,20 @@ Subprograms:
         - Name: x
           Type: 17 BaseType uint
           Locations:
-            - Range: 0xcdf780..0xcdf781
+            - Range: 0xcdf940..0xcdf941
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 143
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0xcdf7a0..0xcdf7a1]
+      OutOfLinePCRanges: [0xcdf960..0xcdf961]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 267 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0xcdf7a0..0xcdf7a1
+            - Range: 0xcdf960..0xcdf961
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9460,13 +9460,13 @@ Subprograms:
       DictRegister: null
     - ID: 144
       Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0xcdf7c0..0xcdf7c1]
+      OutOfLinePCRanges: [0xcdf980..0xcdf981]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 260 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcdf7c0..0xcdf7c1
+            - Range: 0xcdf980..0xcdf981
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9479,13 +9479,13 @@ Subprograms:
       DictRegister: null
     - ID: 145
       Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0xcdf7e0..0xcdf7e1]
+      OutOfLinePCRanges: [0xcdf9a0..0xcdf9a1]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 268 GoSliceHeaderType []struct {}
           Locations:
-            - Range: 0xcdf7e0..0xcdf7e1
+            - Range: 0xcdf9a0..0xcdf9a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9498,13 +9498,13 @@ Subprograms:
       DictRegister: null
     - ID: 146
       Name: main.testSubslices
-      OutOfLinePCRanges: [0xcdf800..0xcdf801]
+      OutOfLinePCRanges: [0xcdf9c0..0xcdf9c1]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 260 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcdf800..0xcdf801
+            - Range: 0xcdf9c0..0xcdf9c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9517,7 +9517,7 @@ Subprograms:
         - Name: bs
           Type: 260 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcdf800..0xcdf801
+            - Range: 0xcdf9c0..0xcdf9c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -9530,7 +9530,7 @@ Subprograms:
         - Name: cs
           Type: 260 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcdf800..0xcdf801
+            - Range: 0xcdf9c0..0xcdf9c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -9543,34 +9543,34 @@ Subprograms:
       DictRegister: null
     - ID: 147
       Name: main.stackC
-      OutOfLinePCRanges: [0xcdfba0..0xcdfbf2]
+      OutOfLinePCRanges: [0xce0180..0xce01d2]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcdfba0..0xcdfbe5
+            - Range: 0xce0180..0xce01c5
               Pieces: []
-            - Range: 0xcdfbe5..0xcdfbe6
+            - Range: 0xce01c5..0xce01c6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdfbe6..0xcdfbf2
+            - Range: 0xce01c6..0xce01d2
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 148
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xcdfc00..0xcdfc01]
+      OutOfLinePCRanges: [0xce01e0..0xce01e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcdfc00..0xcdfc01
+            - Range: 0xce01e0..0xce01e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9581,13 +9581,13 @@ Subprograms:
       DictRegister: null
     - ID: 149
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xcdfc20..0xcdfc21]
+      OutOfLinePCRanges: [0xce0200..0xce0201]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcdfc20..0xcdfc21
+            - Range: 0xce0200..0xce0201
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9598,7 +9598,7 @@ Subprograms:
         - Name: "y"
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcdfc20..0xcdfc21
+            - Range: 0xce0200..0xce0201
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9609,7 +9609,7 @@ Subprograms:
         - Name: z
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcdfc20..0xcdfc21
+            - Range: 0xce0200..0xce0201
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9620,13 +9620,13 @@ Subprograms:
       DictRegister: null
     - ID: 150
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xcdfc40..0xcdfc5f]
+      OutOfLinePCRanges: [0xce0220..0xce023f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 270 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xcdfc40..0xcdfc5f
+            - Range: 0xce0220..0xce023f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9645,39 +9645,39 @@ Subprograms:
       DictRegister: null
     - ID: 151
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xcdfc60..0xcdfc61]
+      OutOfLinePCRanges: [0xce0240..0xce0241]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 271 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xcdfc60..0xcdfc61
+            - Range: 0xce0240..0xce0241
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 152
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xcdfc80..0xcdfc81]
+      OutOfLinePCRanges: [0xce0260..0xce0261]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 272 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xcdfc80..0xcdfc81
+            - Range: 0xce0260..0xce0261
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 153
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0xcdfca0..0xcdfca1]
+      OutOfLinePCRanges: [0xce0280..0xce0281]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcdfca0..0xcdfca1
+            - Range: 0xce0280..0xce0281
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9688,13 +9688,13 @@ Subprograms:
       DictRegister: null
     - ID: 154
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xcdfcc0..0xcdfcc1]
+      OutOfLinePCRanges: [0xce02a0..0xce02a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcdfcc0..0xcdfcc1
+            - Range: 0xce02a0..0xce02a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9705,13 +9705,13 @@ Subprograms:
       DictRegister: null
     - ID: 155
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0xcdfce0..0xcdfce1]
+      OutOfLinePCRanges: [0xce02c0..0xce02c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcdfce0..0xcdfce1
+            - Range: 0xce02c0..0xce02c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9722,13 +9722,13 @@ Subprograms:
       DictRegister: null
     - ID: 156
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0xcdfd00..0xcdfd01]
+      OutOfLinePCRanges: [0xce02e0..0xce02e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcdfd00..0xcdfd01
+            - Range: 0xce02e0..0xce02e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9739,7 +9739,7 @@ Subprograms:
         - Name: b
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcdfd00..0xcdfd01
+            - Range: 0xce02e0..0xce02e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9750,7 +9750,7 @@ Subprograms:
         - Name: c
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcdfd00..0xcdfd01
+            - Range: 0xce02e0..0xce02e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9761,26 +9761,26 @@ Subprograms:
       DictRegister: null
     - ID: 157
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0xcdfe80..0xcdfe81]
+      OutOfLinePCRanges: [0xce0460..0xce0461]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 274 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0xcdfe80..0xcdfe81
+            - Range: 0xce0460..0xce0461
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 158
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0xcdfea0..0xcdfebf]
+      OutOfLinePCRanges: [0xce0480..0xce049f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 287 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0xcdfea0..0xcdfebf
+            - Range: 0xce0480..0xce049f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9799,13 +9799,13 @@ Subprograms:
       DictRegister: null
     - ID: 159
       Name: main.testStruct
-      OutOfLinePCRanges: [0xcdffe0..0xce0003]
+      OutOfLinePCRanges: [0xce05c0..0xce05e3]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 318 StructureType main.aStruct
           Locations:
-            - Range: 0xcdffe0..0xce0003
+            - Range: 0xce05c0..0xce05e3
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -9826,91 +9826,91 @@ Subprograms:
       DictRegister: null
     - ID: 160
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0xce00e0..0xce00e1]
+      OutOfLinePCRanges: [0xce06c0..0xce06c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 319 PointerType *main.anotherStruct
           Locations:
-            - Range: 0xce00e0..0xce00e1
+            - Range: 0xce06c0..0xce06c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 161
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0xce0100..0xce0101]
+      OutOfLinePCRanges: [0xce06e0..0xce06e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 321 StructureType main.tenStrings
           Locations:
-            - Range: 0xce0100..0xce0101
+            - Range: 0xce06e0..0xce06e1
               Pieces: [{Size: 160, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 162
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xce0160..0xce0161]
+      OutOfLinePCRanges: [0xce0740..0xce0741]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 322 StructureType main.emptyStruct
-          Locations: [{Range: 0xce0160..0xce0161, Pieces: []}]
+          Locations: [{Range: 0xce0740..0xce0741, Pieces: []}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 163
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xce0180..0xce0181]
+      OutOfLinePCRanges: [0xce0760..0xce0761]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 323 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xce0180..0xce0181
+            - Range: 0xce0760..0xce0761
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 164
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0xce2440..0xce2444]
+      OutOfLinePCRanges: [0xce2a20..0xce2a24]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0xce2440..0xce2444
+            - Range: 0xce2a20..0xce2a24
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 325 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xce2440..0xce2443
+            - Range: 0xce2a20..0xce2a23
               Pieces: []
-            - Range: 0xce2443..0xce2444
+            - Range: 0xce2a23..0xce2a24
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 165
       Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0xce2460..0xce246c]
+      OutOfLinePCRanges: [0xce2a40..0xce2a4c]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce2460..0xce246b
+            - Range: 0xce2a40..0xce2a4b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce246b..0xce246c
+            - Range: 0xce2a4b..0xce2a4c
               Pieces:
                 - Size: 8
                   Op: null
@@ -9921,9 +9921,9 @@ Subprograms:
         - Name: ~r0
           Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xce2460..0xce246b
+            - Range: 0xce2a40..0xce2a4b
               Pieces: []
-            - Range: 0xce246b..0xce246c
+            - Range: 0xce2a4b..0xce2a4c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9934,41 +9934,41 @@ Subprograms:
       DictRegister: 0
     - ID: 166
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0xce2480..0xce2484]
+      OutOfLinePCRanges: [0xce2a60..0xce2a64]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 325 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xce2480..0xce2484
+            - Range: 0xce2a60..0xce2a64
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0xce2480..0xce2483
+            - Range: 0xce2a60..0xce2a63
               Pieces: []
-            - Range: 0xce2483..0xce2484
+            - Range: 0xce2a63..0xce2a64
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 167
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0xce24a0..0xce24ac]
+      OutOfLinePCRanges: [0xce2a80..0xce2a8c]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xce24a0..0xce24ab
+            - Range: 0xce2a80..0xce2a8b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce24ab..0xce24ac
+            - Range: 0xce2a8b..0xce2a8c
               Pieces:
                 - Size: 8
                   Op: null
@@ -9979,9 +9979,9 @@ Subprograms:
         - Name: ~r0
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce24a0..0xce24ab
+            - Range: 0xce2a80..0xce2a8b
               Pieces: []
-            - Range: 0xce24ab..0xce24ac
+            - Range: 0xce2a8b..0xce2a8c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9992,13 +9992,13 @@ Subprograms:
       DictRegister: 0
     - ID: 168
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0xce2520..0xce2656]
+      OutOfLinePCRanges: [0xce2b00..0xce2c36]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 328 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce2520..0xce2553
+            - Range: 0xce2b00..0xce2b33
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10006,7 +10006,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce2553..0xce255b
+            - Range: 0xce2b33..0xce2b3b
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -10014,7 +10014,7 @@ Subprograms:
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: null
-            - Range: 0xce255b..0xce2656
+            - Range: 0xce2b3b..0xce2c36
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -10027,18 +10027,18 @@ Subprograms:
         - Name: pred
           Type: 330 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0xce2520..0xce255b
+            - Range: 0xce2b00..0xce2b3b
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xce255b..0xce2656
+            - Range: 0xce2b3b..0xce2c36
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 328 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce2520..0xce2614
+            - Range: 0xce2b00..0xce2bf4
               Pieces: []
-            - Range: 0xce2614..0xce2615
+            - Range: 0xce2bf4..0xce2bf5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10046,14 +10046,14 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce2615..0xce2656
+            - Range: 0xce2bf5..0xce2c36
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
           Type: 328 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce255b..0xce2579
+            - Range: 0xce2b3b..0xce2b59
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10061,7 +10061,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce2579..0xce2581
+            - Range: 0xce2b59..0xce2b61
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10069,7 +10069,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce2581..0xce2589
+            - Range: 0xce2b61..0xce2b69
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10077,7 +10077,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce2589..0xce2589
+            - Range: 0xce2b69..0xce2b69
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10085,7 +10085,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce2589..0xce25b3
+            - Range: 0xce2b69..0xce2b93
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
@@ -10093,7 +10093,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce25b3..0xce260b
+            - Range: 0xce2b93..0xce2beb
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10101,7 +10101,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce260b..0xce2656
+            - Range: 0xce2beb..0xce2c36
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
@@ -10114,132 +10114,132 @@ Subprograms:
         - Name: item
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0xce25a6..0xce25b3
+            - Range: 0xce2b86..0xce2b93
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce25b3..0xce260b
+            - Range: 0xce2b93..0xce2beb
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
     - ID: 169
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xce2660..0xce26a4]
+      OutOfLinePCRanges: [0xce2c40..0xce2c84]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 325 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xce2660..0xce2679
+            - Range: 0xce2c40..0xce2c59
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
           Type: 331 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0xce2660..0xce2679
+            - Range: 0xce2c40..0xce2c59
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xce2660..0xce2679
+            - Range: 0xce2c40..0xce2c59
               Pieces: []
-            - Range: 0xce2679..0xce267a
+            - Range: 0xce2c59..0xce2c5a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce267a..0xce26a4
+            - Range: 0xce2c5a..0xce2c84
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
     - ID: 170
       Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0xce2940..0xce2944]
+      OutOfLinePCRanges: [0xce2f20..0xce2f24]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 329 PointerType *go.shape.int
           Locations:
-            - Range: 0xce2940..0xce2944
+            - Range: 0xce2f20..0xce2f24
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 329 PointerType *go.shape.int
           Locations:
-            - Range: 0xce2940..0xce2943
+            - Range: 0xce2f20..0xce2f23
               Pieces: []
-            - Range: 0xce2943..0xce2944
+            - Range: 0xce2f23..0xce2f24
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 171
       Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0xce2960..0xce2964]
+      OutOfLinePCRanges: [0xce2f40..0xce2f44]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 332 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0xce2960..0xce2964
+            - Range: 0xce2f40..0xce2f44
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 332 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0xce2960..0xce2963
+            - Range: 0xce2f40..0xce2f43
               Pieces: []
-            - Range: 0xce2963..0xce2964
+            - Range: 0xce2f43..0xce2f44
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 172
       Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0xce2980..0xce2984]
+      OutOfLinePCRanges: [0xce2f60..0xce2f64]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 334 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0xce2980..0xce2984
+            - Range: 0xce2f60..0xce2f64
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 334 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0xce2980..0xce2983
+            - Range: 0xce2f60..0xce2f63
               Pieces: []
-            - Range: 0xce2983..0xce2984
+            - Range: 0xce2f63..0xce2f64
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 173
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0xce29a0..0xce29b1]
+      OutOfLinePCRanges: [0xce2f80..0xce2f91]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 336 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0xce29a0..0xce29b1
+            - Range: 0xce2f80..0xce2f91
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce29a0..0xce29b0
+            - Range: 0xce2f80..0xce2f90
               Pieces: []
-            - Range: 0xce29b0..0xce29b1
+            - Range: 0xce2f90..0xce2f91
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10250,69 +10250,69 @@ Subprograms:
       DictRegister: 0
     - ID: 174
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0xce2a40..0xce2a49]
+      OutOfLinePCRanges: [0xce3020..0xce3029]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 338 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0xce2a40..0xce2a49
+            - Range: 0xce3020..0xce3029
               Pieces: [{Size: 136, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0xce2a40..0xce2a48
+            - Range: 0xce3020..0xce3028
               Pieces: []
-            - Range: 0xce2a48..0xce2a49
+            - Range: 0xce3028..0xce3029
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 175
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0xce2b00..0xce2b08]
+      OutOfLinePCRanges: [0xce30e0..0xce30e8]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 339 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0xce2b00..0xce2b08
+            - Range: 0xce30e0..0xce30e8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0xce2b00..0xce2b08
+            - Range: 0xce30e0..0xce30e8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
           Type: 341 BaseType go.shape.bool
           Locations:
-            - Range: 0xce2b00..0xce2b08
+            - Range: 0xce30e0..0xce30e8
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
     - ID: 176
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0xce2ba0..0xce2c11]
+      OutOfLinePCRanges: [0xce3180..0xce31f1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 342 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0xce2ba0..0xce2c11
+            - Range: 0xce3180..0xce31f1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce2ba0..0xce2c11
+            - Range: 0xce3180..0xce31f1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10323,20 +10323,20 @@ Subprograms:
         - Name: v
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0xce2ba0..0xce2c11
+            - Range: 0xce3180..0xce31f1
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
     - ID: 177
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0xce2ca0..0xce2ca8]
+      OutOfLinePCRanges: [0xce3280..0xce3288]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce2ca0..0xce2ca8
+            - Range: 0xce3280..0xce3288
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10347,25 +10347,25 @@ Subprograms:
         - Name: b
           Type: 341 BaseType go.shape.bool
           Locations:
-            - Range: 0xce2ca0..0xce2ca8
+            - Range: 0xce3280..0xce3288
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 341 BaseType go.shape.bool
           Locations:
-            - Range: 0xce2ca0..0xce2ca7
+            - Range: 0xce3280..0xce3287
               Pieces: []
-            - Range: 0xce2ca7..0xce2ca8
+            - Range: 0xce3287..0xce3288
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce2ca0..0xce2ca7
+            - Range: 0xce3280..0xce3287
               Pieces: []
-            - Range: 0xce2ca7..0xce2ca8
+            - Range: 0xce3287..0xce3288
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10376,26 +10376,26 @@ Subprograms:
       DictRegister: 0
     - ID: 178
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xce2cc0..0xce2ccf]
+      OutOfLinePCRanges: [0xce32a0..0xce32af]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0xce2cc0..0xce2cce
+            - Range: 0xce32a0..0xce32ae
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce2cc0..0xce2ccb
+            - Range: 0xce32a0..0xce32ab
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce2ccb..0xce2ccf
+            - Range: 0xce32ab..0xce32af
               Pieces:
                 - Size: 8
                   Op: null
@@ -10406,9 +10406,9 @@ Subprograms:
         - Name: ~r0
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce2cc0..0xce2cce
+            - Range: 0xce32a0..0xce32ae
               Pieces: []
-            - Range: 0xce2cce..0xce2ccf
+            - Range: 0xce32ae..0xce32af
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10419,56 +10419,56 @@ Subprograms:
         - Name: ~r1
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0xce2cc0..0xce2cce
+            - Range: 0xce32a0..0xce32ae
               Pieces: []
-            - Range: 0xce2cce..0xce2ccf
+            - Range: 0xce32ae..0xce32af
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 179
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0xce2ce0..0xce2d1a]
+      OutOfLinePCRanges: [0xce32c0..0xce32fa]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 344 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0xce2ce0..0xce2cf9
+            - Range: 0xce32c0..0xce32d9
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce2ce0..0xce2cf9
+            - Range: 0xce32c0..0xce32d9
               Pieces: []
-            - Range: 0xce2cf9..0xce2cfa
+            - Range: 0xce32d9..0xce32da
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce2cfa..0xce2d1a
+            - Range: 0xce32da..0xce32fa
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 180
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0xce2d20..0xce2d6d]
+      OutOfLinePCRanges: [0xce3300..0xce334d]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 345 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0xce2d20..0xce2d3f
+            - Range: 0xce3300..0xce331f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce2d3f..0xce2d42
+            - Range: 0xce331f..0xce3322
               Pieces:
                 - Size: 8
                   Op: null
@@ -10479,37 +10479,37 @@ Subprograms:
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce2d20..0xce2d42
+            - Range: 0xce3300..0xce3322
               Pieces: []
-            - Range: 0xce2d42..0xce2d43
+            - Range: 0xce3322..0xce3323
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce2d43..0xce2d6d
+            - Range: 0xce3323..0xce334d
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 181
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0xce2d80..0xce2d88]
+      OutOfLinePCRanges: [0xce3360..0xce3368]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 346 PointerType *go.shape.string
           Locations:
-            - Range: 0xce2d80..0xce2d87
+            - Range: 0xce3360..0xce3367
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce2d80..0xce2d87
+            - Range: 0xce3360..0xce3367
               Pieces: []
-            - Range: 0xce2d87..0xce2d88
+            - Range: 0xce3367..0xce3368
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10520,22 +10520,22 @@ Subprograms:
       DictRegister: 0
     - ID: 182
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0xce2da0..0xce2df7]
+      OutOfLinePCRanges: [0xce3380..0xce33d7]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 347 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xce2da0..0xce2ddd
+            - Range: 0xce3380..0xce33bd
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 348 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xce2da0..0xce2df1
+            - Range: 0xce3380..0xce33d1
               Pieces: []
-            - Range: 0xce2df1..0xce2df2
+            - Range: 0xce33d1..0xce33d2
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10549,20 +10549,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xce2df2..0xce2df7
+            - Range: 0xce33d2..0xce33d7
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 183
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0xce2e00..0xce2e24]
+      OutOfLinePCRanges: [0xce33e0..0xce3404]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 328 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce2e00..0xce2e24
+            - Range: 0xce33e0..0xce3404
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10575,33 +10575,33 @@ Subprograms:
         - Name: needle
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0xce2e00..0xce2e24
+            - Range: 0xce33e0..0xce3404
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xce2e00..0xce2e20
+            - Range: 0xce33e0..0xce3400
               Pieces: []
-            - Range: 0xce2e20..0xce2e21
+            - Range: 0xce3400..0xce3401
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce2e21..0xce2e23
+            - Range: 0xce3401..0xce3403
               Pieces: []
-            - Range: 0xce2e23..0xce2e24
+            - Range: 0xce3403..0xce3404
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 184
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0xce2e40..0xce2eff]
+      OutOfLinePCRanges: [0xce3420..0xce34df]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 349 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0xce2e40..0xce2e5d
+            - Range: 0xce3420..0xce343d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10609,7 +10609,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce2e5d..0xce2e5f
+            - Range: 0xce343d..0xce343f
               Pieces:
                 - Size: 8
                   Op: null
@@ -10622,13 +10622,13 @@ Subprograms:
         - Name: needle
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce2e40..0xce2e8c
+            - Range: 0xce3420..0xce346c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xce2e8c..0xce2eff
+            - Range: 0xce346c..0xce34df
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
@@ -10639,28 +10639,28 @@ Subprograms:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xce2e40..0xce2eab
+            - Range: 0xce3420..0xce348b
               Pieces: []
-            - Range: 0xce2eab..0xce2eac
+            - Range: 0xce348b..0xce348c
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce2eac..0xce2eb3
+            - Range: 0xce348c..0xce3493
               Pieces: []
-            - Range: 0xce2eb3..0xce2eb4
+            - Range: 0xce3493..0xce3494
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce2eb4..0xce2eff
+            - Range: 0xce3494..0xce34df
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce2e6f..0xce2e81
+            - Range: 0xce344f..0xce3461
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xce2e81..0xce2e8c
+            - Range: 0xce3461..0xce346c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10671,54 +10671,54 @@ Subprograms:
       DictRegister: 0
     - ID: 185
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0xce2f00..0xce2f07]
+      OutOfLinePCRanges: [0xce34e0..0xce34e7]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 350 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0xce2f00..0xce2f06
+            - Range: 0xce34e0..0xce34e6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0xce2f00..0xce2f07
+            - Range: 0xce34e0..0xce34e7
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xce2f00..0xce2f06
+            - Range: 0xce34e0..0xce34e6
               Pieces: []
-            - Range: 0xce2f06..0xce2f07
+            - Range: 0xce34e6..0xce34e7
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 3
     - ID: 186
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0xce2f80..0xce2fec]
+      OutOfLinePCRanges: [0xce3560..0xce35cc]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 351 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0xce2f80..0xce2fa0
+            - Range: 0xce3560..0xce3580
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce2fa0..0xce2fa8
+            - Range: 0xce3580..0xce3588
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce2fa8..0xce2fad
+            - Range: 0xce3588..0xce358d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10729,7 +10729,7 @@ Subprograms:
         - Name: value
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce2f80..0xce2fad
+            - Range: 0xce3560..0xce358d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -10740,11 +10740,11 @@ Subprograms:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xce2f80..0xce2fad
+            - Range: 0xce3560..0xce358d
               Pieces: []
-            - Range: 0xce2fad..0xce2fae
+            - Range: 0xce358d..0xce358e
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce2fae..0xce2fec
+            - Range: 0xce358e..0xce35cc
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10882,31 +10882,31 @@ Subprograms:
       DictRegister: 0
     - ID: 188
       Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0xcd9720..0xcd9782]
+      OutOfLinePCRanges: [0xcd9820..0xcd9882]
       InlinePCRanges:
-        - Ranges: [0xcd97b1..0xcd97ed]
-          RootRanges: [0xcd97a0..0xcd9811]
-        - Ranges: [0xcd98f2..0xcd992e]
-          RootRanges: [0xcd98c0..0xcd9948]
-        - Ranges: [0xcd997c..0xcd99b8]
-          RootRanges: [0xcd9960..0xcd9a25]
-        - Ranges: [0xcd9a4f..0xcd9a8b]
-          RootRanges: [0xcd9a40..0xcd9aa2]
+        - Ranges: [0xcd98b1..0xcd98ed]
+          RootRanges: [0xcd98a0..0xcd9911]
+        - Ranges: [0xcd99f2..0xcd9a2e]
+          RootRanges: [0xcd99c0..0xcd9a48]
+        - Ranges: [0xcd9a7c..0xcd9ab8]
+          RootRanges: [0xcd9a60..0xcd9b25]
+        - Ranges: [0xcd9b4f..0xcd9b8b]
+          RootRanges: [0xcd9b40..0xcd9ba2]
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcd9720..0xcd9739
+            - Range: 0xcd9820..0xcd9839
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd97b1..0xcd97bc
+            - Range: 0xcd98b1..0xcd98bc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd98f2..0xcd98fd
+            - Range: 0xcd99f2..0xcd99fd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd9976..0xcd9987
+            - Range: 0xcd9a76..0xcd9a87
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd9987..0xcd9a25
+            - Range: 0xcd9a87..0xcd9b25
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xcd9a40..0xcd9a5a
+            - Range: 0xcd9b40..0xcd9b5a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10915,37 +10915,37 @@ Subprograms:
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcd99c6..0xcd99fe]
-          RootRanges: [0xcd9960..0xcd9a25]
+        - Ranges: [0xcd9ac6..0xcd9afe]
+          RootRanges: [0xcd9a60..0xcd9b25]
       Variables: []
       DictRegister: null
     - ID: 190
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcd9ad3..0xcd9b11]
-          RootRanges: [0xcd9ac0..0xcd9bce]
+        - Ranges: [0xcd9bd3..0xcd9c11]
+          RootRanges: [0xcd9bc0..0xcd9cce]
       Variables: []
       DictRegister: null
     - ID: 191
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcd9b86..0xcd9bbe]
-          RootRanges: [0xcd9ac0..0xcd9bce]
+        - Ranges: [0xcd9c86..0xcd9cbe]
+          RootRanges: [0xcd9bc0..0xcd9cce]
       Variables: []
       DictRegister: null
     - ID: 192
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcd9be1..0xcd9be5]
-          RootRanges: [0xcd9be0..0xcd9be6]
+        - Ranges: [0xcd9ce1..0xcd9ce5]
+          RootRanges: [0xcd9ce0..0xcd9ce6]
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcd9be0..0xcd9be5
+            - Range: 0xcd9ce0..0xcd9ce5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10954,38 +10954,38 @@ Subprograms:
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcd9c25..0xcd9c3d]
-          RootRanges: [0xcd9c00..0xcd9c43]
-        - Ranges: [0xcd9cc5..0xcd9ce3]
-          RootRanges: [0xcd9c60..0xcd9de5]
+        - Ranges: [0xcd9d25..0xcd9d3d]
+          RootRanges: [0xcd9d00..0xcd9d43]
+        - Ranges: [0xcd9dc5..0xcd9de3]
+          RootRanges: [0xcd9d60..0xcd9ee5]
       Variables:
         - Name: a
           Type: 164 ArrayType [5]int
           Locations:
-            - Range: 0xcd9c0d..0xcd9c43
+            - Range: 0xcd9d0d..0xcd9d43
               Pieces: [{Size: 40, Op: {CfaOffset: -56}}]
-            - Range: 0xcd9cac..0xcd9de5
+            - Range: 0xcd9dac..0xcd9ee5
               Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 194
       Name: main.firstBehavior.DoSomething
-      OutOfLinePCRanges: [0xcd9e00..0xcd9e71]
+      OutOfLinePCRanges: [0xcd9f00..0xcd9f71]
       InlinePCRanges:
-        - Ranges: [0xce30a3..0xce30e5]
-          RootRanges: [0xce3080..0xce3116]
+        - Ranges: [0xce3683..0xce36c5]
+          RootRanges: [0xce3660..0xce36f6]
       Variables:
         - Name: b
           Type: 356 StructureType main.firstBehavior
           Locations:
-            - Range: 0xcd9e00..0xcd9e28
+            - Range: 0xcd9f00..0xcd9f28
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd9e28..0xcd9e2d
+            - Range: 0xcd9f28..0xcd9f2d
               Pieces:
                 - Size: 8
                   Op: null
@@ -10996,15 +10996,15 @@ Subprograms:
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcd9e00..0xcd9e50
+            - Range: 0xcd9f00..0xcd9f50
               Pieces: []
-            - Range: 0xcd9e50..0xcd9e51
+            - Range: 0xcd9f50..0xcd9f51
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd9e51..0xcd9e71
+            - Range: 0xcd9f51..0xcd9f71
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11013,8 +11013,8 @@ Subprograms:
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcda5b0..0xcda5b7]
-          RootRanges: [0xcda460..0xcda605]
+        - Ranges: [0xcda7dd..0xcda7e4]
+          RootRanges: [0xcda740..0xcda82b]
         - Ranges: [0x5230a1..0x5230a9]
           RootRanges: [0x5230a0..0x5230aa]
       Variables: []
@@ -11322,7 +11322,7 @@ Types:
       ID: 40
       Name: '*[]runtime.ancestorInfo'
       ByteSize: 8
-      GoRuntimeType: 488832
+      GoRuntimeType: 489088
       GoKind: 22
       Pointee: 41 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
@@ -11425,7 +11425,7 @@ Types:
       ID: 12
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 392832
+      GoRuntimeType: 392960
       GoKind: 22
       Pointee: 5 BaseType bool
     - __kind: PointerType
@@ -11848,7 +11848,7 @@ Types:
       ID: 105
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 391744
+      GoRuntimeType: 391872
       GoKind: 22
       Pointee: 14 GoInterfaceType error
     - __kind: PointerType
@@ -11869,14 +11869,14 @@ Types:
       ID: 107
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 392704
+      GoRuntimeType: 392832
       GoKind: 22
       Pointee: 18 BaseType float32
     - __kind: PointerType
       ID: 97
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 392768
+      GoRuntimeType: 392896
       GoKind: 22
       Pointee: 19 BaseType float64
     - __kind: PointerType
@@ -12735,42 +12735,42 @@ Types:
       ID: 99
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 392384
+      GoRuntimeType: 392512
       GoKind: 22
       Pointee: 8 BaseType int
     - __kind: PointerType
       ID: 102
       Name: '*int16'
       ByteSize: 8
-      GoRuntimeType: 392000
+      GoRuntimeType: 392128
       GoKind: 22
       Pointee: 103 BaseType int16
     - __kind: PointerType
       ID: 21
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 392128
+      GoRuntimeType: 392256
       GoKind: 22
       Pointee: 11 BaseType int32
     - __kind: PointerType
       ID: 98
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 392256
+      GoRuntimeType: 392384
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
       ID: 104
       Name: '*int8'
       ByteSize: 8
-      GoRuntimeType: 391872
+      GoRuntimeType: 392000
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
       ID: 166
       Name: '*interface {}'
       ByteSize: 8
-      GoRuntimeType: 392960
+      GoRuntimeType: 393088
       GoKind: 22
       Pointee: 160 GoEmptyInterfaceType interface {}
     - __kind: PointerType
@@ -12791,7 +12791,7 @@ Types:
       ID: 1047
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
-      GoRuntimeType: 901376
+      GoRuntimeType: 901760
       GoKind: 22
       Pointee: 1048 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
@@ -12816,12 +12816,12 @@ Types:
       GoKind: 22
       Pointee: 934 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 660
+      ID: 663
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
-      GoRuntimeType: 900320
+      GoRuntimeType: 900704
       GoKind: 22
-      Pointee: 661 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 664 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
       ID: 1093
       Name: '*io.PipeWriter'
@@ -13907,12 +13907,12 @@ Types:
       GoKind: 22
       Pointee: 637 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 662
+      ID: 665
       Name: '*reflect.ValueError'
       ByteSize: 8
-      GoRuntimeType: 900992
+      GoRuntimeType: 901376
       GoKind: 22
-      Pointee: 663 UnresolvedPointeeType reflect.ValueError
+      Pointee: 666 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
       ID: 757
       Name: '*regexp/syntax.Error'
@@ -13924,21 +13924,21 @@ Types:
       ID: 869
       Name: '*runtime.PanicNilError'
       ByteSize: 8
-      GoRuntimeType: 1029088
+      GoRuntimeType: 1029344
       GoKind: 22
       Pointee: 870 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
       ID: 873
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
-      GoRuntimeType: 1030880
+      GoRuntimeType: 1031136
       GoKind: 22
       Pointee: 874 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 27
       Name: '*runtime._defer'
       ByteSize: 8
-      GoRuntimeType: 393024
+      GoRuntimeType: 393152
       GoKind: 22
       Pointee: 28 UnresolvedPointeeType runtime._defer
     - __kind: PointerType
@@ -13952,21 +13952,21 @@ Types:
       ID: 871
       Name: '*runtime.boundsError'
       ByteSize: 8
-      GoRuntimeType: 1029216
+      GoRuntimeType: 1029472
       GoKind: 22
       Pointee: 872 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 63
       Name: '*runtime.cgoCallers'
       ByteSize: 8
-      GoRuntimeType: 393664
+      GoRuntimeType: 393792
       GoKind: 22
       Pointee: 64 UnresolvedPointeeType runtime.cgoCallers
     - __kind: PointerType
       ID: 48
       Name: '*runtime.coro'
       ByteSize: 8
-      GoRuntimeType: 393728
+      GoRuntimeType: 393856
       GoKind: 22
       Pointee: 49 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
@@ -13980,7 +13980,7 @@ Types:
       ID: 867
       Name: '*runtime.errorString'
       ByteSize: 8
-      GoRuntimeType: 1028704
+      GoRuntimeType: 1028960
       GoKind: 22
       Pointee: 848 GoStringHeaderType runtime.errorString
     - __kind: PointerType
@@ -13992,21 +13992,21 @@ Types:
       ID: 56
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 899552
+      GoRuntimeType: 899936
       GoKind: 22
       Pointee: 23 StructureType runtime.g
     - __kind: PointerType
       ID: 29
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 1030368
+      GoRuntimeType: 1030624
       GoKind: 22
       Pointee: 30 StructureType runtime.m
     - __kind: PointerType
       ID: 868
       Name: '*runtime.plainError'
       ByteSize: 8
-      GoRuntimeType: 1028832
+      GoRuntimeType: 1029088
       GoKind: 22
       Pointee: 851 GoStringHeaderType runtime.plainError
     - __kind: PointerType
@@ -14018,7 +14018,7 @@ Types:
       ID: 42
       Name: '*runtime.sudog'
       ByteSize: 8
-      GoRuntimeType: 394432
+      GoRuntimeType: 394560
       GoKind: 22
       Pointee: 43 UnresolvedPointeeType runtime.sudog
     - __kind: PointerType
@@ -14039,7 +14039,7 @@ Types:
       ID: 77
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1624064
+      GoRuntimeType: 1624448
       GoKind: 22
       Pointee: 78 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
@@ -14053,7 +14053,7 @@ Types:
       ID: 94
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 391808
+      GoRuntimeType: 391936
       GoKind: 22
       Pointee: 10 GoStringHeaderType string
     - __kind: PointerType
@@ -14247,21 +14247,21 @@ Types:
       ID: 997
       Name: '*time.Location'
       ByteSize: 8
-      GoRuntimeType: 1629056
+      GoRuntimeType: 1620608
       GoKind: 22
       Pointee: 998 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 665
+      ID: 661
       Name: '*time.ParseError'
       ByteSize: 8
-      GoRuntimeType: 902144
+      GoRuntimeType: 898112
       GoKind: 22
-      Pointee: 666 UnresolvedPointeeType time.ParseError
+      Pointee: 662 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 664
+      ID: 660
       Name: '*time.fileSizeError'
       ByteSize: 8
-      GoRuntimeType: 902048
+      GoRuntimeType: 898016
       GoKind: 22
       Pointee: 586 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
@@ -14273,42 +14273,42 @@ Types:
       ID: 106
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 392448
+      GoRuntimeType: 392576
       GoKind: 22
       Pointee: 17 BaseType uint
     - __kind: PointerType
       ID: 101
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 392064
+      GoRuntimeType: 392192
       GoKind: 22
       Pointee: 7 BaseType uint16
     - __kind: PointerType
       ID: 22
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 392192
+      GoRuntimeType: 392320
       GoKind: 22
       Pointee: 3 BaseType uint32
     - __kind: PointerType
       ID: 100
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 392320
+      GoRuntimeType: 392448
       GoKind: 22
       Pointee: 9 BaseType uint64
     - __kind: PointerType
       ID: 6
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 391936
+      GoRuntimeType: 392064
       GoKind: 22
       Pointee: 4 BaseType uint8
     - __kind: PointerType
       ID: 20
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 392512
+      GoRuntimeType: 392640
       GoKind: 22
       Pointee: 2 BaseType uintptr
     - __kind: PointerType
@@ -23445,7 +23445,7 @@ Types:
       ID: 90
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 701696
+      GoRuntimeType: 703136
       GoKind: 17
       Count: 10
       HasCount: true
@@ -23472,7 +23472,7 @@ Types:
       ID: 76
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 701312
+      GoRuntimeType: 702752
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23481,7 +23481,7 @@ Types:
       ID: 75
       Name: '[2][2]*runtime.traceBuf'
       ByteSize: 32
-      GoRuntimeType: 701408
+      GoRuntimeType: 702848
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23506,7 +23506,7 @@ Types:
       ID: 82
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 701600
+      GoRuntimeType: 703040
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23648,7 +23648,7 @@ Types:
       ID: 66
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 701120
+      GoRuntimeType: 702560
       GoKind: 17
       Count: 32
       HasCount: true
@@ -23666,7 +23666,7 @@ Types:
       ID: 54
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 700832
+      GoRuntimeType: 702272
       GoKind: 17
       Count: 3
       HasCount: true
@@ -23736,7 +23736,7 @@ Types:
       ID: 83
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 701504
+      GoRuntimeType: 702944
       GoKind: 17
       Count: 8
       HasCount: true
@@ -24154,7 +24154,7 @@ Types:
       ID: 266
       Name: '[]bool'
       ByteSize: 24
-      GoRuntimeType: 487040
+      GoRuntimeType: 487296
       GoKind: 23
       RawFields:
         - Name: array
@@ -24177,7 +24177,7 @@ Types:
       ID: 1020
       Name: '[]float64'
       ByteSize: 24
-      GoRuntimeType: 486912
+      GoRuntimeType: 487168
       GoKind: 23
       RawFields:
         - Name: array
@@ -24267,7 +24267,7 @@ Types:
       ID: 1301
       Name: '[]interface {}'
       ByteSize: 24
-      GoRuntimeType: 487360
+      GoRuntimeType: 487616
       GoKind: 23
       RawFields:
         - Name: array
@@ -24523,7 +24523,7 @@ Types:
       ID: 157
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 487168
+      GoRuntimeType: 487424
       GoKind: 23
       RawFields:
         - Name: array
@@ -24567,7 +24567,7 @@ Types:
       ID: 260
       Name: '[]uint'
       ByteSize: 24
-      GoRuntimeType: 486656
+      GoRuntimeType: 486912
       GoKind: 23
       RawFields:
         - Name: array
@@ -24590,7 +24590,7 @@ Types:
       ID: 267
       Name: '[]uint16'
       ByteSize: 24
-      GoRuntimeType: 486016
+      GoRuntimeType: 486272
       GoKind: 23
       RawFields:
         - Name: array
@@ -24613,7 +24613,7 @@ Types:
       ID: 39
       Name: '[]uint8'
       ByteSize: 24
-      GoRuntimeType: 485888
+      GoRuntimeType: 486144
       GoKind: 23
       RawFields:
         - Name: array
@@ -24636,7 +24636,7 @@ Types:
       ID: 44
       Name: '[]uintptr'
       ByteSize: 24
-      GoRuntimeType: 486720
+      GoRuntimeType: 486976
       GoKind: 23
       RawFields:
         - Name: array
@@ -25109,7 +25109,7 @@ Types:
       ID: 14
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1028576
+      GoRuntimeType: 1028832
       GoKind: 20
       RawFields:
         - Name: tab
@@ -25160,7 +25160,7 @@ Types:
       ID: 71
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 849472
+      GoRuntimeType: 849760
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 355
@@ -26750,7 +26750,7 @@ Types:
       ID: 160
       Name: interface {}
       ByteSize: 16
-      GoRuntimeType: 849184
+      GoRuntimeType: 849472
       GoKind: 20
       RawFields:
         - Name: _type
@@ -26804,11 +26804,11 @@ Types:
     - __kind: StructureType
       ID: 934
       Name: internal/poll.errNetClosing
-      GoRuntimeType: 1480096
+      GoRuntimeType: 1480416
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 661
+      ID: 664
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -26892,7 +26892,7 @@ Types:
       ID: 1250
       Name: internal/sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1477536
+      GoRuntimeType: 1477856
       GoKind: 25
       RawFields:
         - Name: state
@@ -30630,7 +30630,7 @@ Types:
       GoRuntimeType: 839008
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 663
+      ID: 666
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -30696,7 +30696,7 @@ Types:
       ID: 930
       Name: runtime.errorAddressString
       ByteSize: 24
-      GoRuntimeType: 1754912
+      GoRuntimeType: 1755104
       GoKind: 25
       RawFields:
         - Name: msg
@@ -30919,7 +30919,7 @@ Types:
       ID: 31
       Name: runtime.gobuf
       ByteSize: 56
-      GoRuntimeType: 1972032
+      GoRuntimeType: 1972320
       GoKind: 25
       RawFields:
         - Name: sp
@@ -30947,7 +30947,7 @@ Types:
       ID: 47
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1474976
+      GoRuntimeType: 1475296
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -30960,7 +30960,7 @@ Types:
       ID: 57
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1753952
+      GoRuntimeType: 1754144
       GoKind: 25
       RawFields:
         - Name: stack
@@ -30979,13 +30979,13 @@ Types:
       ID: 32
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 831712
+      GoRuntimeType: 832000
       GoKind: 12
     - __kind: StructureType
       ID: 91
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1474816
+      GoRuntimeType: 1475136
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -30998,7 +30998,7 @@ Types:
       ID: 79
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 1915936
+      GoRuntimeType: 1916192
       GoKind: 25
       RawFields:
         - Name: fn
@@ -31023,7 +31023,7 @@ Types:
       ID: 92
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 831616
+      GoRuntimeType: 831904
       GoKind: 2
     - __kind: StructureType
       ID: 30
@@ -31252,7 +31252,7 @@ Types:
       ID: 68
       Name: runtime.mLockProfile
       ByteSize: 64
-      GoRuntimeType: 1972320
+      GoRuntimeType: 1972608
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -31280,7 +31280,7 @@ Types:
       ID: 86
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 1841280
+      GoRuntimeType: 1841504
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -31302,7 +31302,7 @@ Types:
       ID: 73
       Name: runtime.mTraceState
       ByteSize: 56
-      GoRuntimeType: 1841056
+      GoRuntimeType: 1841280
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -31334,7 +31334,7 @@ Types:
       ID: 38
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 831328
+      GoRuntimeType: 831616
       GoKind: 12
     - __kind: StructureType
       ID: 65
@@ -31347,7 +31347,7 @@ Types:
       ID: 81
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1474656
+      GoRuntimeType: 1474976
       GoKind: 25
       RawFields:
         - Name: entries
@@ -31360,7 +31360,7 @@ Types:
       ID: 84
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1754720
+      GoRuntimeType: 1754912
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -31398,13 +31398,13 @@ Types:
       ID: 61
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 831520
+      GoRuntimeType: 831808
       GoKind: 12
     - __kind: ArrayType
       ID: 58
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 899168
+      GoRuntimeType: 899552
       GoKind: 17
       Count: 2
       HasCount: true
@@ -31413,7 +31413,7 @@ Types:
       ID: 24
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1473056
+      GoRuntimeType: 1473376
       GoKind: 25
       RawFields:
         - Name: lo
@@ -31454,7 +31454,7 @@ Types:
       ID: 53
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1474016
+      GoRuntimeType: 1474336
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -32302,14 +32302,14 @@ Types:
       ID: 1146
       Name: time.Duration
       ByteSize: 8
-      GoRuntimeType: 1916704
+      GoRuntimeType: 1914144
       GoKind: 6
     - __kind: UnresolvedPointeeType
       ID: 998
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 666
+      ID: 662
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
@@ -32332,7 +32332,7 @@ Types:
       ID: 586
       Name: time.fileSizeError
       ByteSize: 16
-      GoRuntimeType: 832096
+      GoRuntimeType: 830848
       GoKind: 24
       RawFields:
         - Name: str
@@ -32535,10 +32535,10 @@ Issues:
       issue:
         Kind: 7
         Message: return value selector (e.g., @return.r0) must be used for multi-value returns
-GoModuledataInfo: {FirstModuledataAddr: "0x18113a0", TypesOffset: 296}
+GoModuledataInfo: {FirstModuledataAddr: "0x18123a0", TypesOffset: 296}
 GoMapHashInfo:
-    UseAeshashAddr: "0x190096b"
-    AeskeyschedAddr: "0x1901ac0"
+    UseAeshashAddr: "0x190196b"
+    AeskeyschedAddr: "0x1902ac0"
 CommonTypes:
     G: 23 StructureType runtime.g
     M: 30 StructureType runtime.m

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -13,11 +13,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1600 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0xce434a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce492a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1601 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0xce4385", Frameless: false}]
+              InjectionPoints: [{PC: "0xce4965", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -33,11 +33,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1439 EventRootType Probe[main.testAny]
-              InjectionPoints: [{PC: "0xcde76a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde86a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1440 EventRootType Probe[main.testAny]Return
-              InjectionPoints: [{PC: "0xcde7a5", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde8a5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -59,11 +59,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1442 EventRootType Probe[main.testAnyPtr]
-              InjectionPoints: [{PC: "0xcde80a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde90a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1443 EventRootType Probe[main.testAnyPtr]Return
-              InjectionPoints: [{PC: "0xcde83d", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde93d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -84,11 +84,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1571 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0xce2d8e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2f4e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1572 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0xce2e42", Frameless: false}]
+              InjectionPoints: [{PC: "0xce3002", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -110,7 +110,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1387 EventRootType Probe[main.testArrayEmptyStructs]
-              InjectionPoints: [{PC: "0xcd9a60", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9b60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -132,7 +132,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1383 EventRootType Probe[main.testArrayOfArrays]
-              InjectionPoints: [{PC: "0xcd99e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9ae0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -154,7 +154,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1385 EventRootType Probe[main.testArrayOfArraysOfArrays]
-              InjectionPoints: [{PC: "0xcd9a20", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9b20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -176,7 +176,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1451 EventRootType Probe[main.testArrayOfMaps]
-              InjectionPoints: [{PC: "0xcdef40", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf100", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -198,7 +198,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1384 EventRootType Probe[main.testArrayOfStrings]
-              InjectionPoints: [{PC: "0xcd9a00", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9b00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -219,7 +219,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1386 EventRootType Probe[main.testArrayOfStructs]
-              InjectionPoints: [{PC: "0xcd9a40", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9b40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -241,11 +241,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1473 EventRootType Probe[main.testAtomicAdd]
-              InjectionPoints: [{PC: "0xce0e20", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0fe0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1474 EventRootType Probe[main.testAtomicAdd]Return
-              InjectionPoints: [{PC: "0xce0e32", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0ff2", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -267,11 +267,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1405 EventRootType Probe[main.testBigStruct]
-              InjectionPoints: [{PC: "0xcda160", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda260", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1406 EventRootType Probe[main.testBigStruct]Return
-              InjectionPoints: [{PC: "0xcda17e", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda27e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -293,7 +293,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1372 EventRootType Probe[main.testBoolArray]
-              InjectionPoints: [{PC: "0xcd9880", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9980", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -315,7 +315,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1369 EventRootType Probe[main.testByteArray]
-              InjectionPoints: [{PC: "0xcd9820", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9920", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -342,11 +342,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1619 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xce4780", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4d60", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1620 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0xce47a2", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4d82", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -366,15 +366,15 @@ Probes:
             - Kind: Line
               Type: 1680 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xcddf8e"
+                - PC: "0xcde08e"
                   Frameless: false
-                - PC: "0xcde011"
+                - PC: "0xcde111"
                   Frameless: false
-                - PC: "0xcde152"
+                - PC: "0xcde252"
                   Frameless: false
-                - PC: "0xcde1dc"
+                - PC: "0xcde2dc"
                   Frameless: false
-                - PC: "0xcde2af"
+                - PC: "0xcde3af"
                   Frameless: false
               Condition: null
     - id: testCaptureExprLineCond
@@ -396,15 +396,15 @@ Probes:
             - Kind: Line
               Type: 1681 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xcddf8e"
+                - PC: "0xcde08e"
                   Frameless: false
-                - PC: "0xcde011"
+                - PC: "0xcde111"
                   Frameless: false
-                - PC: "0xcde152"
+                - PC: "0xcde252"
                   Frameless: false
-                - PC: "0xcde1dc"
+                - PC: "0xcde2dc"
                   Frameless: false
-                - PC: "0xcde2af"
+                - PC: "0xcde3af"
                   Frameless: false
               Condition:
                 Type: 5 BaseType bool
@@ -440,15 +440,15 @@ Probes:
             - Kind: Line
               Type: 1682 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xcddf8e"
+                - PC: "0xcde08e"
                   Frameless: false
-                - PC: "0xcde011"
+                - PC: "0xcde111"
                   Frameless: false
-                - PC: "0xcde152"
+                - PC: "0xcde252"
                   Frameless: false
-                - PC: "0xcde1dc"
+                - PC: "0xcde2dc"
                   Frameless: false
-                - PC: "0xcde2af"
+                - PC: "0xcde3af"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -476,7 +476,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1470 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0xce0a80", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0c40", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -495,7 +495,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1471 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0xce0a80", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0c40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -521,7 +521,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1627 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0xce48a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4e80", Frameless: true}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -557,7 +557,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1475 EventRootType Probe[main.testChannel]
-              InjectionPoints: [{PC: "0xce0e40", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1000", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -587,7 +587,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1469 EventRootType Probe[main.testCombinedByte]
-              InjectionPoints: [{PC: "0xce0a40", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0c00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{w}, {x}, {y}'
@@ -616,11 +616,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1536 EventRootType Probe[main.testConflictingReturn]
-              InjectionPoints: [{PC: "0xce1fce", Frameless: false}]
+              InjectionPoints: [{PC: "0xce218e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1537 EventRootType Probe[main.testConflictingReturn]Return
-              InjectionPoints: [{PC: "0xce2091", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2251", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -642,7 +642,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1483 EventRootType Probe[main.testCycle]
-              InjectionPoints: [{PC: "0xce1200", Frameless: true}]
+              InjectionPoints: [{PC: "0xce13c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{t}'
@@ -664,7 +664,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1412 EventRootType Probe[main.testDeepMap1]
-              InjectionPoints: [{PC: "0xcda640", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda740", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -686,7 +686,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1413 EventRootType Probe[main.testDeepMap7]
-              InjectionPoints: [{PC: "0xcda660", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda760", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -708,7 +708,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1408 EventRootType Probe[main.testDeepPtr1]
-              InjectionPoints: [{PC: "0xcda320", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda420", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -730,7 +730,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1409 EventRootType Probe[main.testDeepPtr7]
-              InjectionPoints: [{PC: "0xcda340", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda440", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -752,7 +752,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1410 EventRootType Probe[main.testDeepSlice1]
-              InjectionPoints: [{PC: "0xcda4c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda5c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -774,7 +774,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1411 EventRootType Probe[main.testDeepSlice7]
-              InjectionPoints: [{PC: "0xcda4e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda5e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -796,7 +796,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1588 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0xce3e60", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4020", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -823,7 +823,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1591 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0xce3ec0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4080", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -851,7 +851,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1614 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0xce4480", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4a60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -873,7 +873,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1628 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0xce4900", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4ee0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -894,7 +894,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1629 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0xce4920", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4f00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -916,7 +916,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1441 EventRootType Probe[main.testError]
-              InjectionPoints: [{PC: "0xcde7e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcde8e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -950,7 +950,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1407 EventRootType Probe[main.testErrorAtLine]Line
-              InjectionPoints: [{PC: "0xcda1fb", Frameless: false}]
+              InjectionPoints: [{PC: "0xcda2fb", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}, err={err}
@@ -978,11 +978,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1423 EventRootType Probe[main.testEsotericHeap]
-              InjectionPoints: [{PC: "0xcdcb6a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdcc6a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1424 EventRootType Probe[main.testEsotericHeap]Return
-              InjectionPoints: [{PC: "0xcdcbac", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdccac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1004,11 +1004,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1421 EventRootType Probe[main.testEsotericStack]
-              InjectionPoints: [{PC: "0xcdca4e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdcb4e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1422 EventRootType Probe[main.testEsotericStack]Return
-              InjectionPoints: [{PC: "0xcdcadb", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdcbdb", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1030,11 +1030,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1433 EventRootType Probe[main.testFrameless]
-              InjectionPoints: [{PC: "0xcde440", Frameless: true}]
+              InjectionPoints: [{PC: "0xcde540", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1434 EventRootType Probe[main.testFrameless]Return
-              InjectionPoints: [{PC: "0xcde445", Frameless: true}]
+              InjectionPoints: [{PC: "0xcde545", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1056,11 +1056,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1435 EventRootType Probe[main.testFramelessArray]
-              InjectionPoints: [{PC: "0xcde464", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde564", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1436 EventRootType Probe[main.testFramelessArray]Return
-              InjectionPoints: [{PC: "0xcde49d", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde59d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1085,7 +1085,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1437 EventRootType Probe[main.testFramelessArray]Line
-              InjectionPoints: [{PC: "0xcde468", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde568", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1107,11 +1107,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1666 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0xce7420", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7a00", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1667 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce7427", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7a07", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1125,11 +1125,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1668 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0xce7444", Frameless: false}]
+              InjectionPoints: [{PC: "0xce7a24", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1669 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0xce7491", Frameless: false}]
+              InjectionPoints: [{PC: "0xce7a71", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1152,11 +1152,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1662 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0xce738a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce796a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1663 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0xce7399", Frameless: false}]
+              InjectionPoints: [{PC: "0xce7979", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1170,11 +1170,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1664 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0xce73ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xce79aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1665 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0xce73e2", Frameless: false}]
+              InjectionPoints: [{PC: "0xce79c2", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1197,14 +1197,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1670 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0xce74a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7a80", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1671 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0xce74c0"
+                - PC: "0xce7aa0"
                   Frameless: true
-                - PC: "0xce74c3"
+                - PC: "0xce7aa3"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1219,14 +1219,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1672 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0xce74ea", Frameless: false}]
+              InjectionPoints: [{PC: "0xce7aca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1673 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0xce754b"
+                - PC: "0xce7b2b"
                   Frameless: false
-                - PC: "0xce7553"
+                - PC: "0xce7b33"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1253,7 +1253,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1674 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0xce74a5", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7a85", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1265,7 +1265,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1675 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0xce74ff", Frameless: false}]
+              InjectionPoints: [{PC: "0xce7adf", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1286,11 +1286,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1650 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0xce7040", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7620", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1651 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0xce7050", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7630", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1304,11 +1304,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1652 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0xce70e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce76c0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1653 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0xce70e8", Frameless: true}]
+              InjectionPoints: [{PC: "0xce76c8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1332,11 +1332,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1638 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0xce6bce", Frameless: false}]
+              InjectionPoints: [{PC: "0xce71ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1639 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce6cb4", Frameless: false}]
+              InjectionPoints: [{PC: "0xce7294", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1378,11 +1378,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1642 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xce6d0a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce72ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1643 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce6d19", Frameless: false}]
+              InjectionPoints: [{PC: "0xce72f9", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1405,11 +1405,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1676 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0xce75a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7b80", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1677 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0xce75a6", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7b86", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1423,11 +1423,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1678 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0xce762a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce7c0a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1679 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0xce764d", Frameless: false}]
+              InjectionPoints: [{PC: "0xce7c2d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1450,11 +1450,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1634 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0xce6b20", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7100", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1635 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce6b23", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7103", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1468,11 +1468,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1636 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0xce6b40", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7120", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1637 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce6b4b", Frameless: true}]
+              InjectionPoints: [{PC: "0xce712b", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1495,11 +1495,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1654 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0xce71a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7780", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1655 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0xce71a7", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7787", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1513,11 +1513,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1656 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0xce724a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce782a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1657 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0xce7273", Frameless: false}]
+              InjectionPoints: [{PC: "0xce7853", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1540,11 +1540,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1644 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0xce6fe0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce75c0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1645 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce6fe3", Frameless: true}]
+              InjectionPoints: [{PC: "0xce75c3", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1558,11 +1558,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1646 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0xce7000", Frameless: true}]
+              InjectionPoints: [{PC: "0xce75e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1647 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0xce7003", Frameless: true}]
+              InjectionPoints: [{PC: "0xce75e3", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1576,11 +1576,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1648 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0xce7020", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7600", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1649 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0xce7023", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7603", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1603,11 +1603,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1658 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0xce7340", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7920", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1659 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0xce7347", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7927", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1621,11 +1621,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1660 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xce7360", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7940", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1661 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce736e", Frameless: true}]
+              InjectionPoints: [{PC: "0xce794e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1648,11 +1648,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1630 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0xce6ae0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce70c0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1631 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce6ae3", Frameless: true}]
+              InjectionPoints: [{PC: "0xce70c3", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1666,11 +1666,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1632 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0xce6b00", Frameless: true}]
+              InjectionPoints: [{PC: "0xce70e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1633 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce6b0b", Frameless: true}]
+              InjectionPoints: [{PC: "0xce70eb", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1693,11 +1693,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1425 EventRootType Probe[main.testInlinedBA]
-              InjectionPoints: [{PC: "0xcde12a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde22a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1426 EventRootType Probe[main.testInlinedBA]Return
-              InjectionPoints: [{PC: "0xcde18e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde28e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1724,11 +1724,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1427 EventRootType Probe[main.testInlinedBB]
-              InjectionPoints: [{PC: "0xcde1ce", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde2ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1428 EventRootType Probe[main.testInlinedBB]Return
-              InjectionPoints: [{PC: "0xcde25e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde35e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}'
@@ -1755,11 +1755,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1429 EventRootType Probe[main.testInlinedBBA]
-              InjectionPoints: [{PC: "0xcde2aa", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde3aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1430 EventRootType Probe[main.testInlinedBBA]Return
-              InjectionPoints: [{PC: "0xcde2eb", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde3eb", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1781,7 +1781,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1686 EventRootType Probe[main.testInlinedBBB]
-              InjectionPoints: [{PC: "0xcde226", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde326", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBBB
@@ -1799,11 +1799,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1431 EventRootType Probe[main.testInlinedBC]
-              InjectionPoints: [{PC: "0xcde32e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde42e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1432 EventRootType Probe[main.testInlinedBC]Return
-              InjectionPoints: [{PC: "0xcde413", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde513", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBC
@@ -1821,7 +1821,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1687 EventRootType Probe[main.testInlinedBCA]
-              InjectionPoints: [{PC: "0xcde333", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde433", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1842,7 +1842,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1688 EventRootType Probe[main.testInlinedBCA]Line
-              InjectionPoints: [{PC: "0xcde333", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde433", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1860,7 +1860,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1689 EventRootType Probe[main.testInlinedBCB]
-              InjectionPoints: [{PC: "0xcde3db", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde4db", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1881,7 +1881,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1690 EventRootType Probe[main.testInlinedBCB]Line
-              InjectionPoints: [{PC: "0xcde3db", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde4db", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1902,7 +1902,7 @@ Probes:
               InjectionPoints:
                 - PC: "0x52bec1"
                   Frameless: true
-                - PC: "0xcdedb0"
+                - PC: "0xcdefdd"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1923,20 +1923,20 @@ Probes:
             - Kind: Entry
               Type: 1683 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
-                - PC: "0xcddf8a"
+                - PC: "0xcde08a"
                   Frameless: false
-                - PC: "0xcde011"
+                - PC: "0xcde111"
                   Frameless: false
-                - PC: "0xcde152"
+                - PC: "0xcde252"
                   Frameless: false
-                - PC: "0xcde1dc"
+                - PC: "0xcde2dc"
                   Frameless: false
-                - PC: "0xcde2af"
+                - PC: "0xcde3af"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1684 EventRootType Probe[main.testInlinedPrint]Return
-              InjectionPoints: [{PC: "0xcddfca", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde0ca", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1962,15 +1962,15 @@ Probes:
             - Kind: Line
               Type: 1685 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xcddf8e"
+                - PC: "0xcde08e"
                   Frameless: false
-                - PC: "0xcde011"
+                - PC: "0xcde111"
                   Frameless: false
-                - PC: "0xcde152"
+                - PC: "0xcde252"
                   Frameless: false
-                - PC: "0xcde1dc"
+                - PC: "0xcde2dc"
                   Frameless: false
-                - PC: "0xcde2af"
+                - PC: "0xcde3af"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1993,7 +1993,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1691 EventRootType Probe[main.testInlinedSq]
-              InjectionPoints: [{PC: "0xcde441", Frameless: true}]
+              InjectionPoints: [{PC: "0xcde541", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2018,7 +2018,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1692 EventRootType Probe[main.testInlinedSq]Line
-              InjectionPoints: [{PC: "0xcde441", Frameless: true}]
+              InjectionPoints: [{PC: "0xcde541", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2042,9 +2042,9 @@ Probes:
             - Kind: Entry
               Type: 1693 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
-                - PC: "0xcde485"
+                - PC: "0xcde585"
                   Frameless: false
-                - PC: "0xcde525"
+                - PC: "0xcde625"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2067,7 +2067,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1375 EventRootType Probe[main.testInt16Array]
-              InjectionPoints: [{PC: "0xcd98e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd99e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2089,7 +2089,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1376 EventRootType Probe[main.testInt32Array]
-              InjectionPoints: [{PC: "0xcd9900", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9a00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2111,7 +2111,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1377 EventRootType Probe[main.testInt64Array]
-              InjectionPoints: [{PC: "0xcd9920", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9a20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2133,7 +2133,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1374 EventRootType Probe[main.testInt8Array]
-              InjectionPoints: [{PC: "0xcd98c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd99c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2155,7 +2155,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1373 EventRootType Probe[main.testIntArray]
-              InjectionPoints: [{PC: "0xcd98a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd99a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2177,7 +2177,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1438 EventRootType Probe[main.testInterface]
-              InjectionPoints: [{PC: "0xcde740", Frameless: true}]
+              InjectionPoints: [{PC: "0xcde840", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -2198,11 +2198,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1569 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0xce2bee", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2dae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1570 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xce2d53", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2f13", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2224,7 +2224,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1477 EventRootType Probe[main.testLinkedList]
-              InjectionPoints: [{PC: "0xce1020", Frameless: true}]
+              InjectionPoints: [{PC: "0xce11e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -2249,7 +2249,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1416 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0xcda6da", Frameless: false}]
+              InjectionPoints: [{PC: "0xcda7da", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2271,7 +2271,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1417 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0xcda78d", Frameless: false}]
+              InjectionPoints: [{PC: "0xcda88d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2293,7 +2293,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1418 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0xcda854", Frameless: false}]
+              InjectionPoints: [{PC: "0xcda954", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2336,11 +2336,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1575 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0xce30b3", Frameless: false}]
+              InjectionPoints: [{PC: "0xce3273", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1576 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0xce32c2", Frameless: false}]
+              InjectionPoints: [{PC: "0xce3482", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2403,7 +2403,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1419 EventRootType Probe[main.testManyPointers]
-              InjectionPoints: [{PC: "0xcdad40", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdae40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2427,7 +2427,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1420 EventRootType Probe[main.testManyStrings]
-              InjectionPoints: [{PC: "0xcdc720", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc820", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{ss}'
@@ -2449,7 +2449,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1449 EventRootType Probe[main.testMapArrayToArray]
-              InjectionPoints: [{PC: "0xcdef00", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf0c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2471,7 +2471,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1456 EventRootType Probe[main.testMapEmbeddedMaps]
-              InjectionPoints: [{PC: "0xcdefc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf180", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2493,7 +2493,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1466 EventRootType Probe[main.testMapEmptyKey]
-              InjectionPoints: [{PC: "0xcdf100", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf2c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2515,7 +2515,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1468 EventRootType Probe[main.testMapEmptyKeyAndValue]
-              InjectionPoints: [{PC: "0xcdf140", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf300", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2537,7 +2537,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1467 EventRootType Probe[main.testMapEmptyValue]
-              InjectionPoints: [{PC: "0xcdf120", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf2e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2559,7 +2559,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1453 EventRootType Probe[main.testMapIntToInt]
-              InjectionPoints: [{PC: "0xcdef80", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf140", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2581,7 +2581,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1465 EventRootType Probe[main.testMapLargeKeyLargeValue]
-              InjectionPoints: [{PC: "0xcdf0e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf2a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2603,7 +2603,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1464 EventRootType Probe[main.testMapLargeKeySmallValue]
-              InjectionPoints: [{PC: "0xcdf0c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf280", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2627,7 +2627,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1454 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0xcdefa0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf160", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2651,7 +2651,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1455 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0xcdefa0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf160", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2673,7 +2673,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1463 EventRootType Probe[main.testMapSmallKeyLargeValue]
-              InjectionPoints: [{PC: "0xcdf0a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf260", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2695,7 +2695,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1462 EventRootType Probe[main.testMapSmallKeySmallValue]
-              InjectionPoints: [{PC: "0xcdf080", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf240", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2717,7 +2717,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1447 EventRootType Probe[main.testMapStringToInt]
-              InjectionPoints: [{PC: "0xcdeec0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf080", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2739,7 +2739,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1448 EventRootType Probe[main.testMapStringToSlice]
-              InjectionPoints: [{PC: "0xcdeee0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf0a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2761,7 +2761,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1446 EventRootType Probe[main.testMapStringToStruct]
-              InjectionPoints: [{PC: "0xcdeea0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf060", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2783,7 +2783,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1457 EventRootType Probe[main.testMapWithLinkedList]
-              InjectionPoints: [{PC: "0xcdefe0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf1a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2805,7 +2805,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1460 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-              InjectionPoints: [{PC: "0xcdf040", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf200", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2827,7 +2827,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1461 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-              InjectionPoints: [{PC: "0xcdf060", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf220", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2849,7 +2849,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1458 EventRootType Probe[main.testMapWithSmallValue]
-              InjectionPoints: [{PC: "0xcdf000", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf1c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2873,7 +2873,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1459 EventRootType Probe[main.testMapWithSmallValueMassive]
-              InjectionPoints: [{PC: "0xcdf020", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf1e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2895,7 +2895,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1611 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xce4440", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4a20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2918,7 +2918,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1612 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xce4440", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4a20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2965,11 +2965,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1577 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0xce3353", Frameless: false}]
+              InjectionPoints: [{PC: "0xce3513", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1578 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0xce358b", Frameless: false}]
+              InjectionPoints: [{PC: "0xce374b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -3035,11 +3035,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1581 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0xce36ce", Frameless: false}]
+              InjectionPoints: [{PC: "0xce388e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1582 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0xce379f", Frameless: false}]
+              InjectionPoints: [{PC: "0xce395f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3070,11 +3070,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1573 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0xce2e6e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce302e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1574 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0xce308a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce324a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3100,11 +3100,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1514 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xce1e0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1fce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1515 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xce1eaf", Frameless: false}]
+              InjectionPoints: [{PC: "0xce206f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3140,7 +3140,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1472 EventRootType Probe[main.testMultipleSimpleParams]
-              InjectionPoints: [{PC: "0xce0c00", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0dc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -3181,11 +3181,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1508 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xce1d6a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1f2a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1509 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xce1dd5", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1f95", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3209,11 +3209,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1510 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xce1d6a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1f2a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1511 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xce1dd5", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1f95", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
       version: 0
@@ -3232,11 +3232,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1516 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xce1e0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1fce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1517 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xce1eaf", Frameless: false}]
+              InjectionPoints: [{PC: "0xce206f", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
       version: 0
@@ -3256,11 +3256,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1518 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xce1e0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1fce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1519 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xce1eaf", Frameless: false}]
+              InjectionPoints: [{PC: "0xce206f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r1={result} r2={result2}
@@ -3293,11 +3293,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1512 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xce1d6a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1f2a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1513 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xce1dd5", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1f95", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Parameter {i} * 2 = result {result}
@@ -3325,7 +3325,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1623 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xce4880", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4e60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3350,7 +3350,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1624 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xce4880", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4e60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3381,7 +3381,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1625 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xce4880", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4e60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3406,7 +3406,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1626 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xce4880", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4e60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3433,7 +3433,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1482 EventRootType Probe[main.testNilPointer]
-              InjectionPoints: [{PC: "0xce11c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1380", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}, {a}'
@@ -3460,7 +3460,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1595 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0xce3f40", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4100", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3487,7 +3487,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1592 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0xce3ee0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce40a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3522,7 +3522,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1594 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0xce3f20", Frameless: true}]
+              InjectionPoints: [{PC: "0xce40e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3554,7 +3554,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1610 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0xce4420", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4a00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3576,7 +3576,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1478 EventRootType Probe[main.testPointerLoop]
-              InjectionPoints: [{PC: "0xce1040", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1200", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3598,7 +3598,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1452 EventRootType Probe[main.testPointerToMap]
-              InjectionPoints: [{PC: "0xcdef60", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf120", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3620,7 +3620,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1476 EventRootType Probe[main.testPointerToSimpleStruct]
-              InjectionPoints: [{PC: "0xce1000", Frameless: true}]
+              InjectionPoints: [{PC: "0xce11c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3644,11 +3644,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1484 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xce164a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce180a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1485 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xce169b", Frameless: false}]
+              InjectionPoints: [{PC: "0xce185b", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
       version: 0
@@ -3668,11 +3668,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1528 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xce1eee", Frameless: false}]
+              InjectionPoints: [{PC: "0xce20ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1529 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xce1f8d", Frameless: false}]
+              InjectionPoints: [{PC: "0xce214d", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3715,11 +3715,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1494 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xce176e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce192e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1495 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xce1824", Frameless: false}]
+              InjectionPoints: [{PC: "0xce19e4", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3759,11 +3759,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1486 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xce164a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce180a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1487 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xce169b", Frameless: false}]
+              InjectionPoints: [{PC: "0xce185b", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3806,11 +3806,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1496 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xce176e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce192e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1497 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xce1824", Frameless: false}]
+              InjectionPoints: [{PC: "0xce19e4", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3852,11 +3852,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1530 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xce1eee", Frameless: false}]
+              InjectionPoints: [{PC: "0xce20ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1531 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xce1f8d", Frameless: false}]
+              InjectionPoints: [{PC: "0xce214d", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
       version: 0
@@ -3873,11 +3873,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1532 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xce1eee", Frameless: false}]
+              InjectionPoints: [{PC: "0xce20ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1533 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xce1f8d", Frameless: false}]
+              InjectionPoints: [{PC: "0xce214d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r0={@return.r0}
@@ -3899,11 +3899,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1488 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xce164a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce180a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1489 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xce169b", Frameless: false}]
+              InjectionPoints: [{PC: "0xce185b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: result={@return}
@@ -3926,18 +3926,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1504 EventRootType Probe[main.testReturnsAny]
-              InjectionPoints: [{PC: "0xce1a0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1bce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1505 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
-                - PC: "0xce1ab5"
+                - PC: "0xce1c75"
                   Frameless: false
-                - PC: "0xce1b04"
+                - PC: "0xce1cc4"
                   Frameless: false
-                - PC: "0xce1bc0"
+                - PC: "0xce1d80"
                   Frameless: false
-                - PC: "0xce1bca"
+                - PC: "0xce1d8a"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3965,18 +3965,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1502 EventRootType Probe[main.testReturnsAnyAndError]
-              InjectionPoints: [{PC: "0xce18ae", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1a6e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1503 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
-                - PC: "0xce1904"
+                - PC: "0xce1ac4"
                   Frameless: false
-                - PC: "0xce1953"
+                - PC: "0xce1b13"
                   Frameless: false
-                - PC: "0xce1987"
+                - PC: "0xce1b47"
                   Frameless: false
-                - PC: "0xce19b9"
+                - PC: "0xce1b79"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4003,11 +4003,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1547 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0xce268a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce284a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1548 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0xce26ed", Frameless: false}]
+              InjectionPoints: [{PC: "0xce28ad", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -4024,11 +4024,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1549 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0xce270a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce28ca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1550 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0xce274b", Frameless: false}]
+              InjectionPoints: [{PC: "0xce290b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -4045,11 +4045,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1551 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0xce276a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce292a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1552 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0xce27a6", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2966", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4066,11 +4066,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1555 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0xce284e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2a0e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1556 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0xce28ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2a8a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4087,11 +4087,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1567 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0xce2b8a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2d4a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1568 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0xce2bd0", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2d90", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4108,11 +4108,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1543 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0xce254a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce270a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1544 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0xce25a6", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2766", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4130,14 +4130,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1500 EventRootType Probe[main.testReturnsError]
-              InjectionPoints: [{PC: "0xce184a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1a0a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1501 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
-                - PC: "0xce187a"
+                - PC: "0xce1a3a"
                   Frameless: false
-                - PC: "0xce1885"
+                - PC: "0xce1a45"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4159,11 +4159,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1490 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xce164a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce180a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1491 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xce169b", Frameless: false}]
+              InjectionPoints: [{PC: "0xce185b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4184,11 +4184,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1498 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xce176e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce192e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1499 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xce1824", Frameless: false}]
+              InjectionPoints: [{PC: "0xce19e4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4209,11 +4209,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1492 EventRootType Probe[main.testReturnsIntPointer]
-              InjectionPoints: [{PC: "0xce16ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xce188a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1493 EventRootType Probe[main.testReturnsIntPointer]Return
-              InjectionPoints: [{PC: "0xce1734", Frameless: false}]
+              InjectionPoints: [{PC: "0xce18f4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4235,14 +4235,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1506 EventRootType Probe[main.testReturnsInterface]
-              InjectionPoints: [{PC: "0xce1c0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1dce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1507 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
-                - PC: "0xce1cdf"
+                - PC: "0xce1e9f"
                   Frameless: false
-                - PC: "0xce1ce9"
+                - PC: "0xce1ea9"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4264,11 +4264,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1545 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0xce25ce", Frameless: false}]
+              InjectionPoints: [{PC: "0xce278e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1546 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0xce2653", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2813", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4285,11 +4285,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1541 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0xce244e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce260e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1542 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0xce2527", Frameless: false}]
+              InjectionPoints: [{PC: "0xce26e7", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4306,11 +4306,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1559 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0xce29aa", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2b6a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1560 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0xce2a0c", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2bcc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4327,11 +4327,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1553 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0xce27ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xce298a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1554 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0xce2818", Frameless: false}]
+              InjectionPoints: [{PC: "0xce29d8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4348,11 +4348,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1565 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0xce2b0a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2cca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1566 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0xce2b56", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2d16", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
@@ -4372,7 +4372,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1538 EventRootType Probe[main.testReturnsNamedDeferLine]Line
-              InjectionPoints: [{PC: "0xce21cf", Frameless: false}]
+              InjectionPoints: [{PC: "0xce238f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4393,11 +4393,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1563 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0xce2aaa", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2c6a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1564 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0xce2aee", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2cae", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4414,11 +4414,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1539 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0xce23ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xce258a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1540 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0xce2431", Frameless: false}]
+              InjectionPoints: [{PC: "0xce25f1", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4435,11 +4435,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1561 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0xce2a2a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2bea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1562 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0xce2a8d", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2c4d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4456,11 +4456,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1557 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0xce28ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2aae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1558 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0xce2974", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2b34", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4478,7 +4478,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1370 EventRootType Probe[main.testRuneArray]
-              InjectionPoints: [{PC: "0xcd9840", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9940", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4513,11 +4513,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1520 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xce1e0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1fce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1521 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xce1eaf", Frameless: false}]
+              InjectionPoints: [{PC: "0xce206f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -4563,7 +4563,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1391 EventRootType Probe[main.testSingleBool]
-              InjectionPoints: [{PC: "0xcd9e60", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9f60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4585,7 +4585,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1389 EventRootType Probe[main.testSingleByte]
-              InjectionPoints: [{PC: "0xcd9e20", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9f20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4607,7 +4607,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1402 EventRootType Probe[main.testSingleFloat32]
-              InjectionPoints: [{PC: "0xcd9fc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda0c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4625,7 +4625,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1403 EventRootType Probe[main.testSingleFloat64]
-              InjectionPoints: [{PC: "0xcd9fe0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda0e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4643,7 +4643,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1392 EventRootType Probe[main.testSingleInt]
-              InjectionPoints: [{PC: "0xcd9e80", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9f80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4665,7 +4665,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1394 EventRootType Probe[main.testSingleInt16]
-              InjectionPoints: [{PC: "0xcd9ec0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9fc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}
@@ -4688,7 +4688,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1395 EventRootType Probe[main.testSingleInt32]
-              InjectionPoints: [{PC: "0xcd9ee0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9fe0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4710,7 +4710,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1396 EventRootType Probe[main.testSingleInt64]
-              InjectionPoints: [{PC: "0xcd9f00", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda000", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4739,7 +4739,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1393 EventRootType Probe[main.testSingleInt8]
-              InjectionPoints: [{PC: "0xcd9ea0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9fa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}{x}{x}
@@ -4770,7 +4770,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1390 EventRootType Probe[main.testSingleRune]
-              InjectionPoints: [{PC: "0xcd9e40", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9f40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4792,7 +4792,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1602 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0xce43a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4980", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4814,7 +4814,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1397 EventRootType Probe[main.testSingleUint]
-              InjectionPoints: [{PC: "0xcd9f20", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda020", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4836,7 +4836,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1399 EventRootType Probe[main.testSingleUint16]
-              InjectionPoints: [{PC: "0xcd9f60", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda060", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4858,7 +4858,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1400 EventRootType Probe[main.testSingleUint32]
-              InjectionPoints: [{PC: "0xcd9f80", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda080", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4880,7 +4880,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1401 EventRootType Probe[main.testSingleUint64]
-              InjectionPoints: [{PC: "0xcd9fa0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda0a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4902,7 +4902,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1398 EventRootType Probe[main.testSingleUint8]
-              InjectionPoints: [{PC: "0xcd9f40", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda040", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4924,7 +4924,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1598 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0xce3f80", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4140", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -4946,7 +4946,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1589 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0xce3e80", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4040", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -4968,7 +4968,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1450 EventRootType Probe[main.testSmallMap]
-              InjectionPoints: [{PC: "0xcdef20", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf0e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -4989,11 +4989,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1534 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xce1eee", Frameless: false}]
+              InjectionPoints: [{PC: "0xce20ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1535 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xce1f8d", Frameless: false}]
+              InjectionPoints: [{PC: "0xce214d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -5014,11 +5014,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1579 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0xce362a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce37ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1580 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0xce369c", Frameless: false}]
+              InjectionPoints: [{PC: "0xce385c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5040,7 +5040,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1371 EventRootType Probe[main.testStringArray]
-              InjectionPoints: [{PC: "0xcd9860", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9960", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5062,7 +5062,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1481 EventRootType Probe[main.testStringPointer]
-              InjectionPoints: [{PC: "0xce1180", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1340", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}'
@@ -5084,7 +5084,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1593 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0xce3f00", Frameless: true}]
+              InjectionPoints: [{PC: "0xce40c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5106,7 +5106,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1414 EventRootType Probe[main.testStringType1]
-              InjectionPoints: [{PC: "0xcda680", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda780", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5128,7 +5128,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1415 EventRootType Probe[main.testStringType2]
-              InjectionPoints: [{PC: "0xcda6a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda7a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5150,11 +5150,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1621 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xce4780", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4d60", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1622 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0xce47a2", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4d82", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5181,7 +5181,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1590 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0xce3ea0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4060", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5208,7 +5208,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1444 EventRootType Probe[main.testStructWithAny]
-              InjectionPoints: [{PC: "0xcde860", Frameless: true}]
+              InjectionPoints: [{PC: "0xcde960", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5229,11 +5229,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1583 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0xce37ce", Frameless: false}]
+              InjectionPoints: [{PC: "0xce398e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1584 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0xce387c", Frameless: false}]
+              InjectionPoints: [{PC: "0xce3a3c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5255,11 +5255,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1617 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0xce4640", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4c20", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1618 EventRootType Probe[main.testStructWithCyclicMaps]Return
-              InjectionPoints: [{PC: "0xce465e", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4c3e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5280,7 +5280,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1616 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0xce4620", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4c00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5307,7 +5307,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1445 EventRootType Probe[main.testStructWithMap]
-              InjectionPoints: [{PC: "0xcdee80", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf040", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s} {@duration}'
@@ -5340,7 +5340,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1599 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0xce3fa0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4160", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5380,7 +5380,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1615 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0xce44a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4a80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5413,11 +5413,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1522 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xce1e0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1fce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1523 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xce1eaf", Frameless: false}]
+              InjectionPoints: [{PC: "0xce206f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{nonexistentVariable}'
@@ -5438,11 +5438,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1524 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xce1e0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1fce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1525 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xce1eaf", Frameless: false}]
+              InjectionPoints: [{PC: "0xce206f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{unsupportedExpression}'
@@ -5465,11 +5465,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1526 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xce1e0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1fce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1527 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xce1eaf", Frameless: false}]
+              InjectionPoints: [{PC: "0xce206f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -5501,7 +5501,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1603 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0xce43c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce49a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5533,11 +5533,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1604 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xce43e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce49c0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1605 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0xce43fe", Frameless: true}]
+              InjectionPoints: [{PC: "0xce49de", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5567,11 +5567,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1606 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xce43e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce49c0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1607 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0xce43fe", Frameless: true}]
+              InjectionPoints: [{PC: "0xce49de", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5603,7 +5603,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1608 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xce4400", Frameless: true}]
+              InjectionPoints: [{PC: "0xce49e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5633,7 +5633,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1609 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xce4400", Frameless: true}]
+              InjectionPoints: [{PC: "0xce49e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5665,7 +5665,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1404 EventRootType Probe[main.testTypeAlias]
-              InjectionPoints: [{PC: "0xcda000", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda100", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5687,7 +5687,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1380 EventRootType Probe[main.testUint16Array]
-              InjectionPoints: [{PC: "0xcd9980", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9a80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5709,7 +5709,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1381 EventRootType Probe[main.testUint32Array]
-              InjectionPoints: [{PC: "0xcd99a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9aa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5731,7 +5731,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1382 EventRootType Probe[main.testUint64Array]
-              InjectionPoints: [{PC: "0xcd99c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9ac0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5753,7 +5753,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1379 EventRootType Probe[main.testUint8Array]
-              InjectionPoints: [{PC: "0xcd9960", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9a60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5775,7 +5775,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1378 EventRootType Probe[main.testUintArray]
-              InjectionPoints: [{PC: "0xcd9940", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9a40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5797,7 +5797,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1480 EventRootType Probe[main.testUintPointer]
-              InjectionPoints: [{PC: "0xce10a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1260", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5819,7 +5819,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1587 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0xce3e40", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4000", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5841,7 +5841,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1613 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0xce4460", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4a40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5863,7 +5863,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1479 EventRootType Probe[main.testUnsafePointer]
-              InjectionPoints: [{PC: "0xce1060", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1220", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5885,7 +5885,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1388 EventRootType Probe[main.testVeryLargeArray]
-              InjectionPoints: [{PC: "0xcd9aa0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9ba0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5907,7 +5907,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1596 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xce3f60", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4120", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5929,7 +5929,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1597 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xce3f60", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4120", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5952,14 +5952,14 @@ Probes:
             - Kind: Entry
               Type: 1694 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
-                - PC: "0xcde66a"
+                - PC: "0xcde76a"
                   Frameless: false
-                - PC: "0xce7743"
+                - PC: "0xce7d23"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1695 EventRootType Probe[main.firstBehavior.DoSomething]Return
-              InjectionPoints: [{PC: "0xcde6a5", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde7a5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testWhollyInlinedSubroutine
@@ -5981,11 +5981,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1585 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0xce38ae", Frameless: false}]
+              InjectionPoints: [{PC: "0xce3a6e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1586 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xce392c", Frameless: false}]
+              InjectionPoints: [{PC: "0xce3aec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -6002,481 +6002,481 @@ Probes:
 Subprograms:
     - ID: 1
       Name: main.testByteArray
-      OutOfLinePCRanges: [0xcd9820..0xcd9821]
+      OutOfLinePCRanges: [0xcd9920..0xcd9921]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 110 ArrayType [2]uint8
           Locations:
-            - Range: 0xcd9820..0xcd9821
+            - Range: 0xcd9920..0xcd9921
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 2
       Name: main.testRuneArray
-      OutOfLinePCRanges: [0xcd9840..0xcd9841]
+      OutOfLinePCRanges: [0xcd9940..0xcd9941]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 111 ArrayType [2]int32
           Locations:
-            - Range: 0xcd9840..0xcd9841
+            - Range: 0xcd9940..0xcd9941
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 3
       Name: main.testStringArray
-      OutOfLinePCRanges: [0xcd9860..0xcd9861]
+      OutOfLinePCRanges: [0xcd9960..0xcd9961]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 112 ArrayType [2]string
           Locations:
-            - Range: 0xcd9860..0xcd9861
+            - Range: 0xcd9960..0xcd9961
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 4
       Name: main.testBoolArray
-      OutOfLinePCRanges: [0xcd9880..0xcd9881]
+      OutOfLinePCRanges: [0xcd9980..0xcd9981]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 113 ArrayType [2]bool
           Locations:
-            - Range: 0xcd9880..0xcd9881
+            - Range: 0xcd9980..0xcd9981
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 5
       Name: main.testIntArray
-      OutOfLinePCRanges: [0xcd98a0..0xcd98a1]
+      OutOfLinePCRanges: [0xcd99a0..0xcd99a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 114 ArrayType [2]int
           Locations:
-            - Range: 0xcd98a0..0xcd98a1
+            - Range: 0xcd99a0..0xcd99a1
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 6
       Name: main.testInt8Array
-      OutOfLinePCRanges: [0xcd98c0..0xcd98c1]
+      OutOfLinePCRanges: [0xcd99c0..0xcd99c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 115 ArrayType [2]int8
           Locations:
-            - Range: 0xcd98c0..0xcd98c1
+            - Range: 0xcd99c0..0xcd99c1
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 7
       Name: main.testInt16Array
-      OutOfLinePCRanges: [0xcd98e0..0xcd98e1]
+      OutOfLinePCRanges: [0xcd99e0..0xcd99e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 116 ArrayType [2]int16
           Locations:
-            - Range: 0xcd98e0..0xcd98e1
+            - Range: 0xcd99e0..0xcd99e1
               Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 8
       Name: main.testInt32Array
-      OutOfLinePCRanges: [0xcd9900..0xcd9901]
+      OutOfLinePCRanges: [0xcd9a00..0xcd9a01]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 111 ArrayType [2]int32
           Locations:
-            - Range: 0xcd9900..0xcd9901
+            - Range: 0xcd9a00..0xcd9a01
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 9
       Name: main.testInt64Array
-      OutOfLinePCRanges: [0xcd9920..0xcd9921]
+      OutOfLinePCRanges: [0xcd9a20..0xcd9a21]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 117 ArrayType [2]int64
           Locations:
-            - Range: 0xcd9920..0xcd9921
+            - Range: 0xcd9a20..0xcd9a21
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 10
       Name: main.testUintArray
-      OutOfLinePCRanges: [0xcd9940..0xcd9941]
+      OutOfLinePCRanges: [0xcd9a40..0xcd9a41]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 118 ArrayType [2]uint
           Locations:
-            - Range: 0xcd9940..0xcd9941
+            - Range: 0xcd9a40..0xcd9a41
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 11
       Name: main.testUint8Array
-      OutOfLinePCRanges: [0xcd9960..0xcd9961]
+      OutOfLinePCRanges: [0xcd9a60..0xcd9a61]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 110 ArrayType [2]uint8
           Locations:
-            - Range: 0xcd9960..0xcd9961
+            - Range: 0xcd9a60..0xcd9a61
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 12
       Name: main.testUint16Array
-      OutOfLinePCRanges: [0xcd9980..0xcd9981]
+      OutOfLinePCRanges: [0xcd9a80..0xcd9a81]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 119 ArrayType [2]uint16
           Locations:
-            - Range: 0xcd9980..0xcd9981
+            - Range: 0xcd9a80..0xcd9a81
               Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 13
       Name: main.testUint32Array
-      OutOfLinePCRanges: [0xcd99a0..0xcd99a1]
+      OutOfLinePCRanges: [0xcd9aa0..0xcd9aa1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 120 ArrayType [2]uint32
           Locations:
-            - Range: 0xcd99a0..0xcd99a1
+            - Range: 0xcd9aa0..0xcd9aa1
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 14
       Name: main.testUint64Array
-      OutOfLinePCRanges: [0xcd99c0..0xcd99c1]
+      OutOfLinePCRanges: [0xcd9ac0..0xcd9ac1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 55 ArrayType [2]uint64
           Locations:
-            - Range: 0xcd99c0..0xcd99c1
+            - Range: 0xcd9ac0..0xcd9ac1
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 15
       Name: main.testArrayOfArrays
-      OutOfLinePCRanges: [0xcd99e0..0xcd99e1]
+      OutOfLinePCRanges: [0xcd9ae0..0xcd9ae1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 121 ArrayType [2][2]int
           Locations:
-            - Range: 0xcd99e0..0xcd99e1
+            - Range: 0xcd9ae0..0xcd9ae1
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 16
       Name: main.testArrayOfStrings
-      OutOfLinePCRanges: [0xcd9a00..0xcd9a01]
+      OutOfLinePCRanges: [0xcd9b00..0xcd9b01]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 112 ArrayType [2]string
           Locations:
-            - Range: 0xcd9a00..0xcd9a01
+            - Range: 0xcd9b00..0xcd9b01
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 17
       Name: main.testArrayOfArraysOfArrays
-      OutOfLinePCRanges: [0xcd9a20..0xcd9a21]
+      OutOfLinePCRanges: [0xcd9b20..0xcd9b21]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 122 ArrayType [2][2][2]int
           Locations:
-            - Range: 0xcd9a20..0xcd9a21
+            - Range: 0xcd9b20..0xcd9b21
               Pieces: [{Size: 64, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 18
       Name: main.testArrayOfStructs
-      OutOfLinePCRanges: [0xcd9a40..0xcd9a41]
+      OutOfLinePCRanges: [0xcd9b40..0xcd9b41]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 123 ArrayType [2]main.nestedStruct
           Locations:
-            - Range: 0xcd9a40..0xcd9a41
+            - Range: 0xcd9b40..0xcd9b41
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 19
       Name: main.testArrayEmptyStructs
-      OutOfLinePCRanges: [0xcd9a60..0xcd9a61]
+      OutOfLinePCRanges: [0xcd9b60..0xcd9b61]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 125 ArrayType [2]struct {}
           Locations:
-            - Range: 0xcd9a60..0xcd9a61
+            - Range: 0xcd9b60..0xcd9b61
               Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 20
       Name: main.testVeryLargeArray
-      OutOfLinePCRanges: [0xcd9aa0..0xcd9aa1]
+      OutOfLinePCRanges: [0xcd9ba0..0xcd9ba1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 127 ArrayType [100]uint
           Locations:
-            - Range: 0xcd9aa0..0xcd9aa1
+            - Range: 0xcd9ba0..0xcd9ba1
               Pieces: [{Size: 800, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 21
       Name: main.testSingleByte
-      OutOfLinePCRanges: [0xcd9e20..0xcd9e21]
+      OutOfLinePCRanges: [0xcd9f20..0xcd9f21]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xcd9e20..0xcd9e21
+            - Range: 0xcd9f20..0xcd9f21
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 22
       Name: main.testSingleRune
-      OutOfLinePCRanges: [0xcd9e40..0xcd9e41]
+      OutOfLinePCRanges: [0xcd9f40..0xcd9f41]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 BaseType int32
           Locations:
-            - Range: 0xcd9e40..0xcd9e41
+            - Range: 0xcd9f40..0xcd9f41
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 23
       Name: main.testSingleBool
-      OutOfLinePCRanges: [0xcd9e60..0xcd9e61]
+      OutOfLinePCRanges: [0xcd9f60..0xcd9f61]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xcd9e60..0xcd9e61
+            - Range: 0xcd9f60..0xcd9f61
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 24
       Name: main.testSingleInt
-      OutOfLinePCRanges: [0xcd9e80..0xcd9e81]
+      OutOfLinePCRanges: [0xcd9f80..0xcd9f81]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcd9e80..0xcd9e81
+            - Range: 0xcd9f80..0xcd9f81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 25
       Name: main.testSingleInt8
-      OutOfLinePCRanges: [0xcd9ea0..0xcd9ea1]
+      OutOfLinePCRanges: [0xcd9fa0..0xcd9fa1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType int8
           Locations:
-            - Range: 0xcd9ea0..0xcd9ea1
+            - Range: 0xcd9fa0..0xcd9fa1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 26
       Name: main.testSingleInt16
-      OutOfLinePCRanges: [0xcd9ec0..0xcd9ec1]
+      OutOfLinePCRanges: [0xcd9fc0..0xcd9fc1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 105 BaseType int16
           Locations:
-            - Range: 0xcd9ec0..0xcd9ec1
+            - Range: 0xcd9fc0..0xcd9fc1
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 27
       Name: main.testSingleInt32
-      OutOfLinePCRanges: [0xcd9ee0..0xcd9ee1]
+      OutOfLinePCRanges: [0xcd9fe0..0xcd9fe1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 BaseType int32
           Locations:
-            - Range: 0xcd9ee0..0xcd9ee1
+            - Range: 0xcd9fe0..0xcd9fe1
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 28
       Name: main.testSingleInt64
-      OutOfLinePCRanges: [0xcd9f00..0xcd9f01]
+      OutOfLinePCRanges: [0xcda000..0xcda001]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType int64
           Locations:
-            - Range: 0xcd9f00..0xcd9f01
+            - Range: 0xcda000..0xcda001
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 29
       Name: main.testSingleUint
-      OutOfLinePCRanges: [0xcd9f20..0xcd9f21]
+      OutOfLinePCRanges: [0xcda020..0xcda021]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 18 BaseType uint
           Locations:
-            - Range: 0xcd9f20..0xcd9f21
+            - Range: 0xcda020..0xcda021
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 30
       Name: main.testSingleUint8
-      OutOfLinePCRanges: [0xcd9f40..0xcd9f41]
+      OutOfLinePCRanges: [0xcda040..0xcda041]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xcd9f40..0xcd9f41
+            - Range: 0xcda040..0xcda041
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 31
       Name: main.testSingleUint16
-      OutOfLinePCRanges: [0xcd9f60..0xcd9f61]
+      OutOfLinePCRanges: [0xcda060..0xcda061]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType uint16
           Locations:
-            - Range: 0xcd9f60..0xcd9f61
+            - Range: 0xcda060..0xcda061
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 32
       Name: main.testSingleUint32
-      OutOfLinePCRanges: [0xcd9f80..0xcd9f81]
+      OutOfLinePCRanges: [0xcda080..0xcda081]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint32
           Locations:
-            - Range: 0xcd9f80..0xcd9f81
+            - Range: 0xcda080..0xcda081
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 33
       Name: main.testSingleUint64
-      OutOfLinePCRanges: [0xcd9fa0..0xcd9fa1]
+      OutOfLinePCRanges: [0xcda0a0..0xcda0a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0xcd9fa0..0xcd9fa1
+            - Range: 0xcda0a0..0xcda0a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 34
       Name: main.testSingleFloat32
-      OutOfLinePCRanges: [0xcd9fc0..0xcd9fc1]
+      OutOfLinePCRanges: [0xcda0c0..0xcda0c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 19 BaseType float32
           Locations:
-            - Range: 0xcd9fc0..0xcd9fc1
+            - Range: 0xcda0c0..0xcda0c1
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 35
       Name: main.testSingleFloat64
-      OutOfLinePCRanges: [0xcd9fe0..0xcd9fe1]
+      OutOfLinePCRanges: [0xcda0e0..0xcda0e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 BaseType float64
           Locations:
-            - Range: 0xcd9fe0..0xcd9fe1
+            - Range: 0xcda0e0..0xcda0e1
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 36
       Name: main.testTypeAlias
-      OutOfLinePCRanges: [0xcda000..0xcda001]
+      OutOfLinePCRanges: [0xcda100..0xcda101]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 128 BaseType main.typeAlias
           Locations:
-            - Range: 0xcda000..0xcda001
+            - Range: 0xcda100..0xcda101
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 37
       Name: main.testBigStruct
-      OutOfLinePCRanges: [0xcda160..0xcda17f]
+      OutOfLinePCRanges: [0xcda260..0xcda27f]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 129 StructureType main.bigStruct
           Locations:
-            - Range: 0xcda160..0xcda17f
+            - Range: 0xcda260..0xcda27f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6495,87 +6495,87 @@ Subprograms:
       DictRegister: null
     - ID: 38
       Name: main.testErrorAtLine
-      OutOfLinePCRanges: [0xcda1c0..0xcda2ba]
+      OutOfLinePCRanges: [0xcda2c0..0xcda3ba]
       InlinePCRanges: []
       Variables:
         - Name: shouldErr
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xcda1c0..0xcda1d8
+            - Range: 0xcda2c0..0xcda2d8
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
-          Locations: [{Range: 0xcda1c0..0xcda2ba, Pieces: []}]
+          Locations: [{Range: 0xcda2c0..0xcda3ba, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 8 BaseType int
-          Locations: [{Range: 0xcda1c0..0xcda2ba, Pieces: []}]
+          Locations: [{Range: 0xcda2c0..0xcda3ba, Pieces: []}]
           Role: Local
           DictIndex: -1
         - Name: err
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0xcda1e9..0xcda205
+            - Range: 0xcda2e9..0xcda305
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
-            - Range: 0xcda205..0xcda272
+            - Range: 0xcda305..0xcda372
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcda272..0xcda277
+            - Range: 0xcda372..0xcda377
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcda277..0xcda2ba
+            - Range: 0xcda377..0xcda3ba
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}, {Size: 8, Op: null}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 39
       Name: main.testDeepPtr1
-      OutOfLinePCRanges: [0xcda320..0xcda321]
+      OutOfLinePCRanges: [0xcda420..0xcda421]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 133 StructureType main.deepPtr1
           Locations:
-            - Range: 0xcda320..0xcda321
+            - Range: 0xcda420..0xcda421
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 40
       Name: main.testDeepPtr7
-      OutOfLinePCRanges: [0xcda340..0xcda341]
+      OutOfLinePCRanges: [0xcda440..0xcda441]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 136 PointerType *main.deepPtr7
           Locations:
-            - Range: 0xcda340..0xcda341
+            - Range: 0xcda440..0xcda441
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 41
       Name: main.testDeepSlice1
-      OutOfLinePCRanges: [0xcda4c0..0xcda4c1]
+      OutOfLinePCRanges: [0xcda5c0..0xcda5c1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 138 StructureType main.deepSlice1
           Locations:
-            - Range: 0xcda4c0..0xcda4c1
+            - Range: 0xcda5c0..0xcda5c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6588,142 +6588,142 @@ Subprograms:
       DictRegister: null
     - ID: 42
       Name: main.testDeepSlice7
-      OutOfLinePCRanges: [0xcda4e0..0xcda4e1]
+      OutOfLinePCRanges: [0xcda5e0..0xcda5e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 142 PointerType *main.deepSlice7
           Locations:
-            - Range: 0xcda4e0..0xcda4e1
+            - Range: 0xcda5e0..0xcda5e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 43
       Name: main.testDeepMap1
-      OutOfLinePCRanges: [0xcda640..0xcda641]
+      OutOfLinePCRanges: [0xcda740..0xcda741]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 144 StructureType main.deepMap1
           Locations:
-            - Range: 0xcda640..0xcda641
+            - Range: 0xcda740..0xcda741
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 44
       Name: main.testDeepMap7
-      OutOfLinePCRanges: [0xcda660..0xcda661]
+      OutOfLinePCRanges: [0xcda760..0xcda761]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 150 PointerType *main.deepMap7
           Locations:
-            - Range: 0xcda660..0xcda661
+            - Range: 0xcda760..0xcda761
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 45
       Name: main.testStringType1
-      OutOfLinePCRanges: [0xcda680..0xcda681]
+      OutOfLinePCRanges: [0xcda780..0xcda781]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 152 PointerType *main.stringType1
           Locations:
-            - Range: 0xcda680..0xcda681
+            - Range: 0xcda780..0xcda781
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 46
       Name: main.testStringType2
-      OutOfLinePCRanges: [0xcda6a0..0xcda6a1]
+      OutOfLinePCRanges: [0xcda7a0..0xcda7a1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 154 PointerType **main.stringType2
           Locations:
-            - Range: 0xcda6a0..0xcda6a1
+            - Range: 0xcda7a0..0xcda7a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 47
       Name: main.testLongFunctionWithChangingState
-      OutOfLinePCRanges: [0xcda6c0..0xcda90a]
+      OutOfLinePCRanges: [0xcda7c0..0xcdaa0a]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcda7a4..0xcda7c5
+            - Range: 0xcda8a4..0xcda8c5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcda878..0xcda88f
+            - Range: 0xcda978..0xcda98f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: aPerArch
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcda78d..0xcda790
+            - Range: 0xcda88d..0xcda890
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcda790..0xcda7c5
+            - Range: 0xcda890..0xcda8c5
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcda7c5..0xcda86b
+            - Range: 0xcda8c5..0xcda96b
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0xcda86b..0xcda878
+            - Range: 0xcda96b..0xcda978
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0xcda878..0xcda90a
+            - Range: 0xcda978..0xcdaa0a
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
           Role: Local
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcda787..0xcda790
+            - Range: 0xcda887..0xcda890
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcda790..0xcda790
+            - Range: 0xcda890..0xcda890
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcda790..0xcda7c5
+            - Range: 0xcda890..0xcda8c5
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcda7c5..0xcda86b
+            - Range: 0xcda8c5..0xcda96b
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0xcda86b..0xcda870
+            - Range: 0xcda96b..0xcda970
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0xcda870..0xcda878
+            - Range: 0xcda970..0xcda978
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
-            - Range: 0xcda878..0xcda88f
+            - Range: 0xcda978..0xcda98f
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
-            - Range: 0xcda88f..0xcda90a
+            - Range: 0xcda98f..0xcdaa0a
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 48
       Name: main.testManyPointers
-      OutOfLinePCRanges: [0xcdad40..0xcdad41]
+      OutOfLinePCRanges: [0xcdae40..0xcdae41]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 156 StructureType main.manyPointers
           Locations:
-            - Range: 0xcdad40..0xcdad41
+            - Range: 0xcdae40..0xcdae41
               Pieces: [{Size: 560, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 49
       Name: main.testManyStrings
-      OutOfLinePCRanges: [0xcdc720..0xcdc721]
+      OutOfLinePCRanges: [0xcdc820..0xcdc821]
       InlinePCRanges: []
       Variables:
         - Name: ss
           Type: 159 GoSliceHeaderType []string
           Locations:
-            - Range: 0xcdc720..0xcdc721
+            - Range: 0xcdc820..0xcdc821
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6736,13 +6736,13 @@ Subprograms:
       DictRegister: null
     - ID: 50
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0xcdca40..0xcdcb45]
+      OutOfLinePCRanges: [0xcdcb40..0xcdcc45]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 160 StructureType main.esotericStack
           Locations:
-            - Range: 0xcdca40..0xcdca93
+            - Range: 0xcdcb40..0xcdcb93
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -6762,7 +6762,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xcdca93..0xcdca98
+            - Range: 0xcdcb93..0xcdcb98
               Pieces:
                 - Size: 4
                   Op: null
@@ -6782,7 +6782,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xcdca98..0xcdca9d
+            - Range: 0xcdcb98..0xcdcb9d
               Pieces:
                 - Size: 4
                   Op: null
@@ -6807,155 +6807,155 @@ Subprograms:
       DictRegister: null
     - ID: 51
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0xcdcb60..0xcdcbc3]
+      OutOfLinePCRanges: [0xcdcc60..0xcdccc3]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 164 PointerType *main.esotericHeap
           Locations:
-            - Range: 0xcdcb60..0xcdcb8d
+            - Range: 0xcdcc60..0xcdcc8d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 52
       Name: main.testInlinedBA
-      OutOfLinePCRanges: [0xcde120..0xcde1a8]
+      OutOfLinePCRanges: [0xcde220..0xcde2a8]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde120..0xcde135
+            - Range: 0xcde220..0xcde235
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 53
       Name: main.testInlinedBB
-      OutOfLinePCRanges: [0xcde1c0..0xcde285]
+      OutOfLinePCRanges: [0xcde2c0..0xcde385]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde1c0..0xcde1d6
+            - Range: 0xcde2c0..0xcde2d6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: "y"
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde1c0..0xcde1e7
+            - Range: 0xcde2c0..0xcde2e7
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: z
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde1d6..0xcde1e7
+            - Range: 0xcde2d6..0xcde2e7
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcde1e7..0xcde285
+            - Range: 0xcde2e7..0xcde385
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 54
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0xcde2a0..0xcde302]
+      OutOfLinePCRanges: [0xcde3a0..0xcde402]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde2a0..0xcde2ba
+            - Range: 0xcde3a0..0xcde3ba
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 55
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0xcde320..0xcde425]
+      OutOfLinePCRanges: [0xcde420..0xcde525]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde37b..0xcde385
+            - Range: 0xcde47b..0xcde485
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xcde385..0xcde395
+            - Range: 0xcde485..0xcde495
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xcde395..0xcde3a9
+            - Range: 0xcde495..0xcde4a9
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde376..0xcde380
+            - Range: 0xcde476..0xcde480
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xcde380..0xcde395
+            - Range: 0xcde480..0xcde495
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xcde395..0xcde3a4
+            - Range: 0xcde495..0xcde4a4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 56
       Name: main.testFrameless
-      OutOfLinePCRanges: [0xcde440..0xcde446]
+      OutOfLinePCRanges: [0xcde540..0xcde546]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde440..0xcde445
+            - Range: 0xcde540..0xcde545
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde440..0xcde445
+            - Range: 0xcde540..0xcde545
               Pieces: []
-            - Range: 0xcde445..0xcde446
+            - Range: 0xcde545..0xcde546
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 57
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0xcde460..0xcde4a3]
+      OutOfLinePCRanges: [0xcde560..0xcde5a3]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 166 ArrayType [5]int
           Locations:
-            - Range: 0xcde460..0xcde4a3
+            - Range: 0xcde560..0xcde5a3
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde460..0xcde49d
+            - Range: 0xcde560..0xcde59d
               Pieces: []
-            - Range: 0xcde49d..0xcde49e
+            - Range: 0xcde59d..0xcde59e
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcde49e..0xcde4a3
+            - Range: 0xcde59e..0xcde5a3
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 58
       Name: main.testInterface
-      OutOfLinePCRanges: [0xcde740..0xcde741]
+      OutOfLinePCRanges: [0xcde840..0xcde841]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 167 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcde740..0xcde741
+            - Range: 0xcde840..0xcde841
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6966,19 +6966,19 @@ Subprograms:
       DictRegister: null
     - ID: 59
       Name: main.testAny
-      OutOfLinePCRanges: [0xcde760..0xcde7c6]
+      OutOfLinePCRanges: [0xcde860..0xcde8c6]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 162 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcde760..0xcde789
+            - Range: 0xcde860..0xcde889
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcde789..0xcde78e
+            - Range: 0xcde889..0xcde88e
               Pieces:
                 - Size: 8
                   Op: null
@@ -6989,28 +6989,28 @@ Subprograms:
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcde760..0xcde7a5
+            - Range: 0xcde860..0xcde8a5
               Pieces: []
-            - Range: 0xcde7a5..0xcde7a6
+            - Range: 0xcde8a5..0xcde8a6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcde7a6..0xcde7c6
+            - Range: 0xcde8a6..0xcde8c6
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 60
       Name: main.testError
-      OutOfLinePCRanges: [0xcde7e0..0xcde7e1]
+      OutOfLinePCRanges: [0xcde8e0..0xcde8e1]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0xcde7e0..0xcde7e1
+            - Range: 0xcde8e0..0xcde8e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7021,41 +7021,41 @@ Subprograms:
       DictRegister: null
     - ID: 61
       Name: main.testAnyPtr
-      OutOfLinePCRanges: [0xcde800..0xcde854]
+      OutOfLinePCRanges: [0xcde900..0xcde954]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 168 PointerType *interface {}
           Locations:
-            - Range: 0xcde800..0xcde826
+            - Range: 0xcde900..0xcde926
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcde800..0xcde83d
+            - Range: 0xcde900..0xcde93d
               Pieces: []
-            - Range: 0xcde83d..0xcde83e
+            - Range: 0xcde93d..0xcde93e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcde83e..0xcde854
+            - Range: 0xcde93e..0xcde954
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 62
       Name: main.testStructWithAny
-      OutOfLinePCRanges: [0xcde860..0xcde861]
+      OutOfLinePCRanges: [0xcde960..0xcde961]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 169 StructureType main.structWithAny
           Locations:
-            - Range: 0xcde860..0xcde861
+            - Range: 0xcde960..0xcde961
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7066,346 +7066,346 @@ Subprograms:
       DictRegister: null
     - ID: 63
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0xcdee80..0xcdee81]
+      OutOfLinePCRanges: [0xcdf040..0xcdf041]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 170 StructureType main.structWithMap
-          Locations:
-            - Range: 0xcdee80..0xcdee81
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 64
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0xcdeea0..0xcdeea1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 176 GoMapType map[string]main.nestedStruct
-          Locations:
-            - Range: 0xcdeea0..0xcdeea1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 65
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0xcdeec0..0xcdeec1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 181 GoMapType map[string]int
-          Locations:
-            - Range: 0xcdeec0..0xcdeec1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 66
-      Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0xcdeee0..0xcdeee1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 186 GoMapType map[string][]string
-          Locations:
-            - Range: 0xcdeee0..0xcdeee1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 67
-      Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0xcdef00..0xcdef01]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 191 GoMapType map[[4]string][2]int
-          Locations:
-            - Range: 0xcdef00..0xcdef01
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 68
-      Name: main.testSmallMap
-      OutOfLinePCRanges: [0xcdef20..0xcdef21]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 181 GoMapType map[string]int
-          Locations:
-            - Range: 0xcdef20..0xcdef21
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 69
-      Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0xcdef40..0xcdef41]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 196 ArrayType [2]map[string]int
-          Locations:
-            - Range: 0xcdef40..0xcdef41
-              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 70
-      Name: main.testPointerToMap
-      OutOfLinePCRanges: [0xcdef60..0xcdef61]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 197 PointerType *map[string]int
-          Locations:
-            - Range: 0xcdef60..0xcdef61
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 71
-      Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0xcdef80..0xcdef81]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 171 GoMapType map[int]int
-          Locations:
-            - Range: 0xcdef80..0xcdef81
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 72
-      Name: main.testMapMassive
-      OutOfLinePCRanges: [0xcdefa0..0xcdefa1]
-      InlinePCRanges: []
-      Variables:
-        - Name: redactMyEntries
-          Type: 198 GoMapType map[string][]main.structWithMap
-          Locations:
-            - Range: 0xcdefa0..0xcdefa1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 73
-      Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0xcdefc0..0xcdefc1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 198 GoMapType map[string][]main.structWithMap
-          Locations:
-            - Range: 0xcdefc0..0xcdefc1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 74
-      Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0xcdefe0..0xcdefe1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 203 GoMapType map[bool]main.node
-          Locations:
-            - Range: 0xcdefe0..0xcdefe1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 75
-      Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0xcdf000..0xcdf001]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 208 GoMapType map[int]uint8
-          Locations:
-            - Range: 0xcdf000..0xcdf001
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 76
-      Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0xcdf020..0xcdf021]
-      InlinePCRanges: []
-      Variables:
-        - Name: redactMyEntries
-          Type: 208 GoMapType map[int]uint8
-          Locations:
-            - Range: 0xcdf020..0xcdf021
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 77
-      Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0xcdf040..0xcdf041]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 213 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xcdf040..0xcdf041
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 78
-      Name: main.testMapWithSmallKeyAndValueMassive
+    - ID: 64
+      Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0xcdf060..0xcdf061]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 213 GoMapType map[uint8]uint8
+          Type: 176 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0xcdf060..0xcdf061
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 79
-      Name: main.testMapSmallKeySmallValue
+    - ID: 65
+      Name: main.testMapStringToInt
       OutOfLinePCRanges: [0xcdf080..0xcdf081]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 213 GoMapType map[uint8]uint8
+          Type: 181 GoMapType map[string]int
           Locations:
             - Range: 0xcdf080..0xcdf081
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 80
-      Name: main.testMapSmallKeyLargeValue
+    - ID: 66
+      Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0xcdf0a0..0xcdf0a1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 218 GoMapType map[uint8][4]int
+          Type: 186 GoMapType map[string][]string
           Locations:
             - Range: 0xcdf0a0..0xcdf0a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 81
-      Name: main.testMapLargeKeySmallValue
+    - ID: 67
+      Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0xcdf0c0..0xcdf0c1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 223 GoMapType map[[4]int]uint8
+          Type: 191 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0xcdf0c0..0xcdf0c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 82
-      Name: main.testMapLargeKeyLargeValue
+    - ID: 68
+      Name: main.testSmallMap
       OutOfLinePCRanges: [0xcdf0e0..0xcdf0e1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 228 GoMapType map[[4]int][4]int
+          Type: 181 GoMapType map[string]int
           Locations:
             - Range: 0xcdf0e0..0xcdf0e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 83
-      Name: main.testMapEmptyKey
+    - ID: 69
+      Name: main.testArrayOfMaps
       OutOfLinePCRanges: [0xcdf100..0xcdf101]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 233 GoMapType map[struct {}]int
+          Type: 196 ArrayType [2]map[string]int
           Locations:
             - Range: 0xcdf100..0xcdf101
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 84
-      Name: main.testMapEmptyValue
+    - ID: 70
+      Name: main.testPointerToMap
       OutOfLinePCRanges: [0xcdf120..0xcdf121]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 238 GoMapType map[int]struct {}
+          Type: 197 PointerType *map[string]int
           Locations:
             - Range: 0xcdf120..0xcdf121
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 85
-      Name: main.testMapEmptyKeyAndValue
+    - ID: 71
+      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0xcdf140..0xcdf141]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 243 GoMapType map[struct {}]struct {}
+          Type: 171 GoMapType map[int]int
           Locations:
             - Range: 0xcdf140..0xcdf141
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 72
+      Name: main.testMapMassive
+      OutOfLinePCRanges: [0xcdf160..0xcdf161]
+      InlinePCRanges: []
+      Variables:
+        - Name: redactMyEntries
+          Type: 198 GoMapType map[string][]main.structWithMap
+          Locations:
+            - Range: 0xcdf160..0xcdf161
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 73
+      Name: main.testMapEmbeddedMaps
+      OutOfLinePCRanges: [0xcdf180..0xcdf181]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 198 GoMapType map[string][]main.structWithMap
+          Locations:
+            - Range: 0xcdf180..0xcdf181
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 74
+      Name: main.testMapWithLinkedList
+      OutOfLinePCRanges: [0xcdf1a0..0xcdf1a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 203 GoMapType map[bool]main.node
+          Locations:
+            - Range: 0xcdf1a0..0xcdf1a1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 75
+      Name: main.testMapWithSmallValue
+      OutOfLinePCRanges: [0xcdf1c0..0xcdf1c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 208 GoMapType map[int]uint8
+          Locations:
+            - Range: 0xcdf1c0..0xcdf1c1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 76
+      Name: main.testMapWithSmallValueMassive
+      OutOfLinePCRanges: [0xcdf1e0..0xcdf1e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: redactMyEntries
+          Type: 208 GoMapType map[int]uint8
+          Locations:
+            - Range: 0xcdf1e0..0xcdf1e1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 77
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0xcdf200..0xcdf201]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 213 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xcdf200..0xcdf201
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 78
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0xcdf220..0xcdf221]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 213 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xcdf220..0xcdf221
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 79
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0xcdf240..0xcdf241]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 213 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xcdf240..0xcdf241
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 80
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0xcdf260..0xcdf261]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 218 GoMapType map[uint8][4]int
+          Locations:
+            - Range: 0xcdf260..0xcdf261
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 81
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0xcdf280..0xcdf281]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 223 GoMapType map[[4]int]uint8
+          Locations:
+            - Range: 0xcdf280..0xcdf281
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 82
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0xcdf2a0..0xcdf2a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 228 GoMapType map[[4]int][4]int
+          Locations:
+            - Range: 0xcdf2a0..0xcdf2a1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 83
+      Name: main.testMapEmptyKey
+      OutOfLinePCRanges: [0xcdf2c0..0xcdf2c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 233 GoMapType map[struct {}]int
+          Locations:
+            - Range: 0xcdf2c0..0xcdf2c1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 84
+      Name: main.testMapEmptyValue
+      OutOfLinePCRanges: [0xcdf2e0..0xcdf2e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 238 GoMapType map[int]struct {}
+          Locations:
+            - Range: 0xcdf2e0..0xcdf2e1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 85
+      Name: main.testMapEmptyKeyAndValue
+      OutOfLinePCRanges: [0xcdf300..0xcdf301]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 243 GoMapType map[struct {}]struct {}
+          Locations:
+            - Range: 0xcdf300..0xcdf301
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 86
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0xce0a40..0xce0a41]
+      OutOfLinePCRanges: [0xce0c00..0xce0c01]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xce0a40..0xce0a41
+            - Range: 0xce0c00..0xce0c01
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xce0a40..0xce0a41
+            - Range: 0xce0c00..0xce0c01
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: "y"
           Type: 19 BaseType float32
           Locations:
-            - Range: 0xce0a40..0xce0a41
+            - Range: 0xce0c00..0xce0c01
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 87
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0xce0a80..0xce0a81]
+      OutOfLinePCRanges: [0xce0c40..0xce0c41]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xce0a80..0xce0a81
+            - Range: 0xce0c40..0xce0c41
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce0a80..0xce0a81
+            - Range: 0xce0c40..0xce0c41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -7416,48 +7416,48 @@ Subprograms:
         - Name: "y"
           Type: 19 BaseType float32
           Locations:
-            - Range: 0xce0a80..0xce0a81
+            - Range: 0xce0c40..0xce0c41
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 88
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0xce0c00..0xce0c01]
+      OutOfLinePCRanges: [0xce0dc0..0xce0dc1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xce0c00..0xce0c01
+            - Range: 0xce0dc0..0xce0dc1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xce0c00..0xce0c01
+            - Range: 0xce0dc0..0xce0dc1
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 11 BaseType int32
           Locations:
-            - Range: 0xce0c00..0xce0c01
+            - Range: 0xce0dc0..0xce0dc1
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 18 BaseType uint
           Locations:
-            - Range: 0xce0c00..0xce0c01
+            - Range: 0xce0dc0..0xce0dc1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce0c00..0xce0c01
+            - Range: 0xce0dc0..0xce0dc1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7468,61 +7468,61 @@ Subprograms:
       DictRegister: null
     - ID: 89
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0xce0e20..0xce0e33]
+      OutOfLinePCRanges: [0xce0fe0..0xce0ff3]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0xce0e20..0xce0e32
+            - Range: 0xce0fe0..0xce0ff2
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0xce0e20..0xce0e32
+            - Range: 0xce0fe0..0xce0ff2
               Pieces: []
-            - Range: 0xce0e32..0xce0e33
+            - Range: 0xce0ff2..0xce0ff3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 90
       Name: main.testChannel
-      OutOfLinePCRanges: [0xce0e40..0xce0e41]
+      OutOfLinePCRanges: [0xce1000..0xce1001]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 248 GoChannelType chan bool
           Locations:
-            - Range: 0xce0e40..0xce0e41
+            - Range: 0xce1000..0xce1001
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 91
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xce1000..0xce1001]
+      OutOfLinePCRanges: [0xce11c0..0xce11c1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 249 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xce1000..0xce1001
+            - Range: 0xce11c0..0xce11c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 92
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0xce1020..0xce1021]
+      OutOfLinePCRanges: [0xce11e0..0xce11e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 251 StructureType main.node
           Locations:
-            - Range: 0xce1020..0xce1021
+            - Range: 0xce11e0..0xce11e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7533,273 +7533,273 @@ Subprograms:
       DictRegister: null
     - ID: 93
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xce1040..0xce1041]
+      OutOfLinePCRanges: [0xce1200..0xce1201]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 252 PointerType *main.node
-          Locations:
-            - Range: 0xce1040..0xce1041
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 94
-      Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xce1060..0xce1061]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 15 VoidPointerType unsafe.Pointer
-          Locations:
-            - Range: 0xce1060..0xce1061
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 95
-      Name: main.testUintPointer
-      OutOfLinePCRanges: [0xce10a0..0xce10a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 108 PointerType *uint
-          Locations:
-            - Range: 0xce10a0..0xce10a1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 96
-      Name: main.testStringPointer
-      OutOfLinePCRanges: [0xce1180..0xce1181]
-      InlinePCRanges: []
-      Variables:
-        - Name: z
-          Type: 96 PointerType *string
-          Locations:
-            - Range: 0xce1180..0xce1181
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 97
-      Name: main.testNilPointer
-      OutOfLinePCRanges: [0xce11c0..0xce11c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: z
-          Type: 12 PointerType *bool
-          Locations:
-            - Range: 0xce11c0..0xce11c1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: a
-          Type: 18 BaseType uint
-          Locations:
-            - Range: 0xce11c0..0xce11c1
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 98
-      Name: main.testCycle
-      OutOfLinePCRanges: [0xce1200..0xce1201]
-      InlinePCRanges: []
-      Variables:
-        - Name: t
-          Type: 253 PointerType *main.t
           Locations:
             - Range: 0xce1200..0xce1201
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 94
+      Name: main.testUnsafePointer
+      OutOfLinePCRanges: [0xce1220..0xce1221]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 15 VoidPointerType unsafe.Pointer
+          Locations:
+            - Range: 0xce1220..0xce1221
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 95
+      Name: main.testUintPointer
+      OutOfLinePCRanges: [0xce1260..0xce1261]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 108 PointerType *uint
+          Locations:
+            - Range: 0xce1260..0xce1261
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 96
+      Name: main.testStringPointer
+      OutOfLinePCRanges: [0xce1340..0xce1341]
+      InlinePCRanges: []
+      Variables:
+        - Name: z
+          Type: 96 PointerType *string
+          Locations:
+            - Range: 0xce1340..0xce1341
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 97
+      Name: main.testNilPointer
+      OutOfLinePCRanges: [0xce1380..0xce1381]
+      InlinePCRanges: []
+      Variables:
+        - Name: z
+          Type: 12 PointerType *bool
+          Locations:
+            - Range: 0xce1380..0xce1381
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 18 BaseType uint
+          Locations:
+            - Range: 0xce1380..0xce1381
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 98
+      Name: main.testCycle
+      OutOfLinePCRanges: [0xce13c0..0xce13c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: t
+          Type: 253 PointerType *main.t
+          Locations:
+            - Range: 0xce13c0..0xce13c1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 99
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0xce1640..0xce16b2]
+      OutOfLinePCRanges: [0xce1800..0xce1872]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce1640..0xce1652
+            - Range: 0xce1800..0xce1812
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce1640..0xce169b
+            - Range: 0xce1800..0xce185b
               Pieces: []
-            - Range: 0xce169b..0xce169c
+            - Range: 0xce185b..0xce185c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce169c..0xce16b2
+            - Range: 0xce185c..0xce1872
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce1652..0xce1665
+            - Range: 0xce1812..0xce1825
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce1665..0xce16b2
+            - Range: 0xce1825..0xce1872
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 100
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0xce16c0..0xce174f]
+      OutOfLinePCRanges: [0xce1880..0xce190f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce16c0..0xce16da
+            - Range: 0xce1880..0xce189a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce16da..0xce174f
+            - Range: 0xce189a..0xce190f
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 100 PointerType *int
           Locations:
-            - Range: 0xce16c0..0xce1734
+            - Range: 0xce1880..0xce18f4
               Pieces: []
-            - Range: 0xce1734..0xce1735
+            - Range: 0xce18f4..0xce18f5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce1735..0xce174f
+            - Range: 0xce18f5..0xce190f
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: '&result'
           Type: 100 PointerType *int
           Locations:
-            - Range: 0xce16df..0xce16f9
+            - Range: 0xce189f..0xce18b9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce16f9..0xce174f
+            - Range: 0xce18b9..0xce190f
               Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 101
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0xce1760..0xce183e]
+      OutOfLinePCRanges: [0xce1920..0xce19fe]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce1760..0xce17c2
+            - Range: 0xce1920..0xce1982
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce1760..0xce1824
+            - Range: 0xce1920..0xce19e4
               Pieces: []
-            - Range: 0xce1824..0xce1825
+            - Range: 0xce19e4..0xce19e5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce1825..0xce183e
+            - Range: 0xce19e5..0xce19fe
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce1760..0xce183e, Pieces: []}]
+          Locations: [{Range: 0xce1920..0xce19fe, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: resultInt
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce1776..0xce17c7
+            - Range: 0xce1936..0xce1987
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce17c7..0xce183e
+            - Range: 0xce1987..0xce19fe
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
           Role: Local
           DictIndex: -1
         - Name: resultFloat
           Type: 16 BaseType float64
           Locations:
-            - Range: 0xce178f..0xce17c7
+            - Range: 0xce194f..0xce1987
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
-            - Range: 0xce17c7..0xce183e
+            - Range: 0xce1987..0xce19fe
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 102
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0xce1840..0xce189b]
+      OutOfLinePCRanges: [0xce1a00..0xce1a5b]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xce1840..0xce1859
+            - Range: 0xce1a00..0xce1a19
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0xce1840..0xce187a
+            - Range: 0xce1a00..0xce1a3a
               Pieces: []
-            - Range: 0xce187a..0xce187b
+            - Range: 0xce1a3a..0xce1a3b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce187b..0xce1885
+            - Range: 0xce1a3b..0xce1a45
               Pieces: []
-            - Range: 0xce1885..0xce1886
+            - Range: 0xce1a45..0xce1a46
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce1886..0xce189b
+            - Range: 0xce1a46..0xce1a5b
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 103
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0xce18a0..0xce19e6]
+      OutOfLinePCRanges: [0xce1a60..0xce1ba6]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 162 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xce18a0..0xce18eb
+            - Range: 0xce1a60..0xce1aab
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce18eb..0xce18f6
+            - Range: 0xce1aab..0xce1ab6
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce1927..0xce192a
+            - Range: 0xce1ae7..0xce1aea
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce1960..0xce1965
+            - Range: 0xce1b20..0xce1b25
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce1994..0xce1999
+            - Range: 0xce1b54..0xce1b59
               Pieces:
                 - Size: 8
                   Op: null
@@ -7810,117 +7810,117 @@ Subprograms:
         - Name: failed
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xce18a0..0xce18e3
+            - Range: 0xce1a60..0xce1aa3
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 162 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xce18a0..0xce1904
+            - Range: 0xce1a60..0xce1ac4
               Pieces: []
-            - Range: 0xce1904..0xce1905
+            - Range: 0xce1ac4..0xce1ac5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce1905..0xce1953
+            - Range: 0xce1ac5..0xce1b13
               Pieces: []
-            - Range: 0xce1953..0xce1954
+            - Range: 0xce1b13..0xce1b14
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce1954..0xce1987
+            - Range: 0xce1b14..0xce1b47
               Pieces: []
-            - Range: 0xce1987..0xce1988
+            - Range: 0xce1b47..0xce1b48
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce1988..0xce19b9
+            - Range: 0xce1b48..0xce1b79
               Pieces: []
-            - Range: 0xce19b9..0xce19ba
+            - Range: 0xce1b79..0xce1b7a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce19ba..0xce19e6
+            - Range: 0xce1b7a..0xce1ba6
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0xce18a0..0xce1904
+            - Range: 0xce1a60..0xce1ac4
               Pieces: []
-            - Range: 0xce1904..0xce1905
+            - Range: 0xce1ac4..0xce1ac5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce1905..0xce1953
+            - Range: 0xce1ac5..0xce1b13
               Pieces: []
-            - Range: 0xce1953..0xce1954
+            - Range: 0xce1b13..0xce1b14
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce1954..0xce1987
+            - Range: 0xce1b14..0xce1b47
               Pieces: []
-            - Range: 0xce1987..0xce1988
+            - Range: 0xce1b47..0xce1b48
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce1988..0xce19b9
+            - Range: 0xce1b48..0xce1b79
               Pieces: []
-            - Range: 0xce19b9..0xce19ba
+            - Range: 0xce1b79..0xce1b7a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce19ba..0xce19e6
+            - Range: 0xce1b7a..0xce1ba6
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce18eb..0xce18f1
+            - Range: 0xce1aab..0xce1ab1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 104
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0xce1a00..0xce1bee]
+      OutOfLinePCRanges: [0xce1bc0..0xce1dae]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 162 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xce1a00..0xce1a4b
+            - Range: 0xce1bc0..0xce1c0b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce1a4b..0xce1a52
+            - Range: 0xce1c0b..0xce1c12
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xce1a52..0xce1bee
+            - Range: 0xce1c12..0xce1dae
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -7931,1128 +7931,1128 @@ Subprograms:
         - Name: ~r0
           Type: 162 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xce1a00..0xce1ab5
+            - Range: 0xce1bc0..0xce1c75
               Pieces: []
-            - Range: 0xce1ab5..0xce1ab6
+            - Range: 0xce1c75..0xce1c76
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce1ab6..0xce1b04
+            - Range: 0xce1c76..0xce1cc4
               Pieces: []
-            - Range: 0xce1b04..0xce1b05
+            - Range: 0xce1cc4..0xce1cc5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce1b05..0xce1bc0
+            - Range: 0xce1cc5..0xce1d80
               Pieces: []
-            - Range: 0xce1bc0..0xce1bc1
+            - Range: 0xce1d80..0xce1d81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce1bc1..0xce1bca
+            - Range: 0xce1d81..0xce1d8a
               Pieces: []
-            - Range: 0xce1bca..0xce1bcb
+            - Range: 0xce1d8a..0xce1d8b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce1bcb..0xce1bee
+            - Range: 0xce1d8b..0xce1dae
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce1aa0..0xce1aa6
+            - Range: 0xce1c60..0xce1c66
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: '&result'
           Type: 100 PointerType *int
           Locations:
-            - Range: 0xce1ae5..0xce1b04
+            - Range: 0xce1ca5..0xce1cc4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 105
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0xce1c00..0xce1d54]
+      OutOfLinePCRanges: [0xce1dc0..0xce1f14]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 162 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xce1c00..0xce1c40
+            - Range: 0xce1dc0..0xce1e00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce1c40..0xce1c8e
+            - Range: 0xce1e00..0xce1e4e
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xce1c8e..0xce1cef
+            - Range: 0xce1e4e..0xce1eaf
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xce1cef..0xce1d11
+            - Range: 0xce1eaf..0xce1ed1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xce1d11..0xce1d18
+            - Range: 0xce1ed1..0xce1ed8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xce1d18..0xce1d54
+            - Range: 0xce1ed8..0xce1f14
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 167 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xce1c00..0xce1cdf
+            - Range: 0xce1dc0..0xce1e9f
               Pieces: []
-            - Range: 0xce1cdf..0xce1ce0
+            - Range: 0xce1e9f..0xce1ea0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce1ce0..0xce1ce9
+            - Range: 0xce1ea0..0xce1ea9
               Pieces: []
-            - Range: 0xce1ce9..0xce1cea
+            - Range: 0xce1ea9..0xce1eaa
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce1cea..0xce1d54
+            - Range: 0xce1eaa..0xce1f14
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 167 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xce1c00..0xce1c40
+            - Range: 0xce1dc0..0xce1e00
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce1c40..0xce1c8e
+            - Range: 0xce1e00..0xce1e4e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xce1c8e..0xce1c95
+            - Range: 0xce1e4e..0xce1e55
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xce1c95..0xce1ce5
+            - Range: 0xce1e55..0xce1ea5
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xce1ce5..0xce1ce7
+            - Range: 0xce1ea5..0xce1ea7
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xce1ce7..0xce1ce9
+            - Range: 0xce1ea7..0xce1ea9
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xce1ce9..0xce1d54
+            - Range: 0xce1ea9..0xce1f14
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 106
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0xce1d60..0xce1def]
+      OutOfLinePCRanges: [0xce1f20..0xce1faf]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce1d60..0xce1d71
+            - Range: 0xce1f20..0xce1f31
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce1d60..0xce1dd5
+            - Range: 0xce1f20..0xce1f95
               Pieces: []
-            - Range: 0xce1dd5..0xce1dd6
+            - Range: 0xce1f95..0xce1f96
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce1dd6..0xce1def
+            - Range: 0xce1f96..0xce1faf
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 107
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0xce1e00..0xce1ec9]
+      OutOfLinePCRanges: [0xce1fc0..0xce2089]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce1e00..0xce1e51
+            - Range: 0xce1fc0..0xce2011
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce1e00..0xce1eaf
+            - Range: 0xce1fc0..0xce206f
               Pieces: []
-            - Range: 0xce1eaf..0xce1eb0
+            - Range: 0xce206f..0xce2070
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce1eb0..0xce1ec9
+            - Range: 0xce2070..0xce2089
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce1e00..0xce1eaf
+            - Range: 0xce1fc0..0xce206f
               Pieces: []
-            - Range: 0xce1eaf..0xce1eb0
+            - Range: 0xce206f..0xce2070
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce1eb0..0xce1ec9
+            - Range: 0xce2070..0xce2089
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 108
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0xce1ee0..0xce1fa7]
+      OutOfLinePCRanges: [0xce20a0..0xce2167]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce1ee0..0xce1f25
+            - Range: 0xce20a0..0xce20e5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce1f25..0xce1fa7
+            - Range: 0xce20e5..0xce2167
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce1ee0..0xce1f8d
+            - Range: 0xce20a0..0xce214d
               Pieces: []
-            - Range: 0xce1f8d..0xce1f8e
+            - Range: 0xce214d..0xce214e
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce1f8e..0xce1fa7
+            - Range: 0xce214e..0xce2167
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce1ee0..0xce1f8d
+            - Range: 0xce20a0..0xce214d
               Pieces: []
-            - Range: 0xce1f8d..0xce1f8e
+            - Range: 0xce214d..0xce214e
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce1f8e..0xce1fa7
+            - Range: 0xce214e..0xce2167
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce1ee0..0xce1f8d
+            - Range: 0xce20a0..0xce214d
               Pieces: []
-            - Range: 0xce1f8d..0xce1f8e
+            - Range: 0xce214d..0xce214e
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce1f8e..0xce1fa7
+            - Range: 0xce214e..0xce2167
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 109
       Name: main.testConflictingReturn
-      OutOfLinePCRanges: [0xce1fc0..0xce20af]
+      OutOfLinePCRanges: [0xce2180..0xce226f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce1fc0..0xce2005
+            - Range: 0xce2180..0xce21c5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce2005..0xce20af
+            - Range: 0xce21c5..0xce226f
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce1fc0..0xce2091
+            - Range: 0xce2180..0xce2251
               Pieces: []
-            - Range: 0xce2091..0xce2092
+            - Range: 0xce2251..0xce2252
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce2092..0xce20af
+            - Range: 0xce2252..0xce226f
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce1fc0..0xce2091
+            - Range: 0xce2180..0xce2251
               Pieces: []
-            - Range: 0xce2091..0xce2092
+            - Range: 0xce2251..0xce2252
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce2092..0xce20af
+            - Range: 0xce2252..0xce226f
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 110
       Name: main.testReturnsNamedDeferLine
-      OutOfLinePCRanges: [0xce20c0..0xce22cf]
+      OutOfLinePCRanges: [0xce2280..0xce248f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce20c0..0xce2146
+            - Range: 0xce2280..0xce2306
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce2146..0xce22cf
+            - Range: 0xce2306..0xce248f
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce20f7..0xce22cf
+            - Range: 0xce22b7..0xce248f
               Pieces: [{Size: 16, Op: {CfaOffset: -128}}]
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce20fd..0xce22cf
+            - Range: 0xce22bd..0xce248f
               Pieces: [{Size: 16, Op: {CfaOffset: -144}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 111
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0xce23c0..0xce243e]
+      OutOfLinePCRanges: [0xce2580..0xce25fe]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType int8
           Locations:
-            - Range: 0xce23c0..0xce2431
+            - Range: 0xce2580..0xce25f1
               Pieces: []
-            - Range: 0xce2431..0xce2432
+            - Range: 0xce25f1..0xce25f2
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce2432..0xce243e
+            - Range: 0xce25f2..0xce25fe
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 105 BaseType int16
           Locations:
-            - Range: 0xce23c0..0xce2431
+            - Range: 0xce2580..0xce25f1
               Pieces: []
-            - Range: 0xce2431..0xce2432
+            - Range: 0xce25f1..0xce25f2
               Pieces: [{Size: 2, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce2432..0xce243e
+            - Range: 0xce25f2..0xce25fe
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 11 BaseType int32
           Locations:
-            - Range: 0xce23c0..0xce2431
+            - Range: 0xce2580..0xce25f1
               Pieces: []
-            - Range: 0xce2431..0xce2432
+            - Range: 0xce25f1..0xce25f2
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce2432..0xce243e
+            - Range: 0xce25f2..0xce25fe
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 13 BaseType int64
           Locations:
-            - Range: 0xce23c0..0xce2431
+            - Range: 0xce2580..0xce25f1
               Pieces: []
-            - Range: 0xce2431..0xce2432
+            - Range: 0xce25f1..0xce25f2
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xce2432..0xce243e
+            - Range: 0xce25f2..0xce25fe
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xce23c0..0xce2431
+            - Range: 0xce2580..0xce25f1
               Pieces: []
-            - Range: 0xce2431..0xce2432
+            - Range: 0xce25f1..0xce25f2
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xce2432..0xce243e
+            - Range: 0xce25f2..0xce25fe
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 7 BaseType uint16
           Locations:
-            - Range: 0xce23c0..0xce2431
+            - Range: 0xce2580..0xce25f1
               Pieces: []
-            - Range: 0xce2431..0xce2432
+            - Range: 0xce25f1..0xce25f2
               Pieces: [{Size: 2, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xce2432..0xce243e
+            - Range: 0xce25f2..0xce25fe
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 3 BaseType uint32
           Locations:
-            - Range: 0xce23c0..0xce2431
+            - Range: 0xce2580..0xce25f1
               Pieces: []
-            - Range: 0xce2431..0xce2432
+            - Range: 0xce25f1..0xce25f2
               Pieces: [{Size: 4, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xce2432..0xce243e
+            - Range: 0xce25f2..0xce25fe
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0xce23c0..0xce2431
+            - Range: 0xce2580..0xce25f1
               Pieces: []
-            - Range: 0xce2431..0xce2432
+            - Range: 0xce25f1..0xce25f2
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xce2432..0xce243e
+            - Range: 0xce25f2..0xce25fe
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 112
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0xce2440..0xce2537]
+      OutOfLinePCRanges: [0xce2600..0xce26f7]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce2440..0xce2537, Pieces: []}]
+          Locations: [{Range: 0xce2600..0xce26f7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce2440..0xce2537, Pieces: []}]
+          Locations: [{Range: 0xce2600..0xce26f7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce2440..0xce2537, Pieces: []}]
+          Locations: [{Range: 0xce2600..0xce26f7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce2440..0xce2537, Pieces: []}]
+          Locations: [{Range: 0xce2600..0xce26f7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce2440..0xce2537, Pieces: []}]
+          Locations: [{Range: 0xce2600..0xce26f7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce2440..0xce2537, Pieces: []}]
+          Locations: [{Range: 0xce2600..0xce26f7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce2440..0xce2537, Pieces: []}]
+          Locations: [{Range: 0xce2600..0xce26f7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce2440..0xce2537, Pieces: []}]
+          Locations: [{Range: 0xce2600..0xce26f7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce2440..0xce2537, Pieces: []}]
+          Locations: [{Range: 0xce2600..0xce26f7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r9
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce2440..0xce2537, Pieces: []}]
+          Locations: [{Range: 0xce2600..0xce26f7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r10
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce2440..0xce2537, Pieces: []}]
+          Locations: [{Range: 0xce2600..0xce26f7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r11
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce2440..0xce2537, Pieces: []}]
+          Locations: [{Range: 0xce2600..0xce26f7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r12
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce2440..0xce2537, Pieces: []}]
+          Locations: [{Range: 0xce2600..0xce26f7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r13
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce2440..0xce2537, Pieces: []}]
+          Locations: [{Range: 0xce2600..0xce26f7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r14
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce2440..0xce2537, Pieces: []}]
+          Locations: [{Range: 0xce2600..0xce26f7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: onlyOnAmd64_16
           Type: 16 BaseType float64
           Locations:
-            - Range: 0xce2440..0xce2527
+            - Range: 0xce2600..0xce26e7
               Pieces: []
-            - Range: 0xce2527..0xce2528
+            - Range: 0xce26e7..0xce26e8
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xce2528..0xce2537
+            - Range: 0xce26e8..0xce26f7
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: bothArmAndAmd64
           Type: 16 BaseType float64
           Locations:
-            - Range: 0xce2440..0xce2527
+            - Range: 0xce2600..0xce26e7
               Pieces: []
-            - Range: 0xce2527..0xce2528
+            - Range: 0xce26e7..0xce26e8
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xce2528..0xce2537
+            - Range: 0xce26e8..0xce26f7
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 113
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0xce2540..0xce25b3]
+      OutOfLinePCRanges: [0xce2700..0xce2773]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 97 BaseType complex64
-          Locations: [{Range: 0xce2540..0xce25b3, Pieces: []}]
+          Locations: [{Range: 0xce2700..0xce2773, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 98 BaseType complex128
-          Locations: [{Range: 0xce2540..0xce25b3, Pieces: []}]
+          Locations: [{Range: 0xce2700..0xce2773, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 114
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0xce25c0..0xce2665]
+      OutOfLinePCRanges: [0xce2780..0xce2825]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 255 StructureType main.largeStruct
           Locations:
-            - Range: 0xce25c0..0xce2653
+            - Range: 0xce2780..0xce2813
               Pieces: []
-            - Range: 0xce2653..0xce2654
+            - Range: 0xce2813..0xce2814
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
-            - Range: 0xce2654..0xce2665
+            - Range: 0xce2814..0xce2825
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 115
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0xce2680..0xce26fa]
+      OutOfLinePCRanges: [0xce2840..0xce28ba]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 256 ArrayType [3]int
           Locations:
-            - Range: 0xce2680..0xce26ed
+            - Range: 0xce2840..0xce28ad
               Pieces: []
-            - Range: 0xce26ed..0xce26ee
+            - Range: 0xce28ad..0xce28ae
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xce26ee..0xce26fa
+            - Range: 0xce28ae..0xce28ba
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 116
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0xce2700..0xce2758]
+      OutOfLinePCRanges: [0xce28c0..0xce2918]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 257 ArrayType [1]int
           Locations:
-            - Range: 0xce2700..0xce274b
+            - Range: 0xce28c0..0xce290b
               Pieces: []
-            - Range: 0xce274b..0xce274c
+            - Range: 0xce290b..0xce290c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce274c..0xce2758
+            - Range: 0xce290c..0xce2918
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 117
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0xce2760..0xce27b3]
+      OutOfLinePCRanges: [0xce2920..0xce2973]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 258 ArrayType [0]int
           Locations:
-            - Range: 0xce2760..0xce27a6
+            - Range: 0xce2920..0xce2966
               Pieces: []
-            - Range: 0xce27a6..0xce27a7
+            - Range: 0xce2966..0xce2967
               Pieces: []
-            - Range: 0xce27a7..0xce27b3
+            - Range: 0xce2967..0xce2973
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 118
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0xce27c0..0xce2827]
+      OutOfLinePCRanges: [0xce2980..0xce29e7]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 259 StructureType main.mixedStruct
-          Locations: [{Range: 0xce27c0..0xce2827, Pieces: []}]
+          Locations: [{Range: 0xce2980..0xce29e7, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 119
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0xce2840..0xce28da]
+      OutOfLinePCRanges: [0xce2a00..0xce2a9a]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce2840..0xce28ca
+            - Range: 0xce2a00..0xce2a8a
               Pieces: []
-            - Range: 0xce28ca..0xce28cb
+            - Range: 0xce2a8a..0xce2a8b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce28cb..0xce28da
+            - Range: 0xce2a8b..0xce2a9a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce2840..0xce28ca
+            - Range: 0xce2a00..0xce2a8a
               Pieces: []
-            - Range: 0xce28ca..0xce28cb
+            - Range: 0xce2a8a..0xce2a8b
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce28cb..0xce28da
+            - Range: 0xce2a8b..0xce2a9a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce2840..0xce28ca
+            - Range: 0xce2a00..0xce2a8a
               Pieces: []
-            - Range: 0xce28ca..0xce28cb
+            - Range: 0xce2a8a..0xce2a8b
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce28cb..0xce28da
+            - Range: 0xce2a8b..0xce2a9a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce2840..0xce28ca
+            - Range: 0xce2a00..0xce2a8a
               Pieces: []
-            - Range: 0xce28ca..0xce28cb
+            - Range: 0xce2a8a..0xce2a8b
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xce28cb..0xce28da
+            - Range: 0xce2a8b..0xce2a9a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce2840..0xce28ca
+            - Range: 0xce2a00..0xce2a8a
               Pieces: []
-            - Range: 0xce28ca..0xce28cb
+            - Range: 0xce2a8a..0xce2a8b
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xce28cb..0xce28da
+            - Range: 0xce2a8b..0xce2a9a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce2840..0xce28ca
+            - Range: 0xce2a00..0xce2a8a
               Pieces: []
-            - Range: 0xce28ca..0xce28cb
+            - Range: 0xce2a8a..0xce2a8b
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xce28cb..0xce28da
+            - Range: 0xce2a8b..0xce2a9a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce2840..0xce28ca
+            - Range: 0xce2a00..0xce2a8a
               Pieces: []
-            - Range: 0xce28ca..0xce28cb
+            - Range: 0xce2a8a..0xce2a8b
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xce28cb..0xce28da
+            - Range: 0xce2a8b..0xce2a9a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce2840..0xce28ca
+            - Range: 0xce2a00..0xce2a8a
               Pieces: []
-            - Range: 0xce28ca..0xce28cb
+            - Range: 0xce2a8a..0xce2a8b
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xce28cb..0xce28da
+            - Range: 0xce2a8b..0xce2a9a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce2840..0xce28ca
+            - Range: 0xce2a00..0xce2a8a
               Pieces: []
-            - Range: 0xce28ca..0xce28cb
+            - Range: 0xce2a8a..0xce2a8b
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xce28cb..0xce28da
+            - Range: 0xce2a8b..0xce2a9a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 120
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0xce28e0..0xce2985]
+      OutOfLinePCRanges: [0xce2aa0..0xce2b45]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 260 StructureType main.wideStruct
           Locations:
-            - Range: 0xce28e0..0xce2974
+            - Range: 0xce2aa0..0xce2b34
               Pieces: []
-            - Range: 0xce2974..0xce2975
+            - Range: 0xce2b34..0xce2b35
               Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
-            - Range: 0xce2975..0xce2985
+            - Range: 0xce2b35..0xce2b45
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 121
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0xce29a0..0xce2a19]
+      OutOfLinePCRanges: [0xce2b60..0xce2bd9]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce29a0..0xce2a0c
+            - Range: 0xce2b60..0xce2bcc
               Pieces: []
-            - Range: 0xce2a0c..0xce2a0d
+            - Range: 0xce2bcc..0xce2bcd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce2a0d..0xce2a19
+            - Range: 0xce2bcd..0xce2bd9
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce29a0..0xce2a19, Pieces: []}]
+          Locations: [{Range: 0xce2b60..0xce2bd9, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce29a0..0xce2a0c
+            - Range: 0xce2b60..0xce2bcc
               Pieces: []
-            - Range: 0xce2a0c..0xce2a0d
+            - Range: 0xce2bcc..0xce2bcd
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce2a0d..0xce2a19
+            - Range: 0xce2bcd..0xce2bd9
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce29a0..0xce2a19, Pieces: []}]
+          Locations: [{Range: 0xce2b60..0xce2bd9, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce29a0..0xce2a0c
+            - Range: 0xce2b60..0xce2bcc
               Pieces: []
-            - Range: 0xce2a0c..0xce2a0d
+            - Range: 0xce2bcc..0xce2bcd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce2a0d..0xce2a19
+            - Range: 0xce2bcd..0xce2bd9
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 122
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0xce2a20..0xce2a9a]
+      OutOfLinePCRanges: [0xce2be0..0xce2c5a]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 261 StructureType main.structWithArray
           Locations:
-            - Range: 0xce2a20..0xce2a8d
+            - Range: 0xce2be0..0xce2c4d
               Pieces: []
-            - Range: 0xce2a8d..0xce2a8e
+            - Range: 0xce2c4d..0xce2c4e
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xce2a8e..0xce2a9a
+            - Range: 0xce2c4e..0xce2c5a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 123
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0xce2aa0..0xce2afb]
+      OutOfLinePCRanges: [0xce2c60..0xce2cbb]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce2aa0..0xce2afb, Pieces: []}]
+          Locations: [{Range: 0xce2c60..0xce2cbb, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 124
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0xce2b00..0xce2b67]
+      OutOfLinePCRanges: [0xce2cc0..0xce2d27]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 19 BaseType float32
-          Locations: [{Range: 0xce2b00..0xce2b67, Pieces: []}]
+          Locations: [{Range: 0xce2cc0..0xce2d27, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce2b00..0xce2b67, Pieces: []}]
+          Locations: [{Range: 0xce2cc0..0xce2d27, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 125
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0xce2b80..0xce2bdd]
+      OutOfLinePCRanges: [0xce2d40..0xce2d9d]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xce2b80..0xce2bd0
+            - Range: 0xce2d40..0xce2d90
               Pieces: []
-            - Range: 0xce2bd0..0xce2bd1
+            - Range: 0xce2d90..0xce2d91
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce2bd1..0xce2bdd
+            - Range: 0xce2d91..0xce2d9d
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 2 BaseType uintptr
           Locations:
-            - Range: 0xce2b80..0xce2bd0
+            - Range: 0xce2d40..0xce2d90
               Pieces: []
-            - Range: 0xce2bd0..0xce2bd1
+            - Range: 0xce2d90..0xce2d91
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce2bd1..0xce2bdd
+            - Range: 0xce2d91..0xce2d9d
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 126
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0xce2be0..0xce2d65]
+      OutOfLinePCRanges: [0xce2da0..0xce2f25]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 255 StructureType main.largeStruct
           Locations:
-            - Range: 0xce2be0..0xce2d65
+            - Range: 0xce2da0..0xce2f25
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 255 StructureType main.largeStruct
           Locations:
-            - Range: 0xce2be0..0xce2d53
+            - Range: 0xce2da0..0xce2f13
               Pieces: []
-            - Range: 0xce2d53..0xce2d54
+            - Range: 0xce2f13..0xce2f14
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
-            - Range: 0xce2d54..0xce2d65
+            - Range: 0xce2f14..0xce2f25
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 127
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0xce2d80..0xce2e52]
+      OutOfLinePCRanges: [0xce2f40..0xce3012]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 256 ArrayType [3]int
           Locations:
-            - Range: 0xce2d80..0xce2e52
+            - Range: 0xce2f40..0xce3012
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 256 ArrayType [3]int
           Locations:
-            - Range: 0xce2d80..0xce2e42
+            - Range: 0xce2f40..0xce3002
               Pieces: []
-            - Range: 0xce2e42..0xce2e43
+            - Range: 0xce3002..0xce3003
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xce2e43..0xce2e52
+            - Range: 0xce3003..0xce3012
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 128
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0xce2e60..0xce309a]
+      OutOfLinePCRanges: [0xce3020..0xce325a]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 255 StructureType main.largeStruct
           Locations:
-            - Range: 0xce2e60..0xce309a
+            - Range: 0xce3020..0xce325a
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s2
           Type: 255 StructureType main.largeStruct
           Locations:
-            - Range: 0xce2e60..0xce309a
+            - Range: 0xce3020..0xce325a
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 255 StructureType main.largeStruct
           Locations:
-            - Range: 0xce2e60..0xce308a
+            - Range: 0xce3020..0xce324a
               Pieces: []
-            - Range: 0xce308a..0xce308b
+            - Range: 0xce324a..0xce324b
               Pieces: [{Size: 80, Op: {CfaOffset: 160}}]
-            - Range: 0xce308b..0xce309a
+            - Range: 0xce324b..0xce325a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 129
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0xce30a0..0xce332f]
+      OutOfLinePCRanges: [0xce3260..0xce34ef]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce30a0..0xce3150
+            - Range: 0xce3260..0xce3310
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce3150..0xce332f
+            - Range: 0xce3310..0xce34ef
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce30a0..0xce3150
+            - Range: 0xce3260..0xce3310
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce3150..0xce332f
+            - Range: 0xce3310..0xce34ef
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce30a0..0xce313a
+            - Range: 0xce3260..0xce32fa
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce313a..0xce332f
+            - Range: 0xce32fa..0xce34ef
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce30a0..0xce3110
+            - Range: 0xce3260..0xce32d0
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xce3110..0xce332f
+            - Range: 0xce32d0..0xce34ef
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce30a0..0xce3150
+            - Range: 0xce3260..0xce3310
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xce3150..0xce332f
+            - Range: 0xce3310..0xce34ef
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce30a0..0xce3150
+            - Range: 0xce3260..0xce3310
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xce3150..0xce332f
+            - Range: 0xce3310..0xce34ef
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce30a0..0xce3150
+            - Range: 0xce3260..0xce3310
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xce3150..0xce332f
+            - Range: 0xce3310..0xce34ef
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce30a0..0xce3150
+            - Range: 0xce3260..0xce3310
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xce3150..0xce332f
+            - Range: 0xce3310..0xce34ef
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce30a0..0xce3150
+            - Range: 0xce3260..0xce3310
               Pieces: [{Size: 8, Op: {RegNo: 11, Shift: 0}}]
-            - Range: 0xce3150..0xce332f
+            - Range: 0xce3310..0xce34ef
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 114 ArrayType [2]int
           Locations:
-            - Range: 0xce30a0..0xce32c2
+            - Range: 0xce3260..0xce3482
               Pieces: []
-            - Range: 0xce32c2..0xce32c3
+            - Range: 0xce3482..0xce3483
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xce32c3..0xce332f
+            - Range: 0xce3483..0xce34ef
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 130
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0xce3340..0xce360c]
+      OutOfLinePCRanges: [0xce3500..0xce37cc]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce3340..0xce33eb
+            - Range: 0xce3500..0xce35ab
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce33eb..0xce360c
+            - Range: 0xce35ab..0xce37cc
               Pieces: [{Size: 8, Op: {CfaOffset: 96}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce3340..0xce33eb
+            - Range: 0xce3500..0xce35ab
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce33eb..0xce360c
+            - Range: 0xce35ab..0xce37cc
               Pieces: [{Size: 8, Op: {CfaOffset: 104}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce3340..0xce33d5
+            - Range: 0xce3500..0xce3595
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce33d5..0xce360c
+            - Range: 0xce3595..0xce37cc
               Pieces: [{Size: 8, Op: {CfaOffset: 112}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce3340..0xce33a2
+            - Range: 0xce3500..0xce3562
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xce33a2..0xce360c
+            - Range: 0xce3562..0xce37cc
               Pieces: [{Size: 8, Op: {CfaOffset: 120}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce3340..0xce33eb
+            - Range: 0xce3500..0xce35ab
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xce33eb..0xce360c
+            - Range: 0xce35ab..0xce37cc
               Pieces: [{Size: 8, Op: {CfaOffset: 128}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce3340..0xce33eb
+            - Range: 0xce3500..0xce35ab
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xce33eb..0xce360c
+            - Range: 0xce35ab..0xce37cc
               Pieces: [{Size: 8, Op: {CfaOffset: 136}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce3340..0xce33eb
+            - Range: 0xce3500..0xce35ab
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xce33eb..0xce360c
+            - Range: 0xce35ab..0xce37cc
               Pieces: [{Size: 8, Op: {CfaOffset: 144}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce3340..0xce33eb
+            - Range: 0xce3500..0xce35ab
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xce33eb..0xce360c
+            - Range: 0xce35ab..0xce37cc
               Pieces: [{Size: 8, Op: {CfaOffset: 152}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce3340..0xce360c
+            - Range: 0xce3500..0xce37cc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -9063,200 +9063,200 @@ Subprograms:
         - Name: ~r0
           Type: 255 StructureType main.largeStruct
           Locations:
-            - Range: 0xce3340..0xce358b
+            - Range: 0xce3500..0xce374b
               Pieces: []
-            - Range: 0xce358b..0xce358c
+            - Range: 0xce374b..0xce374c
               Pieces: [{Size: 80, Op: {CfaOffset: 16}}]
-            - Range: 0xce358c..0xce360c
+            - Range: 0xce374c..0xce37cc
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 131
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0xce3620..0xce36ac]
+      OutOfLinePCRanges: [0xce37e0..0xce386c]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 166 ArrayType [5]int
           Locations:
-            - Range: 0xce3620..0xce36ac
+            - Range: 0xce37e0..0xce386c
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce3620..0xce369c
+            - Range: 0xce37e0..0xce385c
               Pieces: []
-            - Range: 0xce369c..0xce369d
+            - Range: 0xce385c..0xce385d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce369d..0xce36ac
+            - Range: 0xce385d..0xce386c
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce3620..0xce369c
+            - Range: 0xce37e0..0xce385c
               Pieces: []
-            - Range: 0xce369c..0xce369d
+            - Range: 0xce385c..0xce385d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce369d..0xce36ac
+            - Range: 0xce385d..0xce386c
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce3620..0xce369c
+            - Range: 0xce37e0..0xce385c
               Pieces: []
-            - Range: 0xce369c..0xce369d
+            - Range: 0xce385c..0xce385d
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce369d..0xce36ac
+            - Range: 0xce385d..0xce386c
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 132
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0xce36c0..0xce37af]
+      OutOfLinePCRanges: [0xce3880..0xce396f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 114 ArrayType [2]int
           Locations:
-            - Range: 0xce36c0..0xce37af
+            - Range: 0xce3880..0xce396f
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 256 ArrayType [3]int
           Locations:
-            - Range: 0xce36c0..0xce37af
+            - Range: 0xce3880..0xce396f
               Pieces: [{Size: 24, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce36c0..0xce379f
+            - Range: 0xce3880..0xce395f
               Pieces: []
-            - Range: 0xce379f..0xce37a0
+            - Range: 0xce395f..0xce3960
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce37a0..0xce37af
+            - Range: 0xce3960..0xce396f
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 114 ArrayType [2]int
           Locations:
-            - Range: 0xce36c0..0xce379f
+            - Range: 0xce3880..0xce395f
               Pieces: []
-            - Range: 0xce379f..0xce37a0
+            - Range: 0xce395f..0xce3960
               Pieces: [{Size: 16, Op: {CfaOffset: 40}}]
-            - Range: 0xce37a0..0xce37af
+            - Range: 0xce3960..0xce396f
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 133
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0xce37c0..0xce388c]
+      OutOfLinePCRanges: [0xce3980..0xce3a4c]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 261 StructureType main.structWithArray
           Locations:
-            - Range: 0xce37c0..0xce388c
+            - Range: 0xce3980..0xce3a4c
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce37c0..0xce387c
+            - Range: 0xce3980..0xce3a3c
               Pieces: []
-            - Range: 0xce387c..0xce387d
+            - Range: 0xce3a3c..0xce3a3d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce387d..0xce388c
+            - Range: 0xce3a3d..0xce3a4c
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 261 StructureType main.structWithArray
           Locations:
-            - Range: 0xce37c0..0xce387c
+            - Range: 0xce3980..0xce3a3c
               Pieces: []
-            - Range: 0xce387c..0xce387d
+            - Range: 0xce3a3c..0xce3a3d
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xce387d..0xce388c
+            - Range: 0xce3a3d..0xce3a4c
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce3846..0xce388c
+            - Range: 0xce3a06..0xce3a4c
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 134
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0xce38a0..0xce3946]
+      OutOfLinePCRanges: [0xce3a60..0xce3b06]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 258 ArrayType [0]int
-          Locations: [{Range: 0xce38a0..0xce3946, Pieces: []}]
+          Locations: [{Range: 0xce3a60..0xce3b06, Pieces: []}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce38a0..0xce38e5
+            - Range: 0xce3a60..0xce3aa5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce38e5..0xce3907
+            - Range: 0xce3aa5..0xce3ac7
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xce3907..0xce391a
+            - Range: 0xce3ac7..0xce3ada
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xce391a..0xce3946
+            - Range: 0xce3ada..0xce3b06
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce38a0..0xce392c
+            - Range: 0xce3a60..0xce3aec
               Pieces: []
-            - Range: 0xce392c..0xce392d
+            - Range: 0xce3aec..0xce3aed
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce392d..0xce3946
+            - Range: 0xce3aed..0xce3b06
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 258 ArrayType [0]int
           Locations:
-            - Range: 0xce38a0..0xce392c
+            - Range: 0xce3a60..0xce3aec
               Pieces: []
-            - Range: 0xce392c..0xce392d
+            - Range: 0xce3aec..0xce3aed
               Pieces: []
-            - Range: 0xce392d..0xce3946
+            - Range: 0xce3aed..0xce3b06
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 135
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0xce3e40..0xce3e41]
+      OutOfLinePCRanges: [0xce4000..0xce4001]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 262 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xce3e40..0xce3e41
+            - Range: 0xce4000..0xce4001
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9269,13 +9269,13 @@ Subprograms:
       DictRegister: null
     - ID: 136
       Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xce3e60..0xce3e61]
+      OutOfLinePCRanges: [0xce4020..0xce4021]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 262 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xce3e60..0xce3e61
+            - Range: 0xce4020..0xce4021
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9288,13 +9288,13 @@ Subprograms:
       DictRegister: null
     - ID: 137
       Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xce3e80..0xce3e81]
+      OutOfLinePCRanges: [0xce4040..0xce4041]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 263 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0xce3e80..0xce3e81
+            - Range: 0xce4040..0xce4041
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9307,13 +9307,13 @@ Subprograms:
       DictRegister: null
     - ID: 138
       Name: main.testStructSlice
-      OutOfLinePCRanges: [0xce3ea0..0xce3ea1]
+      OutOfLinePCRanges: [0xce4060..0xce4061]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 265 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xce3ea0..0xce3ea1
+            - Range: 0xce4060..0xce4061
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9326,20 +9326,20 @@ Subprograms:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce3ea0..0xce3ea1
+            - Range: 0xce4060..0xce4061
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 139
       Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xce3ec0..0xce3ec1]
+      OutOfLinePCRanges: [0xce4080..0xce4081]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 265 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xce3ec0..0xce3ec1
+            - Range: 0xce4080..0xce4081
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9352,20 +9352,20 @@ Subprograms:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce3ec0..0xce3ec1
+            - Range: 0xce4080..0xce4081
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 140
       Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xce3ee0..0xce3ee1]
+      OutOfLinePCRanges: [0xce40a0..0xce40a1]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 265 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xce3ee0..0xce3ee1
+            - Range: 0xce40a0..0xce40a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9378,20 +9378,20 @@ Subprograms:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce3ee0..0xce3ee1
+            - Range: 0xce40a0..0xce40a1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 141
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0xce3f00..0xce3f01]
+      OutOfLinePCRanges: [0xce40c0..0xce40c1]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 159 GoSliceHeaderType []string
           Locations:
-            - Range: 0xce3f00..0xce3f01
+            - Range: 0xce40c0..0xce40c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9404,20 +9404,20 @@ Subprograms:
       DictRegister: null
     - ID: 142
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xce3f20..0xce3f21]
+      OutOfLinePCRanges: [0xce40e0..0xce40e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 17 BaseType int8
           Locations:
-            - Range: 0xce3f20..0xce3f21
+            - Range: 0xce40e0..0xce40e1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 268 GoSliceHeaderType []bool
           Locations:
-            - Range: 0xce3f20..0xce3f21
+            - Range: 0xce40e0..0xce40e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9430,20 +9430,20 @@ Subprograms:
         - Name: x
           Type: 18 BaseType uint
           Locations:
-            - Range: 0xce3f20..0xce3f21
+            - Range: 0xce40e0..0xce40e1
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 143
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0xce3f40..0xce3f41]
+      OutOfLinePCRanges: [0xce4100..0xce4101]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 269 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0xce3f40..0xce3f41
+            - Range: 0xce4100..0xce4101
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9456,13 +9456,13 @@ Subprograms:
       DictRegister: null
     - ID: 144
       Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0xce3f60..0xce3f61]
+      OutOfLinePCRanges: [0xce4120..0xce4121]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 262 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xce3f60..0xce3f61
+            - Range: 0xce4120..0xce4121
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9475,13 +9475,13 @@ Subprograms:
       DictRegister: null
     - ID: 145
       Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0xce3f80..0xce3f81]
+      OutOfLinePCRanges: [0xce4140..0xce4141]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 270 GoSliceHeaderType []struct {}
           Locations:
-            - Range: 0xce3f80..0xce3f81
+            - Range: 0xce4140..0xce4141
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9494,13 +9494,13 @@ Subprograms:
       DictRegister: null
     - ID: 146
       Name: main.testSubslices
-      OutOfLinePCRanges: [0xce3fa0..0xce3fa1]
+      OutOfLinePCRanges: [0xce4160..0xce4161]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 262 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xce3fa0..0xce3fa1
+            - Range: 0xce4160..0xce4161
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9513,7 +9513,7 @@ Subprograms:
         - Name: bs
           Type: 262 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xce3fa0..0xce3fa1
+            - Range: 0xce4160..0xce4161
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -9526,7 +9526,7 @@ Subprograms:
         - Name: cs
           Type: 262 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xce3fa0..0xce3fa1
+            - Range: 0xce4160..0xce4161
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -9539,34 +9539,34 @@ Subprograms:
       DictRegister: null
     - ID: 147
       Name: main.stackC
-      OutOfLinePCRanges: [0xce4340..0xce4392]
+      OutOfLinePCRanges: [0xce4920..0xce4972]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce4340..0xce4385
+            - Range: 0xce4920..0xce4965
               Pieces: []
-            - Range: 0xce4385..0xce4386
+            - Range: 0xce4965..0xce4966
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce4386..0xce4392
+            - Range: 0xce4966..0xce4972
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 148
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xce43a0..0xce43a1]
+      OutOfLinePCRanges: [0xce4980..0xce4981]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce43a0..0xce43a1
+            - Range: 0xce4980..0xce4981
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9577,13 +9577,13 @@ Subprograms:
       DictRegister: null
     - ID: 149
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xce43c0..0xce43c1]
+      OutOfLinePCRanges: [0xce49a0..0xce49a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce43c0..0xce43c1
+            - Range: 0xce49a0..0xce49a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9594,7 +9594,7 @@ Subprograms:
         - Name: "y"
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce43c0..0xce43c1
+            - Range: 0xce49a0..0xce49a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9605,7 +9605,7 @@ Subprograms:
         - Name: z
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce43c0..0xce43c1
+            - Range: 0xce49a0..0xce49a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9616,13 +9616,13 @@ Subprograms:
       DictRegister: null
     - ID: 150
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xce43e0..0xce43ff]
+      OutOfLinePCRanges: [0xce49c0..0xce49df]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 272 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xce43e0..0xce43ff
+            - Range: 0xce49c0..0xce49df
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9641,39 +9641,39 @@ Subprograms:
       DictRegister: null
     - ID: 151
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xce4400..0xce4401]
+      OutOfLinePCRanges: [0xce49e0..0xce49e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 273 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xce4400..0xce4401
+            - Range: 0xce49e0..0xce49e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 152
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xce4420..0xce4421]
+      OutOfLinePCRanges: [0xce4a00..0xce4a01]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 274 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xce4420..0xce4421
+            - Range: 0xce4a00..0xce4a01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 153
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0xce4440..0xce4441]
+      OutOfLinePCRanges: [0xce4a20..0xce4a21]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce4440..0xce4441
+            - Range: 0xce4a20..0xce4a21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9684,13 +9684,13 @@ Subprograms:
       DictRegister: null
     - ID: 154
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xce4460..0xce4461]
+      OutOfLinePCRanges: [0xce4a40..0xce4a41]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce4460..0xce4461
+            - Range: 0xce4a40..0xce4a41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9701,13 +9701,13 @@ Subprograms:
       DictRegister: null
     - ID: 155
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0xce4480..0xce4481]
+      OutOfLinePCRanges: [0xce4a60..0xce4a61]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce4480..0xce4481
+            - Range: 0xce4a60..0xce4a61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9718,13 +9718,13 @@ Subprograms:
       DictRegister: null
     - ID: 156
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0xce44a0..0xce44a1]
+      OutOfLinePCRanges: [0xce4a80..0xce4a81]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce44a0..0xce44a1
+            - Range: 0xce4a80..0xce4a81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9735,7 +9735,7 @@ Subprograms:
         - Name: b
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce44a0..0xce44a1
+            - Range: 0xce4a80..0xce4a81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9746,7 +9746,7 @@ Subprograms:
         - Name: c
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce44a0..0xce44a1
+            - Range: 0xce4a80..0xce4a81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9757,26 +9757,26 @@ Subprograms:
       DictRegister: null
     - ID: 157
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0xce4620..0xce4621]
+      OutOfLinePCRanges: [0xce4c00..0xce4c01]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 276 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0xce4620..0xce4621
+            - Range: 0xce4c00..0xce4c01
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 158
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0xce4640..0xce465f]
+      OutOfLinePCRanges: [0xce4c20..0xce4c3f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 289 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0xce4640..0xce465f
+            - Range: 0xce4c20..0xce4c3f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9795,13 +9795,13 @@ Subprograms:
       DictRegister: null
     - ID: 159
       Name: main.testStruct
-      OutOfLinePCRanges: [0xce4780..0xce47a3]
+      OutOfLinePCRanges: [0xce4d60..0xce4d83]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 320 StructureType main.aStruct
           Locations:
-            - Range: 0xce4780..0xce47a3
+            - Range: 0xce4d60..0xce4d83
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -9822,91 +9822,91 @@ Subprograms:
       DictRegister: null
     - ID: 160
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0xce4880..0xce4881]
+      OutOfLinePCRanges: [0xce4e60..0xce4e61]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 321 PointerType *main.anotherStruct
           Locations:
-            - Range: 0xce4880..0xce4881
+            - Range: 0xce4e60..0xce4e61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 161
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0xce48a0..0xce48a1]
+      OutOfLinePCRanges: [0xce4e80..0xce4e81]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 323 StructureType main.tenStrings
           Locations:
-            - Range: 0xce48a0..0xce48a1
+            - Range: 0xce4e80..0xce4e81
               Pieces: [{Size: 160, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 162
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xce4900..0xce4901]
+      OutOfLinePCRanges: [0xce4ee0..0xce4ee1]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 324 StructureType main.emptyStruct
-          Locations: [{Range: 0xce4900..0xce4901, Pieces: []}]
+          Locations: [{Range: 0xce4ee0..0xce4ee1, Pieces: []}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 163
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xce4920..0xce4921]
+      OutOfLinePCRanges: [0xce4f00..0xce4f01]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 325 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xce4920..0xce4921
+            - Range: 0xce4f00..0xce4f01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 164
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0xce6ae0..0xce6ae4]
+      OutOfLinePCRanges: [0xce70c0..0xce70c4]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0xce6ae0..0xce6ae4
+            - Range: 0xce70c0..0xce70c4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xce6ae0..0xce6ae3
+            - Range: 0xce70c0..0xce70c3
               Pieces: []
-            - Range: 0xce6ae3..0xce6ae4
+            - Range: 0xce70c3..0xce70c4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 165
       Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0xce6b00..0xce6b0c]
+      OutOfLinePCRanges: [0xce70e0..0xce70ec]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce6b00..0xce6b0b
+            - Range: 0xce70e0..0xce70eb
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce6b0b..0xce6b0c
+            - Range: 0xce70eb..0xce70ec
               Pieces:
                 - Size: 8
                   Op: null
@@ -9917,9 +9917,9 @@ Subprograms:
         - Name: ~r0
           Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xce6b00..0xce6b0b
+            - Range: 0xce70e0..0xce70eb
               Pieces: []
-            - Range: 0xce6b0b..0xce6b0c
+            - Range: 0xce70eb..0xce70ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9930,41 +9930,41 @@ Subprograms:
       DictRegister: 0
     - ID: 166
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0xce6b20..0xce6b24]
+      OutOfLinePCRanges: [0xce7100..0xce7104]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xce6b20..0xce6b24
+            - Range: 0xce7100..0xce7104
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0xce6b20..0xce6b23
+            - Range: 0xce7100..0xce7103
               Pieces: []
-            - Range: 0xce6b23..0xce6b24
+            - Range: 0xce7103..0xce7104
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 167
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0xce6b40..0xce6b4c]
+      OutOfLinePCRanges: [0xce7120..0xce712c]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xce6b40..0xce6b4b
+            - Range: 0xce7120..0xce712b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce6b4b..0xce6b4c
+            - Range: 0xce712b..0xce712c
               Pieces:
                 - Size: 8
                   Op: null
@@ -9975,9 +9975,9 @@ Subprograms:
         - Name: ~r0
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce6b40..0xce6b4b
+            - Range: 0xce7120..0xce712b
               Pieces: []
-            - Range: 0xce6b4b..0xce6b4c
+            - Range: 0xce712b..0xce712c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9988,13 +9988,13 @@ Subprograms:
       DictRegister: 0
     - ID: 168
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0xce6bc0..0xce6cf6]
+      OutOfLinePCRanges: [0xce71a0..0xce72d6]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 330 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce6bc0..0xce6bf3
+            - Range: 0xce71a0..0xce71d3
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10002,7 +10002,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce6bf3..0xce6bfb
+            - Range: 0xce71d3..0xce71db
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -10010,7 +10010,7 @@ Subprograms:
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: null
-            - Range: 0xce6bfb..0xce6cf6
+            - Range: 0xce71db..0xce72d6
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -10023,18 +10023,18 @@ Subprograms:
         - Name: pred
           Type: 332 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0xce6bc0..0xce6bfb
+            - Range: 0xce71a0..0xce71db
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xce6bfb..0xce6cf6
+            - Range: 0xce71db..0xce72d6
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 330 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce6bc0..0xce6cb4
+            - Range: 0xce71a0..0xce7294
               Pieces: []
-            - Range: 0xce6cb4..0xce6cb5
+            - Range: 0xce7294..0xce7295
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10042,14 +10042,14 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce6cb5..0xce6cf6
+            - Range: 0xce7295..0xce72d6
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
           Type: 330 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce6bfb..0xce6c19
+            - Range: 0xce71db..0xce71f9
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10057,7 +10057,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce6c19..0xce6c21
+            - Range: 0xce71f9..0xce7201
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10065,7 +10065,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce6c21..0xce6c29
+            - Range: 0xce7201..0xce7209
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10073,7 +10073,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce6c29..0xce6c29
+            - Range: 0xce7209..0xce7209
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10081,7 +10081,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce6c29..0xce6c53
+            - Range: 0xce7209..0xce7233
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
@@ -10089,7 +10089,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce6c53..0xce6cab
+            - Range: 0xce7233..0xce728b
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10097,7 +10097,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce6cab..0xce6cf6
+            - Range: 0xce728b..0xce72d6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
@@ -10110,132 +10110,132 @@ Subprograms:
         - Name: item
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0xce6c46..0xce6c53
+            - Range: 0xce7226..0xce7233
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce6c53..0xce6cab
+            - Range: 0xce7233..0xce728b
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
     - ID: 169
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xce6d00..0xce6d44]
+      OutOfLinePCRanges: [0xce72e0..0xce7324]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xce6d00..0xce6d19
+            - Range: 0xce72e0..0xce72f9
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
           Type: 333 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0xce6d00..0xce6d19
+            - Range: 0xce72e0..0xce72f9
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xce6d00..0xce6d19
+            - Range: 0xce72e0..0xce72f9
               Pieces: []
-            - Range: 0xce6d19..0xce6d1a
+            - Range: 0xce72f9..0xce72fa
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce6d1a..0xce6d44
+            - Range: 0xce72fa..0xce7324
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
     - ID: 170
       Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0xce6fe0..0xce6fe4]
+      OutOfLinePCRanges: [0xce75c0..0xce75c4]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 331 PointerType *go.shape.int
           Locations:
-            - Range: 0xce6fe0..0xce6fe4
+            - Range: 0xce75c0..0xce75c4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 331 PointerType *go.shape.int
           Locations:
-            - Range: 0xce6fe0..0xce6fe3
+            - Range: 0xce75c0..0xce75c3
               Pieces: []
-            - Range: 0xce6fe3..0xce6fe4
+            - Range: 0xce75c3..0xce75c4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 171
       Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0xce7000..0xce7004]
+      OutOfLinePCRanges: [0xce75e0..0xce75e4]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 334 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0xce7000..0xce7004
+            - Range: 0xce75e0..0xce75e4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 334 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0xce7000..0xce7003
+            - Range: 0xce75e0..0xce75e3
               Pieces: []
-            - Range: 0xce7003..0xce7004
+            - Range: 0xce75e3..0xce75e4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 172
       Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0xce7020..0xce7024]
+      OutOfLinePCRanges: [0xce7600..0xce7604]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 336 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0xce7020..0xce7024
+            - Range: 0xce7600..0xce7604
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 336 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0xce7020..0xce7023
+            - Range: 0xce7600..0xce7603
               Pieces: []
-            - Range: 0xce7023..0xce7024
+            - Range: 0xce7603..0xce7604
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 173
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0xce7040..0xce7051]
+      OutOfLinePCRanges: [0xce7620..0xce7631]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 338 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0xce7040..0xce7051
+            - Range: 0xce7620..0xce7631
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce7040..0xce7050
+            - Range: 0xce7620..0xce7630
               Pieces: []
-            - Range: 0xce7050..0xce7051
+            - Range: 0xce7630..0xce7631
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10246,69 +10246,69 @@ Subprograms:
       DictRegister: 0
     - ID: 174
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0xce70e0..0xce70e9]
+      OutOfLinePCRanges: [0xce76c0..0xce76c9]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 340 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0xce70e0..0xce70e9
+            - Range: 0xce76c0..0xce76c9
               Pieces: [{Size: 136, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0xce70e0..0xce70e8
+            - Range: 0xce76c0..0xce76c8
               Pieces: []
-            - Range: 0xce70e8..0xce70e9
+            - Range: 0xce76c8..0xce76c9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 175
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0xce71a0..0xce71a8]
+      OutOfLinePCRanges: [0xce7780..0xce7788]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 341 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0xce71a0..0xce71a8
+            - Range: 0xce7780..0xce7788
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0xce71a0..0xce71a8
+            - Range: 0xce7780..0xce7788
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
           Type: 343 BaseType go.shape.bool
           Locations:
-            - Range: 0xce71a0..0xce71a8
+            - Range: 0xce7780..0xce7788
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
     - ID: 176
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0xce7240..0xce72ae]
+      OutOfLinePCRanges: [0xce7820..0xce788e]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 344 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0xce7240..0xce72ae
+            - Range: 0xce7820..0xce788e
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce7240..0xce72ae
+            - Range: 0xce7820..0xce788e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10319,20 +10319,20 @@ Subprograms:
         - Name: v
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0xce7240..0xce72ae
+            - Range: 0xce7820..0xce788e
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
     - ID: 177
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0xce7340..0xce7348]
+      OutOfLinePCRanges: [0xce7920..0xce7928]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce7340..0xce7348
+            - Range: 0xce7920..0xce7928
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10343,25 +10343,25 @@ Subprograms:
         - Name: b
           Type: 343 BaseType go.shape.bool
           Locations:
-            - Range: 0xce7340..0xce7348
+            - Range: 0xce7920..0xce7928
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 343 BaseType go.shape.bool
           Locations:
-            - Range: 0xce7340..0xce7347
+            - Range: 0xce7920..0xce7927
               Pieces: []
-            - Range: 0xce7347..0xce7348
+            - Range: 0xce7927..0xce7928
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce7340..0xce7347
+            - Range: 0xce7920..0xce7927
               Pieces: []
-            - Range: 0xce7347..0xce7348
+            - Range: 0xce7927..0xce7928
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10372,26 +10372,26 @@ Subprograms:
       DictRegister: 0
     - ID: 178
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xce7360..0xce736f]
+      OutOfLinePCRanges: [0xce7940..0xce794f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0xce7360..0xce736e
+            - Range: 0xce7940..0xce794e
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce7360..0xce736b
+            - Range: 0xce7940..0xce794b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce736b..0xce736f
+            - Range: 0xce794b..0xce794f
               Pieces:
                 - Size: 8
                   Op: null
@@ -10402,9 +10402,9 @@ Subprograms:
         - Name: ~r0
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce7360..0xce736e
+            - Range: 0xce7940..0xce794e
               Pieces: []
-            - Range: 0xce736e..0xce736f
+            - Range: 0xce794e..0xce794f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10415,56 +10415,56 @@ Subprograms:
         - Name: ~r1
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0xce7360..0xce736e
+            - Range: 0xce7940..0xce794e
               Pieces: []
-            - Range: 0xce736e..0xce736f
+            - Range: 0xce794e..0xce794f
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 179
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0xce7380..0xce73ba]
+      OutOfLinePCRanges: [0xce7960..0xce799a]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 346 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0xce7380..0xce7399
+            - Range: 0xce7960..0xce7979
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce7380..0xce7399
+            - Range: 0xce7960..0xce7979
               Pieces: []
-            - Range: 0xce7399..0xce739a
+            - Range: 0xce7979..0xce797a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce739a..0xce73ba
+            - Range: 0xce797a..0xce799a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 180
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0xce73c0..0xce740d]
+      OutOfLinePCRanges: [0xce79a0..0xce79ed]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 347 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0xce73c0..0xce73df
+            - Range: 0xce79a0..0xce79bf
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce73df..0xce73e2
+            - Range: 0xce79bf..0xce79c2
               Pieces:
                 - Size: 8
                   Op: null
@@ -10475,37 +10475,37 @@ Subprograms:
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce73c0..0xce73e2
+            - Range: 0xce79a0..0xce79c2
               Pieces: []
-            - Range: 0xce73e2..0xce73e3
+            - Range: 0xce79c2..0xce79c3
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce73e3..0xce740d
+            - Range: 0xce79c3..0xce79ed
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 181
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0xce7420..0xce7428]
+      OutOfLinePCRanges: [0xce7a00..0xce7a08]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 348 PointerType *go.shape.string
           Locations:
-            - Range: 0xce7420..0xce7427
+            - Range: 0xce7a00..0xce7a07
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce7420..0xce7427
+            - Range: 0xce7a00..0xce7a07
               Pieces: []
-            - Range: 0xce7427..0xce7428
+            - Range: 0xce7a07..0xce7a08
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10516,22 +10516,22 @@ Subprograms:
       DictRegister: 0
     - ID: 182
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0xce7440..0xce7497]
+      OutOfLinePCRanges: [0xce7a20..0xce7a77]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 349 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xce7440..0xce747d
+            - Range: 0xce7a20..0xce7a5d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 350 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xce7440..0xce7491
+            - Range: 0xce7a20..0xce7a71
               Pieces: []
-            - Range: 0xce7491..0xce7492
+            - Range: 0xce7a71..0xce7a72
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10545,20 +10545,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xce7492..0xce7497
+            - Range: 0xce7a72..0xce7a77
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 183
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0xce74a0..0xce74c4]
+      OutOfLinePCRanges: [0xce7a80..0xce7aa4]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 330 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce74a0..0xce74c4
+            - Range: 0xce7a80..0xce7aa4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10571,33 +10571,33 @@ Subprograms:
         - Name: needle
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0xce74a0..0xce74c4
+            - Range: 0xce7a80..0xce7aa4
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xce74a0..0xce74c0
+            - Range: 0xce7a80..0xce7aa0
               Pieces: []
-            - Range: 0xce74c0..0xce74c1
+            - Range: 0xce7aa0..0xce7aa1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce74c1..0xce74c3
+            - Range: 0xce7aa1..0xce7aa3
               Pieces: []
-            - Range: 0xce74c3..0xce74c4
+            - Range: 0xce7aa3..0xce7aa4
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 184
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0xce74e0..0xce759f]
+      OutOfLinePCRanges: [0xce7ac0..0xce7b7f]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 351 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0xce74e0..0xce74fd
+            - Range: 0xce7ac0..0xce7add
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10605,7 +10605,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce74fd..0xce74ff
+            - Range: 0xce7add..0xce7adf
               Pieces:
                 - Size: 8
                   Op: null
@@ -10618,13 +10618,13 @@ Subprograms:
         - Name: needle
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce74e0..0xce752c
+            - Range: 0xce7ac0..0xce7b0c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xce752c..0xce759f
+            - Range: 0xce7b0c..0xce7b7f
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
@@ -10635,28 +10635,28 @@ Subprograms:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xce74e0..0xce754b
+            - Range: 0xce7ac0..0xce7b2b
               Pieces: []
-            - Range: 0xce754b..0xce754c
+            - Range: 0xce7b2b..0xce7b2c
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce754c..0xce7553
+            - Range: 0xce7b2c..0xce7b33
               Pieces: []
-            - Range: 0xce7553..0xce7554
+            - Range: 0xce7b33..0xce7b34
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce7554..0xce759f
+            - Range: 0xce7b34..0xce7b7f
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce750f..0xce7521
+            - Range: 0xce7aef..0xce7b01
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xce7521..0xce752c
+            - Range: 0xce7b01..0xce7b0c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10667,54 +10667,54 @@ Subprograms:
       DictRegister: 0
     - ID: 185
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0xce75a0..0xce75a7]
+      OutOfLinePCRanges: [0xce7b80..0xce7b87]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 352 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0xce75a0..0xce75a6
+            - Range: 0xce7b80..0xce7b86
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0xce75a0..0xce75a7
+            - Range: 0xce7b80..0xce7b87
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xce75a0..0xce75a6
+            - Range: 0xce7b80..0xce7b86
               Pieces: []
-            - Range: 0xce75a6..0xce75a7
+            - Range: 0xce7b86..0xce7b87
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 3
     - ID: 186
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0xce7620..0xce768c]
+      OutOfLinePCRanges: [0xce7c00..0xce7c6c]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 353 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0xce7620..0xce7640
+            - Range: 0xce7c00..0xce7c20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce7640..0xce7648
+            - Range: 0xce7c20..0xce7c28
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce7648..0xce764d
+            - Range: 0xce7c28..0xce7c2d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10725,7 +10725,7 @@ Subprograms:
         - Name: value
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce7620..0xce764d
+            - Range: 0xce7c00..0xce7c2d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -10736,11 +10736,11 @@ Subprograms:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xce7620..0xce764d
+            - Range: 0xce7c00..0xce7c2d
               Pieces: []
-            - Range: 0xce764d..0xce764e
+            - Range: 0xce7c2d..0xce7c2e
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce764e..0xce768c
+            - Range: 0xce7c2e..0xce7c6c
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10878,31 +10878,31 @@ Subprograms:
       DictRegister: 0
     - ID: 188
       Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0xcddf80..0xcddfe2]
+      OutOfLinePCRanges: [0xcde080..0xcde0e2]
       InlinePCRanges:
-        - Ranges: [0xcde011..0xcde04d]
-          RootRanges: [0xcde000..0xcde071]
-        - Ranges: [0xcde152..0xcde18e]
-          RootRanges: [0xcde120..0xcde1a8]
-        - Ranges: [0xcde1dc..0xcde218]
-          RootRanges: [0xcde1c0..0xcde285]
-        - Ranges: [0xcde2af..0xcde2eb]
-          RootRanges: [0xcde2a0..0xcde302]
+        - Ranges: [0xcde111..0xcde14d]
+          RootRanges: [0xcde100..0xcde171]
+        - Ranges: [0xcde252..0xcde28e]
+          RootRanges: [0xcde220..0xcde2a8]
+        - Ranges: [0xcde2dc..0xcde318]
+          RootRanges: [0xcde2c0..0xcde385]
+        - Ranges: [0xcde3af..0xcde3eb]
+          RootRanges: [0xcde3a0..0xcde402]
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcddf80..0xcddf99
+            - Range: 0xcde080..0xcde099
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcde011..0xcde01c
+            - Range: 0xcde111..0xcde11c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcde152..0xcde15d
+            - Range: 0xcde252..0xcde25d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcde1d6..0xcde1e7
+            - Range: 0xcde2d6..0xcde2e7
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcde1e7..0xcde285
+            - Range: 0xcde2e7..0xcde385
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xcde2a0..0xcde2ba
+            - Range: 0xcde3a0..0xcde3ba
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10911,37 +10911,37 @@ Subprograms:
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcde226..0xcde25e]
-          RootRanges: [0xcde1c0..0xcde285]
+        - Ranges: [0xcde326..0xcde35e]
+          RootRanges: [0xcde2c0..0xcde385]
       Variables: []
       DictRegister: null
     - ID: 190
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcde333..0xcde371]
-          RootRanges: [0xcde320..0xcde425]
+        - Ranges: [0xcde433..0xcde471]
+          RootRanges: [0xcde420..0xcde525]
       Variables: []
       DictRegister: null
     - ID: 191
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcde3db..0xcde413]
-          RootRanges: [0xcde320..0xcde425]
+        - Ranges: [0xcde4db..0xcde513]
+          RootRanges: [0xcde420..0xcde525]
       Variables: []
       DictRegister: null
     - ID: 192
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcde441..0xcde445]
-          RootRanges: [0xcde440..0xcde446]
+        - Ranges: [0xcde541..0xcde545]
+          RootRanges: [0xcde540..0xcde546]
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde440..0xcde445
+            - Range: 0xcde540..0xcde545
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10950,32 +10950,32 @@ Subprograms:
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcde485..0xcde49d]
-          RootRanges: [0xcde460..0xcde4a3]
-        - Ranges: [0xcde525..0xcde543]
-          RootRanges: [0xcde4c0..0xcde645]
+        - Ranges: [0xcde585..0xcde59d]
+          RootRanges: [0xcde560..0xcde5a3]
+        - Ranges: [0xcde625..0xcde643]
+          RootRanges: [0xcde5c0..0xcde745]
       Variables:
         - Name: a
           Type: 166 ArrayType [5]int
           Locations:
-            - Range: 0xcde46d..0xcde4a3
+            - Range: 0xcde56d..0xcde5a3
               Pieces: [{Size: 40, Op: {CfaOffset: -56}}]
-            - Range: 0xcde50c..0xcde645
+            - Range: 0xcde60c..0xcde745
               Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 194
       Name: main.firstBehavior.DoSomething
-      OutOfLinePCRanges: [0xcde660..0xcde6c6]
+      OutOfLinePCRanges: [0xcde760..0xcde7c6]
       InlinePCRanges:
-        - Ranges: [0xce7743..0xce7771]
-          RootRanges: [0xce7720..0xce779f]
+        - Ranges: [0xce7d23..0xce7d51]
+          RootRanges: [0xce7d00..0xce7d7f]
       Variables:
         - Name: b
           Type: 358 StructureType main.firstBehavior
           Locations:
-            - Range: 0xcde660..0xcde67e
+            - Range: 0xcde760..0xcde77e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10986,15 +10986,15 @@ Subprograms:
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcde660..0xcde6a5
+            - Range: 0xcde760..0xcde7a5
               Pieces: []
-            - Range: 0xcde6a5..0xcde6a6
+            - Range: 0xcde7a5..0xcde7a6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcde6a6..0xcde6c6
+            - Range: 0xcde7a6..0xcde7c6
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11003,8 +11003,8 @@ Subprograms:
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcdedb0..0xcdedb7]
-          RootRanges: [0xcdec60..0xcdee05]
+        - Ranges: [0xcdefdd..0xcdefe4]
+          RootRanges: [0xcdef40..0xcdf02b]
         - Ranges: [0x52bec1..0x52bec9]
           RootRanges: [0x52bec0..0x52beca]
       Variables: []
@@ -11323,7 +11323,7 @@ Types:
       ID: 40
       Name: '*[]runtime.ancestorInfo'
       ByteSize: 8
-      GoRuntimeType: 492320
+      GoRuntimeType: 492576
       GoKind: 22
       Pointee: 41 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
@@ -11426,7 +11426,7 @@ Types:
       ID: 12
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 395552
+      GoRuntimeType: 395680
       GoKind: 22
       Pointee: 5 BaseType bool
     - __kind: PointerType
@@ -11863,7 +11863,7 @@ Types:
       ID: 107
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 394464
+      GoRuntimeType: 394592
       GoKind: 22
       Pointee: 14 GoInterfaceType error
     - __kind: PointerType
@@ -11884,14 +11884,14 @@ Types:
       ID: 109
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 395424
+      GoRuntimeType: 395552
       GoKind: 22
       Pointee: 19 BaseType float32
     - __kind: PointerType
       ID: 99
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 395488
+      GoRuntimeType: 395616
       GoKind: 22
       Pointee: 16 BaseType float64
     - __kind: PointerType
@@ -12750,42 +12750,42 @@ Types:
       ID: 100
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 395104
+      GoRuntimeType: 395232
       GoKind: 22
       Pointee: 8 BaseType int
     - __kind: PointerType
       ID: 104
       Name: '*int16'
       ByteSize: 8
-      GoRuntimeType: 394720
+      GoRuntimeType: 394848
       GoKind: 22
       Pointee: 105 BaseType int16
     - __kind: PointerType
       ID: 21
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 394848
+      GoRuntimeType: 394976
       GoKind: 22
       Pointee: 11 BaseType int32
     - __kind: PointerType
       ID: 101
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 394976
+      GoRuntimeType: 395104
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
       ID: 106
       Name: '*int8'
       ByteSize: 8
-      GoRuntimeType: 394592
+      GoRuntimeType: 394720
       GoKind: 22
       Pointee: 17 BaseType int8
     - __kind: PointerType
       ID: 168
       Name: '*interface {}'
       ByteSize: 8
-      GoRuntimeType: 395680
+      GoRuntimeType: 395808
       GoKind: 22
       Pointee: 162 GoEmptyInterfaceType interface {}
     - __kind: PointerType
@@ -12813,7 +12813,7 @@ Types:
       ID: 1066
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
-      GoRuntimeType: 905984
+      GoRuntimeType: 906368
       GoKind: 22
       Pointee: 1067 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
@@ -12838,12 +12838,12 @@ Types:
       GoKind: 22
       Pointee: 951 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 670
+      ID: 673
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
-      GoRuntimeType: 904928
+      GoRuntimeType: 905312
       GoKind: 22
-      Pointee: 671 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 674 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
       ID: 733
       Name: '*internal/runtime/cgroup.stringError'
@@ -13948,12 +13948,12 @@ Types:
       GoKind: 22
       Pointee: 645 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 672
+      ID: 675
       Name: '*reflect.ValueError'
       ByteSize: 8
-      GoRuntimeType: 905600
+      GoRuntimeType: 905984
       GoKind: 22
-      Pointee: 673 UnresolvedPointeeType reflect.ValueError
+      Pointee: 676 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
       ID: 770
       Name: '*regexp/syntax.Error'
@@ -13965,21 +13965,21 @@ Types:
       ID: 882
       Name: '*runtime.PanicNilError'
       ByteSize: 8
-      GoRuntimeType: 1033312
+      GoRuntimeType: 1033568
       GoKind: 22
       Pointee: 883 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
       ID: 886
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
-      GoRuntimeType: 1035104
+      GoRuntimeType: 1035360
       GoKind: 22
       Pointee: 887 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 27
       Name: '*runtime._defer'
       ByteSize: 8
-      GoRuntimeType: 395744
+      GoRuntimeType: 395872
       GoKind: 22
       Pointee: 28 UnresolvedPointeeType runtime._defer
     - __kind: PointerType
@@ -13993,21 +13993,21 @@ Types:
       ID: 884
       Name: '*runtime.boundsError'
       ByteSize: 8
-      GoRuntimeType: 1033440
+      GoRuntimeType: 1033696
       GoKind: 22
       Pointee: 885 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 66
       Name: '*runtime.cgoCallers'
       ByteSize: 8
-      GoRuntimeType: 396384
+      GoRuntimeType: 396512
       GoKind: 22
       Pointee: 67 UnresolvedPointeeType runtime.cgoCallers
     - __kind: PointerType
       ID: 48
       Name: '*runtime.coro'
       ByteSize: 8
-      GoRuntimeType: 396448
+      GoRuntimeType: 396576
       GoKind: 22
       Pointee: 49 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
@@ -14021,7 +14021,7 @@ Types:
       ID: 880
       Name: '*runtime.errorString'
       ByteSize: 8
-      GoRuntimeType: 1032928
+      GoRuntimeType: 1033184
       GoKind: 22
       Pointee: 861 GoStringHeaderType runtime.errorString
     - __kind: PointerType
@@ -14033,7 +14033,7 @@ Types:
       ID: 56
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 903968
+      GoRuntimeType: 904352
       GoKind: 22
       Pointee: 23 StructureType runtime.g
     - __kind: PointerType
@@ -14047,14 +14047,14 @@ Types:
       ID: 65
       Name: '*runtime.p'
       ByteSize: 8
-      GoRuntimeType: 1034464
+      GoRuntimeType: 1034720
       GoKind: 22
       Pointee: 365 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 881
       Name: '*runtime.plainError'
       ByteSize: 8
-      GoRuntimeType: 1033056
+      GoRuntimeType: 1033312
       GoKind: 22
       Pointee: 864 GoStringHeaderType runtime.plainError
     - __kind: PointerType
@@ -14066,7 +14066,7 @@ Types:
       ID: 42
       Name: '*runtime.sudog'
       ByteSize: 8
-      GoRuntimeType: 397088
+      GoRuntimeType: 397216
       GoKind: 22
       Pointee: 43 UnresolvedPointeeType runtime.sudog
     - __kind: PointerType
@@ -14077,12 +14077,12 @@ Types:
       GoKind: 22
       Pointee: 51 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 668
+      ID: 671
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
-      GoRuntimeType: 904640
+      GoRuntimeType: 905024
       GoKind: 22
-      Pointee: 669 StructureType runtime.synctestDeadlockError
+      Pointee: 672 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 45
       Name: '*runtime.timer'
@@ -14094,7 +14094,7 @@ Types:
       ID: 80
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1629120
+      GoRuntimeType: 1629504
       GoKind: 22
       Pointee: 81 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
@@ -14108,7 +14108,7 @@ Types:
       ID: 96
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 394528
+      GoRuntimeType: 394656
       GoKind: 22
       Pointee: 10 GoStringHeaderType string
     - __kind: PointerType
@@ -14304,21 +14304,21 @@ Types:
       ID: 1014
       Name: '*time.Location'
       ByteSize: 8
-      GoRuntimeType: 1634112
+      GoRuntimeType: 1625472
       GoKind: 22
       Pointee: 1015 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 675
+      ID: 669
       Name: '*time.ParseError'
       ByteSize: 8
-      GoRuntimeType: 906752
+      GoRuntimeType: 902432
       GoKind: 22
-      Pointee: 676 UnresolvedPointeeType time.ParseError
+      Pointee: 670 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 674
+      ID: 668
       Name: '*time.fileSizeError'
       ByteSize: 8
-      GoRuntimeType: 906656
+      GoRuntimeType: 902336
       GoKind: 22
       Pointee: 591 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
@@ -14330,42 +14330,42 @@ Types:
       ID: 108
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 395168
+      GoRuntimeType: 395296
       GoKind: 22
       Pointee: 18 BaseType uint
     - __kind: PointerType
       ID: 103
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 394784
+      GoRuntimeType: 394912
       GoKind: 22
       Pointee: 7 BaseType uint16
     - __kind: PointerType
       ID: 22
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 394912
+      GoRuntimeType: 395040
       GoKind: 22
       Pointee: 3 BaseType uint32
     - __kind: PointerType
       ID: 102
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 395040
+      GoRuntimeType: 395168
       GoKind: 22
       Pointee: 9 BaseType uint64
     - __kind: PointerType
       ID: 6
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 394656
+      GoRuntimeType: 394784
       GoKind: 22
       Pointee: 4 BaseType uint8
     - __kind: PointerType
       ID: 20
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 395232
+      GoRuntimeType: 395360
       GoKind: 22
       Pointee: 2 BaseType uintptr
     - __kind: PointerType
@@ -23495,7 +23495,7 @@ Types:
       ID: 93
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 705408
+      GoRuntimeType: 706848
       GoKind: 17
       Count: 10
       HasCount: true
@@ -23522,7 +23522,7 @@ Types:
       ID: 79
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 705024
+      GoRuntimeType: 706464
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23531,7 +23531,7 @@ Types:
       ID: 78
       Name: '[2][2]*runtime.traceBuf'
       ByteSize: 32
-      GoRuntimeType: 705120
+      GoRuntimeType: 706560
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23556,7 +23556,7 @@ Types:
       ID: 85
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 705312
+      GoRuntimeType: 706752
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23698,7 +23698,7 @@ Types:
       ID: 69
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 704832
+      GoRuntimeType: 706272
       GoKind: 17
       Count: 32
       HasCount: true
@@ -23716,7 +23716,7 @@ Types:
       ID: 54
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 704256
+      GoRuntimeType: 705696
       GoKind: 17
       Count: 3
       HasCount: true
@@ -23786,7 +23786,7 @@ Types:
       ID: 86
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 705216
+      GoRuntimeType: 706656
       GoKind: 17
       Count: 8
       HasCount: true
@@ -23887,7 +23887,7 @@ Types:
       ID: 63
       Name: '[]*runtime.p'
       ByteSize: 24
-      GoRuntimeType: 491872
+      GoRuntimeType: 492128
       GoKind: 23
       RawFields:
         - Name: array
@@ -24227,7 +24227,7 @@ Types:
       ID: 268
       Name: '[]bool'
       ByteSize: 24
-      GoRuntimeType: 490272
+      GoRuntimeType: 490528
       GoKind: 23
       RawFields:
         - Name: array
@@ -24250,7 +24250,7 @@ Types:
       ID: 1039
       Name: '[]float64'
       ByteSize: 24
-      GoRuntimeType: 490144
+      GoRuntimeType: 490400
       GoKind: 23
       RawFields:
         - Name: array
@@ -24340,7 +24340,7 @@ Types:
       ID: 1320
       Name: '[]interface {}'
       ByteSize: 24
-      GoRuntimeType: 490592
+      GoRuntimeType: 490848
       GoKind: 23
       RawFields:
         - Name: array
@@ -24596,7 +24596,7 @@ Types:
       ID: 159
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 490400
+      GoRuntimeType: 490656
       GoKind: 23
       RawFields:
         - Name: array
@@ -24640,7 +24640,7 @@ Types:
       ID: 262
       Name: '[]uint'
       ByteSize: 24
-      GoRuntimeType: 489888
+      GoRuntimeType: 490144
       GoKind: 23
       RawFields:
         - Name: array
@@ -24663,7 +24663,7 @@ Types:
       ID: 269
       Name: '[]uint16'
       ByteSize: 24
-      GoRuntimeType: 489248
+      GoRuntimeType: 489504
       GoKind: 23
       RawFields:
         - Name: array
@@ -24686,7 +24686,7 @@ Types:
       ID: 39
       Name: '[]uint8'
       ByteSize: 24
-      GoRuntimeType: 489120
+      GoRuntimeType: 489376
       GoKind: 23
       RawFields:
         - Name: array
@@ -24709,7 +24709,7 @@ Types:
       ID: 44
       Name: '[]uintptr'
       ByteSize: 24
-      GoRuntimeType: 489952
+      GoRuntimeType: 490208
       GoKind: 23
       RawFields:
         - Name: array
@@ -25192,7 +25192,7 @@ Types:
       ID: 14
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1032800
+      GoRuntimeType: 1033056
       GoKind: 20
       RawFields:
         - Name: tab
@@ -25243,7 +25243,7 @@ Types:
       ID: 74
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 852928
+      GoRuntimeType: 853216
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 357
@@ -26833,7 +26833,7 @@ Types:
       ID: 162
       Name: interface {}
       ByteSize: 16
-      GoRuntimeType: 852640
+      GoRuntimeType: 852928
       GoKind: 20
       RawFields:
         - Name: _type
@@ -26891,11 +26891,11 @@ Types:
     - __kind: StructureType
       ID: 951
       Name: internal/poll.errNetClosing
-      GoRuntimeType: 1485408
+      GoRuntimeType: 1485728
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 671
+      ID: 674
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -27008,7 +27008,7 @@ Types:
       ID: 1269
       Name: internal/sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1482848
+      GoRuntimeType: 1483168
       GoKind: 25
       RawFields:
         - Name: state
@@ -30827,7 +30827,7 @@ Types:
       GoRuntimeType: 842464
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 673
+      ID: 676
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -30893,7 +30893,7 @@ Types:
       ID: 947
       Name: runtime.errorAddressString
       ByteSize: 24
-      GoRuntimeType: 1763040
+      GoRuntimeType: 1763232
       GoKind: 25
       RawFields:
         - Name: msg
@@ -31125,7 +31125,7 @@ Types:
       ID: 31
       Name: runtime.gobuf
       ByteSize: 48
-      GoRuntimeType: 1924128
+      GoRuntimeType: 1924384
       GoKind: 25
       RawFields:
         - Name: sp
@@ -31150,7 +31150,7 @@ Types:
       ID: 47
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1479968
+      GoRuntimeType: 1480288
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -31163,7 +31163,7 @@ Types:
       ID: 57
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1761888
+      GoRuntimeType: 1762080
       GoKind: 25
       RawFields:
         - Name: stack
@@ -31182,13 +31182,13 @@ Types:
       ID: 32
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 835072
+      GoRuntimeType: 835360
       GoKind: 12
     - __kind: StructureType
       ID: 94
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1479808
+      GoRuntimeType: 1480128
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -31201,7 +31201,7 @@ Types:
       ID: 82
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 1924896
+      GoRuntimeType: 1925152
       GoKind: 25
       RawFields:
         - Name: fn
@@ -31226,7 +31226,7 @@ Types:
       ID: 95
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 834976
+      GoRuntimeType: 835264
       GoKind: 2
     - __kind: StructureType
       ID: 30
@@ -31452,7 +31452,7 @@ Types:
       ID: 71
       Name: runtime.mLockProfile
       ByteSize: 56
-      GoRuntimeType: 1924640
+      GoRuntimeType: 1924896
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -31477,7 +31477,7 @@ Types:
       ID: 89
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 1850048
+      GoRuntimeType: 1850272
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -31499,7 +31499,7 @@ Types:
       ID: 76
       Name: runtime.mTraceState
       ByteSize: 56
-      GoRuntimeType: 1849824
+      GoRuntimeType: 1850048
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -31521,7 +31521,7 @@ Types:
       ID: 70
       Name: runtime.mWaitList
       ByteSize: 16
-      GoRuntimeType: 1479488
+      GoRuntimeType: 1479808
       GoKind: 25
       RawFields:
         - Name: next
@@ -31534,7 +31534,7 @@ Types:
       ID: 38
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 834688
+      GoRuntimeType: 834976
       GoKind: 12
     - __kind: StructureType
       ID: 68
@@ -31551,7 +31551,7 @@ Types:
       ID: 84
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1479648
+      GoRuntimeType: 1479968
       GoKind: 25
       RawFields:
         - Name: entries
@@ -31564,7 +31564,7 @@ Types:
       ID: 87
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1762848
+      GoRuntimeType: 1763040
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -31602,13 +31602,13 @@ Types:
       ID: 61
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 834880
+      GoRuntimeType: 835168
       GoKind: 12
     - __kind: ArrayType
       ID: 58
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 903488
+      GoRuntimeType: 903872
       GoKind: 17
       Count: 2
       HasCount: true
@@ -31617,7 +31617,7 @@ Types:
       ID: 24
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1477728
+      GoRuntimeType: 1478048
       GoKind: 25
       RawFields:
         - Name: lo
@@ -31635,7 +31635,7 @@ Types:
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 669
+      ID: 672
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1604160
@@ -31671,7 +31671,7 @@ Types:
       ID: 53
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1478688
+      GoRuntimeType: 1479008
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -32519,14 +32519,14 @@ Types:
       ID: 1163
       Name: time.Duration
       ByteSize: 8
-      GoRuntimeType: 1925664
+      GoRuntimeType: 1922592
       GoKind: 6
     - __kind: UnresolvedPointeeType
       ID: 1015
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 676
+      ID: 670
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
@@ -32549,7 +32549,7 @@ Types:
       ID: 591
       Name: time.fileSizeError
       ByteSize: 16
-      GoRuntimeType: 835456
+      GoRuntimeType: 834208
       GoKind: 24
       RawFields:
         - Name: str
@@ -32752,10 +32752,10 @@ Issues:
       issue:
         Kind: 7
         Message: return value selector (e.g., @return.r0) must be used for multi-value returns
-GoModuledataInfo: {FirstModuledataAddr: "0x1815520", TypesOffset: 296}
+GoModuledataInfo: {FirstModuledataAddr: "0x1817520", TypesOffset: 296}
 GoMapHashInfo:
-    UseAeshashAddr: "0x190842a"
-    AeskeyschedAddr: "0x1909500"
+    UseAeshashAddr: "0x190a42a"
+    AeskeyschedAddr: "0x190b500"
 CommonTypes:
     G: 23 StructureType runtime.g
     M: 30 StructureType runtime.m

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.26rc1.yaml
@@ -13,11 +13,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1600 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0xcf07ea", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf0daa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1601 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0xcf0825", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf0de5", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -33,11 +33,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1439 EventRootType Probe[main.testAny]
-              InjectionPoints: [{PC: "0xceac2a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcead2a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1440 EventRootType Probe[main.testAny]Return
-              InjectionPoints: [{PC: "0xceac65", Frameless: false}]
+              InjectionPoints: [{PC: "0xcead65", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -59,11 +59,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1442 EventRootType Probe[main.testAnyPtr]
-              InjectionPoints: [{PC: "0xceacca", Frameless: false}]
+              InjectionPoints: [{PC: "0xceadca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1443 EventRootType Probe[main.testAnyPtr]Return
-              InjectionPoints: [{PC: "0xceacfd", Frameless: false}]
+              InjectionPoints: [{PC: "0xceadfd", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -84,11 +84,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1571 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0xcef1ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xcef3ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1572 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0xcef2aa", Frameless: false}]
+              InjectionPoints: [{PC: "0xcef46a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -110,7 +110,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1388 EventRootType Probe[main.testArrayEmptyStructs]
-              InjectionPoints: [{PC: "0xce5da0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5ea0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -132,7 +132,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1384 EventRootType Probe[main.testArrayOfArrays]
-              InjectionPoints: [{PC: "0xce5d20", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5e20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -154,7 +154,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1386 EventRootType Probe[main.testArrayOfArraysOfArrays]
-              InjectionPoints: [{PC: "0xce5d60", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5e60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -176,7 +176,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1451 EventRootType Probe[main.testArrayOfMaps]
-              InjectionPoints: [{PC: "0xceb460", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb620", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -198,7 +198,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1385 EventRootType Probe[main.testArrayOfStrings]
-              InjectionPoints: [{PC: "0xce5d40", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5e40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -219,7 +219,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1387 EventRootType Probe[main.testArrayOfStructs]
-              InjectionPoints: [{PC: "0xce5d80", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5e80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -241,11 +241,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1473 EventRootType Probe[main.testAtomicAdd]
-              InjectionPoints: [{PC: "0xced280", Frameless: true}]
+              InjectionPoints: [{PC: "0xced440", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1474 EventRootType Probe[main.testAtomicAdd]Return
-              InjectionPoints: [{PC: "0xced292", Frameless: true}]
+              InjectionPoints: [{PC: "0xced452", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -267,7 +267,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1406 EventRootType Probe[main.testBigStruct]
-              InjectionPoints: [{PC: "0xce64e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce65e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -289,7 +289,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1373 EventRootType Probe[main.testBoolArray]
-              InjectionPoints: [{PC: "0xce5bc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5cc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -311,7 +311,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1370 EventRootType Probe[main.testByteArray]
-              InjectionPoints: [{PC: "0xce5b60", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5c60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -338,7 +338,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1616 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xcf0c20", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf11e0", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -358,15 +358,15 @@ Probes:
             - Kind: Line
               Type: 1675 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xcea44e"
+                - PC: "0xcea54e"
                   Frameless: false
-                - PC: "0xcea4d1"
+                - PC: "0xcea5d1"
                   Frameless: false
-                - PC: "0xcea612"
+                - PC: "0xcea712"
                   Frameless: false
-                - PC: "0xcea69c"
+                - PC: "0xcea79c"
                   Frameless: false
-                - PC: "0xcea76f"
+                - PC: "0xcea86f"
                   Frameless: false
               Condition: null
     - id: testCaptureExprLineCond
@@ -388,15 +388,15 @@ Probes:
             - Kind: Line
               Type: 1676 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xcea44e"
+                - PC: "0xcea54e"
                   Frameless: false
-                - PC: "0xcea4d1"
+                - PC: "0xcea5d1"
                   Frameless: false
-                - PC: "0xcea612"
+                - PC: "0xcea712"
                   Frameless: false
-                - PC: "0xcea69c"
+                - PC: "0xcea79c"
                   Frameless: false
-                - PC: "0xcea76f"
+                - PC: "0xcea86f"
                   Frameless: false
               Condition:
                 Type: 5 BaseType bool
@@ -432,15 +432,15 @@ Probes:
             - Kind: Line
               Type: 1677 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xcea44e"
+                - PC: "0xcea54e"
                   Frameless: false
-                - PC: "0xcea4d1"
+                - PC: "0xcea5d1"
                   Frameless: false
-                - PC: "0xcea612"
+                - PC: "0xcea712"
                   Frameless: false
-                - PC: "0xcea69c"
+                - PC: "0xcea79c"
                   Frameless: false
-                - PC: "0xcea76f"
+                - PC: "0xcea86f"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -468,7 +468,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1470 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0xcecee0", Frameless: true}]
+              InjectionPoints: [{PC: "0xced0a0", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -487,7 +487,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1471 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0xcecee0", Frameless: true}]
+              InjectionPoints: [{PC: "0xced0a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -513,7 +513,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1622 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0xcf0d00", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf12c0", Frameless: true}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -549,7 +549,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1475 EventRootType Probe[main.testChannel]
-              InjectionPoints: [{PC: "0xced2a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xced460", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -579,7 +579,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1469 EventRootType Probe[main.testCombinedByte]
-              InjectionPoints: [{PC: "0xcecea0", Frameless: true}]
+              InjectionPoints: [{PC: "0xced060", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{w}, {x}, {y}'
@@ -608,11 +608,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1536 EventRootType Probe[main.testConflictingReturn]
-              InjectionPoints: [{PC: "0xcee42e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee5ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1537 EventRootType Probe[main.testConflictingReturn]Return
-              InjectionPoints: [{PC: "0xcee4f1", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee6b1", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -634,7 +634,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1483 EventRootType Probe[main.testCycle]
-              InjectionPoints: [{PC: "0xced660", Frameless: true}]
+              InjectionPoints: [{PC: "0xced820", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{t}'
@@ -656,7 +656,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1412 EventRootType Probe[main.testDeepMap1]
-              InjectionPoints: [{PC: "0xce69c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6ac0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -678,7 +678,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1413 EventRootType Probe[main.testDeepMap7]
-              InjectionPoints: [{PC: "0xce69e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6ae0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -700,7 +700,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1408 EventRootType Probe[main.testDeepPtr1]
-              InjectionPoints: [{PC: "0xce66c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce67c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -722,7 +722,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1409 EventRootType Probe[main.testDeepPtr7]
-              InjectionPoints: [{PC: "0xce66e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce67e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -744,7 +744,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1410 EventRootType Probe[main.testDeepSlice1]
-              InjectionPoints: [{PC: "0xce6840", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6940", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -766,7 +766,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1411 EventRootType Probe[main.testDeepSlice7]
-              InjectionPoints: [{PC: "0xce6860", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6960", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -788,7 +788,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1588 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0xcf0340", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0500", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -815,7 +815,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1591 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0xcf03a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0560", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -843,7 +843,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1612 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0xcf0920", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0ee0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -865,7 +865,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1623 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0xcf0d60", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf1320", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -886,7 +886,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1624 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0xcf0d80", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf1340", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -908,7 +908,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1441 EventRootType Probe[main.testError]
-              InjectionPoints: [{PC: "0xceaca0", Frameless: true}]
+              InjectionPoints: [{PC: "0xceada0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -942,7 +942,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1407 EventRootType Probe[main.testErrorAtLine]Line
-              InjectionPoints: [{PC: "0xce6594", Frameless: false}]
+              InjectionPoints: [{PC: "0xce6694", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}, err={err}
@@ -970,11 +970,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1423 EventRootType Probe[main.testEsotericHeap]
-              InjectionPoints: [{PC: "0xce902a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce912a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1424 EventRootType Probe[main.testEsotericHeap]Return
-              InjectionPoints: [{PC: "0xce906c", Frameless: false}]
+              InjectionPoints: [{PC: "0xce916c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -996,11 +996,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1421 EventRootType Probe[main.testEsotericStack]
-              InjectionPoints: [{PC: "0xce8f0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce900e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1422 EventRootType Probe[main.testEsotericStack]Return
-              InjectionPoints: [{PC: "0xce8f9b", Frameless: false}]
+              InjectionPoints: [{PC: "0xce909b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1022,11 +1022,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1433 EventRootType Probe[main.testFrameless]
-              InjectionPoints: [{PC: "0xcea900", Frameless: true}]
+              InjectionPoints: [{PC: "0xceaa00", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1434 EventRootType Probe[main.testFrameless]Return
-              InjectionPoints: [{PC: "0xcea905", Frameless: true}]
+              InjectionPoints: [{PC: "0xceaa05", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1048,11 +1048,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1435 EventRootType Probe[main.testFramelessArray]
-              InjectionPoints: [{PC: "0xcea924", Frameless: false}]
+              InjectionPoints: [{PC: "0xceaa24", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1436 EventRootType Probe[main.testFramelessArray]Return
-              InjectionPoints: [{PC: "0xcea965", Frameless: false}]
+              InjectionPoints: [{PC: "0xceaa65", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1077,7 +1077,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1437 EventRootType Probe[main.testFramelessArray]Line
-              InjectionPoints: [{PC: "0xcea928", Frameless: false}]
+              InjectionPoints: [{PC: "0xceaa28", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1099,11 +1099,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1661 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0xcf3680", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3c40", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1662 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xcf3687", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3c47", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1117,11 +1117,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1663 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0xcf36a4", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf3c64", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1664 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0xcf36f5", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf3cb5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1144,11 +1144,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1657 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0xcf35ea", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf3baa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1658 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0xcf35f9", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf3bb9", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1162,11 +1162,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1659 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0xcf362a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf3bea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1660 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0xcf3642", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf3c02", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1189,14 +1189,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1665 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0xcf3700", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3cc0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1666 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0xcf3720"
+                - PC: "0xcf3ce0"
                   Frameless: true
-                - PC: "0xcf3723"
+                - PC: "0xcf3ce3"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1211,14 +1211,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1667 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0xcf374a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf3d0a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1668 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0xcf37ab"
+                - PC: "0xcf3d6b"
                   Frameless: false
-                - PC: "0xcf37b3"
+                - PC: "0xcf3d73"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1245,7 +1245,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1669 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0xcf3705", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3cc5", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1257,7 +1257,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1670 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0xcf375f", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf3d1f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1278,11 +1278,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1645 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0xcf32a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3860", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1646 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0xcf32b0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3870", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1296,11 +1296,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1647 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0xcf3380", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3940", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1648 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0xcf3388", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3948", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1324,11 +1324,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1633 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0xcf2dd3", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf3393", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1634 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xcf2f5a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf351a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1370,11 +1370,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1637 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xcf2fca", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf358a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1638 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xcf2fd9", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf3599", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1397,11 +1397,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1671 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0xcf3800", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3dc0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1672 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0xcf3806", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3dc6", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1415,11 +1415,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1673 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0xcf386a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf3e2a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1674 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0xcf388d", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf3e4d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1442,11 +1442,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1629 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0xcf2d20", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf32e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1630 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xcf2d23", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf32e3", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1460,11 +1460,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1631 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0xcf2d40", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3300", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1632 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xcf2d4b", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf330b", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1487,11 +1487,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1649 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0xcf3440", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3a00", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1650 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0xcf3447", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3a07", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1505,11 +1505,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1651 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0xcf34ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf3a8a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1652 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0xcf34f3", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf3ab3", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1532,11 +1532,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1639 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0xcf3240", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3800", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1640 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xcf3243", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3803", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1550,11 +1550,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1641 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0xcf3260", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3820", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1642 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0xcf3263", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3823", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1568,11 +1568,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1643 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0xcf3280", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3840", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1644 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0xcf3283", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3843", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1595,11 +1595,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1653 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0xcf35a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3b60", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1654 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0xcf35a7", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3b67", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1613,11 +1613,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1655 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xcf35c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3b80", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1656 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xcf35ce", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3b8e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1640,11 +1640,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1625 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0xcf2ce0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf32a0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1626 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xcf2ce3", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf32a3", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1658,11 +1658,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1627 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0xcf2d00", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf32c0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1628 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xcf2d0b", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf32cb", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1685,11 +1685,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1425 EventRootType Probe[main.testInlinedBA]
-              InjectionPoints: [{PC: "0xcea5ea", Frameless: false}]
+              InjectionPoints: [{PC: "0xcea6ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1426 EventRootType Probe[main.testInlinedBA]Return
-              InjectionPoints: [{PC: "0xcea64e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcea74e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1716,11 +1716,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1427 EventRootType Probe[main.testInlinedBB]
-              InjectionPoints: [{PC: "0xcea68e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcea78e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1428 EventRootType Probe[main.testInlinedBB]Return
-              InjectionPoints: [{PC: "0xcea71e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcea81e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}'
@@ -1747,11 +1747,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1429 EventRootType Probe[main.testInlinedBBA]
-              InjectionPoints: [{PC: "0xcea76a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcea86a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1430 EventRootType Probe[main.testInlinedBBA]Return
-              InjectionPoints: [{PC: "0xcea7ab", Frameless: false}]
+              InjectionPoints: [{PC: "0xcea8ab", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1773,7 +1773,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1681 EventRootType Probe[main.testInlinedBBB]
-              InjectionPoints: [{PC: "0xcea6e6", Frameless: false}]
+              InjectionPoints: [{PC: "0xcea7e6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBBB
@@ -1791,11 +1791,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1431 EventRootType Probe[main.testInlinedBC]
-              InjectionPoints: [{PC: "0xcea7ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xcea8ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1432 EventRootType Probe[main.testInlinedBC]Return
-              InjectionPoints: [{PC: "0xcea8d3", Frameless: false}]
+              InjectionPoints: [{PC: "0xcea9d3", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBC
@@ -1813,7 +1813,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1682 EventRootType Probe[main.testInlinedBCA]
-              InjectionPoints: [{PC: "0xcea7f3", Frameless: false}]
+              InjectionPoints: [{PC: "0xcea8f3", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1834,7 +1834,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1683 EventRootType Probe[main.testInlinedBCA]Line
-              InjectionPoints: [{PC: "0xcea7f3", Frameless: false}]
+              InjectionPoints: [{PC: "0xcea8f3", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1852,7 +1852,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1684 EventRootType Probe[main.testInlinedBCB]
-              InjectionPoints: [{PC: "0xcea89b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcea99b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1873,7 +1873,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1685 EventRootType Probe[main.testInlinedBCB]Line
-              InjectionPoints: [{PC: "0xcea89b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcea99b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1894,7 +1894,7 @@ Probes:
               InjectionPoints:
                 - PC: "0x53dae1"
                   Frameless: true
-                - PC: "0xceb2d3"
+                - PC: "0xceb4fd"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1915,20 +1915,20 @@ Probes:
             - Kind: Entry
               Type: 1678 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
-                - PC: "0xcea44a"
+                - PC: "0xcea54a"
                   Frameless: false
-                - PC: "0xcea4d1"
+                - PC: "0xcea5d1"
                   Frameless: false
-                - PC: "0xcea612"
+                - PC: "0xcea712"
                   Frameless: false
-                - PC: "0xcea69c"
+                - PC: "0xcea79c"
                   Frameless: false
-                - PC: "0xcea76f"
+                - PC: "0xcea86f"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1679 EventRootType Probe[main.testInlinedPrint]Return
-              InjectionPoints: [{PC: "0xcea48a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcea58a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1954,15 +1954,15 @@ Probes:
             - Kind: Line
               Type: 1680 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xcea44e"
+                - PC: "0xcea54e"
                   Frameless: false
-                - PC: "0xcea4d1"
+                - PC: "0xcea5d1"
                   Frameless: false
-                - PC: "0xcea612"
+                - PC: "0xcea712"
                   Frameless: false
-                - PC: "0xcea69c"
+                - PC: "0xcea79c"
                   Frameless: false
-                - PC: "0xcea76f"
+                - PC: "0xcea86f"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1985,7 +1985,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1686 EventRootType Probe[main.testInlinedSq]
-              InjectionPoints: [{PC: "0xcea901", Frameless: true}]
+              InjectionPoints: [{PC: "0xceaa01", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2010,7 +2010,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1687 EventRootType Probe[main.testInlinedSq]Line
-              InjectionPoints: [{PC: "0xcea901", Frameless: true}]
+              InjectionPoints: [{PC: "0xceaa01", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2034,9 +2034,9 @@ Probes:
             - Kind: Entry
               Type: 1688 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
-                - PC: "0xcea94d"
+                - PC: "0xceaa4d"
                   Frameless: false
-                - PC: "0xcea9e3"
+                - PC: "0xceaae3"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2059,7 +2059,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1376 EventRootType Probe[main.testInt16Array]
-              InjectionPoints: [{PC: "0xce5c20", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5d20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2081,7 +2081,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1377 EventRootType Probe[main.testInt32Array]
-              InjectionPoints: [{PC: "0xce5c40", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5d40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2103,7 +2103,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1378 EventRootType Probe[main.testInt64Array]
-              InjectionPoints: [{PC: "0xce5c60", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5d60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2125,7 +2125,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1375 EventRootType Probe[main.testInt8Array]
-              InjectionPoints: [{PC: "0xce5c00", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5d00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2147,7 +2147,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1374 EventRootType Probe[main.testIntArray]
-              InjectionPoints: [{PC: "0xce5be0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5ce0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2169,7 +2169,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1438 EventRootType Probe[main.testInterface]
-              InjectionPoints: [{PC: "0xceac00", Frameless: true}]
+              InjectionPoints: [{PC: "0xcead00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -2190,11 +2190,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1569 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0xcef06e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcef22e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1570 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xcef1cd", Frameless: false}]
+              InjectionPoints: [{PC: "0xcef38d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2216,7 +2216,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1477 EventRootType Probe[main.testLinkedList]
-              InjectionPoints: [{PC: "0xced480", Frameless: true}]
+              InjectionPoints: [{PC: "0xced640", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -2241,7 +2241,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1416 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0xce6a5a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce6b5a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2263,7 +2263,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1417 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0xce6b1f", Frameless: false}]
+              InjectionPoints: [{PC: "0xce6c1f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2285,7 +2285,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1418 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0xce6be5", Frameless: false}]
+              InjectionPoints: [{PC: "0xce6ce5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2328,11 +2328,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1575 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0xcef513", Frameless: false}]
+              InjectionPoints: [{PC: "0xcef6d3", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1576 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0xcef742", Frameless: false}]
+              InjectionPoints: [{PC: "0xcef902", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2395,7 +2395,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1419 EventRootType Probe[main.testManyPointers]
-              InjectionPoints: [{PC: "0xce7060", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7160", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2419,7 +2419,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1420 EventRootType Probe[main.testManyStrings]
-              InjectionPoints: [{PC: "0xce8c00", Frameless: true}]
+              InjectionPoints: [{PC: "0xce8d00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{ss}'
@@ -2441,7 +2441,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1449 EventRootType Probe[main.testMapArrayToArray]
-              InjectionPoints: [{PC: "0xceb420", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb5e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2463,7 +2463,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1456 EventRootType Probe[main.testMapEmbeddedMaps]
-              InjectionPoints: [{PC: "0xceb4e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb6a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2485,7 +2485,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1466 EventRootType Probe[main.testMapEmptyKey]
-              InjectionPoints: [{PC: "0xceb620", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb7e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2507,7 +2507,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1468 EventRootType Probe[main.testMapEmptyKeyAndValue]
-              InjectionPoints: [{PC: "0xceb660", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb820", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2529,7 +2529,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1467 EventRootType Probe[main.testMapEmptyValue]
-              InjectionPoints: [{PC: "0xceb640", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb800", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2551,7 +2551,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1453 EventRootType Probe[main.testMapIntToInt]
-              InjectionPoints: [{PC: "0xceb4a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb660", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2573,7 +2573,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1465 EventRootType Probe[main.testMapLargeKeyLargeValue]
-              InjectionPoints: [{PC: "0xceb600", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb7c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2595,7 +2595,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1464 EventRootType Probe[main.testMapLargeKeySmallValue]
-              InjectionPoints: [{PC: "0xceb5e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb7a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2619,7 +2619,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1454 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0xceb4c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb680", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2643,7 +2643,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1455 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0xceb4c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb680", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2665,7 +2665,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1463 EventRootType Probe[main.testMapSmallKeyLargeValue]
-              InjectionPoints: [{PC: "0xceb5c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb780", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2687,7 +2687,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1462 EventRootType Probe[main.testMapSmallKeySmallValue]
-              InjectionPoints: [{PC: "0xceb5a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb760", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2709,7 +2709,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1447 EventRootType Probe[main.testMapStringToInt]
-              InjectionPoints: [{PC: "0xceb3e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb5a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2731,7 +2731,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1448 EventRootType Probe[main.testMapStringToSlice]
-              InjectionPoints: [{PC: "0xceb400", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb5c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2753,7 +2753,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1446 EventRootType Probe[main.testMapStringToStruct]
-              InjectionPoints: [{PC: "0xceb3c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb580", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2775,7 +2775,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1457 EventRootType Probe[main.testMapWithLinkedList]
-              InjectionPoints: [{PC: "0xceb500", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb6c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2797,7 +2797,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1460 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-              InjectionPoints: [{PC: "0xceb560", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb720", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2819,7 +2819,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1461 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-              InjectionPoints: [{PC: "0xceb580", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb740", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2841,7 +2841,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1458 EventRootType Probe[main.testMapWithSmallValue]
-              InjectionPoints: [{PC: "0xceb520", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb6e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2865,7 +2865,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1459 EventRootType Probe[main.testMapWithSmallValueMassive]
-              InjectionPoints: [{PC: "0xceb540", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb700", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2887,7 +2887,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1609 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xcf08e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0ea0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2910,7 +2910,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1610 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xcf08e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0ea0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2957,11 +2957,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1577 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0xcef7d3", Frameless: false}]
+              InjectionPoints: [{PC: "0xcef993", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1578 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0xcefa02", Frameless: false}]
+              InjectionPoints: [{PC: "0xcefbc2", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -3027,11 +3027,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1581 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0xcefb4e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcefd0e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1582 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0xcefc1d", Frameless: false}]
+              InjectionPoints: [{PC: "0xcefddd", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3062,11 +3062,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1573 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0xcef2ce", Frameless: false}]
+              InjectionPoints: [{PC: "0xcef48e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1574 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0xcef4eb", Frameless: false}]
+              InjectionPoints: [{PC: "0xcef6ab", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3092,11 +3092,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1514 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcee26e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee42e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1515 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcee30f", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee4cf", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3132,7 +3132,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1472 EventRootType Probe[main.testMultipleSimpleParams]
-              InjectionPoints: [{PC: "0xced060", Frameless: true}]
+              InjectionPoints: [{PC: "0xced220", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -3173,11 +3173,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1508 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xcee1ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee38a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1509 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xcee23b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee3fb", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3201,11 +3201,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1510 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xcee1ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee38a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1511 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xcee23b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee3fb", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
       version: 0
@@ -3224,11 +3224,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1516 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcee26e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee42e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1517 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcee30f", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee4cf", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
       version: 0
@@ -3248,11 +3248,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1518 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcee26e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee42e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1519 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcee30f", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee4cf", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r1={result} r2={result2}
@@ -3285,11 +3285,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1512 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xcee1ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee38a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1513 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xcee23b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee3fb", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Parameter {i} * 2 = result {result}
@@ -3317,7 +3317,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1618 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xcf0ce0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf12a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3342,7 +3342,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1619 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xcf0ce0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf12a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3373,7 +3373,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1620 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xcf0ce0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf12a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3398,7 +3398,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1621 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xcf0ce0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf12a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3425,7 +3425,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1482 EventRootType Probe[main.testNilPointer]
-              InjectionPoints: [{PC: "0xced620", Frameless: true}]
+              InjectionPoints: [{PC: "0xced7e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}, {a}'
@@ -3452,7 +3452,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1595 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0xcf0420", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf05e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3479,7 +3479,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1592 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0xcf03c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0580", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3514,7 +3514,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1594 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0xcf0400", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf05c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3546,7 +3546,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1608 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0xcf08c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0e80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3568,7 +3568,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1478 EventRootType Probe[main.testPointerLoop]
-              InjectionPoints: [{PC: "0xced4a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xced660", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3590,7 +3590,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1452 EventRootType Probe[main.testPointerToMap]
-              InjectionPoints: [{PC: "0xceb480", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb640", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3612,7 +3612,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1476 EventRootType Probe[main.testPointerToSimpleStruct]
-              InjectionPoints: [{PC: "0xced460", Frameless: true}]
+              InjectionPoints: [{PC: "0xced620", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3636,11 +3636,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1484 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xceda8a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcedc4a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1485 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xcedadb", Frameless: false}]
+              InjectionPoints: [{PC: "0xcedc9b", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
       version: 0
@@ -3660,11 +3660,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1528 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xcee34e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee50e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1529 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xcee3ed", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee5ad", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3707,11 +3707,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1494 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xcedbae", Frameless: false}]
+              InjectionPoints: [{PC: "0xcedd6e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1495 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xcedc65", Frameless: false}]
+              InjectionPoints: [{PC: "0xcede25", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3751,11 +3751,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1486 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xceda8a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcedc4a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1487 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xcedadb", Frameless: false}]
+              InjectionPoints: [{PC: "0xcedc9b", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3798,11 +3798,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1496 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xcedbae", Frameless: false}]
+              InjectionPoints: [{PC: "0xcedd6e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1497 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xcedc65", Frameless: false}]
+              InjectionPoints: [{PC: "0xcede25", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3844,11 +3844,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1530 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xcee34e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee50e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1531 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xcee3ed", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee5ad", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
       version: 0
@@ -3865,11 +3865,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1532 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xcee34e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee50e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1533 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xcee3ed", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee5ad", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r0={@return.r0}
@@ -3891,11 +3891,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1488 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xceda8a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcedc4a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1489 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xcedadb", Frameless: false}]
+              InjectionPoints: [{PC: "0xcedc9b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: result={@return}
@@ -3918,18 +3918,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1504 EventRootType Probe[main.testReturnsAny]
-              InjectionPoints: [{PC: "0xcede6e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee02e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1505 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
-                - PC: "0xcedf15"
+                - PC: "0xcee0d5"
                   Frameless: false
-                - PC: "0xcedf64"
+                - PC: "0xcee124"
                   Frameless: false
-                - PC: "0xcee02f"
+                - PC: "0xcee1ef"
                   Frameless: false
-                - PC: "0xcee039"
+                - PC: "0xcee1f9"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3957,18 +3957,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1502 EventRootType Probe[main.testReturnsAnyAndError]
-              InjectionPoints: [{PC: "0xcedd0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcedece", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1503 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
-                - PC: "0xcedd64"
+                - PC: "0xcedf24"
                   Frameless: false
-                - PC: "0xceddb3"
+                - PC: "0xcedf73"
                   Frameless: false
-                - PC: "0xceddf3"
+                - PC: "0xcedfb3"
                   Frameless: false
-                - PC: "0xcede2f"
+                - PC: "0xcedfef"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3995,11 +3995,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1547 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0xceeaea", Frameless: false}]
+              InjectionPoints: [{PC: "0xceecaa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1548 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0xceeb4f", Frameless: false}]
+              InjectionPoints: [{PC: "0xceed0f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -4016,11 +4016,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1549 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0xceeb6a", Frameless: false}]
+              InjectionPoints: [{PC: "0xceed2a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1550 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0xceebab", Frameless: false}]
+              InjectionPoints: [{PC: "0xceed6b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -4037,11 +4037,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1551 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0xceebca", Frameless: false}]
+              InjectionPoints: [{PC: "0xceed8a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1552 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0xceec06", Frameless: false}]
+              InjectionPoints: [{PC: "0xceedc6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4058,11 +4058,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1555 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0xceecae", Frameless: false}]
+              InjectionPoints: [{PC: "0xceee6e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1556 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0xceed2a", Frameless: false}]
+              InjectionPoints: [{PC: "0xceeeea", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4079,11 +4079,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1567 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0xcef00a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcef1ca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1568 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0xcef050", Frameless: false}]
+              InjectionPoints: [{PC: "0xcef210", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4100,11 +4100,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1543 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0xcee9aa", Frameless: false}]
+              InjectionPoints: [{PC: "0xceeb6a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1544 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0xceea06", Frameless: false}]
+              InjectionPoints: [{PC: "0xceebc6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4122,14 +4122,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1500 EventRootType Probe[main.testReturnsError]
-              InjectionPoints: [{PC: "0xcedc8a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcede4a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1501 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
-                - PC: "0xcedcc4"
+                - PC: "0xcede84"
                   Frameless: false
-                - PC: "0xcedcce"
+                - PC: "0xcede8e"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4151,11 +4151,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1490 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xceda8a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcedc4a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1491 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xcedadb", Frameless: false}]
+              InjectionPoints: [{PC: "0xcedc9b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4176,11 +4176,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1498 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xcedbae", Frameless: false}]
+              InjectionPoints: [{PC: "0xcedd6e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1499 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xcedc65", Frameless: false}]
+              InjectionPoints: [{PC: "0xcede25", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4201,11 +4201,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1492 EventRootType Probe[main.testReturnsIntPointer]
-              InjectionPoints: [{PC: "0xcedb0a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcedcca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1493 EventRootType Probe[main.testReturnsIntPointer]Return
-              InjectionPoints: [{PC: "0xcedb74", Frameless: false}]
+              InjectionPoints: [{PC: "0xcedd34", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4227,14 +4227,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1506 EventRootType Probe[main.testReturnsInterface]
-              InjectionPoints: [{PC: "0xcee06e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee22e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1507 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
-                - PC: "0xcee13d"
+                - PC: "0xcee2fd"
                   Frameless: false
-                - PC: "0xcee147"
+                - PC: "0xcee307"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4256,11 +4256,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1545 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0xceea2e", Frameless: false}]
+              InjectionPoints: [{PC: "0xceebee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1546 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0xceeac3", Frameless: false}]
+              InjectionPoints: [{PC: "0xceec83", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4277,11 +4277,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1541 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0xcee8ae", Frameless: false}]
+              InjectionPoints: [{PC: "0xceea6e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1542 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0xcee987", Frameless: false}]
+              InjectionPoints: [{PC: "0xceeb47", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4298,11 +4298,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1559 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0xceee2a", Frameless: false}]
+              InjectionPoints: [{PC: "0xceefea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1560 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0xceee8c", Frameless: false}]
+              InjectionPoints: [{PC: "0xcef04c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4319,11 +4319,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1553 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0xceec2a", Frameless: false}]
+              InjectionPoints: [{PC: "0xceedea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1554 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0xceec78", Frameless: false}]
+              InjectionPoints: [{PC: "0xceee38", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4340,11 +4340,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1565 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0xceef8a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcef14a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1566 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0xceefd6", Frameless: false}]
+              InjectionPoints: [{PC: "0xcef196", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
@@ -4364,7 +4364,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1538 EventRootType Probe[main.testReturnsNamedDeferLine]Line
-              InjectionPoints: [{PC: "0xcee62f", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee7ef", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4385,11 +4385,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1563 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0xceef2a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcef0ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1564 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0xceef6e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcef12e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4406,11 +4406,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1539 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0xcee82a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee9ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1540 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0xcee891", Frameless: false}]
+              InjectionPoints: [{PC: "0xceea51", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4427,11 +4427,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1561 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0xceeeaa", Frameless: false}]
+              InjectionPoints: [{PC: "0xcef06a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1562 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0xceef0f", Frameless: false}]
+              InjectionPoints: [{PC: "0xcef0cf", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4448,11 +4448,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1557 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0xceed4e", Frameless: false}]
+              InjectionPoints: [{PC: "0xceef0e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1558 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0xceedf2", Frameless: false}]
+              InjectionPoints: [{PC: "0xceefb2", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4470,7 +4470,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1371 EventRootType Probe[main.testRuneArray]
-              InjectionPoints: [{PC: "0xce5b80", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5c80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4505,11 +4505,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1520 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcee26e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee42e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1521 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcee30f", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee4cf", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -4555,7 +4555,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1392 EventRootType Probe[main.testSingleBool]
-              InjectionPoints: [{PC: "0xce61e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce62e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4577,7 +4577,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1390 EventRootType Probe[main.testSingleByte]
-              InjectionPoints: [{PC: "0xce61a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce62a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4599,7 +4599,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1403 EventRootType Probe[main.testSingleFloat32]
-              InjectionPoints: [{PC: "0xce6340", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6440", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4617,7 +4617,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1404 EventRootType Probe[main.testSingleFloat64]
-              InjectionPoints: [{PC: "0xce6360", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6460", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4635,7 +4635,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1393 EventRootType Probe[main.testSingleInt]
-              InjectionPoints: [{PC: "0xce6200", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6300", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4657,7 +4657,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1395 EventRootType Probe[main.testSingleInt16]
-              InjectionPoints: [{PC: "0xce6240", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6340", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}
@@ -4680,7 +4680,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1396 EventRootType Probe[main.testSingleInt32]
-              InjectionPoints: [{PC: "0xce6260", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6360", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4702,7 +4702,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1397 EventRootType Probe[main.testSingleInt64]
-              InjectionPoints: [{PC: "0xce6280", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6380", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4731,7 +4731,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1394 EventRootType Probe[main.testSingleInt8]
-              InjectionPoints: [{PC: "0xce6220", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6320", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}{x}{x}
@@ -4762,7 +4762,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1391 EventRootType Probe[main.testSingleRune]
-              InjectionPoints: [{PC: "0xce61c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce62c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4784,7 +4784,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1602 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0xcf0840", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0e00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4806,7 +4806,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1398 EventRootType Probe[main.testSingleUint]
-              InjectionPoints: [{PC: "0xce62a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce63a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4828,7 +4828,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1400 EventRootType Probe[main.testSingleUint16]
-              InjectionPoints: [{PC: "0xce62e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce63e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4850,7 +4850,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1401 EventRootType Probe[main.testSingleUint32]
-              InjectionPoints: [{PC: "0xce6300", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6400", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4872,7 +4872,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1402 EventRootType Probe[main.testSingleUint64]
-              InjectionPoints: [{PC: "0xce6320", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6420", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4894,7 +4894,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1399 EventRootType Probe[main.testSingleUint8]
-              InjectionPoints: [{PC: "0xce62c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce63c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4916,7 +4916,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1598 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0xcf0460", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0620", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -4938,7 +4938,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1589 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0xcf0360", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0520", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -4960,7 +4960,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1450 EventRootType Probe[main.testSmallMap]
-              InjectionPoints: [{PC: "0xceb440", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb600", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -4981,11 +4981,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1534 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xcee34e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee50e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1535 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xcee3ed", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee5ad", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -5006,11 +5006,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1579 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0xcefaaa", Frameless: false}]
+              InjectionPoints: [{PC: "0xcefc6a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1580 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0xcefb1e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcefcde", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5032,7 +5032,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1372 EventRootType Probe[main.testStringArray]
-              InjectionPoints: [{PC: "0xce5ba0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5ca0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5054,7 +5054,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1481 EventRootType Probe[main.testStringPointer]
-              InjectionPoints: [{PC: "0xced5e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xced7a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}'
@@ -5076,7 +5076,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1593 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0xcf03e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf05a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5098,7 +5098,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1414 EventRootType Probe[main.testStringType1]
-              InjectionPoints: [{PC: "0xce6a00", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6b00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5120,7 +5120,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1415 EventRootType Probe[main.testStringType2]
-              InjectionPoints: [{PC: "0xce6a20", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6b20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5142,7 +5142,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1617 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xcf0c20", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf11e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5169,7 +5169,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1590 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0xcf0380", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0540", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5196,7 +5196,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1444 EventRootType Probe[main.testStructWithAny]
-              InjectionPoints: [{PC: "0xcead20", Frameless: true}]
+              InjectionPoints: [{PC: "0xceae20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5217,11 +5217,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1583 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0xcefc4e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcefe0e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1584 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0xcefd04", Frameless: false}]
+              InjectionPoints: [{PC: "0xcefec4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5243,7 +5243,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1615 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0xcf0ae0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf10a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5264,7 +5264,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1614 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0xcf0ac0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf1080", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5291,7 +5291,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1445 EventRootType Probe[main.testStructWithMap]
-              InjectionPoints: [{PC: "0xceb3a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb560", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s} {@duration}'
@@ -5324,7 +5324,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1599 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0xcf0480", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0640", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5364,7 +5364,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1613 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0xcf0940", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0f00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5397,11 +5397,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1522 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcee26e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee42e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1523 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcee30f", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee4cf", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{nonexistentVariable}'
@@ -5422,11 +5422,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1524 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcee26e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee42e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1525 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcee30f", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee4cf", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{unsupportedExpression}'
@@ -5449,11 +5449,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1526 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcee26e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee42e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1527 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcee30f", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee4cf", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -5485,7 +5485,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1603 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0xcf0860", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0e20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5517,7 +5517,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1604 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xcf0880", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0e40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5547,7 +5547,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1605 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xcf0880", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0e40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5579,7 +5579,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1606 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xcf08a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0e60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5609,7 +5609,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1607 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xcf08a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0e60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5641,7 +5641,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1405 EventRootType Probe[main.testTypeAlias]
-              InjectionPoints: [{PC: "0xce6380", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6480", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5663,7 +5663,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1381 EventRootType Probe[main.testUint16Array]
-              InjectionPoints: [{PC: "0xce5cc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5dc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5685,7 +5685,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1382 EventRootType Probe[main.testUint32Array]
-              InjectionPoints: [{PC: "0xce5ce0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5de0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5707,7 +5707,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1383 EventRootType Probe[main.testUint64Array]
-              InjectionPoints: [{PC: "0xce5d00", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5e00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5729,7 +5729,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1380 EventRootType Probe[main.testUint8Array]
-              InjectionPoints: [{PC: "0xce5ca0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5da0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5751,7 +5751,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1379 EventRootType Probe[main.testUintArray]
-              InjectionPoints: [{PC: "0xce5c80", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5d80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5773,7 +5773,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1480 EventRootType Probe[main.testUintPointer]
-              InjectionPoints: [{PC: "0xced500", Frameless: true}]
+              InjectionPoints: [{PC: "0xced6c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5795,7 +5795,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1587 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0xcf0320", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf04e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5817,7 +5817,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1611 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0xcf0900", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0ec0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5839,7 +5839,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1479 EventRootType Probe[main.testUnsafePointer]
-              InjectionPoints: [{PC: "0xced4c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xced680", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5861,7 +5861,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1389 EventRootType Probe[main.testVeryLargeArray]
-              InjectionPoints: [{PC: "0xce5de0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5ee0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5883,7 +5883,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1596 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xcf0440", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0600", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5905,7 +5905,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1597 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xcf0440", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0600", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5928,14 +5928,14 @@ Probes:
             - Kind: Entry
               Type: 1689 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
-                - PC: "0xceab2a"
+                - PC: "0xceac2a"
                   Frameless: false
-                - PC: "0xcf395a"
+                - PC: "0xcf3f1a"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1690 EventRootType Probe[main.firstBehavior.DoSomething]Return
-              InjectionPoints: [{PC: "0xceab65", Frameless: false}]
+              InjectionPoints: [{PC: "0xceac65", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testWhollyInlinedSubroutine
@@ -5957,11 +5957,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1585 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0xcefd2e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcefeee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1586 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xcefdac", Frameless: false}]
+              InjectionPoints: [{PC: "0xceff6c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -5978,481 +5978,481 @@ Probes:
 Subprograms:
     - ID: 1
       Name: main.testByteArray
-      OutOfLinePCRanges: [0xce5b60..0xce5b61]
+      OutOfLinePCRanges: [0xce5c60..0xce5c61]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 116 ArrayType [2]uint8
           Locations:
-            - Range: 0xce5b60..0xce5b61
+            - Range: 0xce5c60..0xce5c61
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 2
       Name: main.testRuneArray
-      OutOfLinePCRanges: [0xce5b80..0xce5b81]
+      OutOfLinePCRanges: [0xce5c80..0xce5c81]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 117 ArrayType [2]int32
           Locations:
-            - Range: 0xce5b80..0xce5b81
+            - Range: 0xce5c80..0xce5c81
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 3
       Name: main.testStringArray
-      OutOfLinePCRanges: [0xce5ba0..0xce5ba1]
+      OutOfLinePCRanges: [0xce5ca0..0xce5ca1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 118 ArrayType [2]string
           Locations:
-            - Range: 0xce5ba0..0xce5ba1
+            - Range: 0xce5ca0..0xce5ca1
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 4
       Name: main.testBoolArray
-      OutOfLinePCRanges: [0xce5bc0..0xce5bc1]
+      OutOfLinePCRanges: [0xce5cc0..0xce5cc1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 119 ArrayType [2]bool
           Locations:
-            - Range: 0xce5bc0..0xce5bc1
+            - Range: 0xce5cc0..0xce5cc1
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 5
       Name: main.testIntArray
-      OutOfLinePCRanges: [0xce5be0..0xce5be1]
+      OutOfLinePCRanges: [0xce5ce0..0xce5ce1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 120 ArrayType [2]int
           Locations:
-            - Range: 0xce5be0..0xce5be1
+            - Range: 0xce5ce0..0xce5ce1
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 6
       Name: main.testInt8Array
-      OutOfLinePCRanges: [0xce5c00..0xce5c01]
+      OutOfLinePCRanges: [0xce5d00..0xce5d01]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 121 ArrayType [2]int8
           Locations:
-            - Range: 0xce5c00..0xce5c01
+            - Range: 0xce5d00..0xce5d01
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 7
       Name: main.testInt16Array
-      OutOfLinePCRanges: [0xce5c20..0xce5c21]
+      OutOfLinePCRanges: [0xce5d20..0xce5d21]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 122 ArrayType [2]int16
           Locations:
-            - Range: 0xce5c20..0xce5c21
+            - Range: 0xce5d20..0xce5d21
               Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 8
       Name: main.testInt32Array
-      OutOfLinePCRanges: [0xce5c40..0xce5c41]
+      OutOfLinePCRanges: [0xce5d40..0xce5d41]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 117 ArrayType [2]int32
           Locations:
-            - Range: 0xce5c40..0xce5c41
+            - Range: 0xce5d40..0xce5d41
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 9
       Name: main.testInt64Array
-      OutOfLinePCRanges: [0xce5c60..0xce5c61]
+      OutOfLinePCRanges: [0xce5d60..0xce5d61]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 123 ArrayType [2]int64
           Locations:
-            - Range: 0xce5c60..0xce5c61
+            - Range: 0xce5d60..0xce5d61
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 10
       Name: main.testUintArray
-      OutOfLinePCRanges: [0xce5c80..0xce5c81]
+      OutOfLinePCRanges: [0xce5d80..0xce5d81]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 124 ArrayType [2]uint
           Locations:
-            - Range: 0xce5c80..0xce5c81
+            - Range: 0xce5d80..0xce5d81
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 11
       Name: main.testUint8Array
-      OutOfLinePCRanges: [0xce5ca0..0xce5ca1]
+      OutOfLinePCRanges: [0xce5da0..0xce5da1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 116 ArrayType [2]uint8
           Locations:
-            - Range: 0xce5ca0..0xce5ca1
+            - Range: 0xce5da0..0xce5da1
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 12
       Name: main.testUint16Array
-      OutOfLinePCRanges: [0xce5cc0..0xce5cc1]
+      OutOfLinePCRanges: [0xce5dc0..0xce5dc1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 125 ArrayType [2]uint16
           Locations:
-            - Range: 0xce5cc0..0xce5cc1
+            - Range: 0xce5dc0..0xce5dc1
               Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 13
       Name: main.testUint32Array
-      OutOfLinePCRanges: [0xce5ce0..0xce5ce1]
+      OutOfLinePCRanges: [0xce5de0..0xce5de1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 126 ArrayType [2]uint32
           Locations:
-            - Range: 0xce5ce0..0xce5ce1
+            - Range: 0xce5de0..0xce5de1
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 14
       Name: main.testUint64Array
-      OutOfLinePCRanges: [0xce5d00..0xce5d01]
+      OutOfLinePCRanges: [0xce5e00..0xce5e01]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 59 ArrayType [2]uint64
           Locations:
-            - Range: 0xce5d00..0xce5d01
+            - Range: 0xce5e00..0xce5e01
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 15
       Name: main.testArrayOfArrays
-      OutOfLinePCRanges: [0xce5d20..0xce5d21]
+      OutOfLinePCRanges: [0xce5e20..0xce5e21]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 127 ArrayType [2][2]int
           Locations:
-            - Range: 0xce5d20..0xce5d21
+            - Range: 0xce5e20..0xce5e21
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 16
       Name: main.testArrayOfStrings
-      OutOfLinePCRanges: [0xce5d40..0xce5d41]
+      OutOfLinePCRanges: [0xce5e40..0xce5e41]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 118 ArrayType [2]string
           Locations:
-            - Range: 0xce5d40..0xce5d41
+            - Range: 0xce5e40..0xce5e41
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 17
       Name: main.testArrayOfArraysOfArrays
-      OutOfLinePCRanges: [0xce5d60..0xce5d61]
+      OutOfLinePCRanges: [0xce5e60..0xce5e61]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 128 ArrayType [2][2][2]int
           Locations:
-            - Range: 0xce5d60..0xce5d61
+            - Range: 0xce5e60..0xce5e61
               Pieces: [{Size: 64, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 18
       Name: main.testArrayOfStructs
-      OutOfLinePCRanges: [0xce5d80..0xce5d81]
+      OutOfLinePCRanges: [0xce5e80..0xce5e81]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 129 ArrayType [2]main.nestedStruct
           Locations:
-            - Range: 0xce5d80..0xce5d81
+            - Range: 0xce5e80..0xce5e81
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 19
       Name: main.testArrayEmptyStructs
-      OutOfLinePCRanges: [0xce5da0..0xce5da1]
+      OutOfLinePCRanges: [0xce5ea0..0xce5ea1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 131 ArrayType [2]struct {}
           Locations:
-            - Range: 0xce5da0..0xce5da1
+            - Range: 0xce5ea0..0xce5ea1
               Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 20
       Name: main.testVeryLargeArray
-      OutOfLinePCRanges: [0xce5de0..0xce5de1]
+      OutOfLinePCRanges: [0xce5ee0..0xce5ee1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 133 ArrayType [100]uint
           Locations:
-            - Range: 0xce5de0..0xce5de1
+            - Range: 0xce5ee0..0xce5ee1
               Pieces: [{Size: 800, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 21
       Name: main.testSingleByte
-      OutOfLinePCRanges: [0xce61a0..0xce61a1]
+      OutOfLinePCRanges: [0xce62a0..0xce62a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xce61a0..0xce61a1
+            - Range: 0xce62a0..0xce62a1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 22
       Name: main.testSingleRune
-      OutOfLinePCRanges: [0xce61c0..0xce61c1]
+      OutOfLinePCRanges: [0xce62c0..0xce62c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 BaseType int32
           Locations:
-            - Range: 0xce61c0..0xce61c1
+            - Range: 0xce62c0..0xce62c1
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 23
       Name: main.testSingleBool
-      OutOfLinePCRanges: [0xce61e0..0xce61e1]
+      OutOfLinePCRanges: [0xce62e0..0xce62e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xce61e0..0xce61e1
+            - Range: 0xce62e0..0xce62e1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 24
       Name: main.testSingleInt
-      OutOfLinePCRanges: [0xce6200..0xce6201]
+      OutOfLinePCRanges: [0xce6300..0xce6301]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce6200..0xce6201
+            - Range: 0xce6300..0xce6301
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 25
       Name: main.testSingleInt8
-      OutOfLinePCRanges: [0xce6220..0xce6221]
+      OutOfLinePCRanges: [0xce6320..0xce6321]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 21 BaseType int8
           Locations:
-            - Range: 0xce6220..0xce6221
+            - Range: 0xce6320..0xce6321
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 26
       Name: main.testSingleInt16
-      OutOfLinePCRanges: [0xce6240..0xce6241]
+      OutOfLinePCRanges: [0xce6340..0xce6341]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 110 BaseType int16
           Locations:
-            - Range: 0xce6240..0xce6241
+            - Range: 0xce6340..0xce6341
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 27
       Name: main.testSingleInt32
-      OutOfLinePCRanges: [0xce6260..0xce6261]
+      OutOfLinePCRanges: [0xce6360..0xce6361]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 BaseType int32
           Locations:
-            - Range: 0xce6260..0xce6261
+            - Range: 0xce6360..0xce6361
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 28
       Name: main.testSingleInt64
-      OutOfLinePCRanges: [0xce6280..0xce6281]
+      OutOfLinePCRanges: [0xce6380..0xce6381]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType int64
           Locations:
-            - Range: 0xce6280..0xce6281
+            - Range: 0xce6380..0xce6381
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 29
       Name: main.testSingleUint
-      OutOfLinePCRanges: [0xce62a0..0xce62a1]
+      OutOfLinePCRanges: [0xce63a0..0xce63a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 BaseType uint
           Locations:
-            - Range: 0xce62a0..0xce62a1
+            - Range: 0xce63a0..0xce63a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 30
       Name: main.testSingleUint8
-      OutOfLinePCRanges: [0xce62c0..0xce62c1]
+      OutOfLinePCRanges: [0xce63c0..0xce63c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xce62c0..0xce62c1
+            - Range: 0xce63c0..0xce63c1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 31
       Name: main.testSingleUint16
-      OutOfLinePCRanges: [0xce62e0..0xce62e1]
+      OutOfLinePCRanges: [0xce63e0..0xce63e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType uint16
           Locations:
-            - Range: 0xce62e0..0xce62e1
+            - Range: 0xce63e0..0xce63e1
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 32
       Name: main.testSingleUint32
-      OutOfLinePCRanges: [0xce6300..0xce6301]
+      OutOfLinePCRanges: [0xce6400..0xce6401]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint32
           Locations:
-            - Range: 0xce6300..0xce6301
+            - Range: 0xce6400..0xce6401
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 33
       Name: main.testSingleUint64
-      OutOfLinePCRanges: [0xce6320..0xce6321]
+      OutOfLinePCRanges: [0xce6420..0xce6421]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0xce6320..0xce6321
+            - Range: 0xce6420..0xce6421
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 34
       Name: main.testSingleFloat32
-      OutOfLinePCRanges: [0xce6340..0xce6341]
+      OutOfLinePCRanges: [0xce6440..0xce6441]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 18 BaseType float32
           Locations:
-            - Range: 0xce6340..0xce6341
+            - Range: 0xce6440..0xce6441
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 35
       Name: main.testSingleFloat64
-      OutOfLinePCRanges: [0xce6360..0xce6361]
+      OutOfLinePCRanges: [0xce6460..0xce6461]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 BaseType float64
           Locations:
-            - Range: 0xce6360..0xce6361
+            - Range: 0xce6460..0xce6461
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 36
       Name: main.testTypeAlias
-      OutOfLinePCRanges: [0xce6380..0xce6381]
+      OutOfLinePCRanges: [0xce6480..0xce6481]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 134 BaseType main.typeAlias
           Locations:
-            - Range: 0xce6380..0xce6381
+            - Range: 0xce6480..0xce6481
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 37
       Name: main.testBigStruct
-      OutOfLinePCRanges: [0xce64e0..0xce64e1]
+      OutOfLinePCRanges: [0xce65e0..0xce65e1]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 135 StructureType main.bigStruct
           Locations:
-            - Range: 0xce64e0..0xce64e1
+            - Range: 0xce65e0..0xce65e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6471,87 +6471,87 @@ Subprograms:
       DictRegister: null
     - ID: 38
       Name: main.testErrorAtLine
-      OutOfLinePCRanges: [0xce6540..0xce6645]
+      OutOfLinePCRanges: [0xce6640..0xce6745]
       InlinePCRanges: []
       Variables:
         - Name: shouldErr
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xce6540..0xce6558
+            - Range: 0xce6640..0xce6658
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
-          Locations: [{Range: 0xce6540..0xce6645, Pieces: []}]
+          Locations: [{Range: 0xce6640..0xce6745, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 8 BaseType int
-          Locations: [{Range: 0xce6540..0xce6645, Pieces: []}]
+          Locations: [{Range: 0xce6640..0xce6745, Pieces: []}]
           Role: Local
           DictIndex: -1
         - Name: err
           Type: 16 GoInterfaceType error
           Locations:
-            - Range: 0xce6573..0xce658f
+            - Range: 0xce6673..0xce668f
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
-            - Range: 0xce658f..0xce65fd
+            - Range: 0xce668f..0xce66fd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce65fd..0xce6600
+            - Range: 0xce66fd..0xce6700
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce6600..0xce6645
+            - Range: 0xce6700..0xce6745
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}, {Size: 8, Op: null}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 39
       Name: main.testDeepPtr1
-      OutOfLinePCRanges: [0xce66c0..0xce66c1]
+      OutOfLinePCRanges: [0xce67c0..0xce67c1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 139 StructureType main.deepPtr1
           Locations:
-            - Range: 0xce66c0..0xce66c1
+            - Range: 0xce67c0..0xce67c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 40
       Name: main.testDeepPtr7
-      OutOfLinePCRanges: [0xce66e0..0xce66e1]
+      OutOfLinePCRanges: [0xce67e0..0xce67e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 142 PointerType *main.deepPtr7
           Locations:
-            - Range: 0xce66e0..0xce66e1
+            - Range: 0xce67e0..0xce67e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 41
       Name: main.testDeepSlice1
-      OutOfLinePCRanges: [0xce6840..0xce6841]
+      OutOfLinePCRanges: [0xce6940..0xce6941]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 144 StructureType main.deepSlice1
           Locations:
-            - Range: 0xce6840..0xce6841
+            - Range: 0xce6940..0xce6941
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6564,144 +6564,144 @@ Subprograms:
       DictRegister: null
     - ID: 42
       Name: main.testDeepSlice7
-      OutOfLinePCRanges: [0xce6860..0xce6861]
+      OutOfLinePCRanges: [0xce6960..0xce6961]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 148 PointerType *main.deepSlice7
           Locations:
-            - Range: 0xce6860..0xce6861
+            - Range: 0xce6960..0xce6961
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 43
       Name: main.testDeepMap1
-      OutOfLinePCRanges: [0xce69c0..0xce69c1]
+      OutOfLinePCRanges: [0xce6ac0..0xce6ac1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 150 StructureType main.deepMap1
           Locations:
-            - Range: 0xce69c0..0xce69c1
+            - Range: 0xce6ac0..0xce6ac1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 44
       Name: main.testDeepMap7
-      OutOfLinePCRanges: [0xce69e0..0xce69e1]
+      OutOfLinePCRanges: [0xce6ae0..0xce6ae1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 156 PointerType *main.deepMap7
           Locations:
-            - Range: 0xce69e0..0xce69e1
+            - Range: 0xce6ae0..0xce6ae1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 45
       Name: main.testStringType1
-      OutOfLinePCRanges: [0xce6a00..0xce6a01]
+      OutOfLinePCRanges: [0xce6b00..0xce6b01]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 158 PointerType *main.stringType1
           Locations:
-            - Range: 0xce6a00..0xce6a01
+            - Range: 0xce6b00..0xce6b01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 46
       Name: main.testStringType2
-      OutOfLinePCRanges: [0xce6a20..0xce6a21]
+      OutOfLinePCRanges: [0xce6b20..0xce6b21]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 160 PointerType **main.stringType2
           Locations:
-            - Range: 0xce6a20..0xce6a21
+            - Range: 0xce6b20..0xce6b21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 47
       Name: main.testLongFunctionWithChangingState
-      OutOfLinePCRanges: [0xce6a40..0xce6c78]
+      OutOfLinePCRanges: [0xce6b40..0xce6d78]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce6b1f..0xce6b37
+            - Range: 0xce6c1f..0xce6c37
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce6be5..0xce6bfd
+            - Range: 0xce6ce5..0xce6cfd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: aPerArch
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce6b08..0xce6b0b
+            - Range: 0xce6c08..0xce6c0b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce6b0b..0xce6b1f
+            - Range: 0xce6c0b..0xce6c1f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce6b1f..0xce6b37
+            - Range: 0xce6c1f..0xce6c37
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0xce6b37..0xce6bd8
+            - Range: 0xce6c37..0xce6cd8
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0xce6bd8..0xce6be5
+            - Range: 0xce6cd8..0xce6ce5
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0xce6be5..0xce6c78
+            - Range: 0xce6ce5..0xce6d78
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
           Role: Local
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce6b02..0xce6b0b
+            - Range: 0xce6c02..0xce6c0b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce6b0b..0xce6b0b
+            - Range: 0xce6c0b..0xce6c0b
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce6b0b..0xce6b1f
+            - Range: 0xce6c0b..0xce6c1f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce6b1f..0xce6bd8
+            - Range: 0xce6c1f..0xce6cd8
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0xce6bd8..0xce6bdd
+            - Range: 0xce6cd8..0xce6cdd
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0xce6bdd..0xce6be5
+            - Range: 0xce6cdd..0xce6ce5
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
-            - Range: 0xce6be5..0xce6bea
+            - Range: 0xce6ce5..0xce6cea
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
-            - Range: 0xce6bea..0xce6c78
+            - Range: 0xce6cea..0xce6d78
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 48
       Name: main.testManyPointers
-      OutOfLinePCRanges: [0xce7060..0xce7061]
+      OutOfLinePCRanges: [0xce7160..0xce7161]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 162 StructureType main.manyPointers
           Locations:
-            - Range: 0xce7060..0xce7061
+            - Range: 0xce7160..0xce7161
               Pieces: [{Size: 560, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 49
       Name: main.testManyStrings
-      OutOfLinePCRanges: [0xce8c00..0xce8c01]
+      OutOfLinePCRanges: [0xce8d00..0xce8d01]
       InlinePCRanges: []
       Variables:
         - Name: ss
           Type: 165 GoSliceHeaderType []string
           Locations:
-            - Range: 0xce8c00..0xce8c01
+            - Range: 0xce8d00..0xce8d01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6714,13 +6714,13 @@ Subprograms:
       DictRegister: null
     - ID: 50
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0xce8f00..0xce9005]
+      OutOfLinePCRanges: [0xce9000..0xce9105]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 166 StructureType main.esotericStack
           Locations:
-            - Range: 0xce8f00..0xce8f53
+            - Range: 0xce9000..0xce9053
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -6740,7 +6740,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xce8f53..0xce8f58
+            - Range: 0xce9053..0xce9058
               Pieces:
                 - Size: 4
                   Op: null
@@ -6760,7 +6760,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xce8f58..0xce8f5d
+            - Range: 0xce9058..0xce905d
               Pieces:
                 - Size: 4
                   Op: null
@@ -6785,155 +6785,155 @@ Subprograms:
       DictRegister: null
     - ID: 51
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0xce9020..0xce9083]
+      OutOfLinePCRanges: [0xce9120..0xce9183]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 170 PointerType *main.esotericHeap
           Locations:
-            - Range: 0xce9020..0xce904d
+            - Range: 0xce9120..0xce914d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 52
       Name: main.testInlinedBA
-      OutOfLinePCRanges: [0xcea5e0..0xcea668]
+      OutOfLinePCRanges: [0xcea6e0..0xcea768]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcea5e0..0xcea5f5
+            - Range: 0xcea6e0..0xcea6f5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 53
       Name: main.testInlinedBB
-      OutOfLinePCRanges: [0xcea680..0xcea745]
+      OutOfLinePCRanges: [0xcea780..0xcea845]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcea680..0xcea696
+            - Range: 0xcea780..0xcea796
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: "y"
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcea680..0xcea6a7
+            - Range: 0xcea780..0xcea7a7
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: z
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcea696..0xcea6a7
+            - Range: 0xcea796..0xcea7a7
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcea6a7..0xcea745
+            - Range: 0xcea7a7..0xcea845
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 54
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0xcea760..0xcea7c2]
+      OutOfLinePCRanges: [0xcea860..0xcea8c2]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcea760..0xcea77a
+            - Range: 0xcea860..0xcea87a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 55
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0xcea7e0..0xcea8e5]
+      OutOfLinePCRanges: [0xcea8e0..0xcea9e5]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcea83b..0xcea845
+            - Range: 0xcea93b..0xcea945
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xcea845..0xcea855
+            - Range: 0xcea945..0xcea955
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xcea855..0xcea869
+            - Range: 0xcea955..0xcea969
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcea836..0xcea840
+            - Range: 0xcea936..0xcea940
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xcea840..0xcea855
+            - Range: 0xcea940..0xcea955
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xcea855..0xcea864
+            - Range: 0xcea955..0xcea964
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 56
       Name: main.testFrameless
-      OutOfLinePCRanges: [0xcea900..0xcea906]
+      OutOfLinePCRanges: [0xceaa00..0xceaa06]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcea900..0xcea905
+            - Range: 0xceaa00..0xceaa05
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcea900..0xcea905
+            - Range: 0xceaa00..0xceaa05
               Pieces: []
-            - Range: 0xcea905..0xcea906
+            - Range: 0xceaa05..0xceaa06
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 57
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0xcea920..0xcea96b]
+      OutOfLinePCRanges: [0xceaa20..0xceaa6b]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 172 ArrayType [5]int
           Locations:
-            - Range: 0xcea920..0xcea96b
+            - Range: 0xceaa20..0xceaa6b
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcea920..0xcea965
+            - Range: 0xceaa20..0xceaa65
               Pieces: []
-            - Range: 0xcea965..0xcea966
+            - Range: 0xceaa65..0xceaa66
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcea966..0xcea96b
+            - Range: 0xceaa66..0xceaa6b
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 58
       Name: main.testInterface
-      OutOfLinePCRanges: [0xceac00..0xceac01]
+      OutOfLinePCRanges: [0xcead00..0xcead01]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 173 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xceac00..0xceac01
+            - Range: 0xcead00..0xcead01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6944,19 +6944,19 @@ Subprograms:
       DictRegister: null
     - ID: 59
       Name: main.testAny
-      OutOfLinePCRanges: [0xceac20..0xceac86]
+      OutOfLinePCRanges: [0xcead20..0xcead86]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 168 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xceac20..0xceac49
+            - Range: 0xcead20..0xcead49
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xceac49..0xceac4e
+            - Range: 0xcead49..0xcead4e
               Pieces:
                 - Size: 8
                   Op: null
@@ -6967,28 +6967,28 @@ Subprograms:
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xceac20..0xceac65
+            - Range: 0xcead20..0xcead65
               Pieces: []
-            - Range: 0xceac65..0xceac66
+            - Range: 0xcead65..0xcead66
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xceac66..0xceac86
+            - Range: 0xcead66..0xcead86
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 60
       Name: main.testError
-      OutOfLinePCRanges: [0xceaca0..0xceaca1]
+      OutOfLinePCRanges: [0xceada0..0xceada1]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 16 GoInterfaceType error
           Locations:
-            - Range: 0xceaca0..0xceaca1
+            - Range: 0xceada0..0xceada1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6999,41 +6999,41 @@ Subprograms:
       DictRegister: null
     - ID: 61
       Name: main.testAnyPtr
-      OutOfLinePCRanges: [0xceacc0..0xcead14]
+      OutOfLinePCRanges: [0xceadc0..0xceae14]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 174 PointerType *interface {}
           Locations:
-            - Range: 0xceacc0..0xceace6
+            - Range: 0xceadc0..0xceade6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xceacc0..0xceacfd
+            - Range: 0xceadc0..0xceadfd
               Pieces: []
-            - Range: 0xceacfd..0xceacfe
+            - Range: 0xceadfd..0xceadfe
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xceacfe..0xcead14
+            - Range: 0xceadfe..0xceae14
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 62
       Name: main.testStructWithAny
-      OutOfLinePCRanges: [0xcead20..0xcead21]
+      OutOfLinePCRanges: [0xceae20..0xceae21]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 175 StructureType main.structWithAny
           Locations:
-            - Range: 0xcead20..0xcead21
+            - Range: 0xceae20..0xceae21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7044,346 +7044,346 @@ Subprograms:
       DictRegister: null
     - ID: 63
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0xceb3a0..0xceb3a1]
+      OutOfLinePCRanges: [0xceb560..0xceb561]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 176 StructureType main.structWithMap
-          Locations:
-            - Range: 0xceb3a0..0xceb3a1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 64
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0xceb3c0..0xceb3c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 182 GoMapType map[string]main.nestedStruct
-          Locations:
-            - Range: 0xceb3c0..0xceb3c1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 65
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0xceb3e0..0xceb3e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 187 GoMapType map[string]int
-          Locations:
-            - Range: 0xceb3e0..0xceb3e1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 66
-      Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0xceb400..0xceb401]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 192 GoMapType map[string][]string
-          Locations:
-            - Range: 0xceb400..0xceb401
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 67
-      Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0xceb420..0xceb421]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 197 GoMapType map[[4]string][2]int
-          Locations:
-            - Range: 0xceb420..0xceb421
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 68
-      Name: main.testSmallMap
-      OutOfLinePCRanges: [0xceb440..0xceb441]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 187 GoMapType map[string]int
-          Locations:
-            - Range: 0xceb440..0xceb441
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 69
-      Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0xceb460..0xceb461]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 202 ArrayType [2]map[string]int
-          Locations:
-            - Range: 0xceb460..0xceb461
-              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 70
-      Name: main.testPointerToMap
-      OutOfLinePCRanges: [0xceb480..0xceb481]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 203 PointerType *map[string]int
-          Locations:
-            - Range: 0xceb480..0xceb481
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 71
-      Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0xceb4a0..0xceb4a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 177 GoMapType map[int]int
-          Locations:
-            - Range: 0xceb4a0..0xceb4a1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 72
-      Name: main.testMapMassive
-      OutOfLinePCRanges: [0xceb4c0..0xceb4c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: redactMyEntries
-          Type: 204 GoMapType map[string][]main.structWithMap
-          Locations:
-            - Range: 0xceb4c0..0xceb4c1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 73
-      Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0xceb4e0..0xceb4e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 204 GoMapType map[string][]main.structWithMap
-          Locations:
-            - Range: 0xceb4e0..0xceb4e1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 74
-      Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0xceb500..0xceb501]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 209 GoMapType map[bool]main.node
-          Locations:
-            - Range: 0xceb500..0xceb501
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 75
-      Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0xceb520..0xceb521]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 214 GoMapType map[int]uint8
-          Locations:
-            - Range: 0xceb520..0xceb521
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 76
-      Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0xceb540..0xceb541]
-      InlinePCRanges: []
-      Variables:
-        - Name: redactMyEntries
-          Type: 214 GoMapType map[int]uint8
-          Locations:
-            - Range: 0xceb540..0xceb541
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 77
-      Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0xceb560..0xceb561]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 219 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xceb560..0xceb561
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 78
-      Name: main.testMapWithSmallKeyAndValueMassive
+    - ID: 64
+      Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0xceb580..0xceb581]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 219 GoMapType map[uint8]uint8
+          Type: 182 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0xceb580..0xceb581
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 79
-      Name: main.testMapSmallKeySmallValue
+    - ID: 65
+      Name: main.testMapStringToInt
       OutOfLinePCRanges: [0xceb5a0..0xceb5a1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 219 GoMapType map[uint8]uint8
+          Type: 187 GoMapType map[string]int
           Locations:
             - Range: 0xceb5a0..0xceb5a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 80
-      Name: main.testMapSmallKeyLargeValue
+    - ID: 66
+      Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0xceb5c0..0xceb5c1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 224 GoMapType map[uint8][4]int
+          Type: 192 GoMapType map[string][]string
           Locations:
             - Range: 0xceb5c0..0xceb5c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 81
-      Name: main.testMapLargeKeySmallValue
+    - ID: 67
+      Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0xceb5e0..0xceb5e1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 229 GoMapType map[[4]int]uint8
+          Type: 197 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0xceb5e0..0xceb5e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 82
-      Name: main.testMapLargeKeyLargeValue
+    - ID: 68
+      Name: main.testSmallMap
       OutOfLinePCRanges: [0xceb600..0xceb601]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 234 GoMapType map[[4]int][4]int
+          Type: 187 GoMapType map[string]int
           Locations:
             - Range: 0xceb600..0xceb601
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 83
-      Name: main.testMapEmptyKey
+    - ID: 69
+      Name: main.testArrayOfMaps
       OutOfLinePCRanges: [0xceb620..0xceb621]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 239 GoMapType map[struct {}]int
+          Type: 202 ArrayType [2]map[string]int
           Locations:
             - Range: 0xceb620..0xceb621
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 84
-      Name: main.testMapEmptyValue
+    - ID: 70
+      Name: main.testPointerToMap
       OutOfLinePCRanges: [0xceb640..0xceb641]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 244 GoMapType map[int]struct {}
+          Type: 203 PointerType *map[string]int
           Locations:
             - Range: 0xceb640..0xceb641
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 85
-      Name: main.testMapEmptyKeyAndValue
+    - ID: 71
+      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0xceb660..0xceb661]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 249 GoMapType map[struct {}]struct {}
+          Type: 177 GoMapType map[int]int
           Locations:
             - Range: 0xceb660..0xceb661
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 72
+      Name: main.testMapMassive
+      OutOfLinePCRanges: [0xceb680..0xceb681]
+      InlinePCRanges: []
+      Variables:
+        - Name: redactMyEntries
+          Type: 204 GoMapType map[string][]main.structWithMap
+          Locations:
+            - Range: 0xceb680..0xceb681
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 73
+      Name: main.testMapEmbeddedMaps
+      OutOfLinePCRanges: [0xceb6a0..0xceb6a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 204 GoMapType map[string][]main.structWithMap
+          Locations:
+            - Range: 0xceb6a0..0xceb6a1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 74
+      Name: main.testMapWithLinkedList
+      OutOfLinePCRanges: [0xceb6c0..0xceb6c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 209 GoMapType map[bool]main.node
+          Locations:
+            - Range: 0xceb6c0..0xceb6c1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 75
+      Name: main.testMapWithSmallValue
+      OutOfLinePCRanges: [0xceb6e0..0xceb6e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 214 GoMapType map[int]uint8
+          Locations:
+            - Range: 0xceb6e0..0xceb6e1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 76
+      Name: main.testMapWithSmallValueMassive
+      OutOfLinePCRanges: [0xceb700..0xceb701]
+      InlinePCRanges: []
+      Variables:
+        - Name: redactMyEntries
+          Type: 214 GoMapType map[int]uint8
+          Locations:
+            - Range: 0xceb700..0xceb701
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 77
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0xceb720..0xceb721]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 219 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xceb720..0xceb721
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 78
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0xceb740..0xceb741]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 219 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xceb740..0xceb741
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 79
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0xceb760..0xceb761]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 219 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xceb760..0xceb761
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 80
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0xceb780..0xceb781]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 224 GoMapType map[uint8][4]int
+          Locations:
+            - Range: 0xceb780..0xceb781
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 81
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0xceb7a0..0xceb7a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 229 GoMapType map[[4]int]uint8
+          Locations:
+            - Range: 0xceb7a0..0xceb7a1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 82
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0xceb7c0..0xceb7c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 234 GoMapType map[[4]int][4]int
+          Locations:
+            - Range: 0xceb7c0..0xceb7c1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 83
+      Name: main.testMapEmptyKey
+      OutOfLinePCRanges: [0xceb7e0..0xceb7e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 239 GoMapType map[struct {}]int
+          Locations:
+            - Range: 0xceb7e0..0xceb7e1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 84
+      Name: main.testMapEmptyValue
+      OutOfLinePCRanges: [0xceb800..0xceb801]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 244 GoMapType map[int]struct {}
+          Locations:
+            - Range: 0xceb800..0xceb801
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 85
+      Name: main.testMapEmptyKeyAndValue
+      OutOfLinePCRanges: [0xceb820..0xceb821]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 249 GoMapType map[struct {}]struct {}
+          Locations:
+            - Range: 0xceb820..0xceb821
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 86
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0xcecea0..0xcecea1]
+      OutOfLinePCRanges: [0xced060..0xced061]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xcecea0..0xcecea1
+            - Range: 0xced060..0xced061
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xcecea0..0xcecea1
+            - Range: 0xced060..0xced061
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: "y"
           Type: 18 BaseType float32
           Locations:
-            - Range: 0xcecea0..0xcecea1
+            - Range: 0xced060..0xced061
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 87
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0xcecee0..0xcecee1]
+      OutOfLinePCRanges: [0xced0a0..0xced0a1]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xcecee0..0xcecee1
+            - Range: 0xced0a0..0xced0a1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcecee0..0xcecee1
+            - Range: 0xced0a0..0xced0a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -7394,48 +7394,48 @@ Subprograms:
         - Name: "y"
           Type: 18 BaseType float32
           Locations:
-            - Range: 0xcecee0..0xcecee1
+            - Range: 0xced0a0..0xced0a1
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 88
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0xced060..0xced061]
+      OutOfLinePCRanges: [0xced220..0xced221]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xced060..0xced061
+            - Range: 0xced220..0xced221
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xced060..0xced061
+            - Range: 0xced220..0xced221
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 11 BaseType int32
           Locations:
-            - Range: 0xced060..0xced061
+            - Range: 0xced220..0xced221
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 15 BaseType uint
           Locations:
-            - Range: 0xced060..0xced061
+            - Range: 0xced220..0xced221
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xced060..0xced061
+            - Range: 0xced220..0xced221
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7446,61 +7446,61 @@ Subprograms:
       DictRegister: null
     - ID: 89
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0xced280..0xced293]
+      OutOfLinePCRanges: [0xced440..0xced453]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0xced280..0xced292
+            - Range: 0xced440..0xced452
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0xced280..0xced292
+            - Range: 0xced440..0xced452
               Pieces: []
-            - Range: 0xced292..0xced293
+            - Range: 0xced452..0xced453
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 90
       Name: main.testChannel
-      OutOfLinePCRanges: [0xced2a0..0xced2a1]
+      OutOfLinePCRanges: [0xced460..0xced461]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 254 GoChannelType chan bool
           Locations:
-            - Range: 0xced2a0..0xced2a1
+            - Range: 0xced460..0xced461
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 91
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xced460..0xced461]
+      OutOfLinePCRanges: [0xced620..0xced621]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 255 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xced460..0xced461
+            - Range: 0xced620..0xced621
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 92
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0xced480..0xced481]
+      OutOfLinePCRanges: [0xced640..0xced641]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 257 StructureType main.node
           Locations:
-            - Range: 0xced480..0xced481
+            - Range: 0xced640..0xced641
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7511,273 +7511,273 @@ Subprograms:
       DictRegister: null
     - ID: 93
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xced4a0..0xced4a1]
+      OutOfLinePCRanges: [0xced660..0xced661]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 258 PointerType *main.node
-          Locations:
-            - Range: 0xced4a0..0xced4a1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 94
-      Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xced4c0..0xced4c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 17 VoidPointerType unsafe.Pointer
-          Locations:
-            - Range: 0xced4c0..0xced4c1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 95
-      Name: main.testUintPointer
-      OutOfLinePCRanges: [0xced500..0xced501]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 113 PointerType *uint
-          Locations:
-            - Range: 0xced500..0xced501
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 96
-      Name: main.testStringPointer
-      OutOfLinePCRanges: [0xced5e0..0xced5e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: z
-          Type: 102 PointerType *string
-          Locations:
-            - Range: 0xced5e0..0xced5e1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 97
-      Name: main.testNilPointer
-      OutOfLinePCRanges: [0xced620..0xced621]
-      InlinePCRanges: []
-      Variables:
-        - Name: z
-          Type: 12 PointerType *bool
-          Locations:
-            - Range: 0xced620..0xced621
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: a
-          Type: 15 BaseType uint
-          Locations:
-            - Range: 0xced620..0xced621
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 98
-      Name: main.testCycle
-      OutOfLinePCRanges: [0xced660..0xced661]
-      InlinePCRanges: []
-      Variables:
-        - Name: t
-          Type: 259 PointerType *main.t
           Locations:
             - Range: 0xced660..0xced661
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 94
+      Name: main.testUnsafePointer
+      OutOfLinePCRanges: [0xced680..0xced681]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 17 VoidPointerType unsafe.Pointer
+          Locations:
+            - Range: 0xced680..0xced681
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 95
+      Name: main.testUintPointer
+      OutOfLinePCRanges: [0xced6c0..0xced6c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 113 PointerType *uint
+          Locations:
+            - Range: 0xced6c0..0xced6c1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 96
+      Name: main.testStringPointer
+      OutOfLinePCRanges: [0xced7a0..0xced7a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: z
+          Type: 102 PointerType *string
+          Locations:
+            - Range: 0xced7a0..0xced7a1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 97
+      Name: main.testNilPointer
+      OutOfLinePCRanges: [0xced7e0..0xced7e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: z
+          Type: 12 PointerType *bool
+          Locations:
+            - Range: 0xced7e0..0xced7e1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 15 BaseType uint
+          Locations:
+            - Range: 0xced7e0..0xced7e1
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 98
+      Name: main.testCycle
+      OutOfLinePCRanges: [0xced820..0xced821]
+      InlinePCRanges: []
+      Variables:
+        - Name: t
+          Type: 259 PointerType *main.t
+          Locations:
+            - Range: 0xced820..0xced821
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 99
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0xceda80..0xcedaf2]
+      OutOfLinePCRanges: [0xcedc40..0xcedcb2]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xceda80..0xceda92
+            - Range: 0xcedc40..0xcedc52
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xceda80..0xcedadb
+            - Range: 0xcedc40..0xcedc9b
               Pieces: []
-            - Range: 0xcedadb..0xcedadc
+            - Range: 0xcedc9b..0xcedc9c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcedadc..0xcedaf2
+            - Range: 0xcedc9c..0xcedcb2
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result
           Type: 8 BaseType int
           Locations:
-            - Range: 0xceda92..0xcedaa5
+            - Range: 0xcedc52..0xcedc65
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcedaa5..0xcedaf2
+            - Range: 0xcedc65..0xcedcb2
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 100
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0xcedb00..0xcedb8f]
+      OutOfLinePCRanges: [0xcedcc0..0xcedd4f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcedb00..0xcedb1a
+            - Range: 0xcedcc0..0xcedcda
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcedb1a..0xcedb8f
+            - Range: 0xcedcda..0xcedd4f
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 105 PointerType *int
           Locations:
-            - Range: 0xcedb00..0xcedb74
+            - Range: 0xcedcc0..0xcedd34
               Pieces: []
-            - Range: 0xcedb74..0xcedb75
+            - Range: 0xcedd34..0xcedd35
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcedb75..0xcedb8f
+            - Range: 0xcedd35..0xcedd4f
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: '&result'
           Type: 105 PointerType *int
           Locations:
-            - Range: 0xcedb1f..0xcedb39
+            - Range: 0xcedcdf..0xcedcf9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcedb39..0xcedb8f
+            - Range: 0xcedcf9..0xcedd4f
               Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 101
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0xcedba0..0xcedc7f]
+      OutOfLinePCRanges: [0xcedd60..0xcede3f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcedba0..0xcedc03
+            - Range: 0xcedd60..0xceddc3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcedba0..0xcedc65
+            - Range: 0xcedd60..0xcede25
               Pieces: []
-            - Range: 0xcedc65..0xcedc66
+            - Range: 0xcede25..0xcede26
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcedc66..0xcedc7f
+            - Range: 0xcede26..0xcede3f
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 14 BaseType float64
-          Locations: [{Range: 0xcedba0..0xcedc7f, Pieces: []}]
+          Locations: [{Range: 0xcedd60..0xcede3f, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: resultInt
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcedbb6..0xcedc08
+            - Range: 0xcedd76..0xceddc8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcedc08..0xcedc7f
+            - Range: 0xceddc8..0xcede3f
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
           Role: Local
           DictIndex: -1
         - Name: resultFloat
           Type: 14 BaseType float64
           Locations:
-            - Range: 0xcedbcf..0xcedc08
+            - Range: 0xcedd8f..0xceddc8
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
-            - Range: 0xcedc08..0xcedc7f
+            - Range: 0xceddc8..0xcede3f
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 102
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0xcedc80..0xcedce4]
+      OutOfLinePCRanges: [0xcede40..0xcedea4]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xcedc80..0xcedc97
+            - Range: 0xcede40..0xcede57
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 16 GoInterfaceType error
           Locations:
-            - Range: 0xcedc80..0xcedcc4
+            - Range: 0xcede40..0xcede84
               Pieces: []
-            - Range: 0xcedcc4..0xcedcc5
+            - Range: 0xcede84..0xcede85
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcedcc5..0xcedcce
+            - Range: 0xcede85..0xcede8e
               Pieces: []
-            - Range: 0xcedcce..0xcedccf
+            - Range: 0xcede8e..0xcede8f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcedccf..0xcedce4
+            - Range: 0xcede8f..0xcedea4
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 103
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0xcedd00..0xcede5c]
+      OutOfLinePCRanges: [0xcedec0..0xcee01c]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 168 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcedd00..0xcedd4b
+            - Range: 0xcedec0..0xcedf0b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcedd4b..0xcedd56
+            - Range: 0xcedf0b..0xcedf16
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcedd87..0xcedd8a
+            - Range: 0xcedf47..0xcedf4a
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xceddbe..0xceddc5
+            - Range: 0xcedf7e..0xcedf85
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xceddfe..0xcede05
+            - Range: 0xcedfbe..0xcedfc5
               Pieces:
                 - Size: 8
                   Op: null
@@ -7788,117 +7788,117 @@ Subprograms:
         - Name: failed
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xcedd00..0xcedd56
+            - Range: 0xcedec0..0xcedf16
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 168 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcedd00..0xcedd64
+            - Range: 0xcedec0..0xcedf24
               Pieces: []
-            - Range: 0xcedd64..0xcedd65
+            - Range: 0xcedf24..0xcedf25
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcedd65..0xceddb3
+            - Range: 0xcedf25..0xcedf73
               Pieces: []
-            - Range: 0xceddb3..0xceddb4
+            - Range: 0xcedf73..0xcedf74
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xceddb4..0xceddf3
+            - Range: 0xcedf74..0xcedfb3
               Pieces: []
-            - Range: 0xceddf3..0xceddf4
+            - Range: 0xcedfb3..0xcedfb4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xceddf4..0xcede2f
+            - Range: 0xcedfb4..0xcedfef
               Pieces: []
-            - Range: 0xcede2f..0xcede30
+            - Range: 0xcedfef..0xcedff0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcede30..0xcede5c
+            - Range: 0xcedff0..0xcee01c
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 16 GoInterfaceType error
           Locations:
-            - Range: 0xcedd00..0xcedd64
+            - Range: 0xcedec0..0xcedf24
               Pieces: []
-            - Range: 0xcedd64..0xcedd65
+            - Range: 0xcedf24..0xcedf25
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcedd65..0xceddb3
+            - Range: 0xcedf25..0xcedf73
               Pieces: []
-            - Range: 0xceddb3..0xceddb4
+            - Range: 0xcedf73..0xcedf74
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xceddb4..0xceddf3
+            - Range: 0xcedf74..0xcedfb3
               Pieces: []
-            - Range: 0xceddf3..0xceddf4
+            - Range: 0xcedfb3..0xcedfb4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xceddf4..0xcede2f
+            - Range: 0xcedfb4..0xcedfef
               Pieces: []
-            - Range: 0xcede2f..0xcede30
+            - Range: 0xcedfef..0xcedff0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcede30..0xcede5c
+            - Range: 0xcedff0..0xcee01c
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcedd4b..0xcedd51
+            - Range: 0xcedf0b..0xcedf11
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 104
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0xcede60..0xcee05d]
+      OutOfLinePCRanges: [0xcee020..0xcee21d]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 168 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcede60..0xcedeab
+            - Range: 0xcee020..0xcee06b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcedeab..0xcedeb2
+            - Range: 0xcee06b..0xcee072
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcedeb2..0xcee05d
+            - Range: 0xcee072..0xcee21d
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -7909,1128 +7909,1128 @@ Subprograms:
         - Name: ~r0
           Type: 168 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcede60..0xcedf15
+            - Range: 0xcee020..0xcee0d5
               Pieces: []
-            - Range: 0xcedf15..0xcedf16
+            - Range: 0xcee0d5..0xcee0d6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcedf16..0xcedf64
+            - Range: 0xcee0d6..0xcee124
               Pieces: []
-            - Range: 0xcedf64..0xcedf65
+            - Range: 0xcee124..0xcee125
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcedf65..0xcee02f
+            - Range: 0xcee125..0xcee1ef
               Pieces: []
-            - Range: 0xcee02f..0xcee030
+            - Range: 0xcee1ef..0xcee1f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcee030..0xcee039
+            - Range: 0xcee1f0..0xcee1f9
               Pieces: []
-            - Range: 0xcee039..0xcee03a
+            - Range: 0xcee1f9..0xcee1fa
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcee03a..0xcee05d
+            - Range: 0xcee1fa..0xcee21d
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcedf00..0xcedf06
+            - Range: 0xcee0c0..0xcee0c6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: '&result'
           Type: 105 PointerType *int
           Locations:
-            - Range: 0xcedf45..0xcedf64
+            - Range: 0xcee105..0xcee124
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 105
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0xcee060..0xcee1b4]
+      OutOfLinePCRanges: [0xcee220..0xcee374]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 168 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcee060..0xcee0a0
+            - Range: 0xcee220..0xcee260
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcee0a0..0xcee0f0
+            - Range: 0xcee260..0xcee2b0
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcee0f0..0xcee14d
+            - Range: 0xcee2b0..0xcee30d
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcee14d..0xcee171
+            - Range: 0xcee30d..0xcee331
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcee171..0xcee178
+            - Range: 0xcee331..0xcee338
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcee178..0xcee1b4
+            - Range: 0xcee338..0xcee374
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 173 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcee060..0xcee13d
+            - Range: 0xcee220..0xcee2fd
               Pieces: []
-            - Range: 0xcee13d..0xcee13e
+            - Range: 0xcee2fd..0xcee2fe
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcee13e..0xcee147
+            - Range: 0xcee2fe..0xcee307
               Pieces: []
-            - Range: 0xcee147..0xcee148
+            - Range: 0xcee307..0xcee308
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcee148..0xcee1b4
+            - Range: 0xcee308..0xcee374
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 173 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcee060..0xcee0a0
+            - Range: 0xcee220..0xcee260
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcee0a0..0xcee0f0
+            - Range: 0xcee260..0xcee2b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcee0f0..0xcee0f7
+            - Range: 0xcee2b0..0xcee2b7
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcee0f7..0xcee143
+            - Range: 0xcee2b7..0xcee303
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcee143..0xcee145
+            - Range: 0xcee303..0xcee305
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcee145..0xcee147
+            - Range: 0xcee305..0xcee307
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcee147..0xcee1b4
+            - Range: 0xcee307..0xcee374
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 106
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0xcee1c0..0xcee255]
+      OutOfLinePCRanges: [0xcee380..0xcee415]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcee1c0..0xcee1d1
+            - Range: 0xcee380..0xcee391
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcee1c0..0xcee23b
+            - Range: 0xcee380..0xcee3fb
               Pieces: []
-            - Range: 0xcee23b..0xcee23c
+            - Range: 0xcee3fb..0xcee3fc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcee23c..0xcee255
+            - Range: 0xcee3fc..0xcee415
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 107
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0xcee260..0xcee329]
+      OutOfLinePCRanges: [0xcee420..0xcee4e9]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcee260..0xcee2b2
+            - Range: 0xcee420..0xcee472
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcee260..0xcee30f
+            - Range: 0xcee420..0xcee4cf
               Pieces: []
-            - Range: 0xcee30f..0xcee310
+            - Range: 0xcee4cf..0xcee4d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcee310..0xcee329
+            - Range: 0xcee4d0..0xcee4e9
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcee260..0xcee30f
+            - Range: 0xcee420..0xcee4cf
               Pieces: []
-            - Range: 0xcee30f..0xcee310
+            - Range: 0xcee4cf..0xcee4d0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcee310..0xcee329
+            - Range: 0xcee4d0..0xcee4e9
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 108
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0xcee340..0xcee407]
+      OutOfLinePCRanges: [0xcee500..0xcee5c7]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcee340..0xcee385
+            - Range: 0xcee500..0xcee545
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcee385..0xcee407
+            - Range: 0xcee545..0xcee5c7
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcee340..0xcee3ed
+            - Range: 0xcee500..0xcee5ad
               Pieces: []
-            - Range: 0xcee3ed..0xcee3ee
+            - Range: 0xcee5ad..0xcee5ae
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcee3ee..0xcee407
+            - Range: 0xcee5ae..0xcee5c7
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcee340..0xcee3ed
+            - Range: 0xcee500..0xcee5ad
               Pieces: []
-            - Range: 0xcee3ed..0xcee3ee
+            - Range: 0xcee5ad..0xcee5ae
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcee3ee..0xcee407
+            - Range: 0xcee5ae..0xcee5c7
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcee340..0xcee3ed
+            - Range: 0xcee500..0xcee5ad
               Pieces: []
-            - Range: 0xcee3ed..0xcee3ee
+            - Range: 0xcee5ad..0xcee5ae
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcee3ee..0xcee407
+            - Range: 0xcee5ae..0xcee5c7
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 109
       Name: main.testConflictingReturn
-      OutOfLinePCRanges: [0xcee420..0xcee50f]
+      OutOfLinePCRanges: [0xcee5e0..0xcee6cf]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcee420..0xcee465
+            - Range: 0xcee5e0..0xcee625
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcee465..0xcee50f
+            - Range: 0xcee625..0xcee6cf
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcee420..0xcee4f1
+            - Range: 0xcee5e0..0xcee6b1
               Pieces: []
-            - Range: 0xcee4f1..0xcee4f2
+            - Range: 0xcee6b1..0xcee6b2
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcee4f2..0xcee50f
+            - Range: 0xcee6b2..0xcee6cf
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcee420..0xcee4f1
+            - Range: 0xcee5e0..0xcee6b1
               Pieces: []
-            - Range: 0xcee4f1..0xcee4f2
+            - Range: 0xcee6b1..0xcee6b2
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcee4f2..0xcee50f
+            - Range: 0xcee6b2..0xcee6cf
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 110
       Name: main.testReturnsNamedDeferLine
-      OutOfLinePCRanges: [0xcee520..0xcee72f]
+      OutOfLinePCRanges: [0xcee6e0..0xcee8ef]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcee520..0xcee5a6
+            - Range: 0xcee6e0..0xcee766
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcee5a6..0xcee72f
+            - Range: 0xcee766..0xcee8ef
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcee557..0xcee72f
+            - Range: 0xcee717..0xcee8ef
               Pieces: [{Size: 16, Op: {CfaOffset: -128}}]
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcee55d..0xcee72f
+            - Range: 0xcee71d..0xcee8ef
               Pieces: [{Size: 16, Op: {CfaOffset: -144}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 111
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0xcee820..0xcee89e]
+      OutOfLinePCRanges: [0xcee9e0..0xceea5e]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 21 BaseType int8
           Locations:
-            - Range: 0xcee820..0xcee891
+            - Range: 0xcee9e0..0xceea51
               Pieces: []
-            - Range: 0xcee891..0xcee892
+            - Range: 0xceea51..0xceea52
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcee892..0xcee89e
+            - Range: 0xceea52..0xceea5e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 110 BaseType int16
           Locations:
-            - Range: 0xcee820..0xcee891
+            - Range: 0xcee9e0..0xceea51
               Pieces: []
-            - Range: 0xcee891..0xcee892
+            - Range: 0xceea51..0xceea52
               Pieces: [{Size: 2, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcee892..0xcee89e
+            - Range: 0xceea52..0xceea5e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 11 BaseType int32
           Locations:
-            - Range: 0xcee820..0xcee891
+            - Range: 0xcee9e0..0xceea51
               Pieces: []
-            - Range: 0xcee891..0xcee892
+            - Range: 0xceea51..0xceea52
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcee892..0xcee89e
+            - Range: 0xceea52..0xceea5e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 13 BaseType int64
           Locations:
-            - Range: 0xcee820..0xcee891
+            - Range: 0xcee9e0..0xceea51
               Pieces: []
-            - Range: 0xcee891..0xcee892
+            - Range: 0xceea51..0xceea52
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcee892..0xcee89e
+            - Range: 0xceea52..0xceea5e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xcee820..0xcee891
+            - Range: 0xcee9e0..0xceea51
               Pieces: []
-            - Range: 0xcee891..0xcee892
+            - Range: 0xceea51..0xceea52
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcee892..0xcee89e
+            - Range: 0xceea52..0xceea5e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 7 BaseType uint16
           Locations:
-            - Range: 0xcee820..0xcee891
+            - Range: 0xcee9e0..0xceea51
               Pieces: []
-            - Range: 0xcee891..0xcee892
+            - Range: 0xceea51..0xceea52
               Pieces: [{Size: 2, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcee892..0xcee89e
+            - Range: 0xceea52..0xceea5e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 3 BaseType uint32
           Locations:
-            - Range: 0xcee820..0xcee891
+            - Range: 0xcee9e0..0xceea51
               Pieces: []
-            - Range: 0xcee891..0xcee892
+            - Range: 0xceea51..0xceea52
               Pieces: [{Size: 4, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcee892..0xcee89e
+            - Range: 0xceea52..0xceea5e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0xcee820..0xcee891
+            - Range: 0xcee9e0..0xceea51
               Pieces: []
-            - Range: 0xcee891..0xcee892
+            - Range: 0xceea51..0xceea52
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcee892..0xcee89e
+            - Range: 0xceea52..0xceea5e
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 112
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0xcee8a0..0xcee997]
+      OutOfLinePCRanges: [0xceea60..0xceeb57]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 14 BaseType float64
-          Locations: [{Range: 0xcee8a0..0xcee997, Pieces: []}]
+          Locations: [{Range: 0xceea60..0xceeb57, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 14 BaseType float64
-          Locations: [{Range: 0xcee8a0..0xcee997, Pieces: []}]
+          Locations: [{Range: 0xceea60..0xceeb57, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 14 BaseType float64
-          Locations: [{Range: 0xcee8a0..0xcee997, Pieces: []}]
+          Locations: [{Range: 0xceea60..0xceeb57, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 14 BaseType float64
-          Locations: [{Range: 0xcee8a0..0xcee997, Pieces: []}]
+          Locations: [{Range: 0xceea60..0xceeb57, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 14 BaseType float64
-          Locations: [{Range: 0xcee8a0..0xcee997, Pieces: []}]
+          Locations: [{Range: 0xceea60..0xceeb57, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 14 BaseType float64
-          Locations: [{Range: 0xcee8a0..0xcee997, Pieces: []}]
+          Locations: [{Range: 0xceea60..0xceeb57, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 14 BaseType float64
-          Locations: [{Range: 0xcee8a0..0xcee997, Pieces: []}]
+          Locations: [{Range: 0xceea60..0xceeb57, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 14 BaseType float64
-          Locations: [{Range: 0xcee8a0..0xcee997, Pieces: []}]
+          Locations: [{Range: 0xceea60..0xceeb57, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 14 BaseType float64
-          Locations: [{Range: 0xcee8a0..0xcee997, Pieces: []}]
+          Locations: [{Range: 0xceea60..0xceeb57, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r9
           Type: 14 BaseType float64
-          Locations: [{Range: 0xcee8a0..0xcee997, Pieces: []}]
+          Locations: [{Range: 0xceea60..0xceeb57, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r10
           Type: 14 BaseType float64
-          Locations: [{Range: 0xcee8a0..0xcee997, Pieces: []}]
+          Locations: [{Range: 0xceea60..0xceeb57, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r11
           Type: 14 BaseType float64
-          Locations: [{Range: 0xcee8a0..0xcee997, Pieces: []}]
+          Locations: [{Range: 0xceea60..0xceeb57, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r12
           Type: 14 BaseType float64
-          Locations: [{Range: 0xcee8a0..0xcee997, Pieces: []}]
+          Locations: [{Range: 0xceea60..0xceeb57, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r13
           Type: 14 BaseType float64
-          Locations: [{Range: 0xcee8a0..0xcee997, Pieces: []}]
+          Locations: [{Range: 0xceea60..0xceeb57, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r14
           Type: 14 BaseType float64
-          Locations: [{Range: 0xcee8a0..0xcee997, Pieces: []}]
+          Locations: [{Range: 0xceea60..0xceeb57, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: onlyOnAmd64_16
           Type: 14 BaseType float64
           Locations:
-            - Range: 0xcee8a0..0xcee987
+            - Range: 0xceea60..0xceeb47
               Pieces: []
-            - Range: 0xcee987..0xcee988
+            - Range: 0xceeb47..0xceeb48
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xcee988..0xcee997
+            - Range: 0xceeb48..0xceeb57
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: bothArmAndAmd64
           Type: 14 BaseType float64
           Locations:
-            - Range: 0xcee8a0..0xcee987
+            - Range: 0xceea60..0xceeb47
               Pieces: []
-            - Range: 0xcee987..0xcee988
+            - Range: 0xceeb47..0xceeb48
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcee988..0xcee997
+            - Range: 0xceeb48..0xceeb57
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 113
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0xcee9a0..0xceea13]
+      OutOfLinePCRanges: [0xceeb60..0xceebd3]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 103 BaseType complex64
-          Locations: [{Range: 0xcee9a0..0xceea13, Pieces: []}]
+          Locations: [{Range: 0xceeb60..0xceebd3, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 19 BaseType complex128
-          Locations: [{Range: 0xcee9a0..0xceea13, Pieces: []}]
+          Locations: [{Range: 0xceeb60..0xceebd3, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 114
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0xceea20..0xceead3]
+      OutOfLinePCRanges: [0xceebe0..0xceec93]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0xceea20..0xceeac3
+            - Range: 0xceebe0..0xceec83
               Pieces: []
-            - Range: 0xceeac3..0xceeac4
+            - Range: 0xceec83..0xceec84
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
-            - Range: 0xceeac4..0xceead3
+            - Range: 0xceec84..0xceec93
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 115
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0xceeae0..0xceeb5c]
+      OutOfLinePCRanges: [0xceeca0..0xceed1c]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 262 ArrayType [3]int
           Locations:
-            - Range: 0xceeae0..0xceeb4f
+            - Range: 0xceeca0..0xceed0f
               Pieces: []
-            - Range: 0xceeb4f..0xceeb50
+            - Range: 0xceed0f..0xceed10
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xceeb50..0xceeb5c
+            - Range: 0xceed10..0xceed1c
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 116
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0xceeb60..0xceebb8]
+      OutOfLinePCRanges: [0xceed20..0xceed78]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 263 ArrayType [1]int
           Locations:
-            - Range: 0xceeb60..0xceebab
+            - Range: 0xceed20..0xceed6b
               Pieces: []
-            - Range: 0xceebab..0xceebac
+            - Range: 0xceed6b..0xceed6c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xceebac..0xceebb8
+            - Range: 0xceed6c..0xceed78
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 117
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0xceebc0..0xceec13]
+      OutOfLinePCRanges: [0xceed80..0xceedd3]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 264 ArrayType [0]int
           Locations:
-            - Range: 0xceebc0..0xceec06
+            - Range: 0xceed80..0xceedc6
               Pieces: []
-            - Range: 0xceec06..0xceec07
+            - Range: 0xceedc6..0xceedc7
               Pieces: []
-            - Range: 0xceec07..0xceec13
+            - Range: 0xceedc7..0xceedd3
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 118
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0xceec20..0xceec87]
+      OutOfLinePCRanges: [0xceede0..0xceee47]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 265 StructureType main.mixedStruct
-          Locations: [{Range: 0xceec20..0xceec87, Pieces: []}]
+          Locations: [{Range: 0xceede0..0xceee47, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 119
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0xceeca0..0xceed3a]
+      OutOfLinePCRanges: [0xceee60..0xceeefa]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xceeca0..0xceed2a
+            - Range: 0xceee60..0xceeeea
               Pieces: []
-            - Range: 0xceed2a..0xceed2b
+            - Range: 0xceeeea..0xceeeeb
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xceed2b..0xceed3a
+            - Range: 0xceeeeb..0xceeefa
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 8 BaseType int
           Locations:
-            - Range: 0xceeca0..0xceed2a
+            - Range: 0xceee60..0xceeeea
               Pieces: []
-            - Range: 0xceed2a..0xceed2b
+            - Range: 0xceeeea..0xceeeeb
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xceed2b..0xceed3a
+            - Range: 0xceeeeb..0xceeefa
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0xceeca0..0xceed2a
+            - Range: 0xceee60..0xceeeea
               Pieces: []
-            - Range: 0xceed2a..0xceed2b
+            - Range: 0xceeeea..0xceeeeb
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xceed2b..0xceed3a
+            - Range: 0xceeeeb..0xceeefa
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 8 BaseType int
           Locations:
-            - Range: 0xceeca0..0xceed2a
+            - Range: 0xceee60..0xceeeea
               Pieces: []
-            - Range: 0xceed2a..0xceed2b
+            - Range: 0xceeeea..0xceeeeb
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xceed2b..0xceed3a
+            - Range: 0xceeeeb..0xceeefa
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 8 BaseType int
           Locations:
-            - Range: 0xceeca0..0xceed2a
+            - Range: 0xceee60..0xceeeea
               Pieces: []
-            - Range: 0xceed2a..0xceed2b
+            - Range: 0xceeeea..0xceeeeb
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xceed2b..0xceed3a
+            - Range: 0xceeeeb..0xceeefa
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 8 BaseType int
           Locations:
-            - Range: 0xceeca0..0xceed2a
+            - Range: 0xceee60..0xceeeea
               Pieces: []
-            - Range: 0xceed2a..0xceed2b
+            - Range: 0xceeeea..0xceeeeb
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xceed2b..0xceed3a
+            - Range: 0xceeeeb..0xceeefa
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 8 BaseType int
           Locations:
-            - Range: 0xceeca0..0xceed2a
+            - Range: 0xceee60..0xceeeea
               Pieces: []
-            - Range: 0xceed2a..0xceed2b
+            - Range: 0xceeeea..0xceeeeb
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xceed2b..0xceed3a
+            - Range: 0xceeeeb..0xceeefa
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 8 BaseType int
           Locations:
-            - Range: 0xceeca0..0xceed2a
+            - Range: 0xceee60..0xceeeea
               Pieces: []
-            - Range: 0xceed2a..0xceed2b
+            - Range: 0xceeeea..0xceeeeb
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xceed2b..0xceed3a
+            - Range: 0xceeeeb..0xceeefa
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xceeca0..0xceed2a
+            - Range: 0xceee60..0xceeeea
               Pieces: []
-            - Range: 0xceed2a..0xceed2b
+            - Range: 0xceeeea..0xceeeeb
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xceed2b..0xceed3a
+            - Range: 0xceeeeb..0xceeefa
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 120
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0xceed40..0xceee05]
+      OutOfLinePCRanges: [0xceef00..0xceefc5]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 266 StructureType main.wideStruct
           Locations:
-            - Range: 0xceed40..0xceedf2
+            - Range: 0xceef00..0xceefb2
               Pieces: []
-            - Range: 0xceedf2..0xceedf3
+            - Range: 0xceefb2..0xceefb3
               Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
-            - Range: 0xceedf3..0xceee05
+            - Range: 0xceefb3..0xceefc5
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 121
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0xceee20..0xceee99]
+      OutOfLinePCRanges: [0xceefe0..0xcef059]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xceee20..0xceee8c
+            - Range: 0xceefe0..0xcef04c
               Pieces: []
-            - Range: 0xceee8c..0xceee8d
+            - Range: 0xcef04c..0xcef04d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xceee8d..0xceee99
+            - Range: 0xcef04d..0xcef059
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 14 BaseType float64
-          Locations: [{Range: 0xceee20..0xceee99, Pieces: []}]
+          Locations: [{Range: 0xceefe0..0xcef059, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0xceee20..0xceee8c
+            - Range: 0xceefe0..0xcef04c
               Pieces: []
-            - Range: 0xceee8c..0xceee8d
+            - Range: 0xcef04c..0xcef04d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xceee8d..0xceee99
+            - Range: 0xcef04d..0xcef059
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 14 BaseType float64
-          Locations: [{Range: 0xceee20..0xceee99, Pieces: []}]
+          Locations: [{Range: 0xceefe0..0xcef059, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xceee20..0xceee8c
+            - Range: 0xceefe0..0xcef04c
               Pieces: []
-            - Range: 0xceee8c..0xceee8d
+            - Range: 0xcef04c..0xcef04d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xceee8d..0xceee99
+            - Range: 0xcef04d..0xcef059
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 122
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0xceeea0..0xceef1c]
+      OutOfLinePCRanges: [0xcef060..0xcef0dc]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 267 StructureType main.structWithArray
           Locations:
-            - Range: 0xceeea0..0xceef0f
+            - Range: 0xcef060..0xcef0cf
               Pieces: []
-            - Range: 0xceef0f..0xceef10
+            - Range: 0xcef0cf..0xcef0d0
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xceef10..0xceef1c
+            - Range: 0xcef0d0..0xcef0dc
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 123
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0xceef20..0xceef7b]
+      OutOfLinePCRanges: [0xcef0e0..0xcef13b]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 14 BaseType float64
-          Locations: [{Range: 0xceef20..0xceef7b, Pieces: []}]
+          Locations: [{Range: 0xcef0e0..0xcef13b, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 124
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0xceef80..0xceefe7]
+      OutOfLinePCRanges: [0xcef140..0xcef1a7]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float32
-          Locations: [{Range: 0xceef80..0xceefe7, Pieces: []}]
+          Locations: [{Range: 0xcef140..0xcef1a7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 14 BaseType float64
-          Locations: [{Range: 0xceef80..0xceefe7, Pieces: []}]
+          Locations: [{Range: 0xcef140..0xcef1a7, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 125
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0xcef000..0xcef05d]
+      OutOfLinePCRanges: [0xcef1c0..0xcef21d]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xcef000..0xcef050
+            - Range: 0xcef1c0..0xcef210
               Pieces: []
-            - Range: 0xcef050..0xcef051
+            - Range: 0xcef210..0xcef211
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcef051..0xcef05d
+            - Range: 0xcef211..0xcef21d
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 2 BaseType uintptr
           Locations:
-            - Range: 0xcef000..0xcef050
+            - Range: 0xcef1c0..0xcef210
               Pieces: []
-            - Range: 0xcef050..0xcef051
+            - Range: 0xcef210..0xcef211
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcef051..0xcef05d
+            - Range: 0xcef211..0xcef21d
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 126
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0xcef060..0xcef1dd]
+      OutOfLinePCRanges: [0xcef220..0xcef39d]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0xcef060..0xcef1dd
+            - Range: 0xcef220..0xcef39d
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0xcef060..0xcef1cd
+            - Range: 0xcef220..0xcef38d
               Pieces: []
-            - Range: 0xcef1cd..0xcef1ce
+            - Range: 0xcef38d..0xcef38e
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
-            - Range: 0xcef1ce..0xcef1dd
+            - Range: 0xcef38e..0xcef39d
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 127
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0xcef1e0..0xcef2ba]
+      OutOfLinePCRanges: [0xcef3a0..0xcef47a]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 262 ArrayType [3]int
           Locations:
-            - Range: 0xcef1e0..0xcef2ba
+            - Range: 0xcef3a0..0xcef47a
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 262 ArrayType [3]int
           Locations:
-            - Range: 0xcef1e0..0xcef2aa
+            - Range: 0xcef3a0..0xcef46a
               Pieces: []
-            - Range: 0xcef2aa..0xcef2ab
+            - Range: 0xcef46a..0xcef46b
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xcef2ab..0xcef2ba
+            - Range: 0xcef46b..0xcef47a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 128
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0xcef2c0..0xcef4fb]
+      OutOfLinePCRanges: [0xcef480..0xcef6bb]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0xcef2c0..0xcef4fb
+            - Range: 0xcef480..0xcef6bb
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s2
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0xcef2c0..0xcef4fb
+            - Range: 0xcef480..0xcef6bb
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0xcef2c0..0xcef4eb
+            - Range: 0xcef480..0xcef6ab
               Pieces: []
-            - Range: 0xcef4eb..0xcef4ec
+            - Range: 0xcef6ab..0xcef6ac
               Pieces: [{Size: 80, Op: {CfaOffset: 160}}]
-            - Range: 0xcef4ec..0xcef4fb
+            - Range: 0xcef6ac..0xcef6bb
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 129
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0xcef500..0xcef7af]
+      OutOfLinePCRanges: [0xcef6c0..0xcef96f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcef500..0xcef5c7
+            - Range: 0xcef6c0..0xcef787
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcef5c7..0xcef7af
+            - Range: 0xcef787..0xcef96f
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcef500..0xcef5c7
+            - Range: 0xcef6c0..0xcef787
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcef5c7..0xcef7af
+            - Range: 0xcef787..0xcef96f
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcef500..0xcef56a
+            - Range: 0xcef6c0..0xcef72a
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcef56a..0xcef7af
+            - Range: 0xcef72a..0xcef96f
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcef500..0xcef5c7
+            - Range: 0xcef6c0..0xcef787
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcef5c7..0xcef7af
+            - Range: 0xcef787..0xcef96f
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcef500..0xcef5c7
+            - Range: 0xcef6c0..0xcef787
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcef5c7..0xcef7af
+            - Range: 0xcef787..0xcef96f
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcef500..0xcef5c7
+            - Range: 0xcef6c0..0xcef787
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcef5c7..0xcef7af
+            - Range: 0xcef787..0xcef96f
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcef500..0xcef5c7
+            - Range: 0xcef6c0..0xcef787
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcef5c7..0xcef7af
+            - Range: 0xcef787..0xcef96f
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcef500..0xcef5c7
+            - Range: 0xcef6c0..0xcef787
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcef5c7..0xcef7af
+            - Range: 0xcef787..0xcef96f
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcef500..0xcef5c7
+            - Range: 0xcef6c0..0xcef787
               Pieces: [{Size: 8, Op: {RegNo: 11, Shift: 0}}]
-            - Range: 0xcef5c7..0xcef7af
+            - Range: 0xcef787..0xcef96f
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 120 ArrayType [2]int
           Locations:
-            - Range: 0xcef500..0xcef742
+            - Range: 0xcef6c0..0xcef902
               Pieces: []
-            - Range: 0xcef742..0xcef743
+            - Range: 0xcef902..0xcef903
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xcef743..0xcef7af
+            - Range: 0xcef903..0xcef96f
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 130
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0xcef7c0..0xcefa85]
+      OutOfLinePCRanges: [0xcef980..0xcefc45]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcef7c0..0xcef86a
+            - Range: 0xcef980..0xcefa2a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcef86a..0xcefa85
+            - Range: 0xcefa2a..0xcefc45
               Pieces: [{Size: 8, Op: {CfaOffset: 96}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcef7c0..0xcef86a
+            - Range: 0xcef980..0xcefa2a
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcef86a..0xcefa85
+            - Range: 0xcefa2a..0xcefc45
               Pieces: [{Size: 8, Op: {CfaOffset: 104}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcef7c0..0xcef822
+            - Range: 0xcef980..0xcef9e2
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcef822..0xcefa85
+            - Range: 0xcef9e2..0xcefc45
               Pieces: [{Size: 8, Op: {CfaOffset: 112}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcef7c0..0xcef86a
+            - Range: 0xcef980..0xcefa2a
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcef86a..0xcefa85
+            - Range: 0xcefa2a..0xcefc45
               Pieces: [{Size: 8, Op: {CfaOffset: 120}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcef7c0..0xcef86a
+            - Range: 0xcef980..0xcefa2a
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcef86a..0xcefa85
+            - Range: 0xcefa2a..0xcefc45
               Pieces: [{Size: 8, Op: {CfaOffset: 128}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcef7c0..0xcef86a
+            - Range: 0xcef980..0xcefa2a
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcef86a..0xcefa85
+            - Range: 0xcefa2a..0xcefc45
               Pieces: [{Size: 8, Op: {CfaOffset: 136}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcef7c0..0xcef86a
+            - Range: 0xcef980..0xcefa2a
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcef86a..0xcefa85
+            - Range: 0xcefa2a..0xcefc45
               Pieces: [{Size: 8, Op: {CfaOffset: 144}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcef7c0..0xcef86a
+            - Range: 0xcef980..0xcefa2a
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcef86a..0xcefa85
+            - Range: 0xcefa2a..0xcefc45
               Pieces: [{Size: 8, Op: {CfaOffset: 152}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcef7c0..0xcefa85
+            - Range: 0xcef980..0xcefc45
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -9041,200 +9041,200 @@ Subprograms:
         - Name: ~r0
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0xcef7c0..0xcefa02
+            - Range: 0xcef980..0xcefbc2
               Pieces: []
-            - Range: 0xcefa02..0xcefa03
+            - Range: 0xcefbc2..0xcefbc3
               Pieces: [{Size: 80, Op: {CfaOffset: 16}}]
-            - Range: 0xcefa03..0xcefa85
+            - Range: 0xcefbc3..0xcefc45
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 131
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0xcefaa0..0xcefb2e]
+      OutOfLinePCRanges: [0xcefc60..0xcefcee]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 172 ArrayType [5]int
           Locations:
-            - Range: 0xcefaa0..0xcefb2e
+            - Range: 0xcefc60..0xcefcee
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcefaa0..0xcefb1e
+            - Range: 0xcefc60..0xcefcde
               Pieces: []
-            - Range: 0xcefb1e..0xcefb1f
+            - Range: 0xcefcde..0xcefcdf
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcefb1f..0xcefb2e
+            - Range: 0xcefcdf..0xcefcee
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcefaa0..0xcefb1e
+            - Range: 0xcefc60..0xcefcde
               Pieces: []
-            - Range: 0xcefb1e..0xcefb1f
+            - Range: 0xcefcde..0xcefcdf
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcefb1f..0xcefb2e
+            - Range: 0xcefcdf..0xcefcee
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcefaa0..0xcefb1e
+            - Range: 0xcefc60..0xcefcde
               Pieces: []
-            - Range: 0xcefb1e..0xcefb1f
+            - Range: 0xcefcde..0xcefcdf
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcefb1f..0xcefb2e
+            - Range: 0xcefcdf..0xcefcee
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 132
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0xcefb40..0xcefc2d]
+      OutOfLinePCRanges: [0xcefd00..0xcefded]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 120 ArrayType [2]int
           Locations:
-            - Range: 0xcefb40..0xcefc2d
+            - Range: 0xcefd00..0xcefded
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 262 ArrayType [3]int
           Locations:
-            - Range: 0xcefb40..0xcefc2d
+            - Range: 0xcefd00..0xcefded
               Pieces: [{Size: 24, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcefb40..0xcefc1d
+            - Range: 0xcefd00..0xcefddd
               Pieces: []
-            - Range: 0xcefc1d..0xcefc1e
+            - Range: 0xcefddd..0xcefdde
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcefc1e..0xcefc2d
+            - Range: 0xcefdde..0xcefded
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 120 ArrayType [2]int
           Locations:
-            - Range: 0xcefb40..0xcefc1d
+            - Range: 0xcefd00..0xcefddd
               Pieces: []
-            - Range: 0xcefc1d..0xcefc1e
+            - Range: 0xcefddd..0xcefdde
               Pieces: [{Size: 16, Op: {CfaOffset: 40}}]
-            - Range: 0xcefc1e..0xcefc2d
+            - Range: 0xcefdde..0xcefded
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 133
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0xcefc40..0xcefd14]
+      OutOfLinePCRanges: [0xcefe00..0xcefed4]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 267 StructureType main.structWithArray
           Locations:
-            - Range: 0xcefc40..0xcefd14
+            - Range: 0xcefe00..0xcefed4
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcefc40..0xcefd04
+            - Range: 0xcefe00..0xcefec4
               Pieces: []
-            - Range: 0xcefd04..0xcefd05
+            - Range: 0xcefec4..0xcefec5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcefd05..0xcefd14
+            - Range: 0xcefec5..0xcefed4
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 267 StructureType main.structWithArray
           Locations:
-            - Range: 0xcefc40..0xcefd04
+            - Range: 0xcefe00..0xcefec4
               Pieces: []
-            - Range: 0xcefd04..0xcefd05
+            - Range: 0xcefec4..0xcefec5
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xcefd05..0xcefd14
+            - Range: 0xcefec5..0xcefed4
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcefcce..0xcefd14
+            - Range: 0xcefe8e..0xcefed4
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 134
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0xcefd20..0xcefdc6]
+      OutOfLinePCRanges: [0xcefee0..0xceff86]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 264 ArrayType [0]int
-          Locations: [{Range: 0xcefd20..0xcefdc6, Pieces: []}]
+          Locations: [{Range: 0xcefee0..0xceff86, Pieces: []}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcefd20..0xcefd65
+            - Range: 0xcefee0..0xceff25
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcefd65..0xcefd87
+            - Range: 0xceff25..0xceff47
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xcefd87..0xcefd9a
+            - Range: 0xceff47..0xceff5a
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xcefd9a..0xcefdc6
+            - Range: 0xceff5a..0xceff86
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcefd20..0xcefdac
+            - Range: 0xcefee0..0xceff6c
               Pieces: []
-            - Range: 0xcefdac..0xcefdad
+            - Range: 0xceff6c..0xceff6d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcefdad..0xcefdc6
+            - Range: 0xceff6d..0xceff86
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 264 ArrayType [0]int
           Locations:
-            - Range: 0xcefd20..0xcefdac
+            - Range: 0xcefee0..0xceff6c
               Pieces: []
-            - Range: 0xcefdac..0xcefdad
+            - Range: 0xceff6c..0xceff6d
               Pieces: []
-            - Range: 0xcefdad..0xcefdc6
+            - Range: 0xceff6d..0xceff86
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 135
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0xcf0320..0xcf0321]
+      OutOfLinePCRanges: [0xcf04e0..0xcf04e1]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 268 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcf0320..0xcf0321
+            - Range: 0xcf04e0..0xcf04e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9247,13 +9247,13 @@ Subprograms:
       DictRegister: null
     - ID: 136
       Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xcf0340..0xcf0341]
+      OutOfLinePCRanges: [0xcf0500..0xcf0501]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 268 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcf0340..0xcf0341
+            - Range: 0xcf0500..0xcf0501
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9266,13 +9266,13 @@ Subprograms:
       DictRegister: null
     - ID: 137
       Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xcf0360..0xcf0361]
+      OutOfLinePCRanges: [0xcf0520..0xcf0521]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 269 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0xcf0360..0xcf0361
+            - Range: 0xcf0520..0xcf0521
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9285,13 +9285,13 @@ Subprograms:
       DictRegister: null
     - ID: 138
       Name: main.testStructSlice
-      OutOfLinePCRanges: [0xcf0380..0xcf0381]
+      OutOfLinePCRanges: [0xcf0540..0xcf0541]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 271 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xcf0380..0xcf0381
+            - Range: 0xcf0540..0xcf0541
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9304,20 +9304,20 @@ Subprograms:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcf0380..0xcf0381
+            - Range: 0xcf0540..0xcf0541
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 139
       Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xcf03a0..0xcf03a1]
+      OutOfLinePCRanges: [0xcf0560..0xcf0561]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 271 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xcf03a0..0xcf03a1
+            - Range: 0xcf0560..0xcf0561
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9330,20 +9330,20 @@ Subprograms:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcf03a0..0xcf03a1
+            - Range: 0xcf0560..0xcf0561
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 140
       Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xcf03c0..0xcf03c1]
+      OutOfLinePCRanges: [0xcf0580..0xcf0581]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 271 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xcf03c0..0xcf03c1
+            - Range: 0xcf0580..0xcf0581
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9356,20 +9356,20 @@ Subprograms:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcf03c0..0xcf03c1
+            - Range: 0xcf0580..0xcf0581
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 141
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0xcf03e0..0xcf03e1]
+      OutOfLinePCRanges: [0xcf05a0..0xcf05a1]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 165 GoSliceHeaderType []string
           Locations:
-            - Range: 0xcf03e0..0xcf03e1
+            - Range: 0xcf05a0..0xcf05a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9382,20 +9382,20 @@ Subprograms:
       DictRegister: null
     - ID: 142
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xcf0400..0xcf0401]
+      OutOfLinePCRanges: [0xcf05c0..0xcf05c1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 21 BaseType int8
           Locations:
-            - Range: 0xcf0400..0xcf0401
+            - Range: 0xcf05c0..0xcf05c1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 274 GoSliceHeaderType []bool
           Locations:
-            - Range: 0xcf0400..0xcf0401
+            - Range: 0xcf05c0..0xcf05c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9408,20 +9408,20 @@ Subprograms:
         - Name: x
           Type: 15 BaseType uint
           Locations:
-            - Range: 0xcf0400..0xcf0401
+            - Range: 0xcf05c0..0xcf05c1
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 143
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0xcf0420..0xcf0421]
+      OutOfLinePCRanges: [0xcf05e0..0xcf05e1]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 275 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0xcf0420..0xcf0421
+            - Range: 0xcf05e0..0xcf05e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9434,13 +9434,13 @@ Subprograms:
       DictRegister: null
     - ID: 144
       Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0xcf0440..0xcf0441]
+      OutOfLinePCRanges: [0xcf0600..0xcf0601]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 268 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcf0440..0xcf0441
+            - Range: 0xcf0600..0xcf0601
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9453,13 +9453,13 @@ Subprograms:
       DictRegister: null
     - ID: 145
       Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0xcf0460..0xcf0461]
+      OutOfLinePCRanges: [0xcf0620..0xcf0621]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 276 GoSliceHeaderType []struct {}
           Locations:
-            - Range: 0xcf0460..0xcf0461
+            - Range: 0xcf0620..0xcf0621
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9472,13 +9472,13 @@ Subprograms:
       DictRegister: null
     - ID: 146
       Name: main.testSubslices
-      OutOfLinePCRanges: [0xcf0480..0xcf0481]
+      OutOfLinePCRanges: [0xcf0640..0xcf0641]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 268 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcf0480..0xcf0481
+            - Range: 0xcf0640..0xcf0641
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9491,7 +9491,7 @@ Subprograms:
         - Name: bs
           Type: 268 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcf0480..0xcf0481
+            - Range: 0xcf0640..0xcf0641
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -9504,7 +9504,7 @@ Subprograms:
         - Name: cs
           Type: 268 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcf0480..0xcf0481
+            - Range: 0xcf0640..0xcf0641
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -9517,34 +9517,34 @@ Subprograms:
       DictRegister: null
     - ID: 147
       Name: main.stackC
-      OutOfLinePCRanges: [0xcf07e0..0xcf0832]
+      OutOfLinePCRanges: [0xcf0da0..0xcf0df2]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcf07e0..0xcf0825
+            - Range: 0xcf0da0..0xcf0de5
               Pieces: []
-            - Range: 0xcf0825..0xcf0826
+            - Range: 0xcf0de5..0xcf0de6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf0826..0xcf0832
+            - Range: 0xcf0de6..0xcf0df2
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 148
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xcf0840..0xcf0841]
+      OutOfLinePCRanges: [0xcf0e00..0xcf0e01]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcf0840..0xcf0841
+            - Range: 0xcf0e00..0xcf0e01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9555,13 +9555,13 @@ Subprograms:
       DictRegister: null
     - ID: 149
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xcf0860..0xcf0861]
+      OutOfLinePCRanges: [0xcf0e20..0xcf0e21]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcf0860..0xcf0861
+            - Range: 0xcf0e20..0xcf0e21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9572,7 +9572,7 @@ Subprograms:
         - Name: "y"
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcf0860..0xcf0861
+            - Range: 0xcf0e20..0xcf0e21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9583,7 +9583,7 @@ Subprograms:
         - Name: z
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcf0860..0xcf0861
+            - Range: 0xcf0e20..0xcf0e21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9594,13 +9594,13 @@ Subprograms:
       DictRegister: null
     - ID: 150
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xcf0880..0xcf0881]
+      OutOfLinePCRanges: [0xcf0e40..0xcf0e41]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 278 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xcf0880..0xcf0881
+            - Range: 0xcf0e40..0xcf0e41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9619,39 +9619,39 @@ Subprograms:
       DictRegister: null
     - ID: 151
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xcf08a0..0xcf08a1]
+      OutOfLinePCRanges: [0xcf0e60..0xcf0e61]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 279 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xcf08a0..0xcf08a1
+            - Range: 0xcf0e60..0xcf0e61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 152
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xcf08c0..0xcf08c1]
+      OutOfLinePCRanges: [0xcf0e80..0xcf0e81]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 280 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xcf08c0..0xcf08c1
+            - Range: 0xcf0e80..0xcf0e81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 153
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0xcf08e0..0xcf08e1]
+      OutOfLinePCRanges: [0xcf0ea0..0xcf0ea1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcf08e0..0xcf08e1
+            - Range: 0xcf0ea0..0xcf0ea1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9662,13 +9662,13 @@ Subprograms:
       DictRegister: null
     - ID: 154
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xcf0900..0xcf0901]
+      OutOfLinePCRanges: [0xcf0ec0..0xcf0ec1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcf0900..0xcf0901
+            - Range: 0xcf0ec0..0xcf0ec1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9679,13 +9679,13 @@ Subprograms:
       DictRegister: null
     - ID: 155
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0xcf0920..0xcf0921]
+      OutOfLinePCRanges: [0xcf0ee0..0xcf0ee1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcf0920..0xcf0921
+            - Range: 0xcf0ee0..0xcf0ee1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9696,13 +9696,13 @@ Subprograms:
       DictRegister: null
     - ID: 156
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0xcf0940..0xcf0941]
+      OutOfLinePCRanges: [0xcf0f00..0xcf0f01]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcf0940..0xcf0941
+            - Range: 0xcf0f00..0xcf0f01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9713,7 +9713,7 @@ Subprograms:
         - Name: b
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcf0940..0xcf0941
+            - Range: 0xcf0f00..0xcf0f01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9724,7 +9724,7 @@ Subprograms:
         - Name: c
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcf0940..0xcf0941
+            - Range: 0xcf0f00..0xcf0f01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9735,26 +9735,26 @@ Subprograms:
       DictRegister: null
     - ID: 157
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0xcf0ac0..0xcf0ac1]
+      OutOfLinePCRanges: [0xcf1080..0xcf1081]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 282 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0xcf0ac0..0xcf0ac1
+            - Range: 0xcf1080..0xcf1081
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 158
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0xcf0ae0..0xcf0ae1]
+      OutOfLinePCRanges: [0xcf10a0..0xcf10a1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 295 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0xcf0ae0..0xcf0ae1
+            - Range: 0xcf10a0..0xcf10a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9773,13 +9773,13 @@ Subprograms:
       DictRegister: null
     - ID: 159
       Name: main.testStruct
-      OutOfLinePCRanges: [0xcf0c20..0xcf0c21]
+      OutOfLinePCRanges: [0xcf11e0..0xcf11e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 326 StructureType main.aStruct
           Locations:
-            - Range: 0xcf0c20..0xcf0c21
+            - Range: 0xcf11e0..0xcf11e1
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -9800,91 +9800,91 @@ Subprograms:
       DictRegister: null
     - ID: 160
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0xcf0ce0..0xcf0ce1]
+      OutOfLinePCRanges: [0xcf12a0..0xcf12a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 327 PointerType *main.anotherStruct
           Locations:
-            - Range: 0xcf0ce0..0xcf0ce1
+            - Range: 0xcf12a0..0xcf12a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 161
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0xcf0d00..0xcf0d01]
+      OutOfLinePCRanges: [0xcf12c0..0xcf12c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 329 StructureType main.tenStrings
           Locations:
-            - Range: 0xcf0d00..0xcf0d01
+            - Range: 0xcf12c0..0xcf12c1
               Pieces: [{Size: 160, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 162
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xcf0d60..0xcf0d61]
+      OutOfLinePCRanges: [0xcf1320..0xcf1321]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 330 StructureType main.emptyStruct
-          Locations: [{Range: 0xcf0d60..0xcf0d61, Pieces: []}]
+          Locations: [{Range: 0xcf1320..0xcf1321, Pieces: []}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 163
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xcf0d80..0xcf0d81]
+      OutOfLinePCRanges: [0xcf1340..0xcf1341]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 331 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xcf0d80..0xcf0d81
+            - Range: 0xcf1340..0xcf1341
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 164
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0xcf2ce0..0xcf2ce4]
+      OutOfLinePCRanges: [0xcf32a0..0xcf32a4]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0xcf2ce0..0xcf2ce4
+            - Range: 0xcf32a0..0xcf32a4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xcf2ce0..0xcf2ce3
+            - Range: 0xcf32a0..0xcf32a3
               Pieces: []
-            - Range: 0xcf2ce3..0xcf2ce4
+            - Range: 0xcf32a3..0xcf32a4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 165
       Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0xcf2d00..0xcf2d0c]
+      OutOfLinePCRanges: [0xcf32c0..0xcf32cc]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf2d00..0xcf2d0b
+            - Range: 0xcf32c0..0xcf32cb
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcf2d0b..0xcf2d0c
+            - Range: 0xcf32cb..0xcf32cc
               Pieces:
                 - Size: 8
                   Op: null
@@ -9895,9 +9895,9 @@ Subprograms:
         - Name: ~r0
           Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xcf2d00..0xcf2d0b
+            - Range: 0xcf32c0..0xcf32cb
               Pieces: []
-            - Range: 0xcf2d0b..0xcf2d0c
+            - Range: 0xcf32cb..0xcf32cc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9908,41 +9908,41 @@ Subprograms:
       DictRegister: 0
     - ID: 166
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0xcf2d20..0xcf2d24]
+      OutOfLinePCRanges: [0xcf32e0..0xcf32e4]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xcf2d20..0xcf2d24
+            - Range: 0xcf32e0..0xcf32e4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0xcf2d20..0xcf2d23
+            - Range: 0xcf32e0..0xcf32e3
               Pieces: []
-            - Range: 0xcf2d23..0xcf2d24
+            - Range: 0xcf32e3..0xcf32e4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 167
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0xcf2d40..0xcf2d4c]
+      OutOfLinePCRanges: [0xcf3300..0xcf330c]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xcf2d40..0xcf2d4b
+            - Range: 0xcf3300..0xcf330b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcf2d4b..0xcf2d4c
+            - Range: 0xcf330b..0xcf330c
               Pieces:
                 - Size: 8
                   Op: null
@@ -9953,9 +9953,9 @@ Subprograms:
         - Name: ~r0
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf2d40..0xcf2d4b
+            - Range: 0xcf3300..0xcf330b
               Pieces: []
-            - Range: 0xcf2d4b..0xcf2d4c
+            - Range: 0xcf330b..0xcf330c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9966,13 +9966,13 @@ Subprograms:
       DictRegister: 0
     - ID: 168
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0xcf2dc0..0xcf2fa5]
+      OutOfLinePCRanges: [0xcf3380..0xcf3565]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 336 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xcf2dc0..0xcf2dfe
+            - Range: 0xcf3380..0xcf33be
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9980,7 +9980,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcf2dfe..0xcf2e09
+            - Range: 0xcf33be..0xcf33c9
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -9988,7 +9988,7 @@ Subprograms:
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: null
-            - Range: 0xcf2e09..0xcf2fa5
+            - Range: 0xcf33c9..0xcf3565
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -10001,18 +10001,18 @@ Subprograms:
         - Name: pred
           Type: 338 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0xcf2dc0..0xcf2e09
+            - Range: 0xcf3380..0xcf33c9
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcf2e09..0xcf2fa5
+            - Range: 0xcf33c9..0xcf3565
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 336 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xcf2dc0..0xcf2f5a
+            - Range: 0xcf3380..0xcf351a
               Pieces: []
-            - Range: 0xcf2f5a..0xcf2f5b
+            - Range: 0xcf351a..0xcf351b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10020,14 +10020,14 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcf2f5b..0xcf2fa5
+            - Range: 0xcf351b..0xcf3565
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
           Type: 336 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xcf2e09..0xcf2e36
+            - Range: 0xcf33c9..0xcf33f6
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10035,7 +10035,7 @@ Subprograms:
                   Op: {CfaOffset: -88}
                 - Size: 8
                   Op: {CfaOffset: -80}
-            - Range: 0xcf2e36..0xcf2e36
+            - Range: 0xcf33f6..0xcf33f6
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10043,7 +10043,7 @@ Subprograms:
                   Op: {CfaOffset: -88}
                 - Size: 8
                   Op: {CfaOffset: -80}
-            - Range: 0xcf2e36..0xcf2e6c
+            - Range: 0xcf33f6..0xcf342c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -10051,7 +10051,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0xcf2e6c..0xcf2f25
+            - Range: 0xcf342c..0xcf34e5
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10059,7 +10059,7 @@ Subprograms:
                   Op: {CfaOffset: -88}
                 - Size: 8
                   Op: {CfaOffset: -80}
-            - Range: 0xcf2f25..0xcf2f36
+            - Range: 0xcf34e5..0xcf34f6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -10067,7 +10067,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0xcf2f36..0xcf2f48
+            - Range: 0xcf34f6..0xcf3508
               Pieces:
                 - Size: 8
                   Op: null
@@ -10075,7 +10075,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0xcf2f51..0xcf2f57
+            - Range: 0xcf3511..0xcf3517
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10083,7 +10083,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0xcf2f57..0xcf2fa5
+            - Range: 0xcf3517..0xcf3565
               Pieces:
                 - Size: 8
                   Op: null
@@ -10096,132 +10096,132 @@ Subprograms:
         - Name: item
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0xcf2e5f..0xcf2e6c
+            - Range: 0xcf341f..0xcf342c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf2e6c..0xcf2f25
+            - Range: 0xcf342c..0xcf34e5
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
     - ID: 169
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xcf2fc0..0xcf3004]
+      OutOfLinePCRanges: [0xcf3580..0xcf35c4]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xcf2fc0..0xcf2fd9
+            - Range: 0xcf3580..0xcf3599
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
           Type: 339 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0xcf2fc0..0xcf2fd9
+            - Range: 0xcf3580..0xcf3599
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xcf2fc0..0xcf2fd9
+            - Range: 0xcf3580..0xcf3599
               Pieces: []
-            - Range: 0xcf2fd9..0xcf2fda
+            - Range: 0xcf3599..0xcf359a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf2fda..0xcf3004
+            - Range: 0xcf359a..0xcf35c4
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
     - ID: 170
       Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0xcf3240..0xcf3244]
+      OutOfLinePCRanges: [0xcf3800..0xcf3804]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 337 PointerType *go.shape.int
           Locations:
-            - Range: 0xcf3240..0xcf3244
+            - Range: 0xcf3800..0xcf3804
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 337 PointerType *go.shape.int
           Locations:
-            - Range: 0xcf3240..0xcf3243
+            - Range: 0xcf3800..0xcf3803
               Pieces: []
-            - Range: 0xcf3243..0xcf3244
+            - Range: 0xcf3803..0xcf3804
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 171
       Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0xcf3260..0xcf3264]
+      OutOfLinePCRanges: [0xcf3820..0xcf3824]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 340 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0xcf3260..0xcf3264
+            - Range: 0xcf3820..0xcf3824
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 340 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0xcf3260..0xcf3263
+            - Range: 0xcf3820..0xcf3823
               Pieces: []
-            - Range: 0xcf3263..0xcf3264
+            - Range: 0xcf3823..0xcf3824
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 172
       Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0xcf3280..0xcf3284]
+      OutOfLinePCRanges: [0xcf3840..0xcf3844]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 342 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0xcf3280..0xcf3284
+            - Range: 0xcf3840..0xcf3844
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 342 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0xcf3280..0xcf3283
+            - Range: 0xcf3840..0xcf3843
               Pieces: []
-            - Range: 0xcf3283..0xcf3284
+            - Range: 0xcf3843..0xcf3844
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 173
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0xcf32a0..0xcf32b1]
+      OutOfLinePCRanges: [0xcf3860..0xcf3871]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 344 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0xcf32a0..0xcf32b1
+            - Range: 0xcf3860..0xcf3871
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf32a0..0xcf32b0
+            - Range: 0xcf3860..0xcf3870
               Pieces: []
-            - Range: 0xcf32b0..0xcf32b1
+            - Range: 0xcf3870..0xcf3871
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10232,69 +10232,69 @@ Subprograms:
       DictRegister: 0
     - ID: 174
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0xcf3380..0xcf3389]
+      OutOfLinePCRanges: [0xcf3940..0xcf3949]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 346 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0xcf3380..0xcf3389
+            - Range: 0xcf3940..0xcf3949
               Pieces: [{Size: 136, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0xcf3380..0xcf3388
+            - Range: 0xcf3940..0xcf3948
               Pieces: []
-            - Range: 0xcf3388..0xcf3389
+            - Range: 0xcf3948..0xcf3949
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 175
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0xcf3440..0xcf3448]
+      OutOfLinePCRanges: [0xcf3a00..0xcf3a08]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 347 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0xcf3440..0xcf3448
+            - Range: 0xcf3a00..0xcf3a08
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0xcf3440..0xcf3448
+            - Range: 0xcf3a00..0xcf3a08
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
           Type: 349 BaseType go.shape.bool
           Locations:
-            - Range: 0xcf3440..0xcf3448
+            - Range: 0xcf3a00..0xcf3a08
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
     - ID: 176
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0xcf34c0..0xcf352e]
+      OutOfLinePCRanges: [0xcf3a80..0xcf3aee]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 350 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0xcf34c0..0xcf352e
+            - Range: 0xcf3a80..0xcf3aee
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf34c0..0xcf352e
+            - Range: 0xcf3a80..0xcf3aee
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10305,20 +10305,20 @@ Subprograms:
         - Name: v
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0xcf34c0..0xcf352e
+            - Range: 0xcf3a80..0xcf3aee
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
     - ID: 177
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0xcf35a0..0xcf35a8]
+      OutOfLinePCRanges: [0xcf3b60..0xcf3b68]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf35a0..0xcf35a8
+            - Range: 0xcf3b60..0xcf3b68
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10329,25 +10329,25 @@ Subprograms:
         - Name: b
           Type: 349 BaseType go.shape.bool
           Locations:
-            - Range: 0xcf35a0..0xcf35a8
+            - Range: 0xcf3b60..0xcf3b68
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 349 BaseType go.shape.bool
           Locations:
-            - Range: 0xcf35a0..0xcf35a7
+            - Range: 0xcf3b60..0xcf3b67
               Pieces: []
-            - Range: 0xcf35a7..0xcf35a8
+            - Range: 0xcf3b67..0xcf3b68
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf35a0..0xcf35a7
+            - Range: 0xcf3b60..0xcf3b67
               Pieces: []
-            - Range: 0xcf35a7..0xcf35a8
+            - Range: 0xcf3b67..0xcf3b68
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10358,26 +10358,26 @@ Subprograms:
       DictRegister: 0
     - ID: 178
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xcf35c0..0xcf35cf]
+      OutOfLinePCRanges: [0xcf3b80..0xcf3b8f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0xcf35c0..0xcf35ce
+            - Range: 0xcf3b80..0xcf3b8e
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf35c0..0xcf35cb
+            - Range: 0xcf3b80..0xcf3b8b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcf35cb..0xcf35cf
+            - Range: 0xcf3b8b..0xcf3b8f
               Pieces:
                 - Size: 8
                   Op: null
@@ -10388,9 +10388,9 @@ Subprograms:
         - Name: ~r0
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf35c0..0xcf35ce
+            - Range: 0xcf3b80..0xcf3b8e
               Pieces: []
-            - Range: 0xcf35ce..0xcf35cf
+            - Range: 0xcf3b8e..0xcf3b8f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10401,56 +10401,56 @@ Subprograms:
         - Name: ~r1
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0xcf35c0..0xcf35ce
+            - Range: 0xcf3b80..0xcf3b8e
               Pieces: []
-            - Range: 0xcf35ce..0xcf35cf
+            - Range: 0xcf3b8e..0xcf3b8f
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 179
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0xcf35e0..0xcf361a]
+      OutOfLinePCRanges: [0xcf3ba0..0xcf3bda]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 352 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0xcf35e0..0xcf35f9
+            - Range: 0xcf3ba0..0xcf3bb9
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcf35e0..0xcf35f9
+            - Range: 0xcf3ba0..0xcf3bb9
               Pieces: []
-            - Range: 0xcf35f9..0xcf35fa
+            - Range: 0xcf3bb9..0xcf3bba
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf35fa..0xcf361a
+            - Range: 0xcf3bba..0xcf3bda
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 180
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0xcf3620..0xcf366d]
+      OutOfLinePCRanges: [0xcf3be0..0xcf3c2d]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 353 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0xcf3620..0xcf363f
+            - Range: 0xcf3be0..0xcf3bff
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcf363f..0xcf3642
+            - Range: 0xcf3bff..0xcf3c02
               Pieces:
                 - Size: 8
                   Op: null
@@ -10461,37 +10461,37 @@ Subprograms:
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcf3620..0xcf3642
+            - Range: 0xcf3be0..0xcf3c02
               Pieces: []
-            - Range: 0xcf3642..0xcf3643
+            - Range: 0xcf3c02..0xcf3c03
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf3643..0xcf366d
+            - Range: 0xcf3c03..0xcf3c2d
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 181
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0xcf3680..0xcf3688]
+      OutOfLinePCRanges: [0xcf3c40..0xcf3c48]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 354 PointerType *go.shape.string
           Locations:
-            - Range: 0xcf3680..0xcf3687
+            - Range: 0xcf3c40..0xcf3c47
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf3680..0xcf3687
+            - Range: 0xcf3c40..0xcf3c47
               Pieces: []
-            - Range: 0xcf3687..0xcf3688
+            - Range: 0xcf3c47..0xcf3c48
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10502,22 +10502,22 @@ Subprograms:
       DictRegister: 0
     - ID: 182
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0xcf36a0..0xcf36fb]
+      OutOfLinePCRanges: [0xcf3c60..0xcf3cbb]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 355 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xcf36a0..0xcf36e1
+            - Range: 0xcf3c60..0xcf3ca1
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 356 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xcf36a0..0xcf36f5
+            - Range: 0xcf3c60..0xcf3cb5
               Pieces: []
-            - Range: 0xcf36f5..0xcf36f6
+            - Range: 0xcf3cb5..0xcf3cb6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10531,20 +10531,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xcf36f6..0xcf36fb
+            - Range: 0xcf3cb6..0xcf3cbb
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 183
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0xcf3700..0xcf3724]
+      OutOfLinePCRanges: [0xcf3cc0..0xcf3ce4]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 336 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xcf3700..0xcf3724
+            - Range: 0xcf3cc0..0xcf3ce4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10557,33 +10557,33 @@ Subprograms:
         - Name: needle
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0xcf3700..0xcf3724
+            - Range: 0xcf3cc0..0xcf3ce4
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xcf3700..0xcf3720
+            - Range: 0xcf3cc0..0xcf3ce0
               Pieces: []
-            - Range: 0xcf3720..0xcf3721
+            - Range: 0xcf3ce0..0xcf3ce1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf3721..0xcf3723
+            - Range: 0xcf3ce1..0xcf3ce3
               Pieces: []
-            - Range: 0xcf3723..0xcf3724
+            - Range: 0xcf3ce3..0xcf3ce4
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 184
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0xcf3740..0xcf37ff]
+      OutOfLinePCRanges: [0xcf3d00..0xcf3dbf]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 357 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0xcf3740..0xcf375d
+            - Range: 0xcf3d00..0xcf3d1d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10591,7 +10591,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcf375d..0xcf375f
+            - Range: 0xcf3d1d..0xcf3d1f
               Pieces:
                 - Size: 8
                   Op: null
@@ -10604,13 +10604,13 @@ Subprograms:
         - Name: needle
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf3740..0xcf378c
+            - Range: 0xcf3d00..0xcf3d4c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xcf378c..0xcf37ff
+            - Range: 0xcf3d4c..0xcf3dbf
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
@@ -10621,28 +10621,28 @@ Subprograms:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xcf3740..0xcf37ab
+            - Range: 0xcf3d00..0xcf3d6b
               Pieces: []
-            - Range: 0xcf37ab..0xcf37ac
+            - Range: 0xcf3d6b..0xcf3d6c
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf37ac..0xcf37b3
+            - Range: 0xcf3d6c..0xcf3d73
               Pieces: []
-            - Range: 0xcf37b3..0xcf37b4
+            - Range: 0xcf3d73..0xcf3d74
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf37b4..0xcf37ff
+            - Range: 0xcf3d74..0xcf3dbf
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf376f..0xcf3781
+            - Range: 0xcf3d2f..0xcf3d41
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xcf3781..0xcf378c
+            - Range: 0xcf3d41..0xcf3d4c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10653,54 +10653,54 @@ Subprograms:
       DictRegister: 0
     - ID: 185
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0xcf3800..0xcf3807]
+      OutOfLinePCRanges: [0xcf3dc0..0xcf3dc7]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 358 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0xcf3800..0xcf3806
+            - Range: 0xcf3dc0..0xcf3dc6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0xcf3800..0xcf3807
+            - Range: 0xcf3dc0..0xcf3dc7
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xcf3800..0xcf3806
+            - Range: 0xcf3dc0..0xcf3dc6
               Pieces: []
-            - Range: 0xcf3806..0xcf3807
+            - Range: 0xcf3dc6..0xcf3dc7
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 3
     - ID: 186
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0xcf3860..0xcf38cc]
+      OutOfLinePCRanges: [0xcf3e20..0xcf3e8c]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 359 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0xcf3860..0xcf3880
+            - Range: 0xcf3e20..0xcf3e40
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf3880..0xcf3888
+            - Range: 0xcf3e40..0xcf3e48
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf3888..0xcf388d
+            - Range: 0xcf3e48..0xcf3e4d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10711,7 +10711,7 @@ Subprograms:
         - Name: value
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf3860..0xcf388d
+            - Range: 0xcf3e20..0xcf3e4d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -10722,11 +10722,11 @@ Subprograms:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xcf3860..0xcf388d
+            - Range: 0xcf3e20..0xcf3e4d
               Pieces: []
-            - Range: 0xcf388d..0xcf388e
+            - Range: 0xcf3e4d..0xcf3e4e
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf388e..0xcf38cc
+            - Range: 0xcf3e4e..0xcf3e8c
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10872,31 +10872,31 @@ Subprograms:
       DictRegister: 0
     - ID: 188
       Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0xcea440..0xcea4a2]
+      OutOfLinePCRanges: [0xcea540..0xcea5a2]
       InlinePCRanges:
-        - Ranges: [0xcea4d1..0xcea50d]
-          RootRanges: [0xcea4c0..0xcea531]
-        - Ranges: [0xcea612..0xcea64e]
-          RootRanges: [0xcea5e0..0xcea668]
-        - Ranges: [0xcea69c..0xcea6d8]
-          RootRanges: [0xcea680..0xcea745]
-        - Ranges: [0xcea76f..0xcea7ab]
-          RootRanges: [0xcea760..0xcea7c2]
+        - Ranges: [0xcea5d1..0xcea60d]
+          RootRanges: [0xcea5c0..0xcea631]
+        - Ranges: [0xcea712..0xcea74e]
+          RootRanges: [0xcea6e0..0xcea768]
+        - Ranges: [0xcea79c..0xcea7d8]
+          RootRanges: [0xcea780..0xcea845]
+        - Ranges: [0xcea86f..0xcea8ab]
+          RootRanges: [0xcea860..0xcea8c2]
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcea440..0xcea459
+            - Range: 0xcea540..0xcea559
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcea4d1..0xcea4dc
+            - Range: 0xcea5d1..0xcea5dc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcea612..0xcea61d
+            - Range: 0xcea712..0xcea71d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcea696..0xcea6a7
+            - Range: 0xcea796..0xcea7a7
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcea6a7..0xcea745
+            - Range: 0xcea7a7..0xcea845
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xcea760..0xcea77a
+            - Range: 0xcea860..0xcea87a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10905,37 +10905,37 @@ Subprograms:
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcea6e6..0xcea71e]
-          RootRanges: [0xcea680..0xcea745]
+        - Ranges: [0xcea7e6..0xcea81e]
+          RootRanges: [0xcea780..0xcea845]
       Variables: []
       DictRegister: null
     - ID: 190
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcea7f3..0xcea831]
-          RootRanges: [0xcea7e0..0xcea8e5]
+        - Ranges: [0xcea8f3..0xcea931]
+          RootRanges: [0xcea8e0..0xcea9e5]
       Variables: []
       DictRegister: null
     - ID: 191
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcea89b..0xcea8d3]
-          RootRanges: [0xcea7e0..0xcea8e5]
+        - Ranges: [0xcea99b..0xcea9d3]
+          RootRanges: [0xcea8e0..0xcea9e5]
       Variables: []
       DictRegister: null
     - ID: 192
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcea901..0xcea905]
-          RootRanges: [0xcea900..0xcea906]
+        - Ranges: [0xceaa01..0xceaa05]
+          RootRanges: [0xceaa00..0xceaa06]
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcea900..0xcea905
+            - Range: 0xceaa00..0xceaa05
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10944,32 +10944,32 @@ Subprograms:
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcea94d..0xcea965]
-          RootRanges: [0xcea920..0xcea96b]
-        - Ranges: [0xcea9e3..0xceaa01]
-          RootRanges: [0xcea980..0xceab05]
+        - Ranges: [0xceaa4d..0xceaa65]
+          RootRanges: [0xceaa20..0xceaa6b]
+        - Ranges: [0xceaae3..0xceab01]
+          RootRanges: [0xceaa80..0xceac05]
       Variables:
         - Name: a
           Type: 172 ArrayType [5]int
           Locations:
-            - Range: 0xcea92c..0xcea96b
+            - Range: 0xceaa2c..0xceaa6b
               Pieces: [{Size: 40, Op: {CfaOffset: -56}}]
-            - Range: 0xcea9c7..0xceab05
+            - Range: 0xceaac7..0xceac05
               Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 194
       Name: main.firstBehavior.DoSomething
-      OutOfLinePCRanges: [0xceab20..0xceab86]
+      OutOfLinePCRanges: [0xceac20..0xceac86]
       InlinePCRanges:
-        - Ranges: [0xcf395a..0xcf3988]
-          RootRanges: [0xcf3940..0xcf39a5]
+        - Ranges: [0xcf3f1a..0xcf3f48]
+          RootRanges: [0xcf3f00..0xcf3f65]
       Variables:
         - Name: b
           Type: 364 StructureType main.firstBehavior
           Locations:
-            - Range: 0xceab20..0xceab3e
+            - Range: 0xceac20..0xceac3e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10980,15 +10980,15 @@ Subprograms:
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xceab20..0xceab65
+            - Range: 0xceac20..0xceac65
               Pieces: []
-            - Range: 0xceab65..0xceab66
+            - Range: 0xceac65..0xceac66
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xceab66..0xceab86
+            - Range: 0xceac66..0xceac86
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10997,8 +10997,8 @@ Subprograms:
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xceb2d3..0xceb2da]
-          RootRanges: [0xceb180..0xceb325]
+        - Ranges: [0xceb4fd..0xceb504]
+          RootRanges: [0xceb460..0xceb54b]
         - Ranges: [0x53dae1..0x53dae9]
           RootRanges: [0x53dae0..0x53daea]
       Variables: []
@@ -11317,7 +11317,7 @@ Types:
       ID: 41
       Name: '*[]runtime.ancestorInfo'
       ByteSize: 8
-      GoRuntimeType: 496960
+      GoRuntimeType: 497216
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
@@ -11420,7 +11420,7 @@ Types:
       ID: 12
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 400576
+      GoRuntimeType: 400704
       GoKind: 22
       Pointee: 5 BaseType bool
     - __kind: PointerType
@@ -11448,7 +11448,7 @@ Types:
       ID: 115
       Name: '*complex128'
       ByteSize: 8
-      GoRuntimeType: 400384
+      GoRuntimeType: 400512
       GoKind: 22
       Pointee: 19 BaseType complex128
     - __kind: PointerType
@@ -11838,7 +11838,7 @@ Types:
       ID: 112
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 399488
+      GoRuntimeType: 399616
       GoKind: 22
       Pointee: 16 GoInterfaceType error
     - __kind: PointerType
@@ -11859,14 +11859,14 @@ Types:
       ID: 114
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 400448
+      GoRuntimeType: 400576
       GoKind: 22
       Pointee: 18 BaseType float32
     - __kind: PointerType
       ID: 104
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 400512
+      GoRuntimeType: 400640
       GoKind: 22
       Pointee: 14 BaseType float64
     - __kind: PointerType
@@ -12725,42 +12725,42 @@ Types:
       ID: 105
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 400128
+      GoRuntimeType: 400256
       GoKind: 22
       Pointee: 8 BaseType int
     - __kind: PointerType
       ID: 109
       Name: '*int16'
       ByteSize: 8
-      GoRuntimeType: 399744
+      GoRuntimeType: 399872
       GoKind: 22
       Pointee: 110 BaseType int16
     - __kind: PointerType
       ID: 22
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 399872
+      GoRuntimeType: 400000
       GoKind: 22
       Pointee: 11 BaseType int32
     - __kind: PointerType
       ID: 106
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 400000
+      GoRuntimeType: 400128
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
       ID: 111
       Name: '*int8'
       ByteSize: 8
-      GoRuntimeType: 399616
+      GoRuntimeType: 399744
       GoKind: 22
       Pointee: 21 BaseType int8
     - __kind: PointerType
       ID: 174
       Name: '*interface {}'
       ByteSize: 8
-      GoRuntimeType: 400704
+      GoRuntimeType: 400832
       GoKind: 22
       Pointee: 168 GoEmptyInterfaceType interface {}
     - __kind: PointerType
@@ -12788,7 +12788,7 @@ Types:
       ID: 1068
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
-      GoRuntimeType: 914560
+      GoRuntimeType: 915040
       GoKind: 22
       Pointee: 1069 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
@@ -12813,12 +12813,12 @@ Types:
       GoKind: 22
       Pointee: 953 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 674
+      ID: 679
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
-      GoRuntimeType: 913408
+      GoRuntimeType: 913888
       GoKind: 22
-      Pointee: 675 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 680 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
       ID: 100
       Name: '*internal/runtime/atomic.Pointer[runtime.m]'
@@ -12846,12 +12846,12 @@ Types:
       GoKind: 22
       Pointee: 910 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
-      ID: 678
+      ID: 683
       Name: '*internal/strconv.Error'
       ByteSize: 8
-      GoRuntimeType: 914176
+      GoRuntimeType: 914656
       GoKind: 22
-      Pointee: 597 BaseType internal/strconv.Error
+      Pointee: 600 BaseType internal/strconv.Error
     - __kind: PointerType
       ID: 1114
       Name: '*io.PipeWriter'
@@ -13937,12 +13937,12 @@ Types:
       GoKind: 22
       Pointee: 649 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 676
+      ID: 681
       Name: '*reflect.ValueError'
       ByteSize: 8
-      GoRuntimeType: 914080
+      GoRuntimeType: 914560
       GoKind: 22
-      Pointee: 677 UnresolvedPointeeType reflect.ValueError
+      Pointee: 682 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
       ID: 777
       Name: '*regexp/syntax.Error'
@@ -13954,21 +13954,21 @@ Types:
       ID: 884
       Name: '*runtime.PanicNilError'
       ByteSize: 8
-      GoRuntimeType: 1043456
+      GoRuntimeType: 1043712
       GoKind: 22
       Pointee: 885 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
       ID: 888
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
-      GoRuntimeType: 1044096
+      GoRuntimeType: 1044352
       GoKind: 22
       Pointee: 889 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 28
       Name: '*runtime._defer'
       ByteSize: 8
-      GoRuntimeType: 400768
+      GoRuntimeType: 400896
       GoKind: 22
       Pointee: 29 UnresolvedPointeeType runtime._defer
     - __kind: PointerType
@@ -13982,21 +13982,21 @@ Types:
       ID: 886
       Name: '*runtime.boundsError'
       ByteSize: 8
-      GoRuntimeType: 1043584
+      GoRuntimeType: 1043840
       GoKind: 22
       Pointee: 887 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 70
       Name: '*runtime.cgoCallers'
       ByteSize: 8
-      GoRuntimeType: 402944
+      GoRuntimeType: 403072
       GoKind: 22
       Pointee: 71 UnresolvedPointeeType runtime.cgoCallers
     - __kind: PointerType
       ID: 49
       Name: '*runtime.coro'
       ByteSize: 8
-      GoRuntimeType: 401664
+      GoRuntimeType: 401792
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
@@ -14010,7 +14010,7 @@ Types:
       ID: 882
       Name: '*runtime.errorString'
       ByteSize: 8
-      GoRuntimeType: 1041792
+      GoRuntimeType: 1042048
       GoKind: 22
       Pointee: 863 GoStringHeaderType runtime.errorString
     - __kind: PointerType
@@ -14036,14 +14036,14 @@ Types:
       ID: 69
       Name: '*runtime.p'
       ByteSize: 8
-      GoRuntimeType: 1043200
+      GoRuntimeType: 1043456
       GoKind: 22
       Pointee: 371 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 883
       Name: '*runtime.plainError'
       ByteSize: 8
-      GoRuntimeType: 1041920
+      GoRuntimeType: 1042176
       GoKind: 22
       Pointee: 866 GoStringHeaderType runtime.plainError
     - __kind: PointerType
@@ -14055,7 +14055,7 @@ Types:
       ID: 43
       Name: '*runtime.sudog'
       ByteSize: 8
-      GoRuntimeType: 401536
+      GoRuntimeType: 401664
       GoKind: 22
       Pointee: 44 UnresolvedPointeeType runtime.sudog
     - __kind: PointerType
@@ -14066,12 +14066,12 @@ Types:
       GoKind: 22
       Pointee: 52 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 672
+      ID: 677
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
-      GoRuntimeType: 913120
+      GoRuntimeType: 913600
       GoKind: 22
-      Pointee: 673 StructureType runtime.synctestDeadlockError
+      Pointee: 678 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 46
       Name: '*runtime.timer'
@@ -14083,14 +14083,14 @@ Types:
       ID: 84
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1645472
+      GoRuntimeType: 1645856
       GoKind: 22
       Pointee: 85 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 54
       Name: '*runtime.xRegState'
       ByteSize: 8
-      GoRuntimeType: 401856
+      GoRuntimeType: 401984
       GoKind: 22
       Pointee: 55 UnresolvedPointeeType runtime.xRegState
     - __kind: PointerType
@@ -14104,7 +14104,7 @@ Types:
       ID: 102
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 399552
+      GoRuntimeType: 399680
       GoKind: 22
       Pointee: 10 GoStringHeaderType string
     - __kind: PointerType
@@ -14300,75 +14300,75 @@ Types:
       ID: 1016
       Name: '*time.Location'
       ByteSize: 8
-      GoRuntimeType: 1650080
+      GoRuntimeType: 1641056
       GoKind: 22
       Pointee: 1017 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 682
+      ID: 675
       Name: '*time.ParseError'
       ByteSize: 8
-      GoRuntimeType: 915424
+      GoRuntimeType: 910816
       GoKind: 22
-      Pointee: 683 UnresolvedPointeeType time.ParseError
+      Pointee: 676 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 679
+      ID: 672
       Name: '*time.fileSizeError'
       ByteSize: 8
-      GoRuntimeType: 915232
+      GoRuntimeType: 910624
       GoKind: 22
-      Pointee: 598 GoStringHeaderType time.fileSizeError
+      Pointee: 597 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 600
+      ID: 599
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 599 GoStringDataType time.fileSizeError.str
+      Pointee: 598 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 680
+      ID: 673
       Name: '*time.parseDurationError'
       ByteSize: 8
-      GoRuntimeType: 915328
+      GoRuntimeType: 910720
       GoKind: 22
-      Pointee: 681 UnresolvedPointeeType time.parseDurationError
+      Pointee: 674 UnresolvedPointeeType time.parseDurationError
     - __kind: PointerType
       ID: 113
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 400192
+      GoRuntimeType: 400320
       GoKind: 22
       Pointee: 15 BaseType uint
     - __kind: PointerType
       ID: 108
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 399808
+      GoRuntimeType: 399936
       GoKind: 22
       Pointee: 7 BaseType uint16
     - __kind: PointerType
       ID: 23
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 399936
+      GoRuntimeType: 400064
       GoKind: 22
       Pointee: 3 BaseType uint32
     - __kind: PointerType
       ID: 107
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 400064
+      GoRuntimeType: 400192
       GoKind: 22
       Pointee: 9 BaseType uint64
     - __kind: PointerType
       ID: 6
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 399680
+      GoRuntimeType: 399808
       GoKind: 22
       Pointee: 4 BaseType uint8
     - __kind: PointerType
       ID: 20
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 400256
+      GoRuntimeType: 400384
       GoKind: 22
       Pointee: 2 BaseType uintptr
     - __kind: PointerType
@@ -23529,7 +23529,7 @@ Types:
       ID: 83
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 712480
+      GoRuntimeType: 713824
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23538,7 +23538,7 @@ Types:
       ID: 82
       Name: '[2][2]*runtime.traceBuf'
       ByteSize: 32
-      GoRuntimeType: 712576
+      GoRuntimeType: 713920
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23563,7 +23563,7 @@ Types:
       ID: 88
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 712768
+      GoRuntimeType: 714112
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23723,7 +23723,7 @@ Types:
       ID: 58
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 710752
+      GoRuntimeType: 712096
       GoKind: 17
       Count: 3
       HasCount: true
@@ -23793,7 +23793,7 @@ Types:
       ID: 89
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 712672
+      GoRuntimeType: 714016
       GoKind: 17
       Count: 8
       HasCount: true
@@ -24234,7 +24234,7 @@ Types:
       ID: 274
       Name: '[]bool'
       ByteSize: 24
-      GoRuntimeType: 496000
+      GoRuntimeType: 496256
       GoKind: 23
       RawFields:
         - Name: array
@@ -24257,7 +24257,7 @@ Types:
       ID: 1041
       Name: '[]float64'
       ByteSize: 24
-      GoRuntimeType: 495872
+      GoRuntimeType: 496128
       GoKind: 23
       RawFields:
         - Name: array
@@ -24347,7 +24347,7 @@ Types:
       ID: 1321
       Name: '[]interface {}'
       ByteSize: 24
-      GoRuntimeType: 496320
+      GoRuntimeType: 496576
       GoKind: 23
       RawFields:
         - Name: array
@@ -24603,7 +24603,7 @@ Types:
       ID: 165
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 496128
+      GoRuntimeType: 496384
       GoKind: 23
       RawFields:
         - Name: array
@@ -24647,7 +24647,7 @@ Types:
       ID: 268
       Name: '[]uint'
       ByteSize: 24
-      GoRuntimeType: 495616
+      GoRuntimeType: 495872
       GoKind: 23
       RawFields:
         - Name: array
@@ -24670,7 +24670,7 @@ Types:
       ID: 275
       Name: '[]uint16'
       ByteSize: 24
-      GoRuntimeType: 494976
+      GoRuntimeType: 495232
       GoKind: 23
       RawFields:
         - Name: array
@@ -24693,7 +24693,7 @@ Types:
       ID: 40
       Name: '[]uint8'
       ByteSize: 24
-      GoRuntimeType: 494848
+      GoRuntimeType: 495104
       GoKind: 23
       RawFields:
         - Name: array
@@ -24716,7 +24716,7 @@ Types:
       ID: 45
       Name: '[]uintptr'
       ByteSize: 24
-      GoRuntimeType: 495680
+      GoRuntimeType: 495936
       GoKind: 23
       RawFields:
         - Name: array
@@ -25172,7 +25172,7 @@ Types:
       ID: 16
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1041664
+      GoRuntimeType: 1041920
       GoKind: 20
       RawFields:
         - Name: tab
@@ -26813,7 +26813,7 @@ Types:
       ID: 168
       Name: interface {}
       ByteSize: 16
-      GoRuntimeType: 860352
+      GoRuntimeType: 860640
       GoKind: 20
       RawFields:
         - Name: _type
@@ -26877,11 +26877,11 @@ Types:
     - __kind: StructureType
       ID: 953
       Name: internal/poll.errNetClosing
-      GoRuntimeType: 1497472
+      GoRuntimeType: 1497952
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 675
+      ID: 680
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -26982,16 +26982,16 @@ Types:
           Offset: 0
           Type: 1022 PointerType *internal/abi.Type
     - __kind: BaseType
-      ID: 597
+      ID: 600
       Name: internal/strconv.Error
       ByteSize: 8
-      GoRuntimeType: 842208
+      GoRuntimeType: 842496
       GoKind: 2
     - __kind: StructureType
       ID: 1270
       Name: internal/sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1494912
+      GoRuntimeType: 1495392
       GoKind: 25
       RawFields:
         - Name: state
@@ -30794,7 +30794,7 @@ Types:
       GoRuntimeType: 849408
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 677
+      ID: 682
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -30854,7 +30854,7 @@ Types:
       ID: 949
       Name: runtime.errorAddressString
       ByteSize: 24
-      GoRuntimeType: 1781088
+      GoRuntimeType: 1781280
       GoKind: 25
       RawFields:
         - Name: msg
@@ -31098,7 +31098,7 @@ Types:
       ID: 32
       Name: runtime.gobuf
       ByteSize: 48
-      GoRuntimeType: 1943008
+      GoRuntimeType: 1943264
       GoKind: 25
       RawFields:
         - Name: sp
@@ -31123,7 +31123,7 @@ Types:
       ID: 48
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1489472
+      GoRuntimeType: 1489952
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -31136,7 +31136,7 @@ Types:
       ID: 61
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1779936
+      GoRuntimeType: 1780128
       GoKind: 25
       RawFields:
         - Name: stack
@@ -31155,13 +31155,13 @@ Types:
       ID: 33
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 841536
+      GoRuntimeType: 841824
       GoKind: 12
     - __kind: StructureType
       ID: 97
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1491872
+      GoRuntimeType: 1492352
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -31174,7 +31174,7 @@ Types:
       ID: 73
       Name: runtime.listNodeManual
       ByteSize: 16
-      GoRuntimeType: 1491072
+      GoRuntimeType: 1491552
       GoKind: 25
       RawFields:
         - Name: prev
@@ -31187,7 +31187,7 @@ Types:
       ID: 98
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 841920
+      GoRuntimeType: 842208
       GoKind: 2
     - __kind: StructureType
       ID: 31
@@ -31422,7 +31422,7 @@ Types:
       ID: 76
       Name: runtime.mLockProfile
       ByteSize: 56
-      GoRuntimeType: 1943520
+      GoRuntimeType: 1943776
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -31447,7 +31447,7 @@ Types:
       ID: 92
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 1868544
+      GoRuntimeType: 1868768
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -31469,7 +31469,7 @@ Types:
       ID: 81
       Name: runtime.mTraceState
       ByteSize: 72
-      GoRuntimeType: 1943776
+      GoRuntimeType: 1944032
       GoKind: 25
       RawFields:
         - Name: writing
@@ -31494,7 +31494,7 @@ Types:
       ID: 75
       Name: runtime.mWaitList
       ByteSize: 16
-      GoRuntimeType: 1491552
+      GoRuntimeType: 1492032
       GoKind: 25
       RawFields:
         - Name: next
@@ -31517,7 +31517,7 @@ Types:
       ID: 39
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 841632
+      GoRuntimeType: 841920
       GoKind: 12
     - __kind: StructureType
       ID: 72
@@ -31534,7 +31534,7 @@ Types:
       ID: 87
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1491712
+      GoRuntimeType: 1492192
       GoKind: 25
       RawFields:
         - Name: entries
@@ -31547,7 +31547,7 @@ Types:
       ID: 90
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1780896
+      GoRuntimeType: 1781088
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -31585,13 +31585,13 @@ Types:
       ID: 65
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 841824
+      GoRuntimeType: 842112
       GoKind: 12
     - __kind: ArrayType
       ID: 62
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 911680
+      GoRuntimeType: 912160
       GoKind: 17
       Count: 2
       HasCount: true
@@ -31600,7 +31600,7 @@ Types:
       ID: 25
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1488192
+      GoRuntimeType: 1488672
       GoKind: 25
       RawFields:
         - Name: lo
@@ -31618,7 +31618,7 @@ Types:
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 673
+      ID: 678
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1619264
@@ -31654,7 +31654,7 @@ Types:
       ID: 57
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1489792
+      GoRuntimeType: 1490272
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -32516,14 +32516,14 @@ Types:
       ID: 1152
       Name: time.Duration
       ByteSize: 8
-      GoRuntimeType: 1944544
+      GoRuntimeType: 1941472
       GoKind: 6
     - __kind: UnresolvedPointeeType
       ID: 1017
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 683
+      ID: 676
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
@@ -32543,26 +32543,26 @@ Types:
           Offset: 16
           Type: 1016 PointerType *time.Location
     - __kind: GoStringHeaderType
-      ID: 598
+      ID: 597
       Name: time.fileSizeError
       ByteSize: 16
-      GoRuntimeType: 842400
+      GoRuntimeType: 841056
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 600 PointerType *time.fileSizeError.str
+          Type: 599 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 8 BaseType int
-      Data: 599 GoStringDataType time.fileSizeError.str
+      Data: 598 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 599
+      ID: 598
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 681
+      ID: 674
       Name: time.parseDurationError
       ByteSize: 8
     - __kind: BaseType
@@ -32753,10 +32753,10 @@ Issues:
       issue:
         Kind: 7
         Message: return value selector (e.g., @return.r0) must be used for multi-value returns
-GoModuledataInfo: {FirstModuledataAddr: "0x1864d00", TypesOffset: 296}
+GoModuledataInfo: {FirstModuledataAddr: "0x1865d00", TypesOffset: 296}
 GoMapHashInfo:
-    UseAeshashAddr: "0x196622a"
-    AeskeyschedAddr: "0x1967300"
+    UseAeshashAddr: "0x196722a"
+    AeskeyschedAddr: "0x1968300"
 CommonTypes:
     G: 24 StructureType runtime.g
     M: 31 StructureType runtime.m

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -13,11 +13,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1406 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0x896548", Frameless: false}]
+              InjectionPoints: [{PC: "0x8969e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1407 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0x89657c", Frameless: false}]
+              InjectionPoints: [{PC: "0x896a1c", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -33,11 +33,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1245 EventRootType Probe[main.testAny]
-              InjectionPoints: [{PC: "0x8915f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8916f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1246 EventRootType Probe[main.testAny]Return
-              InjectionPoints: [{PC: "0x891624", Frameless: false}]
+              InjectionPoints: [{PC: "0x891724", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -59,11 +59,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1248 EventRootType Probe[main.testAnyPtr]
-              InjectionPoints: [{PC: "0x891678", Frameless: false}]
+              InjectionPoints: [{PC: "0x891778", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1249 EventRootType Probe[main.testAnyPtr]Return
-              InjectionPoints: [{PC: "0x8916a4", Frameless: false}]
+              InjectionPoints: [{PC: "0x8917a4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -84,11 +84,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1377 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0x89529c", Frameless: false}]
+              InjectionPoints: [{PC: "0x89545c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1378 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0x895334", Frameless: false}]
+              InjectionPoints: [{PC: "0x8954f4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -110,7 +110,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1193 EventRootType Probe[main.testArrayEmptyStructs]
-              InjectionPoints: [{PC: "0x88d180", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d280", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -132,7 +132,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1189 EventRootType Probe[main.testArrayOfArrays]
-              InjectionPoints: [{PC: "0x88d140", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d240", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -154,7 +154,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1191 EventRootType Probe[main.testArrayOfArraysOfArrays]
-              InjectionPoints: [{PC: "0x88d160", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d260", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -176,7 +176,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1257 EventRootType Probe[main.testArrayOfMaps]
-              InjectionPoints: [{PC: "0x891cf0", Frameless: true}]
+              InjectionPoints: [{PC: "0x891eb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -198,7 +198,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1190 EventRootType Probe[main.testArrayOfStrings]
-              InjectionPoints: [{PC: "0x88d150", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d250", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -219,7 +219,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1192 EventRootType Probe[main.testArrayOfStructs]
-              InjectionPoints: [{PC: "0x88d170", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d270", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -241,11 +241,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1279 EventRootType Probe[main.testAtomicAdd]
-              InjectionPoints: [{PC: "0x8933e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8935a0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1280 EventRootType Probe[main.testAtomicAdd]Return
-              InjectionPoints: [{PC: "0x89341c", Frameless: true}]
+              InjectionPoints: [{PC: "0x8935dc", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -267,11 +267,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1211 EventRootType Probe[main.testBigStruct]
-              InjectionPoints: [{PC: "0x88d6d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d7d0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1212 EventRootType Probe[main.testBigStruct]Return
-              InjectionPoints: [{PC: "0x88d6e8", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d7e8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -293,7 +293,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1178 EventRootType Probe[main.testBoolArray]
-              InjectionPoints: [{PC: "0x88d090", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d190", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -315,7 +315,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1175 EventRootType Probe[main.testByteArray]
-              InjectionPoints: [{PC: "0x88d060", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d160", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -342,11 +342,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1425 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x8968a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896d40", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1426 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0x8968bc", Frameless: true}]
+              InjectionPoints: [{PC: "0x896d5c", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -366,15 +366,15 @@ Probes:
             - Kind: Line
               Type: 1486 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x890e98"
+                - PC: "0x890f98"
                   Frameless: false
-                - PC: "0x890f0c"
+                - PC: "0x89100c"
                   Frameless: false
-                - PC: "0x891058"
+                - PC: "0x891158"
                   Frameless: false
-                - PC: "0x8910d4"
+                - PC: "0x8911d4"
                   Frameless: false
-                - PC: "0x89119c"
+                - PC: "0x89129c"
                   Frameless: false
               Condition: null
     - id: testCaptureExprLineCond
@@ -396,15 +396,15 @@ Probes:
             - Kind: Line
               Type: 1487 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x890e98"
+                - PC: "0x890f98"
                   Frameless: false
-                - PC: "0x890f0c"
+                - PC: "0x89100c"
                   Frameless: false
-                - PC: "0x891058"
+                - PC: "0x891158"
                   Frameless: false
-                - PC: "0x8910d4"
+                - PC: "0x8911d4"
                   Frameless: false
-                - PC: "0x89119c"
+                - PC: "0x89129c"
                   Frameless: false
               Condition:
                 Type: 5 BaseType bool
@@ -440,15 +440,15 @@ Probes:
             - Kind: Line
               Type: 1488 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x890e98"
+                - PC: "0x890f98"
                   Frameless: false
-                - PC: "0x890f0c"
+                - PC: "0x89100c"
                   Frameless: false
-                - PC: "0x891058"
+                - PC: "0x891158"
                   Frameless: false
-                - PC: "0x8910d4"
+                - PC: "0x8911d4"
                   Frameless: false
-                - PC: "0x89119c"
+                - PC: "0x89129c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -476,7 +476,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1276 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x893180", Frameless: true}]
+              InjectionPoints: [{PC: "0x893340", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -495,7 +495,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1277 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x893180", Frameless: true}]
+              InjectionPoints: [{PC: "0x893340", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -521,7 +521,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1433 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0x896950", Frameless: true}]
+              InjectionPoints: [{PC: "0x896df0", Frameless: true}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -557,7 +557,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1281 EventRootType Probe[main.testChannel]
-              InjectionPoints: [{PC: "0x893420", Frameless: true}]
+              InjectionPoints: [{PC: "0x8935e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -587,7 +587,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1275 EventRootType Probe[main.testCombinedByte]
-              InjectionPoints: [{PC: "0x893160", Frameless: true}]
+              InjectionPoints: [{PC: "0x893320", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{w}, {x}, {y}'
@@ -616,11 +616,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1342 EventRootType Probe[main.testConflictingReturn]
-              InjectionPoints: [{PC: "0x894498", Frameless: false}]
+              InjectionPoints: [{PC: "0x894658", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1343 EventRootType Probe[main.testConflictingReturn]Return
-              InjectionPoints: [{PC: "0x894548", Frameless: false}]
+              InjectionPoints: [{PC: "0x894708", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -642,7 +642,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1289 EventRootType Probe[main.testCycle]
-              InjectionPoints: [{PC: "0x8936d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x893890", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{t}'
@@ -664,7 +664,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1218 EventRootType Probe[main.testDeepMap1]
-              InjectionPoints: [{PC: "0x88dbd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88dcd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -686,7 +686,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1219 EventRootType Probe[main.testDeepMap7]
-              InjectionPoints: [{PC: "0x88dbe0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88dce0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -708,7 +708,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1214 EventRootType Probe[main.testDeepPtr1]
-              InjectionPoints: [{PC: "0x88d8c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d9c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -730,7 +730,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1215 EventRootType Probe[main.testDeepPtr7]
-              InjectionPoints: [{PC: "0x88d8d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d9d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -752,7 +752,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1216 EventRootType Probe[main.testDeepSlice1]
-              InjectionPoints: [{PC: "0x88da70", Frameless: true}]
+              InjectionPoints: [{PC: "0x88db70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -774,7 +774,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1217 EventRootType Probe[main.testDeepSlice7]
-              InjectionPoints: [{PC: "0x88da80", Frameless: true}]
+              InjectionPoints: [{PC: "0x88db80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -796,7 +796,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1394 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0x896170", Frameless: true}]
+              InjectionPoints: [{PC: "0x896330", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -823,7 +823,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1397 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0x8961a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896360", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -851,7 +851,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1420 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0x896620", Frameless: true}]
+              InjectionPoints: [{PC: "0x896ac0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -873,7 +873,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1434 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0x8969a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896e40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -894,7 +894,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1435 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0x8969b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896e50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -916,7 +916,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1247 EventRootType Probe[main.testError]
-              InjectionPoints: [{PC: "0x891650", Frameless: true}]
+              InjectionPoints: [{PC: "0x891750", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -950,7 +950,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1213 EventRootType Probe[main.testErrorAtLine]Line
-              InjectionPoints: [{PC: "0x88d75c", Frameless: false}]
+              InjectionPoints: [{PC: "0x88d85c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}, err={err}
@@ -978,11 +978,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1229 EventRootType Probe[main.testEsotericHeap]
-              InjectionPoints: [{PC: "0x88fea8", Frameless: false}]
+              InjectionPoints: [{PC: "0x88ffa8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1230 EventRootType Probe[main.testEsotericHeap]Return
-              InjectionPoints: [{PC: "0x88fee4", Frameless: false}]
+              InjectionPoints: [{PC: "0x88ffe4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1004,11 +1004,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1227 EventRootType Probe[main.testEsotericStack]
-              InjectionPoints: [{PC: "0x88fdbc", Frameless: false}]
+              InjectionPoints: [{PC: "0x88febc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1228 EventRootType Probe[main.testEsotericStack]Return
-              InjectionPoints: [{PC: "0x88fe2c", Frameless: false}]
+              InjectionPoints: [{PC: "0x88ff2c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1030,11 +1030,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1239 EventRootType Probe[main.testFrameless]
-              InjectionPoints: [{PC: "0x891320", Frameless: true}]
+              InjectionPoints: [{PC: "0x891420", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1240 EventRootType Probe[main.testFrameless]Return
-              InjectionPoints: [{PC: "0x891328", Frameless: true}]
+              InjectionPoints: [{PC: "0x891428", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1056,11 +1056,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1241 EventRootType Probe[main.testFramelessArray]
-              InjectionPoints: [{PC: "0x89133c", Frameless: false}]
+              InjectionPoints: [{PC: "0x89143c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1242 EventRootType Probe[main.testFramelessArray]Return
-              InjectionPoints: [{PC: "0x891378", Frameless: false}]
+              InjectionPoints: [{PC: "0x891478", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1085,7 +1085,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1243 EventRootType Probe[main.testFramelessArray]Line
-              InjectionPoints: [{PC: "0x89133c", Frameless: false}]
+              InjectionPoints: [{PC: "0x89143c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1107,11 +1107,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1472 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0x898d10", Frameless: true}]
+              InjectionPoints: [{PC: "0x8991b0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1473 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x898d18", Frameless: true}]
+              InjectionPoints: [{PC: "0x8991b8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1125,11 +1125,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1474 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0x898d30", Frameless: false}]
+              InjectionPoints: [{PC: "0x8991d0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1475 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0x898d6c", Frameless: false}]
+              InjectionPoints: [{PC: "0x89920c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1152,11 +1152,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1468 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0x898c78", Frameless: false}]
+              InjectionPoints: [{PC: "0x899118", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1469 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0x898c88", Frameless: false}]
+              InjectionPoints: [{PC: "0x899128", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1170,11 +1170,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1470 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0x898cc8", Frameless: false}]
+              InjectionPoints: [{PC: "0x899168", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1471 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0x898ce0", Frameless: false}]
+              InjectionPoints: [{PC: "0x899180", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1197,14 +1197,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1476 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0x898d80", Frameless: true}]
+              InjectionPoints: [{PC: "0x899220", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1477 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0x898da8"
+                - PC: "0x899248"
                   Frameless: true
-                - PC: "0x898db0"
+                - PC: "0x899250"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1219,14 +1219,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1478 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0x898dd8", Frameless: false}]
+              InjectionPoints: [{PC: "0x899278", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1479 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0x898e38"
+                - PC: "0x8992d8"
                   Frameless: false
-                - PC: "0x898e48"
+                - PC: "0x8992e8"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1253,7 +1253,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1480 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0x898d84", Frameless: true}]
+              InjectionPoints: [{PC: "0x899224", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1265,7 +1265,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1481 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0x898de8", Frameless: false}]
+              InjectionPoints: [{PC: "0x899288", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1286,11 +1286,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1456 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0x898950", Frameless: true}]
+              InjectionPoints: [{PC: "0x898df0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1457 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0x898958", Frameless: true}]
+              InjectionPoints: [{PC: "0x898df8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1304,11 +1304,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1458 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0x8989e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x898e80", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1459 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0x8989e4", Frameless: true}]
+              InjectionPoints: [{PC: "0x898e84", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1332,11 +1332,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1444 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0x8984f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x898998", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1445 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x8985cc", Frameless: false}]
+              InjectionPoints: [{PC: "0x898a6c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1378,11 +1378,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1448 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x898628", Frameless: false}]
+              InjectionPoints: [{PC: "0x898ac8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1449 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x898638", Frameless: false}]
+              InjectionPoints: [{PC: "0x898ad8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1405,11 +1405,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1482 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0x898e90", Frameless: true}]
+              InjectionPoints: [{PC: "0x899330", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1483 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0x898e98", Frameless: true}]
+              InjectionPoints: [{PC: "0x899338", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1423,11 +1423,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1484 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0x898f38", Frameless: false}]
+              InjectionPoints: [{PC: "0x8993d8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1485 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0x898f5c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8993fc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1450,11 +1450,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1440 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0x898450", Frameless: true}]
+              InjectionPoints: [{PC: "0x8988f0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1441 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x898454", Frameless: true}]
+              InjectionPoints: [{PC: "0x8988f4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1468,11 +1468,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1442 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0x898460", Frameless: true}]
+              InjectionPoints: [{PC: "0x898900", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1443 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x89846c", Frameless: true}]
+              InjectionPoints: [{PC: "0x89890c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1495,11 +1495,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1460 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0x898a80", Frameless: true}]
+              InjectionPoints: [{PC: "0x898f20", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1461 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0x898a88", Frameless: true}]
+              InjectionPoints: [{PC: "0x898f28", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1513,11 +1513,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1462 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0x898b28", Frameless: false}]
+              InjectionPoints: [{PC: "0x898fc8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1463 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0x898b54", Frameless: false}]
+              InjectionPoints: [{PC: "0x898ff4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1540,11 +1540,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1450 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0x898920", Frameless: true}]
+              InjectionPoints: [{PC: "0x898dc0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1451 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x898924", Frameless: true}]
+              InjectionPoints: [{PC: "0x898dc4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1558,11 +1558,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1452 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0x898930", Frameless: true}]
+              InjectionPoints: [{PC: "0x898dd0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1453 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0x898934", Frameless: true}]
+              InjectionPoints: [{PC: "0x898dd4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1576,11 +1576,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1454 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0x898940", Frameless: true}]
+              InjectionPoints: [{PC: "0x898de0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1455 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0x898944", Frameless: true}]
+              InjectionPoints: [{PC: "0x898de4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1603,11 +1603,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1464 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0x898c30", Frameless: true}]
+              InjectionPoints: [{PC: "0x8990d0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1465 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0x898c38", Frameless: true}]
+              InjectionPoints: [{PC: "0x8990d8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1621,11 +1621,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1466 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x898c40", Frameless: true}]
+              InjectionPoints: [{PC: "0x8990e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1467 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x898c50", Frameless: true}]
+              InjectionPoints: [{PC: "0x8990f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1648,11 +1648,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1436 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0x898430", Frameless: true}]
+              InjectionPoints: [{PC: "0x8988d0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1437 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x898434", Frameless: true}]
+              InjectionPoints: [{PC: "0x8988d4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1666,11 +1666,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1438 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0x898440", Frameless: true}]
+              InjectionPoints: [{PC: "0x8988e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1439 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x89844c", Frameless: true}]
+              InjectionPoints: [{PC: "0x8988ec", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1693,11 +1693,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1231 EventRootType Probe[main.testInlinedBA]
-              InjectionPoints: [{PC: "0x891038", Frameless: false}]
+              InjectionPoints: [{PC: "0x891138", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1232 EventRootType Probe[main.testInlinedBA]Return
-              InjectionPoints: [{PC: "0x891090", Frameless: false}]
+              InjectionPoints: [{PC: "0x891190", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1724,11 +1724,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1233 EventRootType Probe[main.testInlinedBB]
-              InjectionPoints: [{PC: "0x8910c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8911c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1234 EventRootType Probe[main.testInlinedBB]Return
-              InjectionPoints: [{PC: "0x891150", Frameless: false}]
+              InjectionPoints: [{PC: "0x891250", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}'
@@ -1755,11 +1755,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1235 EventRootType Probe[main.testInlinedBBA]
-              InjectionPoints: [{PC: "0x891198", Frameless: false}]
+              InjectionPoints: [{PC: "0x891298", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1236 EventRootType Probe[main.testInlinedBBA]Return
-              InjectionPoints: [{PC: "0x8911d4", Frameless: false}]
+              InjectionPoints: [{PC: "0x8912d4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1781,7 +1781,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1492 EventRootType Probe[main.testInlinedBBB]
-              InjectionPoints: [{PC: "0x891118", Frameless: false}]
+              InjectionPoints: [{PC: "0x891218", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBBB
@@ -1799,11 +1799,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1237 EventRootType Probe[main.testInlinedBC]
-              InjectionPoints: [{PC: "0x891218", Frameless: false}]
+              InjectionPoints: [{PC: "0x891318", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1238 EventRootType Probe[main.testInlinedBC]Return
-              InjectionPoints: [{PC: "0x891308", Frameless: false}]
+              InjectionPoints: [{PC: "0x891408", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBC
@@ -1821,7 +1821,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1493 EventRootType Probe[main.testInlinedBCA]
-              InjectionPoints: [{PC: "0x89121c", Frameless: false}]
+              InjectionPoints: [{PC: "0x89131c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1842,7 +1842,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1494 EventRootType Probe[main.testInlinedBCA]Line
-              InjectionPoints: [{PC: "0x89121c", Frameless: false}]
+              InjectionPoints: [{PC: "0x89131c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1860,7 +1860,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1495 EventRootType Probe[main.testInlinedBCB]
-              InjectionPoints: [{PC: "0x8912d0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8913d0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1881,7 +1881,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1496 EventRootType Probe[main.testInlinedBCB]Line
-              InjectionPoints: [{PC: "0x8912d0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8913d0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1902,7 +1902,7 @@ Probes:
               InjectionPoints:
                 - PC: "0x12a824"
                   Frameless: true
-                - PC: "0x891bbc"
+                - PC: "0x891df4"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1923,20 +1923,20 @@ Probes:
             - Kind: Entry
               Type: 1489 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
-                - PC: "0x890e98"
+                - PC: "0x890f98"
                   Frameless: false
-                - PC: "0x890f0c"
+                - PC: "0x89100c"
                   Frameless: false
-                - PC: "0x891058"
+                - PC: "0x891158"
                   Frameless: false
-                - PC: "0x8910d4"
+                - PC: "0x8911d4"
                   Frameless: false
-                - PC: "0x89119c"
+                - PC: "0x89129c"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1490 EventRootType Probe[main.testInlinedPrint]Return
-              InjectionPoints: [{PC: "0x890ed0", Frameless: false}]
+              InjectionPoints: [{PC: "0x890fd0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1962,15 +1962,15 @@ Probes:
             - Kind: Line
               Type: 1491 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x890e98"
+                - PC: "0x890f98"
                   Frameless: false
-                - PC: "0x890f0c"
+                - PC: "0x89100c"
                   Frameless: false
-                - PC: "0x891058"
+                - PC: "0x891158"
                   Frameless: false
-                - PC: "0x8910d4"
+                - PC: "0x8911d4"
                   Frameless: false
-                - PC: "0x89119c"
+                - PC: "0x89129c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1993,7 +1993,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1497 EventRootType Probe[main.testInlinedSq]
-              InjectionPoints: [{PC: "0x891324", Frameless: true}]
+              InjectionPoints: [{PC: "0x891424", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2018,7 +2018,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1498 EventRootType Probe[main.testInlinedSq]Line
-              InjectionPoints: [{PC: "0x891324", Frameless: true}]
+              InjectionPoints: [{PC: "0x891424", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2042,9 +2042,9 @@ Probes:
             - Kind: Entry
               Type: 1499 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
-                - PC: "0x891354"
+                - PC: "0x891454"
                   Frameless: false
-                - PC: "0x8913ec"
+                - PC: "0x8914ec"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2067,7 +2067,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1181 EventRootType Probe[main.testInt16Array]
-              InjectionPoints: [{PC: "0x88d0c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d1c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2089,7 +2089,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1182 EventRootType Probe[main.testInt32Array]
-              InjectionPoints: [{PC: "0x88d0d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d1d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2111,7 +2111,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1183 EventRootType Probe[main.testInt64Array]
-              InjectionPoints: [{PC: "0x88d0e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d1e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2133,7 +2133,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1180 EventRootType Probe[main.testInt8Array]
-              InjectionPoints: [{PC: "0x88d0b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d1b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2155,7 +2155,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1179 EventRootType Probe[main.testIntArray]
-              InjectionPoints: [{PC: "0x88d0a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d1a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2177,7 +2177,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1244 EventRootType Probe[main.testInterface]
-              InjectionPoints: [{PC: "0x8915d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8916d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -2198,11 +2198,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1375 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0x8950c0", Frameless: false}]
+              InjectionPoints: [{PC: "0x895280", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1376 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x895218", Frameless: false}]
+              InjectionPoints: [{PC: "0x8953d8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2224,7 +2224,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1283 EventRootType Probe[main.testLinkedList]
-              InjectionPoints: [{PC: "0x8935e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8937a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -2249,7 +2249,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1222 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x88dc2c", Frameless: false}]
+              InjectionPoints: [{PC: "0x88dd2c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2271,7 +2271,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1223 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x88dcc0", Frameless: false}]
+              InjectionPoints: [{PC: "0x88ddc0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2293,7 +2293,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1224 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x88dd6c", Frameless: false}]
+              InjectionPoints: [{PC: "0x88de6c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2336,11 +2336,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1381 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0x8955cc", Frameless: false}]
+              InjectionPoints: [{PC: "0x89578c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1382 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0x89573c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8958fc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2403,7 +2403,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1225 EventRootType Probe[main.testManyPointers]
-              InjectionPoints: [{PC: "0x88e190", Frameless: true}]
+              InjectionPoints: [{PC: "0x88e290", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2427,7 +2427,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1226 EventRootType Probe[main.testManyStrings]
-              InjectionPoints: [{PC: "0x88fb00", Frameless: true}]
+              InjectionPoints: [{PC: "0x88fc00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{ss}'
@@ -2449,7 +2449,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1255 EventRootType Probe[main.testMapArrayToArray]
-              InjectionPoints: [{PC: "0x891cd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x891e90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2471,7 +2471,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1262 EventRootType Probe[main.testMapEmbeddedMaps]
-              InjectionPoints: [{PC: "0x891d30", Frameless: true}]
+              InjectionPoints: [{PC: "0x891ef0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2493,7 +2493,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1272 EventRootType Probe[main.testMapEmptyKey]
-              InjectionPoints: [{PC: "0x891dd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x891f90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2515,7 +2515,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1274 EventRootType Probe[main.testMapEmptyKeyAndValue]
-              InjectionPoints: [{PC: "0x891df0", Frameless: true}]
+              InjectionPoints: [{PC: "0x891fb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2537,7 +2537,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1273 EventRootType Probe[main.testMapEmptyValue]
-              InjectionPoints: [{PC: "0x891de0", Frameless: true}]
+              InjectionPoints: [{PC: "0x891fa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2559,7 +2559,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1259 EventRootType Probe[main.testMapIntToInt]
-              InjectionPoints: [{PC: "0x891d10", Frameless: true}]
+              InjectionPoints: [{PC: "0x891ed0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2581,7 +2581,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1271 EventRootType Probe[main.testMapLargeKeyLargeValue]
-              InjectionPoints: [{PC: "0x891dc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x891f80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2603,7 +2603,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1270 EventRootType Probe[main.testMapLargeKeySmallValue]
-              InjectionPoints: [{PC: "0x891db0", Frameless: true}]
+              InjectionPoints: [{PC: "0x891f70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2627,7 +2627,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1260 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x891d20", Frameless: true}]
+              InjectionPoints: [{PC: "0x891ee0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2651,7 +2651,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1261 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x891d20", Frameless: true}]
+              InjectionPoints: [{PC: "0x891ee0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2673,7 +2673,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1269 EventRootType Probe[main.testMapSmallKeyLargeValue]
-              InjectionPoints: [{PC: "0x891da0", Frameless: true}]
+              InjectionPoints: [{PC: "0x891f60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2695,7 +2695,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1268 EventRootType Probe[main.testMapSmallKeySmallValue]
-              InjectionPoints: [{PC: "0x891d90", Frameless: true}]
+              InjectionPoints: [{PC: "0x891f50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2717,7 +2717,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1253 EventRootType Probe[main.testMapStringToInt]
-              InjectionPoints: [{PC: "0x891cb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x891e70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2739,7 +2739,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1254 EventRootType Probe[main.testMapStringToSlice]
-              InjectionPoints: [{PC: "0x891cc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x891e80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2761,7 +2761,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1252 EventRootType Probe[main.testMapStringToStruct]
-              InjectionPoints: [{PC: "0x891ca0", Frameless: true}]
+              InjectionPoints: [{PC: "0x891e60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2783,7 +2783,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1263 EventRootType Probe[main.testMapWithLinkedList]
-              InjectionPoints: [{PC: "0x891d40", Frameless: true}]
+              InjectionPoints: [{PC: "0x891f00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2805,7 +2805,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1266 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-              InjectionPoints: [{PC: "0x891d70", Frameless: true}]
+              InjectionPoints: [{PC: "0x891f30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2827,7 +2827,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1267 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-              InjectionPoints: [{PC: "0x891d80", Frameless: true}]
+              InjectionPoints: [{PC: "0x891f40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2849,7 +2849,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1264 EventRootType Probe[main.testMapWithSmallValue]
-              InjectionPoints: [{PC: "0x891d50", Frameless: true}]
+              InjectionPoints: [{PC: "0x891f10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2873,7 +2873,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1265 EventRootType Probe[main.testMapWithSmallValueMassive]
-              InjectionPoints: [{PC: "0x891d60", Frameless: true}]
+              InjectionPoints: [{PC: "0x891f20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2895,7 +2895,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1417 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x896600", Frameless: true}]
+              InjectionPoints: [{PC: "0x896aa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2918,7 +2918,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1418 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x896600", Frameless: true}]
+              InjectionPoints: [{PC: "0x896aa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2965,11 +2965,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1383 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0x8957c0", Frameless: false}]
+              InjectionPoints: [{PC: "0x895980", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1384 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0x895970", Frameless: false}]
+              InjectionPoints: [{PC: "0x895b30", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -3035,11 +3035,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1387 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0x895a9c", Frameless: false}]
+              InjectionPoints: [{PC: "0x895c5c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1388 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0x895b40", Frameless: false}]
+              InjectionPoints: [{PC: "0x895d00", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3070,11 +3070,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1379 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0x895370", Frameless: false}]
+              InjectionPoints: [{PC: "0x895530", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1380 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0x895540", Frameless: false}]
+              InjectionPoints: [{PC: "0x895700", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3100,11 +3100,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1320 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8942f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8944b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1321 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x894384", Frameless: false}]
+              InjectionPoints: [{PC: "0x894544", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3140,7 +3140,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1278 EventRootType Probe[main.testMultipleSimpleParams]
-              InjectionPoints: [{PC: "0x893240", Frameless: true}]
+              InjectionPoints: [{PC: "0x893400", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -3181,11 +3181,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1314 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x894258", Frameless: false}]
+              InjectionPoints: [{PC: "0x894418", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1315 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x8942b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x894478", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3209,11 +3209,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1316 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x894258", Frameless: false}]
+              InjectionPoints: [{PC: "0x894418", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1317 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x8942b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x894478", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
       version: 0
@@ -3232,11 +3232,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1322 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8942f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8944b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1323 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x894384", Frameless: false}]
+              InjectionPoints: [{PC: "0x894544", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
       version: 0
@@ -3256,11 +3256,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1324 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8942f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8944b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1325 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x894384", Frameless: false}]
+              InjectionPoints: [{PC: "0x894544", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r1={result} r2={result2}
@@ -3293,11 +3293,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1318 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x894258", Frameless: false}]
+              InjectionPoints: [{PC: "0x894418", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1319 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x8942b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x894478", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Parameter {i} * 2 = result {result}
@@ -3325,7 +3325,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1429 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x896940", Frameless: true}]
+              InjectionPoints: [{PC: "0x896de0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3350,7 +3350,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1430 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x896940", Frameless: true}]
+              InjectionPoints: [{PC: "0x896de0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3381,7 +3381,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1431 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x896940", Frameless: true}]
+              InjectionPoints: [{PC: "0x896de0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3406,7 +3406,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1432 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x896940", Frameless: true}]
+              InjectionPoints: [{PC: "0x896de0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3433,7 +3433,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1288 EventRootType Probe[main.testNilPointer]
-              InjectionPoints: [{PC: "0x8936b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x893870", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}, {a}'
@@ -3460,7 +3460,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1401 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0x8961e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8963a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3487,7 +3487,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1398 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0x8961b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896370", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3522,7 +3522,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1400 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0x8961d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896390", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3554,7 +3554,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1416 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0x8965f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896a90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3576,7 +3576,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1284 EventRootType Probe[main.testPointerLoop]
-              InjectionPoints: [{PC: "0x8935f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8937b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3598,7 +3598,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1258 EventRootType Probe[main.testPointerToMap]
-              InjectionPoints: [{PC: "0x891d00", Frameless: true}]
+              InjectionPoints: [{PC: "0x891ec0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3620,7 +3620,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1282 EventRootType Probe[main.testPointerToSimpleStruct]
-              InjectionPoints: [{PC: "0x8935d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x893790", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3644,11 +3644,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1290 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x893af8", Frameless: false}]
+              InjectionPoints: [{PC: "0x893cb8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1291 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x893b3c", Frameless: false}]
+              InjectionPoints: [{PC: "0x893cfc", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
       version: 0
@@ -3668,11 +3668,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1334 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x8943c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x894588", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1335 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x894454", Frameless: false}]
+              InjectionPoints: [{PC: "0x894614", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3715,11 +3715,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1300 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x893c18", Frameless: false}]
+              InjectionPoints: [{PC: "0x893dd8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1301 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x893cb0", Frameless: false}]
+              InjectionPoints: [{PC: "0x893e70", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3759,11 +3759,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1292 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x893af8", Frameless: false}]
+              InjectionPoints: [{PC: "0x893cb8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1293 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x893b3c", Frameless: false}]
+              InjectionPoints: [{PC: "0x893cfc", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3806,11 +3806,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1302 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x893c18", Frameless: false}]
+              InjectionPoints: [{PC: "0x893dd8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1303 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x893cb0", Frameless: false}]
+              InjectionPoints: [{PC: "0x893e70", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3852,11 +3852,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1336 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x8943c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x894588", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1337 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x894454", Frameless: false}]
+              InjectionPoints: [{PC: "0x894614", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
       version: 0
@@ -3873,11 +3873,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1338 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x8943c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x894588", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1339 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x894454", Frameless: false}]
+              InjectionPoints: [{PC: "0x894614", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r0={@return.r0}
@@ -3899,11 +3899,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1294 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x893af8", Frameless: false}]
+              InjectionPoints: [{PC: "0x893cb8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1295 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x893b3c", Frameless: false}]
+              InjectionPoints: [{PC: "0x893cfc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: result={@return}
@@ -3926,18 +3926,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1310 EventRootType Probe[main.testReturnsAny]
-              InjectionPoints: [{PC: "0x893ee8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8940a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1311 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
-                - PC: "0x893f88"
+                - PC: "0x894148"
                   Frameless: false
-                - PC: "0x893fd0"
+                - PC: "0x894190"
                   Frameless: false
-                - PC: "0x894094"
+                - PC: "0x894254"
                   Frameless: false
-                - PC: "0x8940a8"
+                - PC: "0x894268"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3965,18 +3965,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1308 EventRootType Probe[main.testReturnsAnyAndError]
-              InjectionPoints: [{PC: "0x893d68", Frameless: false}]
+              InjectionPoints: [{PC: "0x893f28", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1309 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
-                - PC: "0x893dd4"
+                - PC: "0x893f94"
                   Frameless: false
-                - PC: "0x893e20"
+                - PC: "0x893fe0"
                   Frameless: false
-                - PC: "0x893e60"
+                - PC: "0x894020"
                   Frameless: false
-                - PC: "0x893ea0"
+                - PC: "0x894060"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4003,11 +4003,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1353 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0x894acc", Frameless: false}]
+              InjectionPoints: [{PC: "0x894c8c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1354 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0x894b20", Frameless: false}]
+              InjectionPoints: [{PC: "0x894ce0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -4024,11 +4024,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1355 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0x894b58", Frameless: false}]
+              InjectionPoints: [{PC: "0x894d18", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1356 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0x894b94", Frameless: false}]
+              InjectionPoints: [{PC: "0x894d54", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -4045,11 +4045,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1357 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0x894bc8", Frameless: false}]
+              InjectionPoints: [{PC: "0x894d88", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1358 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0x894c00", Frameless: false}]
+              InjectionPoints: [{PC: "0x894dc0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4066,11 +4066,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1361 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0x894cb8", Frameless: false}]
+              InjectionPoints: [{PC: "0x894e78", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1362 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0x894d1c", Frameless: false}]
+              InjectionPoints: [{PC: "0x894edc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4087,11 +4087,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1373 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0x895048", Frameless: false}]
+              InjectionPoints: [{PC: "0x895208", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1374 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0x895088", Frameless: false}]
+              InjectionPoints: [{PC: "0x895248", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4108,11 +4108,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1349 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0x894978", Frameless: false}]
+              InjectionPoints: [{PC: "0x894b38", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1350 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0x8949c4", Frameless: false}]
+              InjectionPoints: [{PC: "0x894b84", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4130,14 +4130,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1306 EventRootType Probe[main.testReturnsError]
-              InjectionPoints: [{PC: "0x893ce8", Frameless: false}]
+              InjectionPoints: [{PC: "0x893ea8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1307 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
-                - PC: "0x893d18"
+                - PC: "0x893ed8"
                   Frameless: false
-                - PC: "0x893d2c"
+                - PC: "0x893eec"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4159,11 +4159,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1296 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x893af8", Frameless: false}]
+              InjectionPoints: [{PC: "0x893cb8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1297 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x893b3c", Frameless: false}]
+              InjectionPoints: [{PC: "0x893cfc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4184,11 +4184,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1304 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x893c18", Frameless: false}]
+              InjectionPoints: [{PC: "0x893dd8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1305 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x893cb0", Frameless: false}]
+              InjectionPoints: [{PC: "0x893e70", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4209,11 +4209,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1298 EventRootType Probe[main.testReturnsIntPointer]
-              InjectionPoints: [{PC: "0x893b78", Frameless: false}]
+              InjectionPoints: [{PC: "0x893d38", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1299 EventRootType Probe[main.testReturnsIntPointer]Return
-              InjectionPoints: [{PC: "0x893bdc", Frameless: false}]
+              InjectionPoints: [{PC: "0x893d9c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4235,14 +4235,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1312 EventRootType Probe[main.testReturnsInterface]
-              InjectionPoints: [{PC: "0x8940e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8942a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1313 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
-                - PC: "0x8941b8"
+                - PC: "0x894378"
                   Frameless: false
-                - PC: "0x8941cc"
+                - PC: "0x89438c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4264,11 +4264,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1351 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0x894a00", Frameless: false}]
+              InjectionPoints: [{PC: "0x894bc0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1352 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0x894a94", Frameless: false}]
+              InjectionPoints: [{PC: "0x894c54", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4285,11 +4285,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1347 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0x8948b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x894a78", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1348 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0x89493c", Frameless: false}]
+              InjectionPoints: [{PC: "0x894afc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4306,11 +4306,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1365 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0x894e38", Frameless: false}]
+              InjectionPoints: [{PC: "0x894ff8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1366 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0x894e90", Frameless: false}]
+              InjectionPoints: [{PC: "0x895050", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4327,11 +4327,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1359 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0x894c38", Frameless: false}]
+              InjectionPoints: [{PC: "0x894df8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1360 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0x894c80", Frameless: false}]
+              InjectionPoints: [{PC: "0x894e40", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4348,11 +4348,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1371 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0x894fc8", Frameless: false}]
+              InjectionPoints: [{PC: "0x895188", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1372 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0x89500c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8951cc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
@@ -4372,7 +4372,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1344 EventRootType Probe[main.testReturnsNamedDeferLine]Line
-              InjectionPoints: [{PC: "0x894648", Frameless: false}]
+              InjectionPoints: [{PC: "0x894808", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4393,11 +4393,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1369 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0x894f58", Frameless: false}]
+              InjectionPoints: [{PC: "0x895118", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1370 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0x894f98", Frameless: false}]
+              InjectionPoints: [{PC: "0x895158", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4414,11 +4414,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1345 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0x894828", Frameless: false}]
+              InjectionPoints: [{PC: "0x8949e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1346 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0x894880", Frameless: false}]
+              InjectionPoints: [{PC: "0x894a40", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4435,11 +4435,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1367 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0x894ecc", Frameless: false}]
+              InjectionPoints: [{PC: "0x89508c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1368 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0x894f20", Frameless: false}]
+              InjectionPoints: [{PC: "0x8950e0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4456,11 +4456,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1363 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0x894d60", Frameless: false}]
+              InjectionPoints: [{PC: "0x894f20", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1364 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0x894e04", Frameless: false}]
+              InjectionPoints: [{PC: "0x894fc4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4478,7 +4478,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1176 EventRootType Probe[main.testRuneArray]
-              InjectionPoints: [{PC: "0x88d070", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d170", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4513,11 +4513,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1326 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8942f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8944b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1327 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x894384", Frameless: false}]
+              InjectionPoints: [{PC: "0x894544", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -4563,7 +4563,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1197 EventRootType Probe[main.testSingleBool]
-              InjectionPoints: [{PC: "0x88d4f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d5f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4585,7 +4585,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1195 EventRootType Probe[main.testSingleByte]
-              InjectionPoints: [{PC: "0x88d4d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d5d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4607,7 +4607,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1208 EventRootType Probe[main.testSingleFloat32]
-              InjectionPoints: [{PC: "0x88d5a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d6a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4625,7 +4625,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1209 EventRootType Probe[main.testSingleFloat64]
-              InjectionPoints: [{PC: "0x88d5b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d6b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4643,7 +4643,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1198 EventRootType Probe[main.testSingleInt]
-              InjectionPoints: [{PC: "0x88d500", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d600", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4665,7 +4665,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1200 EventRootType Probe[main.testSingleInt16]
-              InjectionPoints: [{PC: "0x88d520", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d620", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}
@@ -4688,7 +4688,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1201 EventRootType Probe[main.testSingleInt32]
-              InjectionPoints: [{PC: "0x88d530", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d630", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4710,7 +4710,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1202 EventRootType Probe[main.testSingleInt64]
-              InjectionPoints: [{PC: "0x88d540", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d640", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4739,7 +4739,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1199 EventRootType Probe[main.testSingleInt8]
-              InjectionPoints: [{PC: "0x88d510", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d610", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}{x}{x}
@@ -4770,7 +4770,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1196 EventRootType Probe[main.testSingleRune]
-              InjectionPoints: [{PC: "0x88d4e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d5e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4792,7 +4792,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1408 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0x8965a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896a40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4814,7 +4814,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1203 EventRootType Probe[main.testSingleUint]
-              InjectionPoints: [{PC: "0x88d550", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d650", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4836,7 +4836,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1205 EventRootType Probe[main.testSingleUint16]
-              InjectionPoints: [{PC: "0x88d570", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d670", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4858,7 +4858,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1206 EventRootType Probe[main.testSingleUint32]
-              InjectionPoints: [{PC: "0x88d580", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d680", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4880,7 +4880,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1207 EventRootType Probe[main.testSingleUint64]
-              InjectionPoints: [{PC: "0x88d590", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d690", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4902,7 +4902,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1204 EventRootType Probe[main.testSingleUint8]
-              InjectionPoints: [{PC: "0x88d560", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d660", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4924,7 +4924,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1404 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0x896200", Frameless: true}]
+              InjectionPoints: [{PC: "0x8963c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -4946,7 +4946,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1395 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0x896180", Frameless: true}]
+              InjectionPoints: [{PC: "0x896340", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -4968,7 +4968,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1256 EventRootType Probe[main.testSmallMap]
-              InjectionPoints: [{PC: "0x891ce0", Frameless: true}]
+              InjectionPoints: [{PC: "0x891ea0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -4989,11 +4989,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1340 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x8943c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x894588", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1341 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x894454", Frameless: false}]
+              InjectionPoints: [{PC: "0x894614", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -5014,11 +5014,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1385 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0x8959f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x895bb8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1386 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0x895a5c", Frameless: false}]
+              InjectionPoints: [{PC: "0x895c1c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5040,7 +5040,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1177 EventRootType Probe[main.testStringArray]
-              InjectionPoints: [{PC: "0x88d080", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d180", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5062,7 +5062,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1287 EventRootType Probe[main.testStringPointer]
-              InjectionPoints: [{PC: "0x893690", Frameless: true}]
+              InjectionPoints: [{PC: "0x893850", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}'
@@ -5084,7 +5084,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1399 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0x8961c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896380", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5106,7 +5106,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1220 EventRootType Probe[main.testStringType1]
-              InjectionPoints: [{PC: "0x88dbf0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88dcf0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5128,7 +5128,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1221 EventRootType Probe[main.testStringType2]
-              InjectionPoints: [{PC: "0x88dc00", Frameless: true}]
+              InjectionPoints: [{PC: "0x88dd00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5150,11 +5150,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1427 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x8968a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896d40", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1428 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0x8968bc", Frameless: true}]
+              InjectionPoints: [{PC: "0x896d5c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5181,7 +5181,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1396 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0x896190", Frameless: true}]
+              InjectionPoints: [{PC: "0x896350", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5208,7 +5208,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1250 EventRootType Probe[main.testStructWithAny]
-              InjectionPoints: [{PC: "0x8916d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8917d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5229,11 +5229,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1389 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0x895b7c", Frameless: false}]
+              InjectionPoints: [{PC: "0x895d3c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1390 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0x895c0c", Frameless: false}]
+              InjectionPoints: [{PC: "0x895dcc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5255,11 +5255,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1423 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0x8967b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896c50", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1424 EventRootType Probe[main.testStructWithCyclicMaps]Return
-              InjectionPoints: [{PC: "0x8967c8", Frameless: true}]
+              InjectionPoints: [{PC: "0x896c68", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5280,7 +5280,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1422 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0x8967a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896c40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5307,7 +5307,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1251 EventRootType Probe[main.testStructWithMap]
-              InjectionPoints: [{PC: "0x891c90", Frameless: true}]
+              InjectionPoints: [{PC: "0x891e50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s} {@duration}'
@@ -5340,7 +5340,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1405 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0x896210", Frameless: true}]
+              InjectionPoints: [{PC: "0x8963d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5380,7 +5380,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1421 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0x896630", Frameless: true}]
+              InjectionPoints: [{PC: "0x896ad0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5413,11 +5413,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1328 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8942f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8944b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1329 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x894384", Frameless: false}]
+              InjectionPoints: [{PC: "0x894544", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{nonexistentVariable}'
@@ -5438,11 +5438,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1330 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8942f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8944b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1331 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x894384", Frameless: false}]
+              InjectionPoints: [{PC: "0x894544", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{unsupportedExpression}'
@@ -5465,11 +5465,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1332 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8942f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8944b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1333 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x894384", Frameless: false}]
+              InjectionPoints: [{PC: "0x894544", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -5501,7 +5501,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1409 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0x8965b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896a50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5533,11 +5533,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1410 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x8965c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896a60", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1411 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0x8965d8", Frameless: true}]
+              InjectionPoints: [{PC: "0x896a78", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5567,11 +5567,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1412 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x8965c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896a60", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1413 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0x8965d8", Frameless: true}]
+              InjectionPoints: [{PC: "0x896a78", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5603,7 +5603,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1414 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x8965e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896a80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5633,7 +5633,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1415 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x8965e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896a80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5665,7 +5665,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1210 EventRootType Probe[main.testTypeAlias]
-              InjectionPoints: [{PC: "0x88d5c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d6c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5687,7 +5687,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1186 EventRootType Probe[main.testUint16Array]
-              InjectionPoints: [{PC: "0x88d110", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d210", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5709,7 +5709,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1187 EventRootType Probe[main.testUint32Array]
-              InjectionPoints: [{PC: "0x88d120", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d220", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5731,7 +5731,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1188 EventRootType Probe[main.testUint64Array]
-              InjectionPoints: [{PC: "0x88d130", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d230", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5753,7 +5753,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1185 EventRootType Probe[main.testUint8Array]
-              InjectionPoints: [{PC: "0x88d100", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d200", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5775,7 +5775,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1184 EventRootType Probe[main.testUintArray]
-              InjectionPoints: [{PC: "0x88d0f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d1f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5797,7 +5797,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1286 EventRootType Probe[main.testUintPointer]
-              InjectionPoints: [{PC: "0x893620", Frameless: true}]
+              InjectionPoints: [{PC: "0x8937e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5819,7 +5819,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1393 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0x896160", Frameless: true}]
+              InjectionPoints: [{PC: "0x896320", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5841,7 +5841,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1419 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0x896610", Frameless: true}]
+              InjectionPoints: [{PC: "0x896ab0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5863,7 +5863,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1285 EventRootType Probe[main.testUnsafePointer]
-              InjectionPoints: [{PC: "0x893600", Frameless: true}]
+              InjectionPoints: [{PC: "0x8937c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5885,7 +5885,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1194 EventRootType Probe[main.testVeryLargeArray]
-              InjectionPoints: [{PC: "0x88d1a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88d2a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5907,7 +5907,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1402 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x8961f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8963b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5929,7 +5929,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1403 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x8961f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8963b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5952,14 +5952,14 @@ Probes:
             - Kind: Entry
               Type: 1500 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
-                - PC: "0x8914f8"
+                - PC: "0x8915f8"
                   Frameless: false
-                - PC: "0x89905c"
+                - PC: "0x8994fc"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1501 EventRootType Probe[main.firstBehavior.DoSomething]Return
-              InjectionPoints: [{PC: "0x891530", Frameless: false}]
+              InjectionPoints: [{PC: "0x891630", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testWhollyInlinedSubroutine
@@ -5981,11 +5981,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1391 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0x895c48", Frameless: false}]
+              InjectionPoints: [{PC: "0x895e08", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1392 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x895cb4", Frameless: false}]
+              InjectionPoints: [{PC: "0x895e74", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -6002,481 +6002,481 @@ Probes:
 Subprograms:
     - ID: 1
       Name: main.testByteArray
-      OutOfLinePCRanges: [0x88d060..0x88d070]
+      OutOfLinePCRanges: [0x88d160..0x88d170]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 103 ArrayType [2]uint8
           Locations:
-            - Range: 0x88d060..0x88d070
+            - Range: 0x88d160..0x88d170
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 2
       Name: main.testRuneArray
-      OutOfLinePCRanges: [0x88d070..0x88d080]
+      OutOfLinePCRanges: [0x88d170..0x88d180]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 104 ArrayType [2]int32
           Locations:
-            - Range: 0x88d070..0x88d080
+            - Range: 0x88d170..0x88d180
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 3
       Name: main.testStringArray
-      OutOfLinePCRanges: [0x88d080..0x88d090]
+      OutOfLinePCRanges: [0x88d180..0x88d190]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 105 ArrayType [2]string
           Locations:
-            - Range: 0x88d080..0x88d090
+            - Range: 0x88d180..0x88d190
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 4
       Name: main.testBoolArray
-      OutOfLinePCRanges: [0x88d090..0x88d0a0]
+      OutOfLinePCRanges: [0x88d190..0x88d1a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 106 ArrayType [2]bool
           Locations:
-            - Range: 0x88d090..0x88d0a0
+            - Range: 0x88d190..0x88d1a0
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 5
       Name: main.testIntArray
-      OutOfLinePCRanges: [0x88d0a0..0x88d0b0]
+      OutOfLinePCRanges: [0x88d1a0..0x88d1b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 107 ArrayType [2]int
           Locations:
-            - Range: 0x88d0a0..0x88d0b0
+            - Range: 0x88d1a0..0x88d1b0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 6
       Name: main.testInt8Array
-      OutOfLinePCRanges: [0x88d0b0..0x88d0c0]
+      OutOfLinePCRanges: [0x88d1b0..0x88d1c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 108 ArrayType [2]int8
           Locations:
-            - Range: 0x88d0b0..0x88d0c0
+            - Range: 0x88d1b0..0x88d1c0
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 7
       Name: main.testInt16Array
-      OutOfLinePCRanges: [0x88d0c0..0x88d0d0]
+      OutOfLinePCRanges: [0x88d1c0..0x88d1d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 109 ArrayType [2]int16
           Locations:
-            - Range: 0x88d0c0..0x88d0d0
+            - Range: 0x88d1c0..0x88d1d0
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 8
       Name: main.testInt32Array
-      OutOfLinePCRanges: [0x88d0d0..0x88d0e0]
+      OutOfLinePCRanges: [0x88d1d0..0x88d1e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 104 ArrayType [2]int32
           Locations:
-            - Range: 0x88d0d0..0x88d0e0
+            - Range: 0x88d1d0..0x88d1e0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 9
       Name: main.testInt64Array
-      OutOfLinePCRanges: [0x88d0e0..0x88d0f0]
+      OutOfLinePCRanges: [0x88d1e0..0x88d1f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 110 ArrayType [2]int64
           Locations:
-            - Range: 0x88d0e0..0x88d0f0
+            - Range: 0x88d1e0..0x88d1f0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 10
       Name: main.testUintArray
-      OutOfLinePCRanges: [0x88d0f0..0x88d100]
+      OutOfLinePCRanges: [0x88d1f0..0x88d200]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 111 ArrayType [2]uint
           Locations:
-            - Range: 0x88d0f0..0x88d100
+            - Range: 0x88d1f0..0x88d200
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 11
       Name: main.testUint8Array
-      OutOfLinePCRanges: [0x88d100..0x88d110]
+      OutOfLinePCRanges: [0x88d200..0x88d210]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 103 ArrayType [2]uint8
           Locations:
-            - Range: 0x88d100..0x88d110
+            - Range: 0x88d200..0x88d210
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 12
       Name: main.testUint16Array
-      OutOfLinePCRanges: [0x88d110..0x88d120]
+      OutOfLinePCRanges: [0x88d210..0x88d220]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 112 ArrayType [2]uint16
           Locations:
-            - Range: 0x88d110..0x88d120
+            - Range: 0x88d210..0x88d220
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 13
       Name: main.testUint32Array
-      OutOfLinePCRanges: [0x88d120..0x88d130]
+      OutOfLinePCRanges: [0x88d220..0x88d230]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 113 ArrayType [2]uint32
           Locations:
-            - Range: 0x88d120..0x88d130
+            - Range: 0x88d220..0x88d230
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 14
       Name: main.testUint64Array
-      OutOfLinePCRanges: [0x88d130..0x88d140]
+      OutOfLinePCRanges: [0x88d230..0x88d240]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 53 ArrayType [2]uint64
           Locations:
-            - Range: 0x88d130..0x88d140
+            - Range: 0x88d230..0x88d240
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 15
       Name: main.testArrayOfArrays
-      OutOfLinePCRanges: [0x88d140..0x88d150]
+      OutOfLinePCRanges: [0x88d240..0x88d250]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 114 ArrayType [2][2]int
           Locations:
-            - Range: 0x88d140..0x88d150
+            - Range: 0x88d240..0x88d250
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 16
       Name: main.testArrayOfStrings
-      OutOfLinePCRanges: [0x88d150..0x88d160]
+      OutOfLinePCRanges: [0x88d250..0x88d260]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 105 ArrayType [2]string
           Locations:
-            - Range: 0x88d150..0x88d160
+            - Range: 0x88d250..0x88d260
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 17
       Name: main.testArrayOfArraysOfArrays
-      OutOfLinePCRanges: [0x88d160..0x88d170]
+      OutOfLinePCRanges: [0x88d260..0x88d270]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 115 ArrayType [2][2][2]int
           Locations:
-            - Range: 0x88d160..0x88d170
+            - Range: 0x88d260..0x88d270
               Pieces: [{Size: 64, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 18
       Name: main.testArrayOfStructs
-      OutOfLinePCRanges: [0x88d170..0x88d180]
+      OutOfLinePCRanges: [0x88d270..0x88d280]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 116 ArrayType [2]main.nestedStruct
           Locations:
-            - Range: 0x88d170..0x88d180
+            - Range: 0x88d270..0x88d280
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 19
       Name: main.testArrayEmptyStructs
-      OutOfLinePCRanges: [0x88d180..0x88d190]
+      OutOfLinePCRanges: [0x88d280..0x88d290]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 118 ArrayType [2]struct {}
           Locations:
-            - Range: 0x88d180..0x88d190
+            - Range: 0x88d280..0x88d290
               Pieces: [{Size: 0, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 20
       Name: main.testVeryLargeArray
-      OutOfLinePCRanges: [0x88d1a0..0x88d1b0]
+      OutOfLinePCRanges: [0x88d2a0..0x88d2b0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 120 ArrayType [100]uint
           Locations:
-            - Range: 0x88d1a0..0x88d1b0
+            - Range: 0x88d2a0..0x88d2b0
               Pieces: [{Size: 800, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 21
       Name: main.testSingleByte
-      OutOfLinePCRanges: [0x88d4d0..0x88d4e0]
+      OutOfLinePCRanges: [0x88d5d0..0x88d5e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x88d4d0..0x88d4e0
+            - Range: 0x88d5d0..0x88d5e0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 22
       Name: main.testSingleRune
-      OutOfLinePCRanges: [0x88d4e0..0x88d4f0]
+      OutOfLinePCRanges: [0x88d5e0..0x88d5f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 BaseType int32
           Locations:
-            - Range: 0x88d4e0..0x88d4f0
+            - Range: 0x88d5e0..0x88d5f0
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 23
       Name: main.testSingleBool
-      OutOfLinePCRanges: [0x88d4f0..0x88d500]
+      OutOfLinePCRanges: [0x88d5f0..0x88d600]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x88d4f0..0x88d500
+            - Range: 0x88d5f0..0x88d600
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 24
       Name: main.testSingleInt
-      OutOfLinePCRanges: [0x88d500..0x88d510]
+      OutOfLinePCRanges: [0x88d600..0x88d610]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType int
           Locations:
-            - Range: 0x88d500..0x88d510
+            - Range: 0x88d600..0x88d610
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 25
       Name: main.testSingleInt8
-      OutOfLinePCRanges: [0x88d510..0x88d520]
+      OutOfLinePCRanges: [0x88d610..0x88d620]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 BaseType int8
           Locations:
-            - Range: 0x88d510..0x88d520
+            - Range: 0x88d610..0x88d620
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 26
       Name: main.testSingleInt16
-      OutOfLinePCRanges: [0x88d520..0x88d530]
+      OutOfLinePCRanges: [0x88d620..0x88d630]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 90 BaseType int16
           Locations:
-            - Range: 0x88d520..0x88d530
+            - Range: 0x88d620..0x88d630
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 27
       Name: main.testSingleInt32
-      OutOfLinePCRanges: [0x88d530..0x88d540]
+      OutOfLinePCRanges: [0x88d630..0x88d640]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 BaseType int32
           Locations:
-            - Range: 0x88d530..0x88d540
+            - Range: 0x88d630..0x88d640
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 28
       Name: main.testSingleInt64
-      OutOfLinePCRanges: [0x88d540..0x88d550]
+      OutOfLinePCRanges: [0x88d640..0x88d650]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 BaseType int64
           Locations:
-            - Range: 0x88d540..0x88d550
+            - Range: 0x88d640..0x88d650
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 29
       Name: main.testSingleUint
-      OutOfLinePCRanges: [0x88d550..0x88d560]
+      OutOfLinePCRanges: [0x88d650..0x88d660]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType uint
           Locations:
-            - Range: 0x88d550..0x88d560
+            - Range: 0x88d650..0x88d660
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 30
       Name: main.testSingleUint8
-      OutOfLinePCRanges: [0x88d560..0x88d570]
+      OutOfLinePCRanges: [0x88d660..0x88d670]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x88d560..0x88d570
+            - Range: 0x88d660..0x88d670
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 31
       Name: main.testSingleUint16
-      OutOfLinePCRanges: [0x88d570..0x88d580]
+      OutOfLinePCRanges: [0x88d670..0x88d680]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint16
           Locations:
-            - Range: 0x88d570..0x88d580
+            - Range: 0x88d670..0x88d680
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 32
       Name: main.testSingleUint32
-      OutOfLinePCRanges: [0x88d580..0x88d590]
+      OutOfLinePCRanges: [0x88d680..0x88d690]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint32
           Locations:
-            - Range: 0x88d580..0x88d590
+            - Range: 0x88d680..0x88d690
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 33
       Name: main.testSingleUint64
-      OutOfLinePCRanges: [0x88d590..0x88d5a0]
+      OutOfLinePCRanges: [0x88d690..0x88d6a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 BaseType uint64
           Locations:
-            - Range: 0x88d590..0x88d5a0
+            - Range: 0x88d690..0x88d6a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 34
       Name: main.testSingleFloat32
-      OutOfLinePCRanges: [0x88d5a0..0x88d5b0]
+      OutOfLinePCRanges: [0x88d6a0..0x88d6b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType float32
           Locations:
-            - Range: 0x88d5a0..0x88d5b0
+            - Range: 0x88d6a0..0x88d6b0
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 35
       Name: main.testSingleFloat64
-      OutOfLinePCRanges: [0x88d5b0..0x88d5c0]
+      OutOfLinePCRanges: [0x88d6b0..0x88d6c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 18 BaseType float64
           Locations:
-            - Range: 0x88d5b0..0x88d5c0
+            - Range: 0x88d6b0..0x88d6c0
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 36
       Name: main.testTypeAlias
-      OutOfLinePCRanges: [0x88d5c0..0x88d5d0]
+      OutOfLinePCRanges: [0x88d6c0..0x88d6d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 121 BaseType main.typeAlias
           Locations:
-            - Range: 0x88d5c0..0x88d5d0
+            - Range: 0x88d6c0..0x88d6d0
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 37
       Name: main.testBigStruct
-      OutOfLinePCRanges: [0x88d6d0..0x88d6f0]
+      OutOfLinePCRanges: [0x88d7d0..0x88d7f0]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 122 StructureType main.bigStruct
           Locations:
-            - Range: 0x88d6d0..0x88d6f0
+            - Range: 0x88d7d0..0x88d7f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6495,48 +6495,48 @@ Subprograms:
       DictRegister: null
     - ID: 38
       Name: main.testErrorAtLine
-      OutOfLinePCRanges: [0x88d710..0x88d830]
+      OutOfLinePCRanges: [0x88d810..0x88d930]
       InlinePCRanges: []
       Variables:
         - Name: shouldErr
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x88d710..0x88d730
+            - Range: 0x88d810..0x88d830
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType int
-          Locations: [{Range: 0x88d710..0x88d830, Pieces: []}]
+          Locations: [{Range: 0x88d810..0x88d930, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 10 BaseType int
-          Locations: [{Range: 0x88d710..0x88d830, Pieces: []}]
+          Locations: [{Range: 0x88d810..0x88d930, Pieces: []}]
           Role: Local
           DictIndex: -1
         - Name: err
           Type: 19 GoInterfaceType error
           Locations:
-            - Range: 0x88d748..0x88d768
+            - Range: 0x88d848..0x88d868
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
-            - Range: 0x88d768..0x88d798
+            - Range: 0x88d868..0x88d898
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x88d798..0x88d79c
+            - Range: 0x88d898..0x88d89c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {CfaOffset: -64}
-            - Range: 0x88d79c..0x88d830
+            - Range: 0x88d89c..0x88d930
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
@@ -6547,39 +6547,39 @@ Subprograms:
       DictRegister: null
     - ID: 39
       Name: main.testDeepPtr1
-      OutOfLinePCRanges: [0x88d8c0..0x88d8d0]
+      OutOfLinePCRanges: [0x88d9c0..0x88d9d0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 126 StructureType main.deepPtr1
           Locations:
-            - Range: 0x88d8c0..0x88d8d0
+            - Range: 0x88d9c0..0x88d9d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 40
       Name: main.testDeepPtr7
-      OutOfLinePCRanges: [0x88d8d0..0x88d8e0]
+      OutOfLinePCRanges: [0x88d9d0..0x88d9e0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 129 PointerType *main.deepPtr7
           Locations:
-            - Range: 0x88d8d0..0x88d8e0
+            - Range: 0x88d9d0..0x88d9e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 41
       Name: main.testDeepSlice1
-      OutOfLinePCRanges: [0x88da70..0x88da80]
+      OutOfLinePCRanges: [0x88db70..0x88db80]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 131 StructureType main.deepSlice1
           Locations:
-            - Range: 0x88da70..0x88da80
+            - Range: 0x88db70..0x88db80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6592,142 +6592,142 @@ Subprograms:
       DictRegister: null
     - ID: 42
       Name: main.testDeepSlice7
-      OutOfLinePCRanges: [0x88da80..0x88da90]
+      OutOfLinePCRanges: [0x88db80..0x88db90]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 135 PointerType *main.deepSlice7
           Locations:
-            - Range: 0x88da80..0x88da90
+            - Range: 0x88db80..0x88db90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 43
       Name: main.testDeepMap1
-      OutOfLinePCRanges: [0x88dbd0..0x88dbe0]
+      OutOfLinePCRanges: [0x88dcd0..0x88dce0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 137 StructureType main.deepMap1
           Locations:
-            - Range: 0x88dbd0..0x88dbe0
+            - Range: 0x88dcd0..0x88dce0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 44
       Name: main.testDeepMap7
-      OutOfLinePCRanges: [0x88dbe0..0x88dbf0]
+      OutOfLinePCRanges: [0x88dce0..0x88dcf0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 145 PointerType *main.deepMap7
           Locations:
-            - Range: 0x88dbe0..0x88dbf0
+            - Range: 0x88dce0..0x88dcf0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 45
       Name: main.testStringType1
-      OutOfLinePCRanges: [0x88dbf0..0x88dc00]
+      OutOfLinePCRanges: [0x88dcf0..0x88dd00]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 147 PointerType *main.stringType1
           Locations:
-            - Range: 0x88dbf0..0x88dc00
+            - Range: 0x88dcf0..0x88dd00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 46
       Name: main.testStringType2
-      OutOfLinePCRanges: [0x88dc00..0x88dc10]
+      OutOfLinePCRanges: [0x88dd00..0x88dd10]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 149 PointerType **main.stringType2
           Locations:
-            - Range: 0x88dc00..0x88dc10
+            - Range: 0x88dd00..0x88dd10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 47
       Name: main.testLongFunctionWithChangingState
-      OutOfLinePCRanges: [0x88dc10..0x88de10]
+      OutOfLinePCRanges: [0x88dd10..0x88df10]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 10 BaseType int
           Locations:
-            - Range: 0x88dcd8..0x88dce8
+            - Range: 0x88ddd8..0x88dde8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88dd88..0x88dd98
+            - Range: 0x88de88..0x88de98
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: aPerArch
           Type: 10 BaseType int
           Locations:
-            - Range: 0x88dcc0..0x88dcc4
+            - Range: 0x88ddc0..0x88ddc4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x88dcc4..0x88dce8
+            - Range: 0x88ddc4..0x88dde8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x88dce8..0x88dd7c
+            - Range: 0x88dde8..0x88de7c
               Pieces: [{Size: 8, Op: {CfaOffset: -160}}]
-            - Range: 0x88dd7c..0x88dd84
+            - Range: 0x88de7c..0x88de84
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0x88dd84..0x88de10
+            - Range: 0x88de84..0x88df10
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
           Role: Local
           DictIndex: -1
         - Name: b
           Type: 10 BaseType int
           Locations:
-            - Range: 0x88dcbc..0x88dcc4
+            - Range: 0x88ddbc..0x88ddc4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x88dcc4..0x88dcc4
+            - Range: 0x88ddc4..0x88ddc4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x88dcc4..0x88dce8
+            - Range: 0x88ddc4..0x88dde8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x88dce8..0x88dd7c
+            - Range: 0x88dde8..0x88de7c
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0x88dd7c..0x88dd80
+            - Range: 0x88de7c..0x88de80
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0x88dd80..0x88dd84
+            - Range: 0x88de80..0x88de84
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x88dd84..0x88dd98
+            - Range: 0x88de84..0x88de98
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x88dd98..0x88de10
+            - Range: 0x88de98..0x88df10
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 48
       Name: main.testManyPointers
-      OutOfLinePCRanges: [0x88e190..0x88e1a0]
+      OutOfLinePCRanges: [0x88e290..0x88e2a0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 151 StructureType main.manyPointers
           Locations:
-            - Range: 0x88e190..0x88e1a0
+            - Range: 0x88e290..0x88e2a0
               Pieces: [{Size: 560, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 49
       Name: main.testManyStrings
-      OutOfLinePCRanges: [0x88fb00..0x88fb10]
+      OutOfLinePCRanges: [0x88fc00..0x88fc10]
       InlinePCRanges: []
       Variables:
         - Name: ss
           Type: 154 GoSliceHeaderType []string
           Locations:
-            - Range: 0x88fb00..0x88fb10
+            - Range: 0x88fc00..0x88fc10
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6740,13 +6740,13 @@ Subprograms:
       DictRegister: null
     - ID: 50
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0x88fda0..0x88fe90]
+      OutOfLinePCRanges: [0x88fea0..0x88ff90]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 155 StructureType main.esotericStack
           Locations:
-            - Range: 0x88fda0..0x88fde8
+            - Range: 0x88fea0..0x88fee8
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -6766,7 +6766,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x88fde8..0x88fdec
+            - Range: 0x88fee8..0x88feec
               Pieces:
                 - Size: 4
                   Op: null
@@ -6786,7 +6786,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x88fdec..0x88fdf0
+            - Range: 0x88feec..0x88fef0
               Pieces:
                 - Size: 4
                   Op: null
@@ -6811,255 +6811,155 @@ Subprograms:
       DictRegister: null
     - ID: 51
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0x88fe90..0x88ff10]
+      OutOfLinePCRanges: [0x88ff90..0x890010]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 159 PointerType *main.esotericHeap
           Locations:
-            - Range: 0x88fe90..0x88fec8
+            - Range: 0x88ff90..0x88ffc8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 52
       Name: main.testInlinedBA
-      OutOfLinePCRanges: [0x891020..0x8910b0]
+      OutOfLinePCRanges: [0x891120..0x8911b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType int
           Locations:
-            - Range: 0x891020..0x891058
+            - Range: 0x891120..0x891158
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 53
       Name: main.testInlinedBB
-      OutOfLinePCRanges: [0x8910b0..0x891180]
+      OutOfLinePCRanges: [0x8911b0..0x891280]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType int
           Locations:
-            - Range: 0x8910b0..0x8910cc
+            - Range: 0x8911b0..0x8911cc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: "y"
           Type: 10 BaseType int
           Locations:
-            - Range: 0x8910b0..0x8910dc
+            - Range: 0x8911b0..0x8911dc
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: z
           Type: 10 BaseType int
           Locations:
-            - Range: 0x8910cc..0x8910dc
+            - Range: 0x8911cc..0x8911dc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8910dc..0x891180
+            - Range: 0x8911dc..0x891280
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 54
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0x891180..0x891200]
+      OutOfLinePCRanges: [0x891280..0x891300]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType int
           Locations:
-            - Range: 0x891180..0x8911a4
+            - Range: 0x891280..0x8912a4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 55
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0x891200..0x891320]
+      OutOfLinePCRanges: [0x891300..0x891420]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 10 BaseType int
           Locations:
-            - Range: 0x891268..0x891270
+            - Range: 0x891368..0x891370
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x891270..0x891288
+            - Range: 0x891370..0x891388
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x891288..0x89129c
+            - Range: 0x891388..0x89139c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: i
           Type: 10 BaseType int
           Locations:
-            - Range: 0x891264..0x89126c
+            - Range: 0x891364..0x89136c
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x89126c..0x891288
+            - Range: 0x89136c..0x891388
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x891288..0x891298
+            - Range: 0x891388..0x891398
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 56
       Name: main.testFrameless
-      OutOfLinePCRanges: [0x891320..0x891330]
+      OutOfLinePCRanges: [0x891420..0x891430]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType int
           Locations:
-            - Range: 0x891320..0x891328
+            - Range: 0x891420..0x891428
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0x891320..0x891328
+            - Range: 0x891420..0x891428
               Pieces: []
-            - Range: 0x891328..0x891329
+            - Range: 0x891428..0x891429
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x891329..0x891330
+            - Range: 0x891429..0x891430
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 57
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0x891330..0x891390]
+      OutOfLinePCRanges: [0x891430..0x891490]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 161 ArrayType [5]int
           Locations:
-            - Range: 0x891330..0x891390
+            - Range: 0x891430..0x891490
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0x891330..0x891378
+            - Range: 0x891430..0x891478
               Pieces: []
-            - Range: 0x891378..0x891379
+            - Range: 0x891478..0x891479
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x891379..0x891390
+            - Range: 0x891479..0x891490
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 58
       Name: main.testInterface
-      OutOfLinePCRanges: [0x8915d0..0x8915e0]
+      OutOfLinePCRanges: [0x8916d0..0x8916e0]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 162 GoInterfaceType main.behavior
-          Locations:
-            - Range: 0x8915d0..0x8915e0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 59
-      Name: main.testAny
-      OutOfLinePCRanges: [0x8915e0..0x891650]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 157 GoEmptyInterfaceType interface {}
-          Locations:
-            - Range: 0x8915e0..0x891610
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x891610..0x891614
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-        - Name: ~r0
-          Type: 12 GoStringHeaderType string
-          Locations:
-            - Range: 0x8915e0..0x891624
-              Pieces: []
-            - Range: 0x891624..0x891625
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x891625..0x891650
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-      DictRegister: null
-    - ID: 60
-      Name: main.testError
-      OutOfLinePCRanges: [0x891650..0x891660]
-      InlinePCRanges: []
-      Variables:
-        - Name: e
-          Type: 19 GoInterfaceType error
-          Locations:
-            - Range: 0x891650..0x891660
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 61
-      Name: main.testAnyPtr
-      OutOfLinePCRanges: [0x891660..0x8916d0]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 163 PointerType *interface {}
-          Locations:
-            - Range: 0x891660..0x891690
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: ~r0
-          Type: 12 GoStringHeaderType string
-          Locations:
-            - Range: 0x891660..0x8916a4
-              Pieces: []
-            - Range: 0x8916a4..0x8916a5
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8916a5..0x8916d0
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-      DictRegister: null
-    - ID: 62
-      Name: main.testStructWithAny
-      OutOfLinePCRanges: [0x8916d0..0x8916e0]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 164 StructureType main.structWithAny
           Locations:
             - Range: 0x8916d0..0x8916e0
               Pieces:
@@ -7070,348 +6970,448 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 59
+      Name: main.testAny
+      OutOfLinePCRanges: [0x8916e0..0x891750]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 157 GoEmptyInterfaceType interface {}
+          Locations:
+            - Range: 0x8916e0..0x891710
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x891710..0x891714
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: ~r0
+          Type: 12 GoStringHeaderType string
+          Locations:
+            - Range: 0x8916e0..0x891724
+              Pieces: []
+            - Range: 0x891724..0x891725
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x891725..0x891750
+              Pieces: []
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 60
+      Name: main.testError
+      OutOfLinePCRanges: [0x891750..0x891760]
+      InlinePCRanges: []
+      Variables:
+        - Name: e
+          Type: 19 GoInterfaceType error
+          Locations:
+            - Range: 0x891750..0x891760
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 61
+      Name: main.testAnyPtr
+      OutOfLinePCRanges: [0x891760..0x8917d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 163 PointerType *interface {}
+          Locations:
+            - Range: 0x891760..0x891790
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: ~r0
+          Type: 12 GoStringHeaderType string
+          Locations:
+            - Range: 0x891760..0x8917a4
+              Pieces: []
+            - Range: 0x8917a4..0x8917a5
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x8917a5..0x8917d0
+              Pieces: []
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 62
+      Name: main.testStructWithAny
+      OutOfLinePCRanges: [0x8917d0..0x8917e0]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 164 StructureType main.structWithAny
+          Locations:
+            - Range: 0x8917d0..0x8917e0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 63
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x891c90..0x891ca0]
+      OutOfLinePCRanges: [0x891e50..0x891e60]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 165 StructureType main.structWithMap
           Locations:
-            - Range: 0x891c90..0x891ca0
+            - Range: 0x891e50..0x891e60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 64
       Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x891ca0..0x891cb0]
+      OutOfLinePCRanges: [0x891e60..0x891e70]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 171 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0x891ca0..0x891cb0
+            - Range: 0x891e60..0x891e70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 65
       Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0x891cb0..0x891cc0]
+      OutOfLinePCRanges: [0x891e70..0x891e80]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 176 GoMapType map[string]int
           Locations:
-            - Range: 0x891cb0..0x891cc0
+            - Range: 0x891e70..0x891e80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 66
       Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0x891cc0..0x891cd0]
+      OutOfLinePCRanges: [0x891e80..0x891e90]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 181 GoMapType map[string][]string
           Locations:
-            - Range: 0x891cc0..0x891cd0
+            - Range: 0x891e80..0x891e90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 67
       Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0x891cd0..0x891ce0]
+      OutOfLinePCRanges: [0x891e90..0x891ea0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 186 GoMapType map[[4]string][2]int
           Locations:
-            - Range: 0x891cd0..0x891ce0
+            - Range: 0x891e90..0x891ea0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 68
       Name: main.testSmallMap
-      OutOfLinePCRanges: [0x891ce0..0x891cf0]
+      OutOfLinePCRanges: [0x891ea0..0x891eb0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 176 GoMapType map[string]int
           Locations:
-            - Range: 0x891ce0..0x891cf0
+            - Range: 0x891ea0..0x891eb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 69
       Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0x891cf0..0x891d00]
+      OutOfLinePCRanges: [0x891eb0..0x891ec0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 191 ArrayType [2]map[string]int
           Locations:
-            - Range: 0x891cf0..0x891d00
+            - Range: 0x891eb0..0x891ec0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 70
       Name: main.testPointerToMap
-      OutOfLinePCRanges: [0x891d00..0x891d10]
+      OutOfLinePCRanges: [0x891ec0..0x891ed0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 192 PointerType *map[string]int
           Locations:
-            - Range: 0x891d00..0x891d10
+            - Range: 0x891ec0..0x891ed0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 71
       Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0x891d10..0x891d20]
+      OutOfLinePCRanges: [0x891ed0..0x891ee0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 166 GoMapType map[int]int
           Locations:
-            - Range: 0x891d10..0x891d20
+            - Range: 0x891ed0..0x891ee0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 72
       Name: main.testMapMassive
-      OutOfLinePCRanges: [0x891d20..0x891d30]
+      OutOfLinePCRanges: [0x891ee0..0x891ef0]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 193 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x891d20..0x891d30
+            - Range: 0x891ee0..0x891ef0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 73
       Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0x891d30..0x891d40]
+      OutOfLinePCRanges: [0x891ef0..0x891f00]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 193 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x891d30..0x891d40
+            - Range: 0x891ef0..0x891f00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 74
       Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0x891d40..0x891d50]
+      OutOfLinePCRanges: [0x891f00..0x891f10]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 198 GoMapType map[bool]main.node
           Locations:
-            - Range: 0x891d40..0x891d50
+            - Range: 0x891f00..0x891f10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 75
       Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0x891d50..0x891d60]
+      OutOfLinePCRanges: [0x891f10..0x891f20]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 203 GoMapType map[int]uint8
           Locations:
-            - Range: 0x891d50..0x891d60
+            - Range: 0x891f10..0x891f20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 76
       Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0x891d60..0x891d70]
+      OutOfLinePCRanges: [0x891f20..0x891f30]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 203 GoMapType map[int]uint8
           Locations:
-            - Range: 0x891d60..0x891d70
+            - Range: 0x891f20..0x891f30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 77
       Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0x891d70..0x891d80]
+      OutOfLinePCRanges: [0x891f30..0x891f40]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 208 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x891d70..0x891d80
+            - Range: 0x891f30..0x891f40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 78
       Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0x891d80..0x891d90]
+      OutOfLinePCRanges: [0x891f40..0x891f50]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 208 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x891d80..0x891d90
+            - Range: 0x891f40..0x891f50
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 79
       Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0x891d90..0x891da0]
+      OutOfLinePCRanges: [0x891f50..0x891f60]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 208 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x891d90..0x891da0
+            - Range: 0x891f50..0x891f60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 80
       Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0x891da0..0x891db0]
+      OutOfLinePCRanges: [0x891f60..0x891f70]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 213 GoMapType map[uint8][4]int
           Locations:
-            - Range: 0x891da0..0x891db0
+            - Range: 0x891f60..0x891f70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 81
       Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0x891db0..0x891dc0]
+      OutOfLinePCRanges: [0x891f70..0x891f80]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 218 GoMapType map[[4]int]uint8
           Locations:
-            - Range: 0x891db0..0x891dc0
+            - Range: 0x891f70..0x891f80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 82
       Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0x891dc0..0x891dd0]
+      OutOfLinePCRanges: [0x891f80..0x891f90]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 223 GoMapType map[[4]int][4]int
           Locations:
-            - Range: 0x891dc0..0x891dd0
+            - Range: 0x891f80..0x891f90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 83
       Name: main.testMapEmptyKey
-      OutOfLinePCRanges: [0x891dd0..0x891de0]
+      OutOfLinePCRanges: [0x891f90..0x891fa0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 228 GoMapType map[struct {}]int
           Locations:
-            - Range: 0x891dd0..0x891de0
+            - Range: 0x891f90..0x891fa0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 84
       Name: main.testMapEmptyValue
-      OutOfLinePCRanges: [0x891de0..0x891df0]
+      OutOfLinePCRanges: [0x891fa0..0x891fb0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 233 GoMapType map[int]struct {}
           Locations:
-            - Range: 0x891de0..0x891df0
+            - Range: 0x891fa0..0x891fb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 85
       Name: main.testMapEmptyKeyAndValue
-      OutOfLinePCRanges: [0x891df0..0x891e00]
+      OutOfLinePCRanges: [0x891fb0..0x891fc0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 238 GoMapType map[struct {}]struct {}
           Locations:
-            - Range: 0x891df0..0x891e00
+            - Range: 0x891fb0..0x891fc0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 86
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x893160..0x893170]
+      OutOfLinePCRanges: [0x893320..0x893330]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x893160..0x893170
+            - Range: 0x893320..0x893330
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x893160..0x893170
+            - Range: 0x893320..0x893330
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: "y"
           Type: 17 BaseType float32
           Locations:
-            - Range: 0x893160..0x893170
+            - Range: 0x893320..0x893330
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 87
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0x893180..0x893190]
+      OutOfLinePCRanges: [0x893340..0x893350]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x893180..0x893190
+            - Range: 0x893340..0x893350
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0x893180..0x893190
+            - Range: 0x893340..0x893350
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -7422,48 +7422,48 @@ Subprograms:
         - Name: "y"
           Type: 17 BaseType float32
           Locations:
-            - Range: 0x893180..0x893190
+            - Range: 0x893340..0x893350
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 88
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x893240..0x893250]
+      OutOfLinePCRanges: [0x893400..0x893410]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x893240..0x893250
+            - Range: 0x893400..0x893410
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x893240..0x893250
+            - Range: 0x893400..0x893410
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 14 BaseType int32
           Locations:
-            - Range: 0x893240..0x893250
+            - Range: 0x893400..0x893410
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 13 BaseType uint
           Locations:
-            - Range: 0x893240..0x893250
+            - Range: 0x893400..0x893410
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0x893240..0x893250
+            - Range: 0x893400..0x893410
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7474,63 +7474,63 @@ Subprograms:
       DictRegister: null
     - ID: 89
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0x8933e0..0x893420]
+      OutOfLinePCRanges: [0x8935a0..0x8935e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 BaseType uint64
           Locations:
-            - Range: 0x8933e0..0x89341c
+            - Range: 0x8935a0..0x8935dc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 11 BaseType uint64
           Locations:
-            - Range: 0x8933e0..0x89341c
+            - Range: 0x8935a0..0x8935dc
               Pieces: []
-            - Range: 0x89341c..0x89341d
+            - Range: 0x8935dc..0x8935dd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x89341d..0x893420
+            - Range: 0x8935dd..0x8935e0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 90
       Name: main.testChannel
-      OutOfLinePCRanges: [0x893420..0x893430]
+      OutOfLinePCRanges: [0x8935e0..0x8935f0]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 243 GoChannelType chan bool
           Locations:
-            - Range: 0x893420..0x893430
+            - Range: 0x8935e0..0x8935f0
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 91
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x8935d0..0x8935e0]
+      OutOfLinePCRanges: [0x893790..0x8937a0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 244 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x8935d0..0x8935e0
+            - Range: 0x893790..0x8937a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 92
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x8935e0..0x8935f0]
+      OutOfLinePCRanges: [0x8937a0..0x8937b0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 246 StructureType main.node
           Locations:
-            - Range: 0x8935e0..0x8935f0
+            - Range: 0x8937a0..0x8937b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7541,273 +7541,273 @@ Subprograms:
       DictRegister: null
     - ID: 93
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x8935f0..0x893600]
+      OutOfLinePCRanges: [0x8937b0..0x8937c0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 247 PointerType *main.node
           Locations:
-            - Range: 0x8935f0..0x893600
+            - Range: 0x8937b0..0x8937c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 94
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x893600..0x893610]
+      OutOfLinePCRanges: [0x8937c0..0x8937d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 20 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0x893600..0x893610
+            - Range: 0x8937c0..0x8937d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 95
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x893620..0x893630]
+      OutOfLinePCRanges: [0x8937e0..0x8937f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 101 PointerType *uint
           Locations:
-            - Range: 0x893620..0x893630
+            - Range: 0x8937e0..0x8937f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 96
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x893690..0x8936a0]
+      OutOfLinePCRanges: [0x893850..0x893860]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 89 PointerType *string
           Locations:
-            - Range: 0x893690..0x8936a0
+            - Range: 0x893850..0x893860
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 97
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x8936b0..0x8936c0]
+      OutOfLinePCRanges: [0x893870..0x893880]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 6 PointerType *bool
           Locations:
-            - Range: 0x8936b0..0x8936c0
+            - Range: 0x893870..0x893880
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 13 BaseType uint
           Locations:
-            - Range: 0x8936b0..0x8936c0
+            - Range: 0x893870..0x893880
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 98
       Name: main.testCycle
-      OutOfLinePCRanges: [0x8936d0..0x8936e0]
+      OutOfLinePCRanges: [0x893890..0x8938a0]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 248 PointerType *main.t
           Locations:
-            - Range: 0x8936d0..0x8936e0
+            - Range: 0x893890..0x8938a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 99
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0x893ae0..0x893b60]
+      OutOfLinePCRanges: [0x893ca0..0x893d20]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 10 BaseType int
           Locations:
-            - Range: 0x893ae0..0x893afc
+            - Range: 0x893ca0..0x893cbc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0x893ae0..0x893b3c
+            - Range: 0x893ca0..0x893cfc
               Pieces: []
-            - Range: 0x893b3c..0x893b3d
+            - Range: 0x893cfc..0x893cfd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893b3d..0x893b60
+            - Range: 0x893cfd..0x893d20
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result
           Type: 10 BaseType int
           Locations:
-            - Range: 0x893afc..0x893b08
+            - Range: 0x893cbc..0x893cc8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893b08..0x893b60
+            - Range: 0x893cc8..0x893d20
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 100
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0x893b60..0x893c00]
+      OutOfLinePCRanges: [0x893d20..0x893dc0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 10 BaseType int
           Locations:
-            - Range: 0x893b60..0x893b84
+            - Range: 0x893d20..0x893d44
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893b84..0x893c00
+            - Range: 0x893d44..0x893dc0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 95 PointerType *int
           Locations:
-            - Range: 0x893b60..0x893bdc
+            - Range: 0x893d20..0x893d9c
               Pieces: []
-            - Range: 0x893bdc..0x893bdd
+            - Range: 0x893d9c..0x893d9d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893bdd..0x893c00
+            - Range: 0x893d9d..0x893dc0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: '&result'
           Type: 95 PointerType *int
           Locations:
-            - Range: 0x893b88..0x893ba4
+            - Range: 0x893d48..0x893d64
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893ba4..0x893c00
+            - Range: 0x893d64..0x893dc0
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 101
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0x893c00..0x893cd0]
+      OutOfLinePCRanges: [0x893dc0..0x893e90]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 10 BaseType int
           Locations:
-            - Range: 0x893c00..0x893c58
+            - Range: 0x893dc0..0x893e18
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0x893c00..0x893cb0
+            - Range: 0x893dc0..0x893e70
               Pieces: []
-            - Range: 0x893cb0..0x893cb1
+            - Range: 0x893e70..0x893e71
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893cb1..0x893cd0
+            - Range: 0x893e71..0x893e90
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0x893c00..0x893cd0, Pieces: []}]
+          Locations: [{Range: 0x893dc0..0x893e90, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: resultInt
           Type: 10 BaseType int
           Locations:
-            - Range: 0x893c1c..0x893c5c
+            - Range: 0x893ddc..0x893e1c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x893c5c..0x893cd0
+            - Range: 0x893e1c..0x893e90
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: -1
         - Name: resultFloat
           Type: 18 BaseType float64
           Locations:
-            - Range: 0x893c2c..0x893c5c
+            - Range: 0x893dec..0x893e1c
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-            - Range: 0x893c5c..0x893cd0
+            - Range: 0x893e1c..0x893e90
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 102
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0x893cd0..0x893d50]
+      OutOfLinePCRanges: [0x893e90..0x893f10]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x893cd0..0x893cf4
+            - Range: 0x893e90..0x893eb4
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 19 GoInterfaceType error
           Locations:
-            - Range: 0x893cd0..0x893d18
+            - Range: 0x893e90..0x893ed8
               Pieces: []
-            - Range: 0x893d18..0x893d19
+            - Range: 0x893ed8..0x893ed9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x893d19..0x893d2c
+            - Range: 0x893ed9..0x893eec
               Pieces: []
-            - Range: 0x893d2c..0x893d2d
+            - Range: 0x893eec..0x893eed
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x893d2d..0x893d50
+            - Range: 0x893eed..0x893f10
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 103
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0x893d50..0x893ed0]
+      OutOfLinePCRanges: [0x893f10..0x894090]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x893d50..0x893da8
+            - Range: 0x893f10..0x893f68
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x893da8..0x893dac
+            - Range: 0x893f68..0x893f6c
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x893e04..0x893e08
+            - Range: 0x893fc4..0x893fc8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x893e34..0x893e38
+            - Range: 0x893ff4..0x893ff8
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x893e74..0x893e78
+            - Range: 0x894034..0x894038
               Pieces:
                 - Size: 8
                   Op: null
@@ -7818,117 +7818,117 @@ Subprograms:
         - Name: failed
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x893d50..0x893da4
+            - Range: 0x893f10..0x893f64
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x893d50..0x893dd4
+            - Range: 0x893f10..0x893f94
               Pieces: []
-            - Range: 0x893dd4..0x893dd5
+            - Range: 0x893f94..0x893f95
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x893dd5..0x893e20
+            - Range: 0x893f95..0x893fe0
               Pieces: []
-            - Range: 0x893e20..0x893e21
+            - Range: 0x893fe0..0x893fe1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x893e21..0x893e60
+            - Range: 0x893fe1..0x894020
               Pieces: []
-            - Range: 0x893e60..0x893e61
+            - Range: 0x894020..0x894021
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x893e61..0x893ea0
+            - Range: 0x894021..0x894060
               Pieces: []
-            - Range: 0x893ea0..0x893ea1
+            - Range: 0x894060..0x894061
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x893ea1..0x893ed0
+            - Range: 0x894061..0x894090
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 19 GoInterfaceType error
           Locations:
-            - Range: 0x893d50..0x893dd4
+            - Range: 0x893f10..0x893f94
               Pieces: []
-            - Range: 0x893dd4..0x893dd5
+            - Range: 0x893f94..0x893f95
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x893dd5..0x893e20
+            - Range: 0x893f95..0x893fe0
               Pieces: []
-            - Range: 0x893e20..0x893e21
+            - Range: 0x893fe0..0x893fe1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x893e21..0x893e60
+            - Range: 0x893fe1..0x894020
               Pieces: []
-            - Range: 0x893e60..0x893e61
+            - Range: 0x894020..0x894021
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x893e61..0x893ea0
+            - Range: 0x894021..0x894060
               Pieces: []
-            - Range: 0x893ea0..0x893ea1
+            - Range: 0x894060..0x894061
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x893ea1..0x893ed0
+            - Range: 0x894061..0x894090
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 10 BaseType int
           Locations:
-            - Range: 0x893e04..0x893e0c
+            - Range: 0x893fc4..0x893fcc
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 104
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0x893ed0..0x8940d0]
+      OutOfLinePCRanges: [0x894090..0x894290]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x893ed0..0x893f2c
+            - Range: 0x894090..0x8940ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x893f2c..0x893f30
+            - Range: 0x8940ec..0x8940f0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x893f30..0x8940d0
+            - Range: 0x8940f0..0x894290
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -7939,549 +7939,549 @@ Subprograms:
         - Name: ~r0
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x893ed0..0x893f88
+            - Range: 0x894090..0x894148
               Pieces: []
-            - Range: 0x893f88..0x893f89
+            - Range: 0x894148..0x894149
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x893f89..0x893fd0
+            - Range: 0x894149..0x894190
               Pieces: []
-            - Range: 0x893fd0..0x893fd1
+            - Range: 0x894190..0x894191
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x893fd1..0x894094
+            - Range: 0x894191..0x894254
               Pieces: []
-            - Range: 0x894094..0x894095
+            - Range: 0x894254..0x894255
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x894095..0x8940a8
+            - Range: 0x894255..0x894268
               Pieces: []
-            - Range: 0x8940a8..0x8940a9
+            - Range: 0x894268..0x894269
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8940a9..0x8940d0
+            - Range: 0x894269..0x894290
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 10 BaseType int
           Locations:
-            - Range: 0x893fbc..0x893fc4
+            - Range: 0x89417c..0x894184
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: '&result'
           Type: 95 PointerType *int
           Locations:
-            - Range: 0x893f6c..0x893f88
+            - Range: 0x89412c..0x894148
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 105
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0x8940d0..0x894240]
+      OutOfLinePCRanges: [0x894290..0x894400]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x8940d0..0x89410c
+            - Range: 0x894290..0x8942cc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89410c..0x89416c
+            - Range: 0x8942cc..0x89432c
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x89416c..0x8941d8
+            - Range: 0x89432c..0x894398
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x8941d8..0x894200
+            - Range: 0x894398..0x8943c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x894200..0x894204
+            - Range: 0x8943c0..0x8943c4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x894204..0x894240
+            - Range: 0x8943c4..0x894400
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 162 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x8940d0..0x8941b8
+            - Range: 0x894290..0x894378
               Pieces: []
-            - Range: 0x8941b8..0x8941b9
+            - Range: 0x894378..0x894379
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8941b9..0x8941cc
+            - Range: 0x894379..0x89438c
               Pieces: []
-            - Range: 0x8941cc..0x8941cd
+            - Range: 0x89438c..0x89438d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8941cd..0x894240
+            - Range: 0x89438d..0x894400
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 162 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x8940d0..0x89410c
+            - Range: 0x894290..0x8942cc
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89410c..0x89415c
+            - Range: 0x8942cc..0x89431c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x89415c..0x89416c
+            - Range: 0x89431c..0x89432c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -64}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x89416c..0x8941c4
+            - Range: 0x89432c..0x894384
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -64}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8941c4..0x8941c8
+            - Range: 0x894384..0x894388
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8941c8..0x8941cc
+            - Range: 0x894388..0x89438c
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x8941cc..0x894240
+            - Range: 0x89438c..0x894400
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 106
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0x894240..0x8942e0]
+      OutOfLinePCRanges: [0x894400..0x8944a0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 10 BaseType int
           Locations:
-            - Range: 0x894240..0x89425c
+            - Range: 0x894400..0x89441c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 10 BaseType int
           Locations:
-            - Range: 0x894240..0x8942b8
+            - Range: 0x894400..0x894478
               Pieces: []
-            - Range: 0x8942b8..0x8942b9
+            - Range: 0x894478..0x894479
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8942b9..0x8942e0
+            - Range: 0x894479..0x8944a0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 107
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0x8942e0..0x8943b0]
+      OutOfLinePCRanges: [0x8944a0..0x894570]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 10 BaseType int
           Locations:
-            - Range: 0x8942e0..0x894330
+            - Range: 0x8944a0..0x8944f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 10 BaseType int
           Locations:
-            - Range: 0x8942e0..0x894384
+            - Range: 0x8944a0..0x894544
               Pieces: []
-            - Range: 0x894384..0x894385
+            - Range: 0x894544..0x894545
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x894385..0x8943b0
+            - Range: 0x894545..0x894570
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 10 BaseType int
           Locations:
-            - Range: 0x8942e0..0x894384
+            - Range: 0x8944a0..0x894544
               Pieces: []
-            - Range: 0x894384..0x894385
+            - Range: 0x894544..0x894545
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x894385..0x8943b0
+            - Range: 0x894545..0x894570
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 108
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0x8943b0..0x894480]
+      OutOfLinePCRanges: [0x894570..0x894640]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 10 BaseType int
           Locations:
-            - Range: 0x8943b0..0x8943f0
+            - Range: 0x894570..0x8945b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8943f0..0x894480
+            - Range: 0x8945b0..0x894640
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0x8943b0..0x894454
+            - Range: 0x894570..0x894614
               Pieces: []
-            - Range: 0x894454..0x894455
+            - Range: 0x894614..0x894615
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x894455..0x894480
+            - Range: 0x894615..0x894640
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 10 BaseType int
           Locations:
-            - Range: 0x8943b0..0x894454
+            - Range: 0x894570..0x894614
               Pieces: []
-            - Range: 0x894454..0x894455
+            - Range: 0x894614..0x894615
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x894455..0x894480
+            - Range: 0x894615..0x894640
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 10 BaseType int
           Locations:
-            - Range: 0x8943b0..0x894454
+            - Range: 0x894570..0x894614
               Pieces: []
-            - Range: 0x894454..0x894455
+            - Range: 0x894614..0x894615
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x894455..0x894480
+            - Range: 0x894615..0x894640
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 109
       Name: main.testConflictingReturn
-      OutOfLinePCRanges: [0x894480..0x894570]
+      OutOfLinePCRanges: [0x894640..0x894730]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 10 BaseType int
           Locations:
-            - Range: 0x894480..0x8944c0
+            - Range: 0x894640..0x894680
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8944c0..0x894570
+            - Range: 0x894680..0x894730
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0x894480..0x894548
+            - Range: 0x894640..0x894708
               Pieces: []
-            - Range: 0x894548..0x894549
+            - Range: 0x894708..0x894709
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x894549..0x894570
+            - Range: 0x894709..0x894730
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: r0
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0x894480..0x894548
+            - Range: 0x894640..0x894708
               Pieces: []
-            - Range: 0x894548..0x894549
+            - Range: 0x894708..0x894709
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x894549..0x894570
+            - Range: 0x894709..0x894730
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 110
       Name: main.testReturnsNamedDeferLine
-      OutOfLinePCRanges: [0x894570..0x894730]
+      OutOfLinePCRanges: [0x894730..0x8948f0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 10 BaseType int
           Locations:
-            - Range: 0x894570..0x8945d4
+            - Range: 0x894730..0x894794
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8945d4..0x894730
+            - Range: 0x894794..0x8948f0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0x89459c..0x894730
+            - Range: 0x89475c..0x8948f0
               Pieces: [{Size: 16, Op: {CfaOffset: -120}}]
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0x8945a0..0x894730
+            - Range: 0x894760..0x8948f0
               Pieces: [{Size: 16, Op: {CfaOffset: -136}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 111
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0x894810..0x8948a0]
+      OutOfLinePCRanges: [0x8949d0..0x894a60]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 16 BaseType int8
           Locations:
-            - Range: 0x894810..0x894880
+            - Range: 0x8949d0..0x894a40
               Pieces: []
-            - Range: 0x894880..0x894881
+            - Range: 0x894a40..0x894a41
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x894881..0x8948a0
+            - Range: 0x894a41..0x894a60
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 90 BaseType int16
           Locations:
-            - Range: 0x894810..0x894880
+            - Range: 0x8949d0..0x894a40
               Pieces: []
-            - Range: 0x894880..0x894881
+            - Range: 0x894a40..0x894a41
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x894881..0x8948a0
+            - Range: 0x894a41..0x894a60
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 14 BaseType int32
           Locations:
-            - Range: 0x894810..0x894880
+            - Range: 0x8949d0..0x894a40
               Pieces: []
-            - Range: 0x894880..0x894881
+            - Range: 0x894a40..0x894a41
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x894881..0x8948a0
+            - Range: 0x894a41..0x894a60
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 15 BaseType int64
           Locations:
-            - Range: 0x894810..0x894880
+            - Range: 0x8949d0..0x894a40
               Pieces: []
-            - Range: 0x894880..0x894881
+            - Range: 0x894a40..0x894a41
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x894881..0x8948a0
+            - Range: 0x894a41..0x894a60
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x894810..0x894880
+            - Range: 0x8949d0..0x894a40
               Pieces: []
-            - Range: 0x894880..0x894881
+            - Range: 0x894a40..0x894a41
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x894881..0x8948a0
+            - Range: 0x894a41..0x894a60
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 8 BaseType uint16
           Locations:
-            - Range: 0x894810..0x894880
+            - Range: 0x8949d0..0x894a40
               Pieces: []
-            - Range: 0x894880..0x894881
+            - Range: 0x894a40..0x894a41
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x894881..0x8948a0
+            - Range: 0x894a41..0x894a60
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 3 BaseType uint32
           Locations:
-            - Range: 0x894810..0x894880
+            - Range: 0x8949d0..0x894a40
               Pieces: []
-            - Range: 0x894880..0x894881
+            - Range: 0x894a40..0x894a41
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x894881..0x8948a0
+            - Range: 0x894a41..0x894a60
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 11 BaseType uint64
           Locations:
-            - Range: 0x894810..0x894880
+            - Range: 0x8949d0..0x894a40
               Pieces: []
-            - Range: 0x894880..0x894881
+            - Range: 0x894a40..0x894a41
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x894881..0x8948a0
+            - Range: 0x894a41..0x894a60
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 112
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0x8948a0..0x894960]
+      OutOfLinePCRanges: [0x894a60..0x894b20]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float64
-          Locations: [{Range: 0x8948a0..0x894960, Pieces: []}]
+          Locations: [{Range: 0x894a60..0x894b20, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0x8948a0..0x894960, Pieces: []}]
+          Locations: [{Range: 0x894a60..0x894b20, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 18 BaseType float64
-          Locations: [{Range: 0x8948a0..0x894960, Pieces: []}]
+          Locations: [{Range: 0x894a60..0x894b20, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 18 BaseType float64
-          Locations: [{Range: 0x8948a0..0x894960, Pieces: []}]
+          Locations: [{Range: 0x894a60..0x894b20, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 18 BaseType float64
-          Locations: [{Range: 0x8948a0..0x894960, Pieces: []}]
+          Locations: [{Range: 0x894a60..0x894b20, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 18 BaseType float64
-          Locations: [{Range: 0x8948a0..0x894960, Pieces: []}]
+          Locations: [{Range: 0x894a60..0x894b20, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 18 BaseType float64
-          Locations: [{Range: 0x8948a0..0x894960, Pieces: []}]
+          Locations: [{Range: 0x894a60..0x894b20, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 18 BaseType float64
-          Locations: [{Range: 0x8948a0..0x894960, Pieces: []}]
+          Locations: [{Range: 0x894a60..0x894b20, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 18 BaseType float64
-          Locations: [{Range: 0x8948a0..0x894960, Pieces: []}]
+          Locations: [{Range: 0x894a60..0x894b20, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r9
           Type: 18 BaseType float64
-          Locations: [{Range: 0x8948a0..0x894960, Pieces: []}]
+          Locations: [{Range: 0x894a60..0x894b20, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r10
           Type: 18 BaseType float64
-          Locations: [{Range: 0x8948a0..0x894960, Pieces: []}]
+          Locations: [{Range: 0x894a60..0x894b20, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r11
           Type: 18 BaseType float64
-          Locations: [{Range: 0x8948a0..0x894960, Pieces: []}]
+          Locations: [{Range: 0x894a60..0x894b20, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r12
           Type: 18 BaseType float64
-          Locations: [{Range: 0x8948a0..0x894960, Pieces: []}]
+          Locations: [{Range: 0x894a60..0x894b20, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r13
           Type: 18 BaseType float64
-          Locations: [{Range: 0x8948a0..0x894960, Pieces: []}]
+          Locations: [{Range: 0x894a60..0x894b20, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r14
           Type: 18 BaseType float64
-          Locations: [{Range: 0x8948a0..0x894960, Pieces: []}]
+          Locations: [{Range: 0x894a60..0x894b20, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: onlyOnAmd64_16
           Type: 18 BaseType float64
-          Locations: [{Range: 0x8948a0..0x894960, Pieces: []}]
+          Locations: [{Range: 0x894a60..0x894b20, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: bothArmAndAmd64
           Type: 18 BaseType float64
           Locations:
-            - Range: 0x8948a0..0x89493c
+            - Range: 0x894a60..0x894afc
               Pieces: []
-            - Range: 0x89493c..0x89493d
+            - Range: 0x894afc..0x894afd
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x89493d..0x894960
+            - Range: 0x894afd..0x894b20
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 113
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0x894960..0x8949e0]
+      OutOfLinePCRanges: [0x894b20..0x894ba0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 91 BaseType complex64
-          Locations: [{Range: 0x894960..0x8949e0, Pieces: []}]
+          Locations: [{Range: 0x894b20..0x894ba0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 92 BaseType complex128
-          Locations: [{Range: 0x894960..0x8949e0, Pieces: []}]
+          Locations: [{Range: 0x894b20..0x894ba0, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 114
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0x8949e0..0x894ab0]
+      OutOfLinePCRanges: [0x894ba0..0x894c70]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x8949e0..0x894a94
+            - Range: 0x894ba0..0x894c54
               Pieces: []
-            - Range: 0x894a94..0x894a95
+            - Range: 0x894c54..0x894c55
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8503,193 +8503,193 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x894a95..0x894ab0
+            - Range: 0x894c55..0x894c70
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 115
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0x894ab0..0x894b40]
+      OutOfLinePCRanges: [0x894c70..0x894d00]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0x894ab0..0x894b20
+            - Range: 0x894c70..0x894ce0
               Pieces: []
-            - Range: 0x894b20..0x894b21
+            - Range: 0x894ce0..0x894ce1
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x894b21..0x894b40
+            - Range: 0x894ce1..0x894d00
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 116
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0x894b40..0x894bb0]
+      OutOfLinePCRanges: [0x894d00..0x894d70]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 252 ArrayType [1]int
           Locations:
-            - Range: 0x894b40..0x894b94
+            - Range: 0x894d00..0x894d54
               Pieces: []
-            - Range: 0x894b94..0x894b95
+            - Range: 0x894d54..0x894d55
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x894b95..0x894bb0
+            - Range: 0x894d55..0x894d70
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 117
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0x894bb0..0x894c20]
+      OutOfLinePCRanges: [0x894d70..0x894de0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 253 ArrayType [0]int
           Locations:
-            - Range: 0x894bb0..0x894c00
+            - Range: 0x894d70..0x894dc0
               Pieces: []
-            - Range: 0x894c00..0x894c01
+            - Range: 0x894dc0..0x894dc1
               Pieces: []
-            - Range: 0x894c01..0x894c20
+            - Range: 0x894dc1..0x894de0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 118
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0x894c20..0x894ca0]
+      OutOfLinePCRanges: [0x894de0..0x894e60]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 254 StructureType main.mixedStruct
-          Locations: [{Range: 0x894c20..0x894ca0, Pieces: []}]
+          Locations: [{Range: 0x894de0..0x894e60, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 119
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0x894ca0..0x894d40]
+      OutOfLinePCRanges: [0x894e60..0x894f00]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0x894ca0..0x894d1c
+            - Range: 0x894e60..0x894edc
               Pieces: []
-            - Range: 0x894d1c..0x894d1d
+            - Range: 0x894edc..0x894edd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x894d1d..0x894d40
+            - Range: 0x894edd..0x894f00
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 10 BaseType int
           Locations:
-            - Range: 0x894ca0..0x894d1c
+            - Range: 0x894e60..0x894edc
               Pieces: []
-            - Range: 0x894d1c..0x894d1d
+            - Range: 0x894edc..0x894edd
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x894d1d..0x894d40
+            - Range: 0x894edd..0x894f00
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 10 BaseType int
           Locations:
-            - Range: 0x894ca0..0x894d1c
+            - Range: 0x894e60..0x894edc
               Pieces: []
-            - Range: 0x894d1c..0x894d1d
+            - Range: 0x894edc..0x894edd
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x894d1d..0x894d40
+            - Range: 0x894edd..0x894f00
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 10 BaseType int
           Locations:
-            - Range: 0x894ca0..0x894d1c
+            - Range: 0x894e60..0x894edc
               Pieces: []
-            - Range: 0x894d1c..0x894d1d
+            - Range: 0x894edc..0x894edd
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x894d1d..0x894d40
+            - Range: 0x894edd..0x894f00
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 10 BaseType int
           Locations:
-            - Range: 0x894ca0..0x894d1c
+            - Range: 0x894e60..0x894edc
               Pieces: []
-            - Range: 0x894d1c..0x894d1d
+            - Range: 0x894edc..0x894edd
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x894d1d..0x894d40
+            - Range: 0x894edd..0x894f00
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 10 BaseType int
           Locations:
-            - Range: 0x894ca0..0x894d1c
+            - Range: 0x894e60..0x894edc
               Pieces: []
-            - Range: 0x894d1c..0x894d1d
+            - Range: 0x894edc..0x894edd
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x894d1d..0x894d40
+            - Range: 0x894edd..0x894f00
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 10 BaseType int
           Locations:
-            - Range: 0x894ca0..0x894d1c
+            - Range: 0x894e60..0x894edc
               Pieces: []
-            - Range: 0x894d1c..0x894d1d
+            - Range: 0x894edc..0x894edd
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x894d1d..0x894d40
+            - Range: 0x894edd..0x894f00
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 10 BaseType int
           Locations:
-            - Range: 0x894ca0..0x894d1c
+            - Range: 0x894e60..0x894edc
               Pieces: []
-            - Range: 0x894d1c..0x894d1d
+            - Range: 0x894edc..0x894edd
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x894d1d..0x894d40
+            - Range: 0x894edd..0x894f00
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0x894ca0..0x894d1c
+            - Range: 0x894e60..0x894edc
               Pieces: []
-            - Range: 0x894d1c..0x894d1d
+            - Range: 0x894edc..0x894edd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x894d1d..0x894d40
+            - Range: 0x894edd..0x894f00
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 120
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0x894d40..0x894e20]
+      OutOfLinePCRanges: [0x894f00..0x894fe0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 255 StructureType main.wideStruct
           Locations:
-            - Range: 0x894d40..0x894e04
+            - Range: 0x894f00..0x894fc4
               Pieces: []
-            - Range: 0x894e04..0x894e05
+            - Range: 0x894fc4..0x894fc5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8713,145 +8713,145 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0x894e05..0x894e20
+            - Range: 0x894fc5..0x894fe0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 121
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0x894e20..0x894eb0]
+      OutOfLinePCRanges: [0x894fe0..0x895070]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0x894e20..0x894e90
+            - Range: 0x894fe0..0x895050
               Pieces: []
-            - Range: 0x894e90..0x894e91
+            - Range: 0x895050..0x895051
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x894e91..0x894eb0
+            - Range: 0x895051..0x895070
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0x894e20..0x894eb0, Pieces: []}]
+          Locations: [{Range: 0x894fe0..0x895070, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 10 BaseType int
           Locations:
-            - Range: 0x894e20..0x894e90
+            - Range: 0x894fe0..0x895050
               Pieces: []
-            - Range: 0x894e90..0x894e91
+            - Range: 0x895050..0x895051
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x894e91..0x894eb0
+            - Range: 0x895051..0x895070
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 18 BaseType float64
-          Locations: [{Range: 0x894e20..0x894eb0, Pieces: []}]
+          Locations: [{Range: 0x894fe0..0x895070, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0x894e20..0x894e90
+            - Range: 0x894fe0..0x895050
               Pieces: []
-            - Range: 0x894e90..0x894e91
+            - Range: 0x895050..0x895051
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x894e91..0x894eb0
+            - Range: 0x895051..0x895070
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 122
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0x894eb0..0x894f40]
+      OutOfLinePCRanges: [0x895070..0x895100]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 256 StructureType main.structWithArray
           Locations:
-            - Range: 0x894eb0..0x894f20
+            - Range: 0x895070..0x8950e0
               Pieces: []
-            - Range: 0x894f20..0x894f21
+            - Range: 0x8950e0..0x8950e1
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x894f21..0x894f40
+            - Range: 0x8950e1..0x895100
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 123
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0x894f40..0x894fb0]
+      OutOfLinePCRanges: [0x895100..0x895170]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float64
-          Locations: [{Range: 0x894f40..0x894fb0, Pieces: []}]
+          Locations: [{Range: 0x895100..0x895170, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 124
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0x894fb0..0x895030]
+      OutOfLinePCRanges: [0x895170..0x8951f0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float32
-          Locations: [{Range: 0x894fb0..0x895030, Pieces: []}]
+          Locations: [{Range: 0x895170..0x8951f0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0x894fb0..0x895030, Pieces: []}]
+          Locations: [{Range: 0x895170..0x8951f0, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 125
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0x895030..0x8950a0]
+      OutOfLinePCRanges: [0x8951f0..0x895260]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x895030..0x895088
+            - Range: 0x8951f0..0x895248
               Pieces: []
-            - Range: 0x895088..0x895089
+            - Range: 0x895248..0x895249
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x895089..0x8950a0
+            - Range: 0x895249..0x895260
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 2 BaseType uintptr
           Locations:
-            - Range: 0x895030..0x895088
+            - Range: 0x8951f0..0x895248
               Pieces: []
-            - Range: 0x895088..0x895089
+            - Range: 0x895248..0x895249
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x895089..0x8950a0
+            - Range: 0x895249..0x895260
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 126
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0x8950a0..0x895280]
+      OutOfLinePCRanges: [0x895260..0x895440]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x8950a0..0x89510c
+            - Range: 0x895260..0x8952cc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8873,7 +8873,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x89510c..0x895120
+            - Range: 0x8952cc..0x8952e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8895,7 +8895,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x895120..0x895124
+            - Range: 0x8952e0..0x8952e4
               Pieces:
                 - Size: 8
                   Op: null
@@ -8922,9 +8922,9 @@ Subprograms:
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x8950a0..0x895218
+            - Range: 0x895260..0x8953d8
               Pieces: []
-            - Range: 0x895218..0x895219
+            - Range: 0x8953d8..0x8953d9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8946,44 +8946,44 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x895219..0x895280
+            - Range: 0x8953d9..0x895440
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 127
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0x895280..0x895350]
+      OutOfLinePCRanges: [0x895440..0x895510]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0x895280..0x895350
+            - Range: 0x895440..0x895510
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0x895280..0x895334
+            - Range: 0x895440..0x8954f4
               Pieces: []
-            - Range: 0x895334..0x895335
+            - Range: 0x8954f4..0x8954f5
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x895335..0x895350
+            - Range: 0x8954f5..0x895510
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 128
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0x895350..0x8955b0]
+      OutOfLinePCRanges: [0x895510..0x895770]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x895350..0x8953c0
+            - Range: 0x895510..0x895580
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9005,7 +9005,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8953c0..0x8953d4
+            - Range: 0x895580..0x895594
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9027,7 +9027,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8953d4..0x8953d8
+            - Range: 0x895594..0x895598
               Pieces:
                 - Size: 8
                   Op: null
@@ -9054,16 +9054,16 @@ Subprograms:
         - Name: s2
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x895350..0x8955b0
+            - Range: 0x895510..0x895770
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x895350..0x895540
+            - Range: 0x895510..0x895700
               Pieces: []
-            - Range: 0x895540..0x895541
+            - Range: 0x895700..0x895701
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9085,196 +9085,196 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x895541..0x8955b0
+            - Range: 0x895701..0x895770
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 129
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0x8955b0..0x8957a0]
+      OutOfLinePCRanges: [0x895770..0x895960]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 10 BaseType int
           Locations:
-            - Range: 0x8955b0..0x895628
+            - Range: 0x895770..0x8957e8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x895628..0x8957a0
+            - Range: 0x8957e8..0x895960
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 10 BaseType int
           Locations:
-            - Range: 0x8955b0..0x895628
+            - Range: 0x895770..0x8957e8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x895628..0x8957a0
+            - Range: 0x8957e8..0x895960
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 10 BaseType int
           Locations:
-            - Range: 0x8955b0..0x895628
+            - Range: 0x895770..0x8957e8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x895628..0x8957a0
+            - Range: 0x8957e8..0x895960
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 10 BaseType int
           Locations:
-            - Range: 0x8955b0..0x895628
+            - Range: 0x895770..0x8957e8
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x895628..0x8957a0
+            - Range: 0x8957e8..0x895960
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 10 BaseType int
           Locations:
-            - Range: 0x8955b0..0x895628
+            - Range: 0x895770..0x8957e8
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x895628..0x8957a0
+            - Range: 0x8957e8..0x895960
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 10 BaseType int
           Locations:
-            - Range: 0x8955b0..0x895628
+            - Range: 0x895770..0x8957e8
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x895628..0x8957a0
+            - Range: 0x8957e8..0x895960
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 10 BaseType int
           Locations:
-            - Range: 0x8955b0..0x895628
+            - Range: 0x895770..0x8957e8
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x895628..0x8957a0
+            - Range: 0x8957e8..0x895960
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 10 BaseType int
           Locations:
-            - Range: 0x8955b0..0x895628
+            - Range: 0x895770..0x8957e8
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x895628..0x8957a0
+            - Range: 0x8957e8..0x895960
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: i
           Type: 10 BaseType int
           Locations:
-            - Range: 0x8955b0..0x895628
+            - Range: 0x895770..0x8957e8
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0x895628..0x8957a0
+            - Range: 0x8957e8..0x895960
               Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 107 ArrayType [2]int
           Locations:
-            - Range: 0x8955b0..0x89573c
+            - Range: 0x895770..0x8958fc
               Pieces: []
-            - Range: 0x89573c..0x89573d
+            - Range: 0x8958fc..0x8958fd
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-            - Range: 0x89573d..0x8957a0
+            - Range: 0x8958fd..0x895960
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 130
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0x8957a0..0x8959e0]
+      OutOfLinePCRanges: [0x895960..0x895ba0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 10 BaseType int
           Locations:
-            - Range: 0x8957a0..0x895828
+            - Range: 0x895960..0x8959e8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x895828..0x8959e0
+            - Range: 0x8959e8..0x895ba0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 10 BaseType int
           Locations:
-            - Range: 0x8957a0..0x895828
+            - Range: 0x895960..0x8959e8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x895828..0x8959e0
+            - Range: 0x8959e8..0x895ba0
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 10 BaseType int
           Locations:
-            - Range: 0x8957a0..0x895828
+            - Range: 0x895960..0x8959e8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x895828..0x8959e0
+            - Range: 0x8959e8..0x895ba0
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 10 BaseType int
           Locations:
-            - Range: 0x8957a0..0x895828
+            - Range: 0x895960..0x8959e8
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x895828..0x8959e0
+            - Range: 0x8959e8..0x895ba0
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 10 BaseType int
           Locations:
-            - Range: 0x8957a0..0x895828
+            - Range: 0x895960..0x8959e8
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x895828..0x8959e0
+            - Range: 0x8959e8..0x895ba0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 10 BaseType int
           Locations:
-            - Range: 0x8957a0..0x895828
+            - Range: 0x895960..0x8959e8
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x895828..0x8959e0
+            - Range: 0x8959e8..0x895ba0
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 10 BaseType int
           Locations:
-            - Range: 0x8957a0..0x895828
+            - Range: 0x895960..0x8959e8
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x895828..0x8959e0
+            - Range: 0x8959e8..0x895ba0
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 10 BaseType int
           Locations:
-            - Range: 0x8957a0..0x895828
+            - Range: 0x895960..0x8959e8
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x895828..0x8959e0
+            - Range: 0x8959e8..0x895ba0
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0x8957a0..0x895828
+            - Range: 0x895960..0x8959e8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x895828..0x8959e0
+            - Range: 0x8959e8..0x895ba0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 72}
@@ -9285,9 +9285,9 @@ Subprograms:
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x8957a0..0x895970
+            - Range: 0x895960..0x895b30
               Pieces: []
-            - Range: 0x895970..0x895971
+            - Range: 0x895b30..0x895b31
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9309,196 +9309,196 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x895971..0x8959e0
+            - Range: 0x895b31..0x895ba0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 131
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0x8959e0..0x895a80]
+      OutOfLinePCRanges: [0x895ba0..0x895c40]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 161 ArrayType [5]int
           Locations:
-            - Range: 0x8959e0..0x895a80
+            - Range: 0x895ba0..0x895c40
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0x8959e0..0x895a5c
+            - Range: 0x895ba0..0x895c1c
               Pieces: []
-            - Range: 0x895a5c..0x895a5d
+            - Range: 0x895c1c..0x895c1d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x895a5d..0x895a80
+            - Range: 0x895c1d..0x895c40
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 10 BaseType int
           Locations:
-            - Range: 0x8959e0..0x895a5c
+            - Range: 0x895ba0..0x895c1c
               Pieces: []
-            - Range: 0x895a5c..0x895a5d
+            - Range: 0x895c1c..0x895c1d
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x895a5d..0x895a80
+            - Range: 0x895c1d..0x895c40
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 10 BaseType int
           Locations:
-            - Range: 0x8959e0..0x895a5c
+            - Range: 0x895ba0..0x895c1c
               Pieces: []
-            - Range: 0x895a5c..0x895a5d
+            - Range: 0x895c1c..0x895c1d
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x895a5d..0x895a80
+            - Range: 0x895c1d..0x895c40
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 132
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0x895a80..0x895b60]
+      OutOfLinePCRanges: [0x895c40..0x895d20]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 107 ArrayType [2]int
           Locations:
-            - Range: 0x895a80..0x895b60
+            - Range: 0x895c40..0x895d20
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0x895a80..0x895b60
+            - Range: 0x895c40..0x895d20
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0x895a80..0x895b40
+            - Range: 0x895c40..0x895d00
               Pieces: []
-            - Range: 0x895b40..0x895b41
+            - Range: 0x895d00..0x895d01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x895b41..0x895b60
+            - Range: 0x895d01..0x895d20
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 107 ArrayType [2]int
           Locations:
-            - Range: 0x895a80..0x895b40
+            - Range: 0x895c40..0x895d00
               Pieces: []
-            - Range: 0x895b40..0x895b41
+            - Range: 0x895d00..0x895d01
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
-            - Range: 0x895b41..0x895b60
+            - Range: 0x895d01..0x895d20
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 133
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0x895b60..0x895c30]
+      OutOfLinePCRanges: [0x895d20..0x895df0]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 256 StructureType main.structWithArray
           Locations:
-            - Range: 0x895b60..0x895c30
+            - Range: 0x895d20..0x895df0
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0x895b60..0x895c0c
+            - Range: 0x895d20..0x895dcc
               Pieces: []
-            - Range: 0x895c0c..0x895c0d
+            - Range: 0x895dcc..0x895dcd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x895c0d..0x895c30
+            - Range: 0x895dcd..0x895df0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 256 StructureType main.structWithArray
           Locations:
-            - Range: 0x895b60..0x895c0c
+            - Range: 0x895d20..0x895dcc
               Pieces: []
-            - Range: 0x895c0c..0x895c0d
+            - Range: 0x895dcc..0x895dcd
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x895c0d..0x895c30
+            - Range: 0x895dcd..0x895df0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 10 BaseType int
           Locations:
-            - Range: 0x895be0..0x895c30
+            - Range: 0x895da0..0x895df0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 134
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0x895c30..0x895ce0]
+      OutOfLinePCRanges: [0x895df0..0x895ea0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 253 ArrayType [0]int
-          Locations: [{Range: 0x895c30..0x895ce0, Pieces: []}]
+          Locations: [{Range: 0x895df0..0x895ea0, Pieces: []}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 10 BaseType int
           Locations:
-            - Range: 0x895c30..0x895c70
+            - Range: 0x895df0..0x895e30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x895c70..0x895c8c
+            - Range: 0x895e30..0x895e4c
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x895c8c..0x895ca8
+            - Range: 0x895e4c..0x895e68
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x895ca8..0x895ce0
+            - Range: 0x895e68..0x895ea0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0x895c30..0x895cb4
+            - Range: 0x895df0..0x895e74
               Pieces: []
-            - Range: 0x895cb4..0x895cb5
+            - Range: 0x895e74..0x895e75
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x895cb5..0x895ce0
+            - Range: 0x895e75..0x895ea0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 253 ArrayType [0]int
           Locations:
-            - Range: 0x895c30..0x895cb4
+            - Range: 0x895df0..0x895e74
               Pieces: []
-            - Range: 0x895cb4..0x895cb5
+            - Range: 0x895e74..0x895e75
               Pieces: []
-            - Range: 0x895cb5..0x895ce0
+            - Range: 0x895e75..0x895ea0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 135
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0x896160..0x896170]
+      OutOfLinePCRanges: [0x896320..0x896330]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x896160..0x896170
+            - Range: 0x896320..0x896330
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9511,13 +9511,13 @@ Subprograms:
       DictRegister: null
     - ID: 136
       Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x896170..0x896180]
+      OutOfLinePCRanges: [0x896330..0x896340]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x896170..0x896180
+            - Range: 0x896330..0x896340
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9530,13 +9530,13 @@ Subprograms:
       DictRegister: null
     - ID: 137
       Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x896180..0x896190]
+      OutOfLinePCRanges: [0x896340..0x896350]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 258 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0x896180..0x896190
+            - Range: 0x896340..0x896350
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9549,13 +9549,13 @@ Subprograms:
       DictRegister: null
     - ID: 138
       Name: main.testStructSlice
-      OutOfLinePCRanges: [0x896190..0x8961a0]
+      OutOfLinePCRanges: [0x896350..0x896360]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 260 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x896190..0x8961a0
+            - Range: 0x896350..0x896360
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9568,20 +9568,20 @@ Subprograms:
         - Name: a
           Type: 10 BaseType int
           Locations:
-            - Range: 0x896190..0x8961a0
+            - Range: 0x896350..0x896360
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 139
       Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x8961a0..0x8961b0]
+      OutOfLinePCRanges: [0x896360..0x896370]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 260 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x8961a0..0x8961b0
+            - Range: 0x896360..0x896370
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9594,20 +9594,20 @@ Subprograms:
         - Name: a
           Type: 10 BaseType int
           Locations:
-            - Range: 0x8961a0..0x8961b0
+            - Range: 0x896360..0x896370
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 140
       Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x8961b0..0x8961c0]
+      OutOfLinePCRanges: [0x896370..0x896380]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 260 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x8961b0..0x8961c0
+            - Range: 0x896370..0x896380
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9620,20 +9620,20 @@ Subprograms:
         - Name: a
           Type: 10 BaseType int
           Locations:
-            - Range: 0x8961b0..0x8961c0
+            - Range: 0x896370..0x896380
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 141
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0x8961c0..0x8961d0]
+      OutOfLinePCRanges: [0x896380..0x896390]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 154 GoSliceHeaderType []string
           Locations:
-            - Range: 0x8961c0..0x8961d0
+            - Range: 0x896380..0x896390
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9646,20 +9646,20 @@ Subprograms:
       DictRegister: null
     - ID: 142
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x8961d0..0x8961e0]
+      OutOfLinePCRanges: [0x896390..0x8963a0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 16 BaseType int8
           Locations:
-            - Range: 0x8961d0..0x8961e0
+            - Range: 0x896390..0x8963a0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 263 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x8961d0..0x8961e0
+            - Range: 0x896390..0x8963a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -9672,20 +9672,20 @@ Subprograms:
         - Name: x
           Type: 13 BaseType uint
           Locations:
-            - Range: 0x8961d0..0x8961e0
+            - Range: 0x896390..0x8963a0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 143
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x8961e0..0x8961f0]
+      OutOfLinePCRanges: [0x8963a0..0x8963b0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 264 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x8961e0..0x8961f0
+            - Range: 0x8963a0..0x8963b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9698,13 +9698,13 @@ Subprograms:
       DictRegister: null
     - ID: 144
       Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x8961f0..0x896200]
+      OutOfLinePCRanges: [0x8963b0..0x8963c0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8961f0..0x896200
+            - Range: 0x8963b0..0x8963c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9717,13 +9717,13 @@ Subprograms:
       DictRegister: null
     - ID: 145
       Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0x896200..0x896210]
+      OutOfLinePCRanges: [0x8963c0..0x8963d0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 265 GoSliceHeaderType []struct {}
           Locations:
-            - Range: 0x896200..0x896210
+            - Range: 0x8963c0..0x8963d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9736,13 +9736,13 @@ Subprograms:
       DictRegister: null
     - ID: 146
       Name: main.testSubslices
-      OutOfLinePCRanges: [0x896210..0x896220]
+      OutOfLinePCRanges: [0x8963d0..0x8963e0]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x896210..0x896220
+            - Range: 0x8963d0..0x8963e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9755,7 +9755,7 @@ Subprograms:
         - Name: bs
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x896210..0x896220
+            - Range: 0x8963d0..0x8963e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9768,7 +9768,7 @@ Subprograms:
         - Name: cs
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x896210..0x896220
+            - Range: 0x8963d0..0x8963e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -9781,34 +9781,34 @@ Subprograms:
       DictRegister: null
     - ID: 147
       Name: main.stackC
-      OutOfLinePCRanges: [0x896530..0x8965a0]
+      OutOfLinePCRanges: [0x8969d0..0x896a40]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0x896530..0x89657c
+            - Range: 0x8969d0..0x896a1c
               Pieces: []
-            - Range: 0x89657c..0x89657d
+            - Range: 0x896a1c..0x896a1d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89657d..0x8965a0
+            - Range: 0x896a1d..0x896a40
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 148
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x8965a0..0x8965b0]
+      OutOfLinePCRanges: [0x896a40..0x896a50]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0x8965a0..0x8965b0
+            - Range: 0x896a40..0x896a50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9819,13 +9819,13 @@ Subprograms:
       DictRegister: null
     - ID: 149
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x8965b0..0x8965c0]
+      OutOfLinePCRanges: [0x896a50..0x896a60]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0x8965b0..0x8965c0
+            - Range: 0x896a50..0x896a60
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9836,7 +9836,7 @@ Subprograms:
         - Name: "y"
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0x8965b0..0x8965c0
+            - Range: 0x896a50..0x896a60
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9847,7 +9847,7 @@ Subprograms:
         - Name: z
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0x8965b0..0x8965c0
+            - Range: 0x896a50..0x896a60
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9858,13 +9858,13 @@ Subprograms:
       DictRegister: null
     - ID: 150
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x8965c0..0x8965e0]
+      OutOfLinePCRanges: [0x896a60..0x896a80]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 267 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x8965c0..0x8965e0
+            - Range: 0x896a60..0x896a80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9883,39 +9883,39 @@ Subprograms:
       DictRegister: null
     - ID: 151
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x8965e0..0x8965f0]
+      OutOfLinePCRanges: [0x896a80..0x896a90]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 268 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x8965e0..0x8965f0
+            - Range: 0x896a80..0x896a90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 152
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x8965f0..0x896600]
+      OutOfLinePCRanges: [0x896a90..0x896aa0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 269 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x8965f0..0x896600
+            - Range: 0x896a90..0x896aa0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 153
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0x896600..0x896610]
+      OutOfLinePCRanges: [0x896aa0..0x896ab0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0x896600..0x896610
+            - Range: 0x896aa0..0x896ab0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9926,13 +9926,13 @@ Subprograms:
       DictRegister: null
     - ID: 154
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x896610..0x896620]
+      OutOfLinePCRanges: [0x896ab0..0x896ac0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0x896610..0x896620
+            - Range: 0x896ab0..0x896ac0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9943,13 +9943,13 @@ Subprograms:
       DictRegister: null
     - ID: 155
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0x896620..0x896630]
+      OutOfLinePCRanges: [0x896ac0..0x896ad0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0x896620..0x896630
+            - Range: 0x896ac0..0x896ad0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9960,13 +9960,13 @@ Subprograms:
       DictRegister: null
     - ID: 156
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0x896630..0x896640]
+      OutOfLinePCRanges: [0x896ad0..0x896ae0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0x896630..0x896640
+            - Range: 0x896ad0..0x896ae0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9977,7 +9977,7 @@ Subprograms:
         - Name: b
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0x896630..0x896640
+            - Range: 0x896ad0..0x896ae0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9988,7 +9988,7 @@ Subprograms:
         - Name: c
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0x896630..0x896640
+            - Range: 0x896ad0..0x896ae0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9999,26 +9999,26 @@ Subprograms:
       DictRegister: null
     - ID: 157
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x8967a0..0x8967b0]
+      OutOfLinePCRanges: [0x896c40..0x896c50]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 271 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x8967a0..0x8967b0
+            - Range: 0x896c40..0x896c50
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 158
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x8967b0..0x8967d0]
+      OutOfLinePCRanges: [0x896c50..0x896c70]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 284 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x8967b0..0x8967d0
+            - Range: 0x896c50..0x896c70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10037,13 +10037,13 @@ Subprograms:
       DictRegister: null
     - ID: 159
       Name: main.testStruct
-      OutOfLinePCRanges: [0x8968a0..0x8968c0]
+      OutOfLinePCRanges: [0x896d40..0x896d60]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 315 StructureType main.aStruct
           Locations:
-            - Range: 0x8968a0..0x8968c0
+            - Range: 0x896d40..0x896d60
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -10064,93 +10064,93 @@ Subprograms:
       DictRegister: null
     - ID: 160
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0x896940..0x896950]
+      OutOfLinePCRanges: [0x896de0..0x896df0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 316 PointerType *main.anotherStruct
           Locations:
-            - Range: 0x896940..0x896950
+            - Range: 0x896de0..0x896df0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 161
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0x896950..0x896960]
+      OutOfLinePCRanges: [0x896df0..0x896e00]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 318 StructureType main.tenStrings
           Locations:
-            - Range: 0x896950..0x896960
+            - Range: 0x896df0..0x896e00
               Pieces: [{Size: 160, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 162
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x8969a0..0x8969b0]
+      OutOfLinePCRanges: [0x896e40..0x896e50]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 319 StructureType main.emptyStruct
-          Locations: [{Range: 0x8969a0..0x8969b0, Pieces: []}]
+          Locations: [{Range: 0x896e40..0x896e50, Pieces: []}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 163
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x8969b0..0x8969c0]
+      OutOfLinePCRanges: [0x896e50..0x896e60]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 320 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x8969b0..0x8969c0
+            - Range: 0x896e50..0x896e60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 164
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0x898430..0x898440]
+      OutOfLinePCRanges: [0x8988d0..0x8988e0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0x898430..0x898440
+            - Range: 0x8988d0..0x8988e0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 322 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x898430..0x898434
+            - Range: 0x8988d0..0x8988d4
               Pieces: []
-            - Range: 0x898434..0x898435
+            - Range: 0x8988d4..0x8988d5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x898435..0x898440
+            - Range: 0x8988d5..0x8988e0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 165
       Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0x898440..0x898450]
+      OutOfLinePCRanges: [0x8988e0..0x8988f0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x898440..0x89844c
+            - Range: 0x8988e0..0x8988ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x89844c..0x898450
+            - Range: 0x8988ec..0x8988f0
               Pieces:
                 - Size: 8
                   Op: null
@@ -10161,58 +10161,58 @@ Subprograms:
         - Name: ~r0
           Type: 324 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x898440..0x89844c
+            - Range: 0x8988e0..0x8988ec
               Pieces: []
-            - Range: 0x89844c..0x89844d
+            - Range: 0x8988ec..0x8988ed
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89844d..0x898450
+            - Range: 0x8988ed..0x8988f0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 166
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0x898450..0x898460]
+      OutOfLinePCRanges: [0x8988f0..0x898900]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 322 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x898450..0x898460
+            - Range: 0x8988f0..0x898900
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0x898450..0x898454
+            - Range: 0x8988f0..0x8988f4
               Pieces: []
-            - Range: 0x898454..0x898455
+            - Range: 0x8988f4..0x8988f5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x898455..0x898460
+            - Range: 0x8988f5..0x898900
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 167
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0x898460..0x898470]
+      OutOfLinePCRanges: [0x898900..0x898910]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 324 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x898460..0x89846c
+            - Range: 0x898900..0x89890c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x89846c..0x898470
+            - Range: 0x89890c..0x898910
               Pieces:
                 - Size: 8
                   Op: null
@@ -10223,28 +10223,28 @@ Subprograms:
         - Name: ~r0
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x898460..0x89846c
+            - Range: 0x898900..0x89890c
               Pieces: []
-            - Range: 0x89846c..0x89846d
+            - Range: 0x89890c..0x89890d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89846d..0x898470
+            - Range: 0x89890d..0x898910
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 168
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0x8984e0..0x898610]
+      OutOfLinePCRanges: [0x898980..0x898ab0]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 325 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x8984e0..0x89850c
+            - Range: 0x898980..0x8989ac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10252,7 +10252,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x89850c..0x89851c
+            - Range: 0x8989ac..0x8989bc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10260,7 +10260,7 @@ Subprograms:
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: null
-            - Range: 0x89851c..0x898610
+            - Range: 0x8989bc..0x898ab0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10273,18 +10273,18 @@ Subprograms:
         - Name: pred
           Type: 327 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0x8984e0..0x89851c
+            - Range: 0x898980..0x8989bc
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x89851c..0x898610
+            - Range: 0x8989bc..0x898ab0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 325 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x8984e0..0x8985cc
+            - Range: 0x898980..0x898a6c
               Pieces: []
-            - Range: 0x8985cc..0x8985cd
+            - Range: 0x898a6c..0x898a6d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10292,14 +10292,14 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x8985cd..0x898610
+            - Range: 0x898a6d..0x898ab0
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
           Type: 325 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x89851c..0x898538
+            - Range: 0x8989bc..0x8989d8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10307,7 +10307,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x898538..0x89853c
+            - Range: 0x8989d8..0x8989dc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10315,7 +10315,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x89853c..0x898540
+            - Range: 0x8989dc..0x8989e0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10323,7 +10323,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x898540..0x898540
+            - Range: 0x8989e0..0x8989e0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10331,7 +10331,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x898540..0x89856c
+            - Range: 0x8989e0..0x898a0c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10339,7 +10339,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x89856c..0x8985c0
+            - Range: 0x898a0c..0x898a60
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10347,7 +10347,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x8985c0..0x898610
+            - Range: 0x898a60..0x898ab0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10360,215 +10360,215 @@ Subprograms:
         - Name: item
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0x89855c..0x89856c
+            - Range: 0x8989fc..0x898a0c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x89856c..0x8985c0
+            - Range: 0x898a0c..0x898a60
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
     - ID: 169
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x898610..0x898670]
+      OutOfLinePCRanges: [0x898ab0..0x898b10]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 322 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x898610..0x898638
+            - Range: 0x898ab0..0x898ad8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
           Type: 328 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0x898610..0x898638
+            - Range: 0x898ab0..0x898ad8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 324 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x898610..0x898638
+            - Range: 0x898ab0..0x898ad8
               Pieces: []
-            - Range: 0x898638..0x898639
+            - Range: 0x898ad8..0x898ad9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x898639..0x898670
+            - Range: 0x898ad9..0x898b10
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
     - ID: 170
       Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0x898920..0x898930]
+      OutOfLinePCRanges: [0x898dc0..0x898dd0]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 326 PointerType *go.shape.int
           Locations:
-            - Range: 0x898920..0x898930
+            - Range: 0x898dc0..0x898dd0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 326 PointerType *go.shape.int
           Locations:
-            - Range: 0x898920..0x898924
+            - Range: 0x898dc0..0x898dc4
               Pieces: []
-            - Range: 0x898924..0x898925
+            - Range: 0x898dc4..0x898dc5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x898925..0x898930
+            - Range: 0x898dc5..0x898dd0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 171
       Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0x898930..0x898940]
+      OutOfLinePCRanges: [0x898dd0..0x898de0]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 329 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0x898930..0x898940
+            - Range: 0x898dd0..0x898de0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 329 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0x898930..0x898934
+            - Range: 0x898dd0..0x898dd4
               Pieces: []
-            - Range: 0x898934..0x898935
+            - Range: 0x898dd4..0x898dd5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x898935..0x898940
+            - Range: 0x898dd5..0x898de0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 172
       Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0x898940..0x898950]
+      OutOfLinePCRanges: [0x898de0..0x898df0]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 331 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0x898940..0x898950
+            - Range: 0x898de0..0x898df0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 331 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0x898940..0x898944
+            - Range: 0x898de0..0x898de4
               Pieces: []
-            - Range: 0x898944..0x898945
+            - Range: 0x898de4..0x898de5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x898945..0x898950
+            - Range: 0x898de5..0x898df0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 173
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0x898950..0x898960]
+      OutOfLinePCRanges: [0x898df0..0x898e00]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 333 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0x898950..0x898960
+            - Range: 0x898df0..0x898e00
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x898950..0x898958
+            - Range: 0x898df0..0x898df8
               Pieces: []
-            - Range: 0x898958..0x898959
+            - Range: 0x898df8..0x898df9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x898959..0x898960
+            - Range: 0x898df9..0x898e00
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 174
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0x8989e0..0x8989f0]
+      OutOfLinePCRanges: [0x898e80..0x898e90]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 335 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0x8989e0..0x8989f0
+            - Range: 0x898e80..0x898e90
               Pieces: [{Size: 136, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0x8989e0..0x8989e4
+            - Range: 0x898e80..0x898e84
               Pieces: []
-            - Range: 0x8989e4..0x8989e5
+            - Range: 0x898e84..0x898e85
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8989e5..0x8989f0
+            - Range: 0x898e85..0x898e90
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 175
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0x898a80..0x898a90]
+      OutOfLinePCRanges: [0x898f20..0x898f30]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 336 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0x898a80..0x898a90
+            - Range: 0x898f20..0x898f30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0x898a80..0x898a90
+            - Range: 0x898f20..0x898f30
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
           Type: 338 BaseType go.shape.bool
           Locations:
-            - Range: 0x898a80..0x898a90
+            - Range: 0x898f20..0x898f30
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
     - ID: 176
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0x898b10..0x898ba0]
+      OutOfLinePCRanges: [0x898fb0..0x899040]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 339 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0x898b10..0x898ba0
+            - Range: 0x898fb0..0x899040
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x898b10..0x898ba0
+            - Range: 0x898fb0..0x899040
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10579,20 +10579,20 @@ Subprograms:
         - Name: v
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0x898b10..0x898ba0
+            - Range: 0x898fb0..0x899040
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
     - ID: 177
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0x898c30..0x898c40]
+      OutOfLinePCRanges: [0x8990d0..0x8990e0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x898c30..0x898c40
+            - Range: 0x8990d0..0x8990e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10603,59 +10603,59 @@ Subprograms:
         - Name: b
           Type: 338 BaseType go.shape.bool
           Locations:
-            - Range: 0x898c30..0x898c40
+            - Range: 0x8990d0..0x8990e0
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 338 BaseType go.shape.bool
           Locations:
-            - Range: 0x898c30..0x898c38
+            - Range: 0x8990d0..0x8990d8
               Pieces: []
-            - Range: 0x898c38..0x898c39
+            - Range: 0x8990d8..0x8990d9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x898c39..0x898c40
+            - Range: 0x8990d9..0x8990e0
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x898c30..0x898c38
+            - Range: 0x8990d0..0x8990d8
               Pieces: []
-            - Range: 0x898c38..0x898c39
+            - Range: 0x8990d8..0x8990d9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x898c39..0x898c40
+            - Range: 0x8990d9..0x8990e0
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 178
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x898c40..0x898c60]
+      OutOfLinePCRanges: [0x8990e0..0x899100]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0x898c40..0x898c50
+            - Range: 0x8990e0..0x8990f0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x898c40..0x898c4c
+            - Range: 0x8990e0..0x8990ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x898c4c..0x898c60
+            - Range: 0x8990ec..0x899100
               Pieces:
                 - Size: 8
                   Op: null
@@ -10666,73 +10666,73 @@ Subprograms:
         - Name: ~r0
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x898c40..0x898c50
+            - Range: 0x8990e0..0x8990f0
               Pieces: []
-            - Range: 0x898c50..0x898c51
+            - Range: 0x8990f0..0x8990f1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x898c51..0x898c60
+            - Range: 0x8990f1..0x899100
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0x898c40..0x898c50
+            - Range: 0x8990e0..0x8990f0
               Pieces: []
-            - Range: 0x898c50..0x898c51
+            - Range: 0x8990f0..0x8990f1
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x898c51..0x898c60
+            - Range: 0x8990f1..0x899100
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 179
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0x898c60..0x898cb0]
+      OutOfLinePCRanges: [0x899100..0x899150]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 341 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0x898c60..0x898c88
+            - Range: 0x899100..0x899128
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0x898c60..0x898c88
+            - Range: 0x899100..0x899128
               Pieces: []
-            - Range: 0x898c88..0x898c89
+            - Range: 0x899128..0x899129
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x898c89..0x898cb0
+            - Range: 0x899129..0x899150
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 180
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0x898cb0..0x898d10]
+      OutOfLinePCRanges: [0x899150..0x8991b0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 342 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0x898cb0..0x898cdc
+            - Range: 0x899150..0x89917c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x898cdc..0x898ce0
+            - Range: 0x89917c..0x899180
               Pieces:
                 - Size: 8
                   Op: null
@@ -10743,65 +10743,65 @@ Subprograms:
         - Name: ~r0
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0x898cb0..0x898ce0
+            - Range: 0x899150..0x899180
               Pieces: []
-            - Range: 0x898ce0..0x898ce1
+            - Range: 0x899180..0x899181
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x898ce1..0x898d10
+            - Range: 0x899181..0x8991b0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 181
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0x898d10..0x898d20]
+      OutOfLinePCRanges: [0x8991b0..0x8991c0]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 343 PointerType *go.shape.string
           Locations:
-            - Range: 0x898d10..0x898d18
+            - Range: 0x8991b0..0x8991b8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x898d10..0x898d18
+            - Range: 0x8991b0..0x8991b8
               Pieces: []
-            - Range: 0x898d18..0x898d19
+            - Range: 0x8991b8..0x8991b9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x898d19..0x898d20
+            - Range: 0x8991b9..0x8991c0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 182
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0x898d20..0x898d80]
+      OutOfLinePCRanges: [0x8991c0..0x899220]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 344 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x898d20..0x898d5c
+            - Range: 0x8991c0..0x8991fc
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 345 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x898d20..0x898d6c
+            - Range: 0x8991c0..0x89920c
               Pieces: []
-            - Range: 0x898d6c..0x898d6d
+            - Range: 0x89920c..0x89920d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10815,20 +10815,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x898d6d..0x898d80
+            - Range: 0x89920d..0x899220
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 183
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0x898d80..0x898dc0]
+      OutOfLinePCRanges: [0x899220..0x899260]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 325 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x898d80..0x898d8c
+            - Range: 0x899220..0x89922c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10836,7 +10836,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x898d8c..0x898dc0
+            - Range: 0x89922c..0x899260
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10849,42 +10849,42 @@ Subprograms:
         - Name: needle
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0x898d80..0x898dc0
+            - Range: 0x899220..0x899260
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x898d80..0x898da8
+            - Range: 0x899220..0x899248
               Pieces: []
-            - Range: 0x898da8..0x898da9
+            - Range: 0x899248..0x899249
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x898da9..0x898db0
+            - Range: 0x899249..0x899250
               Pieces: []
-            - Range: 0x898db0..0x898db1
+            - Range: 0x899250..0x899251
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x898db1..0x898dc0
+            - Range: 0x899251..0x899260
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0x898d9c..0x898dac
+            - Range: 0x89923c..0x89924c
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Local
           DictIndex: 1
       DictRegister: 0
     - ID: 184
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0x898dc0..0x898e90]
+      OutOfLinePCRanges: [0x899260..0x899330]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 346 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0x898dc0..0x898de4
+            - Range: 0x899260..0x899284
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10892,7 +10892,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x898de4..0x898de8
+            - Range: 0x899284..0x899288
               Pieces:
                 - Size: 8
                   Op: null
@@ -10905,13 +10905,13 @@ Subprograms:
         - Name: needle
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x898dc0..0x898e1c
+            - Range: 0x899260..0x8992bc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x898e1c..0x898e90
+            - Range: 0x8992bc..0x899330
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 40}
@@ -10922,28 +10922,28 @@ Subprograms:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x898dc0..0x898e38
+            - Range: 0x899260..0x8992d8
               Pieces: []
-            - Range: 0x898e38..0x898e39
+            - Range: 0x8992d8..0x8992d9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x898e39..0x898e48
+            - Range: 0x8992d9..0x8992e8
               Pieces: []
-            - Range: 0x898e48..0x898e49
+            - Range: 0x8992e8..0x8992e9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x898e49..0x898e90
+            - Range: 0x8992e9..0x899330
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x898dfc..0x898e10
+            - Range: 0x89929c..0x8992b0
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x898e10..0x898e1c
+            - Range: 0x8992b0..0x8992bc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10954,56 +10954,56 @@ Subprograms:
       DictRegister: 0
     - ID: 185
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0x898e90..0x898ea0]
+      OutOfLinePCRanges: [0x899330..0x899340]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 347 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0x898e90..0x898e98
+            - Range: 0x899330..0x899338
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0x898e90..0x898ea0
+            - Range: 0x899330..0x899340
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x898e90..0x898e98
+            - Range: 0x899330..0x899338
               Pieces: []
-            - Range: 0x898e98..0x898e99
+            - Range: 0x899338..0x899339
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x898e99..0x898ea0
+            - Range: 0x899339..0x899340
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 1
     - ID: 186
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0x898f20..0x898fa0]
+      OutOfLinePCRanges: [0x8993c0..0x899440]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 348 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0x898f20..0x898f4c
+            - Range: 0x8993c0..0x8993ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x898f4c..0x898f58
+            - Range: 0x8993ec..0x8993f8
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x898f58..0x898f5c
+            - Range: 0x8993f8..0x8993fc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11014,7 +11014,7 @@ Subprograms:
         - Name: value
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x898f20..0x898f5c
+            - Range: 0x8993c0..0x8993fc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -11025,11 +11025,11 @@ Subprograms:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x898f20..0x898f5c
+            - Range: 0x8993c0..0x8993fc
               Pieces: []
-            - Range: 0x898f5c..0x898f5d
+            - Range: 0x8993fc..0x8993fd
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x898f5d..0x898fa0
+            - Range: 0x8993fd..0x899440
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11167,31 +11167,31 @@ Subprograms:
       DictRegister: 0
     - ID: 188
       Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0x890e80..0x890ef0]
+      OutOfLinePCRanges: [0x890f80..0x890ff0]
       InlinePCRanges:
-        - Ranges: [0x890f0c..0x890f44]
-          RootRanges: [0x890ef0..0x890f70]
-        - Ranges: [0x891058..0x891090]
-          RootRanges: [0x891020..0x8910b0]
-        - Ranges: [0x8910d4..0x89110c]
-          RootRanges: [0x8910b0..0x891180]
-        - Ranges: [0x89119c..0x8911d4]
-          RootRanges: [0x891180..0x891200]
+        - Ranges: [0x89100c..0x891044]
+          RootRanges: [0x890ff0..0x891070]
+        - Ranges: [0x891158..0x891190]
+          RootRanges: [0x891120..0x8911b0]
+        - Ranges: [0x8911d4..0x89120c]
+          RootRanges: [0x8911b0..0x891280]
+        - Ranges: [0x89129c..0x8912d4]
+          RootRanges: [0x891280..0x891300]
       Variables:
         - Name: x
           Type: 10 BaseType int
           Locations:
-            - Range: 0x890e80..0x890ea0
+            - Range: 0x890f80..0x890fa0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x890f0c..0x890f14
+            - Range: 0x89100c..0x891014
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x891058..0x891060
+            - Range: 0x891158..0x891160
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8910cc..0x8910dc
+            - Range: 0x8911cc..0x8911dc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8910dc..0x891180
+            - Range: 0x8911dc..0x891280
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x891180..0x8911a4
+            - Range: 0x891280..0x8912a4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -11200,37 +11200,37 @@ Subprograms:
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x891118..0x891150]
-          RootRanges: [0x8910b0..0x891180]
+        - Ranges: [0x891218..0x891250]
+          RootRanges: [0x8911b0..0x891280]
       Variables: []
       DictRegister: null
     - ID: 190
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x89121c..0x891260]
-          RootRanges: [0x891200..0x891320]
+        - Ranges: [0x89131c..0x891360]
+          RootRanges: [0x891300..0x891420]
       Variables: []
       DictRegister: null
     - ID: 191
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x8912d0..0x891308]
-          RootRanges: [0x891200..0x891320]
+        - Ranges: [0x8913d0..0x891408]
+          RootRanges: [0x891300..0x891420]
       Variables: []
       DictRegister: null
     - ID: 192
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x891324..0x891328]
-          RootRanges: [0x891320..0x891330]
+        - Ranges: [0x891424..0x891428]
+          RootRanges: [0x891420..0x891430]
       Variables:
         - Name: x
           Type: 10 BaseType int
           Locations:
-            - Range: 0x891320..0x891328
+            - Range: 0x891420..0x891428
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -11239,38 +11239,38 @@ Subprograms:
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x891354..0x891378]
-          RootRanges: [0x891330..0x891390]
-        - Ranges: [0x8913ec..0x891414]
-          RootRanges: [0x891390..0x8914e0]
+        - Ranges: [0x891454..0x891478]
+          RootRanges: [0x891430..0x891490]
+        - Ranges: [0x8914ec..0x891514]
+          RootRanges: [0x891490..0x8915e0]
       Variables:
         - Name: a
           Type: 161 ArrayType [5]int
           Locations:
-            - Range: 0x891340..0x891390
+            - Range: 0x891440..0x891490
               Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
-            - Range: 0x8913d8..0x8914e0
+            - Range: 0x8914d8..0x8915e0
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 194
       Name: main.firstBehavior.DoSomething
-      OutOfLinePCRanges: [0x8914e0..0x891560]
+      OutOfLinePCRanges: [0x8915e0..0x891660]
       InlinePCRanges:
-        - Ranges: [0x89905c..0x899090]
-          RootRanges: [0x899030..0x8990e0]
+        - Ranges: [0x8994fc..0x899530]
+          RootRanges: [0x8994d0..0x899580]
       Variables:
         - Name: b
           Type: 353 StructureType main.firstBehavior
           Locations:
-            - Range: 0x8914e0..0x89150c
+            - Range: 0x8915e0..0x89160c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89150c..0x891510
+            - Range: 0x89160c..0x891610
               Pieces:
                 - Size: 8
                   Op: null
@@ -11281,15 +11281,15 @@ Subprograms:
         - Name: ~r0
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0x8914e0..0x891530
+            - Range: 0x8915e0..0x891630
               Pieces: []
-            - Range: 0x891530..0x891531
+            - Range: 0x891630..0x891631
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x891531..0x891560
+            - Range: 0x891631..0x891660
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11298,8 +11298,8 @@ Subprograms:
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x891bbc..0x891bc8, 0x891bcc..0x891bd4]
-          RootRanges: [0x891aa0..0x891c20]
+        - Ranges: [0x891df4..0x891e00, 0x891e04..0x891e0c]
+          RootRanges: [0x891d60..0x891e50]
         - Ranges: [0x12a824..0x12a828, 0x12a82c..0x12a834]
           RootRanges: [0x12a810..0x12a840]
       Variables: []
@@ -11472,7 +11472,7 @@ Types:
       ID: 40
       Name: '*[]runtime.ancestorInfo'
       ByteSize: 8
-      GoRuntimeType: 458432
+      GoRuntimeType: 458624
       GoKind: 22
       Pointee: 41 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
@@ -11575,7 +11575,7 @@ Types:
       ID: 6
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 365568
+      GoRuntimeType: 365696
       GoKind: 22
       Pointee: 5 BaseType bool
     - __kind: PointerType
@@ -12105,7 +12105,7 @@ Types:
       ID: 100
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 364480
+      GoRuntimeType: 364608
       GoKind: 22
       Pointee: 19 GoInterfaceType error
     - __kind: PointerType
@@ -12126,14 +12126,14 @@ Types:
       ID: 102
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 365440
+      GoRuntimeType: 365568
       GoKind: 22
       Pointee: 17 BaseType float32
     - __kind: PointerType
       ID: 93
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 365504
+      GoRuntimeType: 365632
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
@@ -13127,42 +13127,42 @@ Types:
       ID: 95
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 365120
+      GoRuntimeType: 365248
       GoKind: 22
       Pointee: 10 BaseType int
     - __kind: PointerType
       ID: 98
       Name: '*int16'
       ByteSize: 8
-      GoRuntimeType: 364736
+      GoRuntimeType: 364864
       GoKind: 22
       Pointee: 90 BaseType int16
     - __kind: PointerType
       ID: 21
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 364864
+      GoRuntimeType: 364992
       GoKind: 22
       Pointee: 14 BaseType int32
     - __kind: PointerType
       ID: 94
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 364992
+      GoRuntimeType: 365120
       GoKind: 22
       Pointee: 15 BaseType int64
     - __kind: PointerType
       ID: 99
       Name: '*int8'
       ByteSize: 8
-      GoRuntimeType: 364608
+      GoRuntimeType: 364736
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
       ID: 163
       Name: '*interface {}'
       ByteSize: 8
-      GoRuntimeType: 365696
+      GoRuntimeType: 365824
       GoKind: 22
       Pointee: 157 GoEmptyInterfaceType interface {}
     - __kind: PointerType
@@ -13176,7 +13176,7 @@ Types:
       ID: 904
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
-      GoRuntimeType: 832640
+      GoRuntimeType: 833024
       GoKind: 22
       Pointee: 905 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
@@ -13201,12 +13201,12 @@ Types:
       GoKind: 22
       Pointee: 797 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 526
+      ID: 529
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
-      GoRuntimeType: 831488
+      GoRuntimeType: 831872
       GoKind: 22
-      Pointee: 527 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 530 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
       ID: 950
       Name: '*io.PipeWriter'
@@ -14015,12 +14015,12 @@ Types:
       GoKind: 22
       Pointee: 503 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 528
+      ID: 531
       Name: '*reflect.ValueError'
       ByteSize: 8
-      GoRuntimeType: 832256
+      GoRuntimeType: 832640
       GoKind: 22
-      Pointee: 529 UnresolvedPointeeType reflect.ValueError
+      Pointee: 532 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
       ID: 621
       Name: '*regexp/syntax.Error'
@@ -14032,21 +14032,21 @@ Types:
       ID: 731
       Name: '*runtime.PanicNilError'
       ByteSize: 8
-      GoRuntimeType: 989888
+      GoRuntimeType: 990144
       GoKind: 22
       Pointee: 732 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
       ID: 736
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
-      GoRuntimeType: 991808
+      GoRuntimeType: 992064
       GoKind: 22
       Pointee: 737 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 27
       Name: '*runtime._defer'
       ByteSize: 8
-      GoRuntimeType: 365760
+      GoRuntimeType: 365888
       GoKind: 22
       Pointee: 28 UnresolvedPointeeType runtime._defer
     - __kind: PointerType
@@ -14060,21 +14060,21 @@ Types:
       ID: 733
       Name: '*runtime.boundsError'
       ByteSize: 8
-      GoRuntimeType: 990016
+      GoRuntimeType: 990272
       GoKind: 22
       Pointee: 734 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 61
       Name: '*runtime.cgoCallers'
       ByteSize: 8
-      GoRuntimeType: 366400
+      GoRuntimeType: 366528
       GoKind: 22
       Pointee: 62 UnresolvedPointeeType runtime.cgoCallers
     - __kind: PointerType
       ID: 48
       Name: '*runtime.coro'
       ByteSize: 8
-      GoRuntimeType: 366464
+      GoRuntimeType: 366592
       GoKind: 22
       Pointee: 49 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
@@ -14088,7 +14088,7 @@ Types:
       ID: 730
       Name: '*runtime.errorString'
       ByteSize: 8
-      GoRuntimeType: 989632
+      GoRuntimeType: 989888
       GoKind: 22
       Pointee: 711 GoStringHeaderType runtime.errorString
     - __kind: PointerType
@@ -14100,28 +14100,28 @@ Types:
       ID: 54
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 830720
+      GoRuntimeType: 831104
       GoKind: 22
       Pointee: 23 StructureType runtime.g
     - __kind: PointerType
       ID: 29
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 991168
+      GoRuntimeType: 991424
       GoKind: 22
       Pointee: 30 StructureType runtime.m
     - __kind: PointerType
       ID: 143
       Name: '*runtime.mapextra'
       ByteSize: 8
-      GoRuntimeType: 368448
+      GoRuntimeType: 368576
       GoKind: 22
       Pointee: 144 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 735
       Name: '*runtime.plainError'
       ByteSize: 8
-      GoRuntimeType: 991552
+      GoRuntimeType: 991808
       GoKind: 22
       Pointee: 714 GoStringHeaderType runtime.plainError
     - __kind: PointerType
@@ -14133,7 +14133,7 @@ Types:
       ID: 42
       Name: '*runtime.sudog'
       ByteSize: 8
-      GoRuntimeType: 367168
+      GoRuntimeType: 367296
       GoKind: 22
       Pointee: 43 UnresolvedPointeeType runtime.sudog
     - __kind: PointerType
@@ -14147,7 +14147,7 @@ Types:
       ID: 73
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1435936
+      GoRuntimeType: 1436320
       GoKind: 22
       Pointee: 74 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
@@ -14161,7 +14161,7 @@ Types:
       ID: 89
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 364544
+      GoRuntimeType: 364672
       GoKind: 22
       Pointee: 12 GoStringHeaderType string
     - __kind: PointerType
@@ -14220,21 +14220,21 @@ Types:
       ID: 860
       Name: '*time.Location'
       ByteSize: 8
-      GoRuntimeType: 1441504
+      GoRuntimeType: 1432480
       GoKind: 22
       Pointee: 861 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 531
+      ID: 527
       Name: '*time.ParseError'
       ByteSize: 8
-      GoRuntimeType: 833408
+      GoRuntimeType: 829280
       GoKind: 22
-      Pointee: 532 UnresolvedPointeeType time.ParseError
+      Pointee: 528 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 530
+      ID: 526
       Name: '*time.fileSizeError'
       ByteSize: 8
-      GoRuntimeType: 833312
+      GoRuntimeType: 829184
       GoKind: 22
       Pointee: 453 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
@@ -14246,42 +14246,42 @@ Types:
       ID: 101
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 365184
+      GoRuntimeType: 365312
       GoKind: 22
       Pointee: 13 BaseType uint
     - __kind: PointerType
       ID: 97
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 364800
+      GoRuntimeType: 364928
       GoKind: 22
       Pointee: 8 BaseType uint16
     - __kind: PointerType
       ID: 22
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 364928
+      GoRuntimeType: 365056
       GoKind: 22
       Pointee: 3 BaseType uint32
     - __kind: PointerType
       ID: 96
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 365056
+      GoRuntimeType: 365184
       GoKind: 22
       Pointee: 11 BaseType uint64
     - __kind: PointerType
       ID: 7
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 364672
+      GoRuntimeType: 364800
       GoKind: 22
       Pointee: 4 BaseType uint8
     - __kind: PointerType
       ID: 9
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 365248
+      GoRuntimeType: 365376
       GoKind: 22
       Pointee: 2 BaseType uintptr
     - __kind: PointerType
@@ -23418,7 +23418,7 @@ Types:
       ID: 86
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 642560
+      GoRuntimeType: 643904
       GoKind: 17
       Count: 10
       HasCount: true
@@ -23445,7 +23445,7 @@ Types:
       ID: 72
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 642272
+      GoRuntimeType: 643616
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23470,7 +23470,7 @@ Types:
       ID: 78
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 642464
+      GoRuntimeType: 643808
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23612,7 +23612,7 @@ Types:
       ID: 64
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 642080
+      GoRuntimeType: 643424
       GoKind: 17
       Count: 32
       HasCount: true
@@ -23630,7 +23630,7 @@ Types:
       ID: 52
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 641792
+      GoRuntimeType: 643136
       GoKind: 17
       Count: 3
       HasCount: true
@@ -23700,7 +23700,7 @@ Types:
       ID: 79
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 642368
+      GoRuntimeType: 643712
       GoKind: 17
       Count: 8
       HasCount: true
@@ -23965,7 +23965,7 @@ Types:
       ID: 263
       Name: '[]bool'
       ByteSize: 24
-      GoRuntimeType: 456640
+      GoRuntimeType: 456832
       GoKind: 23
       RawFields:
         - Name: array
@@ -24150,7 +24150,7 @@ Types:
       ID: 883
       Name: '[]float64'
       ByteSize: 24
-      GoRuntimeType: 456512
+      GoRuntimeType: 456704
       GoKind: 23
       RawFields:
         - Name: array
@@ -24241,7 +24241,7 @@ Types:
       ID: 1144
       Name: '[]interface {}'
       ByteSize: 24
-      GoRuntimeType: 456960
+      GoRuntimeType: 457152
       GoKind: 23
       RawFields:
         - Name: array
@@ -24383,7 +24383,7 @@ Types:
       ID: 154
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 456768
+      GoRuntimeType: 456960
       GoKind: 23
       RawFields:
         - Name: array
@@ -24428,7 +24428,7 @@ Types:
       ID: 257
       Name: '[]uint'
       ByteSize: 24
-      GoRuntimeType: 456256
+      GoRuntimeType: 456448
       GoKind: 23
       RawFields:
         - Name: array
@@ -24451,7 +24451,7 @@ Types:
       ID: 264
       Name: '[]uint16'
       ByteSize: 24
-      GoRuntimeType: 455616
+      GoRuntimeType: 455808
       GoKind: 23
       RawFields:
         - Name: array
@@ -24474,7 +24474,7 @@ Types:
       ID: 39
       Name: '[]uint8'
       ByteSize: 24
-      GoRuntimeType: 455488
+      GoRuntimeType: 455680
       GoKind: 23
       RawFields:
         - Name: array
@@ -24497,7 +24497,7 @@ Types:
       ID: 44
       Name: '[]uintptr'
       ByteSize: 24
-      GoRuntimeType: 456320
+      GoRuntimeType: 456512
       GoKind: 23
       RawFields:
         - Name: array
@@ -25611,7 +25611,7 @@ Types:
       ID: 19
       Name: error
       ByteSize: 16
-      GoRuntimeType: 989504
+      GoRuntimeType: 989760
       GoKind: 20
       RawFields:
         - Name: tab
@@ -25662,7 +25662,7 @@ Types:
       ID: 68
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 781568
+      GoRuntimeType: 781856
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 352
@@ -27792,7 +27792,7 @@ Types:
       ID: 157
       Name: interface {}
       ByteSize: 16
-      GoRuntimeType: 781280
+      GoRuntimeType: 781568
       GoKind: 20
       RawFields:
         - Name: _type
@@ -27842,11 +27842,11 @@ Types:
     - __kind: StructureType
       ID: 797
       Name: internal/poll.errNetClosing
-      GoRuntimeType: 1300544
+      GoRuntimeType: 1300864
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 527
+      ID: 530
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -29837,7 +29837,7 @@ Types:
       GoRuntimeType: 771488
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 529
+      ID: 532
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -29903,7 +29903,7 @@ Types:
       ID: 793
       Name: runtime.errorAddressString
       ByteSize: 24
-      GoRuntimeType: 1636448
+      GoRuntimeType: 1636640
       GoKind: 25
       RawFields:
         - Name: msg
@@ -30120,7 +30120,7 @@ Types:
       ID: 31
       Name: runtime.gobuf
       ByteSize: 56
-      GoRuntimeType: 1842752
+      GoRuntimeType: 1843040
       GoKind: 25
       RawFields:
         - Name: sp
@@ -30148,7 +30148,7 @@ Types:
       ID: 47
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1295584
+      GoRuntimeType: 1295904
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -30161,7 +30161,7 @@ Types:
       ID: 55
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1635488
+      GoRuntimeType: 1635680
       GoKind: 25
       RawFields:
         - Name: stack
@@ -30180,13 +30180,13 @@ Types:
       ID: 32
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 764288
+      GoRuntimeType: 764576
       GoKind: 12
     - __kind: StructureType
       ID: 87
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1295424
+      GoRuntimeType: 1295744
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -30199,7 +30199,7 @@ Types:
       ID: 75
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 1791008
+      GoRuntimeType: 1791264
       GoKind: 25
       RawFields:
         - Name: fn
@@ -30224,7 +30224,7 @@ Types:
       ID: 88
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 764192
+      GoRuntimeType: 764480
       GoKind: 2
     - __kind: StructureType
       ID: 30
@@ -30450,7 +30450,7 @@ Types:
       ID: 65
       Name: runtime.mLockProfile
       ByteSize: 64
-      GoRuntimeType: 1790752
+      GoRuntimeType: 1791008
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -30475,7 +30475,7 @@ Types:
       ID: 82
       Name: runtime.mOS
       ByteSize: 8
-      GoRuntimeType: 1436320
+      GoRuntimeType: 1436704
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -30491,7 +30491,7 @@ Types:
       ID: 70
       Name: runtime.mTraceState
       ByteSize: 32
-      GoRuntimeType: 1436128
+      GoRuntimeType: 1436512
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -30511,7 +30511,7 @@ Types:
       ID: 38
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 763904
+      GoRuntimeType: 764192
       GoKind: 12
     - __kind: StructureType
       ID: 63
@@ -30524,7 +30524,7 @@ Types:
       ID: 77
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1295264
+      GoRuntimeType: 1295584
       GoKind: 25
       RawFields:
         - Name: entries
@@ -30537,7 +30537,7 @@ Types:
       ID: 80
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1636256
+      GoRuntimeType: 1636448
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -30575,13 +30575,13 @@ Types:
       ID: 59
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 764096
+      GoRuntimeType: 764384
       GoKind: 12
     - __kind: ArrayType
       ID: 56
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 830336
+      GoRuntimeType: 830720
       GoKind: 17
       Count: 2
       HasCount: true
@@ -30590,7 +30590,7 @@ Types:
       ID: 24
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1293664
+      GoRuntimeType: 1293984
       GoKind: 25
       RawFields:
         - Name: lo
@@ -30627,7 +30627,7 @@ Types:
       ID: 51
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1294624
+      GoRuntimeType: 1294944
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -30824,14 +30824,14 @@ Types:
       ID: 988
       Name: time.Duration
       ByteSize: 8
-      GoRuntimeType: 1791776
+      GoRuntimeType: 1788960
       GoKind: 6
     - __kind: UnresolvedPointeeType
       ID: 861
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 532
+      ID: 528
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
@@ -30854,7 +30854,7 @@ Types:
       ID: 453
       Name: time.fileSizeError
       ByteSize: 16
-      GoRuntimeType: 764672
+      GoRuntimeType: 763424
       GoKind: 24
       RawFields:
         - Name: str

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -13,11 +13,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1581 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0x853ab8", Frameless: false}]
+              InjectionPoints: [{PC: "0x853f38", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1582 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0x853aec", Frameless: false}]
+              InjectionPoints: [{PC: "0x853f6c", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -33,11 +33,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1420 EventRootType Probe[main.testAny]
-              InjectionPoints: [{PC: "0x84ec68", Frameless: false}]
+              InjectionPoints: [{PC: "0x84ed58", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1421 EventRootType Probe[main.testAny]Return
-              InjectionPoints: [{PC: "0x84ec94", Frameless: false}]
+              InjectionPoints: [{PC: "0x84ed84", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -59,11 +59,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1423 EventRootType Probe[main.testAnyPtr]
-              InjectionPoints: [{PC: "0x84ece8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84edd8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1424 EventRootType Probe[main.testAnyPtr]Return
-              InjectionPoints: [{PC: "0x84ed14", Frameless: false}]
+              InjectionPoints: [{PC: "0x84ee04", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -84,11 +84,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1552 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0x8528ac", Frameless: false}]
+              InjectionPoints: [{PC: "0x852a5c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1553 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0x852944", Frameless: false}]
+              InjectionPoints: [{PC: "0x852af4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -110,7 +110,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1368 EventRootType Probe[main.testArrayEmptyStructs]
-              InjectionPoints: [{PC: "0x84a830", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a920", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -132,7 +132,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1364 EventRootType Probe[main.testArrayOfArrays]
-              InjectionPoints: [{PC: "0x84a7f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a8e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -154,7 +154,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1366 EventRootType Probe[main.testArrayOfArraysOfArrays]
-              InjectionPoints: [{PC: "0x84a810", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a900", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -176,7 +176,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1432 EventRootType Probe[main.testArrayOfMaps]
-              InjectionPoints: [{PC: "0x84f360", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f510", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -198,7 +198,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1365 EventRootType Probe[main.testArrayOfStrings]
-              InjectionPoints: [{PC: "0x84a800", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a8f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -219,7 +219,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1367 EventRootType Probe[main.testArrayOfStructs]
-              InjectionPoints: [{PC: "0x84a820", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a910", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -241,11 +241,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1454 EventRootType Probe[main.testAtomicAdd]
-              InjectionPoints: [{PC: "0x850b00", Frameless: true}]
+              InjectionPoints: [{PC: "0x850cb0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1455 EventRootType Probe[main.testAtomicAdd]Return
-              InjectionPoints: [{PC: "0x850b3c", Frameless: true}]
+              InjectionPoints: [{PC: "0x850cec", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -267,11 +267,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1386 EventRootType Probe[main.testBigStruct]
-              InjectionPoints: [{PC: "0x84ad80", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ae70", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1387 EventRootType Probe[main.testBigStruct]Return
-              InjectionPoints: [{PC: "0x84ad98", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ae88", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -293,7 +293,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1353 EventRootType Probe[main.testBoolArray]
-              InjectionPoints: [{PC: "0x84a740", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a830", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -315,7 +315,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1350 EventRootType Probe[main.testByteArray]
-              InjectionPoints: [{PC: "0x84a710", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a800", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -342,11 +342,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1600 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x853e10", Frameless: true}]
+              InjectionPoints: [{PC: "0x854290", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1601 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0x853e2c", Frameless: true}]
+              InjectionPoints: [{PC: "0x8542ac", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -366,15 +366,15 @@ Probes:
             - Kind: Line
               Type: 1661 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x84e528"
+                - PC: "0x84e618"
                   Frameless: false
-                - PC: "0x84e59c"
+                - PC: "0x84e68c"
                   Frameless: false
-                - PC: "0x84e6e8"
+                - PC: "0x84e7d8"
                   Frameless: false
-                - PC: "0x84e764"
+                - PC: "0x84e854"
                   Frameless: false
-                - PC: "0x84e81c"
+                - PC: "0x84e90c"
                   Frameless: false
               Condition: null
     - id: testCaptureExprLineCond
@@ -396,15 +396,15 @@ Probes:
             - Kind: Line
               Type: 1662 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x84e528"
+                - PC: "0x84e618"
                   Frameless: false
-                - PC: "0x84e59c"
+                - PC: "0x84e68c"
                   Frameless: false
-                - PC: "0x84e6e8"
+                - PC: "0x84e7d8"
                   Frameless: false
-                - PC: "0x84e764"
+                - PC: "0x84e854"
                   Frameless: false
-                - PC: "0x84e81c"
+                - PC: "0x84e90c"
                   Frameless: false
               Condition:
                 Type: 5 BaseType bool
@@ -440,15 +440,15 @@ Probes:
             - Kind: Line
               Type: 1663 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x84e528"
+                - PC: "0x84e618"
                   Frameless: false
-                - PC: "0x84e59c"
+                - PC: "0x84e68c"
                   Frameless: false
-                - PC: "0x84e6e8"
+                - PC: "0x84e7d8"
                   Frameless: false
-                - PC: "0x84e764"
+                - PC: "0x84e854"
                   Frameless: false
-                - PC: "0x84e81c"
+                - PC: "0x84e90c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -476,7 +476,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1451 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x8508a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x850a50", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -495,7 +495,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1452 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x8508a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x850a50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -521,7 +521,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1608 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0x853ec0", Frameless: true}]
+              InjectionPoints: [{PC: "0x854340", Frameless: true}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -557,7 +557,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1456 EventRootType Probe[main.testChannel]
-              InjectionPoints: [{PC: "0x850b40", Frameless: true}]
+              InjectionPoints: [{PC: "0x850cf0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -587,7 +587,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1450 EventRootType Probe[main.testCombinedByte]
-              InjectionPoints: [{PC: "0x850880", Frameless: true}]
+              InjectionPoints: [{PC: "0x850a30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{w}, {x}, {y}'
@@ -616,11 +616,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1517 EventRootType Probe[main.testConflictingReturn]
-              InjectionPoints: [{PC: "0x851ac8", Frameless: false}]
+              InjectionPoints: [{PC: "0x851c78", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1518 EventRootType Probe[main.testConflictingReturn]Return
-              InjectionPoints: [{PC: "0x851b74", Frameless: false}]
+              InjectionPoints: [{PC: "0x851d24", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -642,7 +642,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1464 EventRootType Probe[main.testCycle]
-              InjectionPoints: [{PC: "0x850df0", Frameless: true}]
+              InjectionPoints: [{PC: "0x850fa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{t}'
@@ -664,7 +664,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1393 EventRootType Probe[main.testDeepMap1]
-              InjectionPoints: [{PC: "0x84b280", Frameless: true}]
+              InjectionPoints: [{PC: "0x84b370", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -686,7 +686,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1394 EventRootType Probe[main.testDeepMap7]
-              InjectionPoints: [{PC: "0x84b290", Frameless: true}]
+              InjectionPoints: [{PC: "0x84b380", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -708,7 +708,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1389 EventRootType Probe[main.testDeepPtr1]
-              InjectionPoints: [{PC: "0x84af70", Frameless: true}]
+              InjectionPoints: [{PC: "0x84b060", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -730,7 +730,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1390 EventRootType Probe[main.testDeepPtr7]
-              InjectionPoints: [{PC: "0x84af80", Frameless: true}]
+              InjectionPoints: [{PC: "0x84b070", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -752,7 +752,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1391 EventRootType Probe[main.testDeepSlice1]
-              InjectionPoints: [{PC: "0x84b120", Frameless: true}]
+              InjectionPoints: [{PC: "0x84b210", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -774,7 +774,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1392 EventRootType Probe[main.testDeepSlice7]
-              InjectionPoints: [{PC: "0x84b130", Frameless: true}]
+              InjectionPoints: [{PC: "0x84b220", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -796,7 +796,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1569 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0x8536e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x853890", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -823,7 +823,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1572 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0x853710", Frameless: true}]
+              InjectionPoints: [{PC: "0x8538c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -851,7 +851,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1595 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0x853b90", Frameless: true}]
+              InjectionPoints: [{PC: "0x854010", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -873,7 +873,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1609 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0x853f10", Frameless: true}]
+              InjectionPoints: [{PC: "0x854390", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -894,7 +894,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1610 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0x853f20", Frameless: true}]
+              InjectionPoints: [{PC: "0x8543a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -916,7 +916,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1422 EventRootType Probe[main.testError]
-              InjectionPoints: [{PC: "0x84ecc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84edb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -950,7 +950,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1388 EventRootType Probe[main.testErrorAtLine]Line
-              InjectionPoints: [{PC: "0x84ae0c", Frameless: false}]
+              InjectionPoints: [{PC: "0x84aefc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}, err={err}
@@ -978,11 +978,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1404 EventRootType Probe[main.testEsotericHeap]
-              InjectionPoints: [{PC: "0x84d538", Frameless: false}]
+              InjectionPoints: [{PC: "0x84d628", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1405 EventRootType Probe[main.testEsotericHeap]Return
-              InjectionPoints: [{PC: "0x84d574", Frameless: false}]
+              InjectionPoints: [{PC: "0x84d664", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1004,11 +1004,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1402 EventRootType Probe[main.testEsotericStack]
-              InjectionPoints: [{PC: "0x84d46c", Frameless: false}]
+              InjectionPoints: [{PC: "0x84d55c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1403 EventRootType Probe[main.testEsotericStack]Return
-              InjectionPoints: [{PC: "0x84d4dc", Frameless: false}]
+              InjectionPoints: [{PC: "0x84d5cc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1030,11 +1030,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1414 EventRootType Probe[main.testFrameless]
-              InjectionPoints: [{PC: "0x84e9a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ea90", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1415 EventRootType Probe[main.testFrameless]Return
-              InjectionPoints: [{PC: "0x84e9a8", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ea98", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1056,11 +1056,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1416 EventRootType Probe[main.testFramelessArray]
-              InjectionPoints: [{PC: "0x84e9bc", Frameless: false}]
+              InjectionPoints: [{PC: "0x84eaac", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1417 EventRootType Probe[main.testFramelessArray]Return
-              InjectionPoints: [{PC: "0x84e9f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84eae8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1085,7 +1085,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1418 EventRootType Probe[main.testFramelessArray]Line
-              InjectionPoints: [{PC: "0x84e9bc", Frameless: false}]
+              InjectionPoints: [{PC: "0x84eaac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1107,11 +1107,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1647 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0x856080", Frameless: true}]
+              InjectionPoints: [{PC: "0x856500", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1648 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x856088", Frameless: true}]
+              InjectionPoints: [{PC: "0x856508", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1125,11 +1125,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1649 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0x8560a0", Frameless: false}]
+              InjectionPoints: [{PC: "0x856520", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1650 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0x8560dc", Frameless: false}]
+              InjectionPoints: [{PC: "0x85655c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1152,11 +1152,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1643 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0x855fe8", Frameless: false}]
+              InjectionPoints: [{PC: "0x856468", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1644 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0x855ff8", Frameless: false}]
+              InjectionPoints: [{PC: "0x856478", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1170,11 +1170,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1645 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0x856038", Frameless: false}]
+              InjectionPoints: [{PC: "0x8564b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1646 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0x856050", Frameless: false}]
+              InjectionPoints: [{PC: "0x8564d0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1197,14 +1197,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1651 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0x8560f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x856570", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1652 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0x856118"
+                - PC: "0x856598"
                   Frameless: true
-                - PC: "0x856120"
+                - PC: "0x8565a0"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1219,14 +1219,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1653 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0x856148", Frameless: false}]
+              InjectionPoints: [{PC: "0x8565c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1654 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0x8561a8"
+                - PC: "0x856628"
                   Frameless: false
-                - PC: "0x8561b8"
+                - PC: "0x856638"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1253,7 +1253,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1655 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0x8560f4", Frameless: true}]
+              InjectionPoints: [{PC: "0x856574", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1265,7 +1265,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1656 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0x856158", Frameless: false}]
+              InjectionPoints: [{PC: "0x8565d8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1286,11 +1286,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1631 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0x855ce0", Frameless: true}]
+              InjectionPoints: [{PC: "0x856160", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1632 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0x855ce8", Frameless: true}]
+              InjectionPoints: [{PC: "0x856168", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1304,11 +1304,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1633 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0x855d70", Frameless: true}]
+              InjectionPoints: [{PC: "0x8561f0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1634 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0x855d74", Frameless: true}]
+              InjectionPoints: [{PC: "0x8561f4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1332,11 +1332,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1619 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0x8558e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x855d68", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1620 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x8559bc", Frameless: false}]
+              InjectionPoints: [{PC: "0x855e3c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1378,11 +1378,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1623 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x855a08", Frameless: false}]
+              InjectionPoints: [{PC: "0x855e88", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1624 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x855a18", Frameless: false}]
+              InjectionPoints: [{PC: "0x855e98", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1405,11 +1405,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1657 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0x8561f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x856670", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1658 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0x8561f8", Frameless: true}]
+              InjectionPoints: [{PC: "0x856678", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1423,11 +1423,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1659 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0x856288", Frameless: false}]
+              InjectionPoints: [{PC: "0x856708", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1660 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0x8562ac", Frameless: false}]
+              InjectionPoints: [{PC: "0x85672c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1450,11 +1450,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1615 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0x855850", Frameless: true}]
+              InjectionPoints: [{PC: "0x855cd0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1616 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x855854", Frameless: true}]
+              InjectionPoints: [{PC: "0x855cd4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1468,11 +1468,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1617 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0x855860", Frameless: true}]
+              InjectionPoints: [{PC: "0x855ce0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1618 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x85586c", Frameless: true}]
+              InjectionPoints: [{PC: "0x855cec", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1495,11 +1495,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1635 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0x855e10", Frameless: true}]
+              InjectionPoints: [{PC: "0x856290", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1636 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0x855e18", Frameless: true}]
+              InjectionPoints: [{PC: "0x856298", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1513,11 +1513,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1637 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0x855eb8", Frameless: false}]
+              InjectionPoints: [{PC: "0x856338", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1638 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0x855ee4", Frameless: false}]
+              InjectionPoints: [{PC: "0x856364", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1540,11 +1540,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1625 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0x855cb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x856130", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1626 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x855cb4", Frameless: true}]
+              InjectionPoints: [{PC: "0x856134", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1558,11 +1558,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1627 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0x855cc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x856140", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1628 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0x855cc4", Frameless: true}]
+              InjectionPoints: [{PC: "0x856144", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1576,11 +1576,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1629 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0x855cd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x856150", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1630 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0x855cd4", Frameless: true}]
+              InjectionPoints: [{PC: "0x856154", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1603,11 +1603,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1639 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0x855fa0", Frameless: true}]
+              InjectionPoints: [{PC: "0x856420", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1640 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0x855fa8", Frameless: true}]
+              InjectionPoints: [{PC: "0x856428", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1621,11 +1621,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1641 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x855fb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x856430", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1642 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x855fc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x856440", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1648,11 +1648,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1611 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0x855830", Frameless: true}]
+              InjectionPoints: [{PC: "0x855cb0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1612 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x855834", Frameless: true}]
+              InjectionPoints: [{PC: "0x855cb4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1666,11 +1666,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1613 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0x855840", Frameless: true}]
+              InjectionPoints: [{PC: "0x855cc0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1614 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x85584c", Frameless: true}]
+              InjectionPoints: [{PC: "0x855ccc", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1693,11 +1693,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1406 EventRootType Probe[main.testInlinedBA]
-              InjectionPoints: [{PC: "0x84e6c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84e7b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1407 EventRootType Probe[main.testInlinedBA]Return
-              InjectionPoints: [{PC: "0x84e720", Frameless: false}]
+              InjectionPoints: [{PC: "0x84e810", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1724,11 +1724,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1408 EventRootType Probe[main.testInlinedBB]
-              InjectionPoints: [{PC: "0x84e758", Frameless: false}]
+              InjectionPoints: [{PC: "0x84e848", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1409 EventRootType Probe[main.testInlinedBB]Return
-              InjectionPoints: [{PC: "0x84e7e0", Frameless: false}]
+              InjectionPoints: [{PC: "0x84e8d0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}'
@@ -1755,11 +1755,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1410 EventRootType Probe[main.testInlinedBBA]
-              InjectionPoints: [{PC: "0x84e818", Frameless: false}]
+              InjectionPoints: [{PC: "0x84e908", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1411 EventRootType Probe[main.testInlinedBBA]Return
-              InjectionPoints: [{PC: "0x84e854", Frameless: false}]
+              InjectionPoints: [{PC: "0x84e944", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1781,7 +1781,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1667 EventRootType Probe[main.testInlinedBBB]
-              InjectionPoints: [{PC: "0x84e7a8", Frameless: false}]
+              InjectionPoints: [{PC: "0x84e898", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBBB
@@ -1799,11 +1799,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1412 EventRootType Probe[main.testInlinedBC]
-              InjectionPoints: [{PC: "0x84e898", Frameless: false}]
+              InjectionPoints: [{PC: "0x84e988", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1413 EventRootType Probe[main.testInlinedBC]Return
-              InjectionPoints: [{PC: "0x84e988", Frameless: false}]
+              InjectionPoints: [{PC: "0x84ea78", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBC
@@ -1821,7 +1821,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1668 EventRootType Probe[main.testInlinedBCA]
-              InjectionPoints: [{PC: "0x84e89c", Frameless: false}]
+              InjectionPoints: [{PC: "0x84e98c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1842,7 +1842,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1669 EventRootType Probe[main.testInlinedBCA]Line
-              InjectionPoints: [{PC: "0x84e89c", Frameless: false}]
+              InjectionPoints: [{PC: "0x84e98c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1860,7 +1860,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1670 EventRootType Probe[main.testInlinedBCB]
-              InjectionPoints: [{PC: "0x84e950", Frameless: false}]
+              InjectionPoints: [{PC: "0x84ea40", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1881,7 +1881,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1671 EventRootType Probe[main.testInlinedBCB]Line
-              InjectionPoints: [{PC: "0x84e950", Frameless: false}]
+              InjectionPoints: [{PC: "0x84ea40", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1902,7 +1902,7 @@ Probes:
               InjectionPoints:
                 - PC: "0x129ba8"
                   Frameless: true
-                - PC: "0x84f22c"
+                - PC: "0x84f454"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1923,20 +1923,20 @@ Probes:
             - Kind: Entry
               Type: 1664 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
-                - PC: "0x84e528"
+                - PC: "0x84e618"
                   Frameless: false
-                - PC: "0x84e59c"
+                - PC: "0x84e68c"
                   Frameless: false
-                - PC: "0x84e6e8"
+                - PC: "0x84e7d8"
                   Frameless: false
-                - PC: "0x84e764"
+                - PC: "0x84e854"
                   Frameless: false
-                - PC: "0x84e81c"
+                - PC: "0x84e90c"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1665 EventRootType Probe[main.testInlinedPrint]Return
-              InjectionPoints: [{PC: "0x84e560", Frameless: false}]
+              InjectionPoints: [{PC: "0x84e650", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1962,15 +1962,15 @@ Probes:
             - Kind: Line
               Type: 1666 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x84e528"
+                - PC: "0x84e618"
                   Frameless: false
-                - PC: "0x84e59c"
+                - PC: "0x84e68c"
                   Frameless: false
-                - PC: "0x84e6e8"
+                - PC: "0x84e7d8"
                   Frameless: false
-                - PC: "0x84e764"
+                - PC: "0x84e854"
                   Frameless: false
-                - PC: "0x84e81c"
+                - PC: "0x84e90c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1993,7 +1993,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1672 EventRootType Probe[main.testInlinedSq]
-              InjectionPoints: [{PC: "0x84e9a4", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ea94", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2018,7 +2018,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1673 EventRootType Probe[main.testInlinedSq]Line
-              InjectionPoints: [{PC: "0x84e9a4", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ea94", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2042,9 +2042,9 @@ Probes:
             - Kind: Entry
               Type: 1674 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
-                - PC: "0x84e9d4"
+                - PC: "0x84eac4"
                   Frameless: false
-                - PC: "0x84ea6c"
+                - PC: "0x84eb5c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2067,7 +2067,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1356 EventRootType Probe[main.testInt16Array]
-              InjectionPoints: [{PC: "0x84a770", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a860", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2089,7 +2089,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1357 EventRootType Probe[main.testInt32Array]
-              InjectionPoints: [{PC: "0x84a780", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a870", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2111,7 +2111,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1358 EventRootType Probe[main.testInt64Array]
-              InjectionPoints: [{PC: "0x84a790", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a880", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2133,7 +2133,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1355 EventRootType Probe[main.testInt8Array]
-              InjectionPoints: [{PC: "0x84a760", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a850", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2155,7 +2155,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1354 EventRootType Probe[main.testIntArray]
-              InjectionPoints: [{PC: "0x84a750", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a840", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2177,7 +2177,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1419 EventRootType Probe[main.testInterface]
-              InjectionPoints: [{PC: "0x84ec40", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ed30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -2198,11 +2198,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1550 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0x8526f0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8528a0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1551 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x852848", Frameless: false}]
+              InjectionPoints: [{PC: "0x8529f8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2224,7 +2224,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1458 EventRootType Probe[main.testLinkedList]
-              InjectionPoints: [{PC: "0x850d00", Frameless: true}]
+              InjectionPoints: [{PC: "0x850eb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -2249,7 +2249,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1397 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x84b2dc", Frameless: false}]
+              InjectionPoints: [{PC: "0x84b3cc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2271,7 +2271,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1398 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x84b36c", Frameless: false}]
+              InjectionPoints: [{PC: "0x84b45c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2293,7 +2293,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1399 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x84b414", Frameless: false}]
+              InjectionPoints: [{PC: "0x84b504", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2336,11 +2336,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1556 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0x852bac", Frameless: false}]
+              InjectionPoints: [{PC: "0x852d5c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1557 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0x852d18", Frameless: false}]
+              InjectionPoints: [{PC: "0x852ec8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2403,7 +2403,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1400 EventRootType Probe[main.testManyPointers]
-              InjectionPoints: [{PC: "0x84b840", Frameless: true}]
+              InjectionPoints: [{PC: "0x84b930", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2427,7 +2427,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1401 EventRootType Probe[main.testManyStrings]
-              InjectionPoints: [{PC: "0x84d1b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d2a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{ss}'
@@ -2449,7 +2449,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1430 EventRootType Probe[main.testMapArrayToArray]
-              InjectionPoints: [{PC: "0x84f340", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f4f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2471,7 +2471,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1437 EventRootType Probe[main.testMapEmbeddedMaps]
-              InjectionPoints: [{PC: "0x84f3a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f550", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2493,7 +2493,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1447 EventRootType Probe[main.testMapEmptyKey]
-              InjectionPoints: [{PC: "0x84f440", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f5f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2515,7 +2515,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1449 EventRootType Probe[main.testMapEmptyKeyAndValue]
-              InjectionPoints: [{PC: "0x84f460", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f610", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2537,7 +2537,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1448 EventRootType Probe[main.testMapEmptyValue]
-              InjectionPoints: [{PC: "0x84f450", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f600", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2559,7 +2559,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1434 EventRootType Probe[main.testMapIntToInt]
-              InjectionPoints: [{PC: "0x84f380", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f530", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2581,7 +2581,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1446 EventRootType Probe[main.testMapLargeKeyLargeValue]
-              InjectionPoints: [{PC: "0x84f430", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f5e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2603,7 +2603,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1445 EventRootType Probe[main.testMapLargeKeySmallValue]
-              InjectionPoints: [{PC: "0x84f420", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f5d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2627,7 +2627,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1435 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x84f390", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f540", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2651,7 +2651,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1436 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x84f390", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f540", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2673,7 +2673,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1444 EventRootType Probe[main.testMapSmallKeyLargeValue]
-              InjectionPoints: [{PC: "0x84f410", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f5c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2695,7 +2695,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1443 EventRootType Probe[main.testMapSmallKeySmallValue]
-              InjectionPoints: [{PC: "0x84f400", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f5b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2717,7 +2717,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1428 EventRootType Probe[main.testMapStringToInt]
-              InjectionPoints: [{PC: "0x84f320", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f4d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2739,7 +2739,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1429 EventRootType Probe[main.testMapStringToSlice]
-              InjectionPoints: [{PC: "0x84f330", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f4e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2761,7 +2761,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1427 EventRootType Probe[main.testMapStringToStruct]
-              InjectionPoints: [{PC: "0x84f310", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f4c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2783,7 +2783,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1438 EventRootType Probe[main.testMapWithLinkedList]
-              InjectionPoints: [{PC: "0x84f3b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f560", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2805,7 +2805,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1441 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-              InjectionPoints: [{PC: "0x84f3e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f590", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2827,7 +2827,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1442 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-              InjectionPoints: [{PC: "0x84f3f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f5a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2849,7 +2849,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1439 EventRootType Probe[main.testMapWithSmallValue]
-              InjectionPoints: [{PC: "0x84f3c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f570", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2873,7 +2873,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1440 EventRootType Probe[main.testMapWithSmallValueMassive]
-              InjectionPoints: [{PC: "0x84f3d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f580", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2895,7 +2895,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1592 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x853b70", Frameless: true}]
+              InjectionPoints: [{PC: "0x853ff0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2918,7 +2918,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1593 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x853b70", Frameless: true}]
+              InjectionPoints: [{PC: "0x853ff0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2965,11 +2965,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1558 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0x852d80", Frameless: false}]
+              InjectionPoints: [{PC: "0x852f30", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1559 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0x852f2c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8530dc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -3035,11 +3035,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1562 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0x85302c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8531dc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1563 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0x8530d4", Frameless: false}]
+              InjectionPoints: [{PC: "0x853284", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3070,11 +3070,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1554 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0x852980", Frameless: false}]
+              InjectionPoints: [{PC: "0x852b30", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1555 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0x852b50", Frameless: false}]
+              InjectionPoints: [{PC: "0x852d00", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3100,11 +3100,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1495 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x851938", Frameless: false}]
+              InjectionPoints: [{PC: "0x851ae8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1496 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x8519c4", Frameless: false}]
+              InjectionPoints: [{PC: "0x851b74", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3140,7 +3140,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1453 EventRootType Probe[main.testMultipleSimpleParams]
-              InjectionPoints: [{PC: "0x850960", Frameless: true}]
+              InjectionPoints: [{PC: "0x850b10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -3181,11 +3181,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1489 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x851898", Frameless: false}]
+              InjectionPoints: [{PC: "0x851a48", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1490 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x8518f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x851aa8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3209,11 +3209,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1491 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x851898", Frameless: false}]
+              InjectionPoints: [{PC: "0x851a48", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1492 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x8518f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x851aa8", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
       version: 0
@@ -3232,11 +3232,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1497 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x851938", Frameless: false}]
+              InjectionPoints: [{PC: "0x851ae8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1498 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x8519c4", Frameless: false}]
+              InjectionPoints: [{PC: "0x851b74", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
       version: 0
@@ -3256,11 +3256,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1499 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x851938", Frameless: false}]
+              InjectionPoints: [{PC: "0x851ae8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1500 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x8519c4", Frameless: false}]
+              InjectionPoints: [{PC: "0x851b74", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r1={result} r2={result2}
@@ -3293,11 +3293,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1493 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x851898", Frameless: false}]
+              InjectionPoints: [{PC: "0x851a48", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1494 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x8518f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x851aa8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Parameter {i} * 2 = result {result}
@@ -3325,7 +3325,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1604 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x853eb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x854330", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3350,7 +3350,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1605 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x853eb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x854330", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3381,7 +3381,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1606 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x853eb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x854330", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3406,7 +3406,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1607 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x853eb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x854330", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3433,7 +3433,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1463 EventRootType Probe[main.testNilPointer]
-              InjectionPoints: [{PC: "0x850dd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x850f80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}, {a}'
@@ -3460,7 +3460,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1576 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0x853750", Frameless: true}]
+              InjectionPoints: [{PC: "0x853900", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3487,7 +3487,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1573 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0x853720", Frameless: true}]
+              InjectionPoints: [{PC: "0x8538d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3522,7 +3522,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1575 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0x853740", Frameless: true}]
+              InjectionPoints: [{PC: "0x8538f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3554,7 +3554,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1591 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0x853b60", Frameless: true}]
+              InjectionPoints: [{PC: "0x853fe0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3576,7 +3576,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1459 EventRootType Probe[main.testPointerLoop]
-              InjectionPoints: [{PC: "0x850d10", Frameless: true}]
+              InjectionPoints: [{PC: "0x850ec0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3598,7 +3598,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1433 EventRootType Probe[main.testPointerToMap]
-              InjectionPoints: [{PC: "0x84f370", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f520", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3620,7 +3620,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1457 EventRootType Probe[main.testPointerToSimpleStruct]
-              InjectionPoints: [{PC: "0x850cf0", Frameless: true}]
+              InjectionPoints: [{PC: "0x850ea0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3644,11 +3644,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1465 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x851148", Frameless: false}]
+              InjectionPoints: [{PC: "0x8512f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1466 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x85118c", Frameless: false}]
+              InjectionPoints: [{PC: "0x85133c", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
       version: 0
@@ -3668,11 +3668,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1509 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x851a08", Frameless: false}]
+              InjectionPoints: [{PC: "0x851bb8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1510 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x851a90", Frameless: false}]
+              InjectionPoints: [{PC: "0x851c40", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3715,11 +3715,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1475 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x851268", Frameless: false}]
+              InjectionPoints: [{PC: "0x851418", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1476 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x851300", Frameless: false}]
+              InjectionPoints: [{PC: "0x8514b0", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3759,11 +3759,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1467 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x851148", Frameless: false}]
+              InjectionPoints: [{PC: "0x8512f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1468 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x85118c", Frameless: false}]
+              InjectionPoints: [{PC: "0x85133c", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3806,11 +3806,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1477 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x851268", Frameless: false}]
+              InjectionPoints: [{PC: "0x851418", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1478 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x851300", Frameless: false}]
+              InjectionPoints: [{PC: "0x8514b0", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3852,11 +3852,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1511 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x851a08", Frameless: false}]
+              InjectionPoints: [{PC: "0x851bb8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1512 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x851a90", Frameless: false}]
+              InjectionPoints: [{PC: "0x851c40", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
       version: 0
@@ -3873,11 +3873,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1513 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x851a08", Frameless: false}]
+              InjectionPoints: [{PC: "0x851bb8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1514 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x851a90", Frameless: false}]
+              InjectionPoints: [{PC: "0x851c40", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r0={@return.r0}
@@ -3899,11 +3899,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1469 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x851148", Frameless: false}]
+              InjectionPoints: [{PC: "0x8512f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1470 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x85118c", Frameless: false}]
+              InjectionPoints: [{PC: "0x85133c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: result={@return}
@@ -3926,18 +3926,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1485 EventRootType Probe[main.testReturnsAny]
-              InjectionPoints: [{PC: "0x851538", Frameless: false}]
+              InjectionPoints: [{PC: "0x8516e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1486 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
-                - PC: "0x8515d4"
+                - PC: "0x851784"
                   Frameless: false
-                - PC: "0x85161c"
+                - PC: "0x8517cc"
                   Frameless: false
-                - PC: "0x8516e0"
+                - PC: "0x851890"
                   Frameless: false
-                - PC: "0x8516f4"
+                - PC: "0x8518a4"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3965,18 +3965,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1483 EventRootType Probe[main.testReturnsAnyAndError]
-              InjectionPoints: [{PC: "0x8513b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x851568", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1484 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
-                - PC: "0x85140c"
+                - PC: "0x8515bc"
                   Frameless: false
-                - PC: "0x851470"
+                - PC: "0x851620"
                   Frameless: false
-                - PC: "0x8514b0"
+                - PC: "0x851660"
                   Frameless: false
-                - PC: "0x8514f0"
+                - PC: "0x8516a0"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4003,11 +4003,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1528 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0x8520fc", Frameless: false}]
+              InjectionPoints: [{PC: "0x8522ac", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1529 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0x852150", Frameless: false}]
+              InjectionPoints: [{PC: "0x852300", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -4024,11 +4024,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1530 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0x852188", Frameless: false}]
+              InjectionPoints: [{PC: "0x852338", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1531 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0x8521c4", Frameless: false}]
+              InjectionPoints: [{PC: "0x852374", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -4045,11 +4045,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1532 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0x8521f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8523a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1533 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0x852230", Frameless: false}]
+              InjectionPoints: [{PC: "0x8523e0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4066,11 +4066,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1536 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0x8522e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x852498", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1537 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0x85234c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8524fc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4087,11 +4087,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1548 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0x852678", Frameless: false}]
+              InjectionPoints: [{PC: "0x852828", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1549 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0x8526b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x852868", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4108,11 +4108,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1524 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0x851fa8", Frameless: false}]
+              InjectionPoints: [{PC: "0x852158", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1525 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0x851ff4", Frameless: false}]
+              InjectionPoints: [{PC: "0x8521a4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4130,14 +4130,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1481 EventRootType Probe[main.testReturnsError]
-              InjectionPoints: [{PC: "0x851338", Frameless: false}]
+              InjectionPoints: [{PC: "0x8514e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1482 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
-                - PC: "0x851368"
+                - PC: "0x851518"
                   Frameless: false
-                - PC: "0x85137c"
+                - PC: "0x85152c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4159,11 +4159,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1471 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x851148", Frameless: false}]
+              InjectionPoints: [{PC: "0x8512f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1472 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x85118c", Frameless: false}]
+              InjectionPoints: [{PC: "0x85133c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4184,11 +4184,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1479 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x851268", Frameless: false}]
+              InjectionPoints: [{PC: "0x851418", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1480 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x851300", Frameless: false}]
+              InjectionPoints: [{PC: "0x8514b0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4209,11 +4209,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1473 EventRootType Probe[main.testReturnsIntPointer]
-              InjectionPoints: [{PC: "0x8511c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x851378", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1474 EventRootType Probe[main.testReturnsIntPointer]Return
-              InjectionPoints: [{PC: "0x851228", Frameless: false}]
+              InjectionPoints: [{PC: "0x8513d8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4235,14 +4235,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1487 EventRootType Probe[main.testReturnsInterface]
-              InjectionPoints: [{PC: "0x851738", Frameless: false}]
+              InjectionPoints: [{PC: "0x8518e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1488 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
-                - PC: "0x851804"
+                - PC: "0x8519b4"
                   Frameless: false
-                - PC: "0x851818"
+                - PC: "0x8519c8"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4264,11 +4264,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1526 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0x852030", Frameless: false}]
+              InjectionPoints: [{PC: "0x8521e0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1527 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0x8520c4", Frameless: false}]
+              InjectionPoints: [{PC: "0x852274", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4285,11 +4285,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1522 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0x851ee8", Frameless: false}]
+              InjectionPoints: [{PC: "0x852098", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1523 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0x851f6c", Frameless: false}]
+              InjectionPoints: [{PC: "0x85211c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4306,11 +4306,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1540 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0x852468", Frameless: false}]
+              InjectionPoints: [{PC: "0x852618", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1541 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0x8524c0", Frameless: false}]
+              InjectionPoints: [{PC: "0x852670", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4327,11 +4327,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1534 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0x852268", Frameless: false}]
+              InjectionPoints: [{PC: "0x852418", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1535 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0x8522b0", Frameless: false}]
+              InjectionPoints: [{PC: "0x852460", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4348,11 +4348,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1546 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0x8525f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8527a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1547 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0x85263c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8527ec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
@@ -4372,7 +4372,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1519 EventRootType Probe[main.testReturnsNamedDeferLine]Line
-              InjectionPoints: [{PC: "0x851c78", Frameless: false}]
+              InjectionPoints: [{PC: "0x851e28", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4393,11 +4393,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1544 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0x852588", Frameless: false}]
+              InjectionPoints: [{PC: "0x852738", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1545 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0x8525c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x852778", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4414,11 +4414,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1520 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0x851e58", Frameless: false}]
+              InjectionPoints: [{PC: "0x852008", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1521 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0x851eb0", Frameless: false}]
+              InjectionPoints: [{PC: "0x852060", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4435,11 +4435,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1542 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0x8524fc", Frameless: false}]
+              InjectionPoints: [{PC: "0x8526ac", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1543 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0x852550", Frameless: false}]
+              InjectionPoints: [{PC: "0x852700", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4456,11 +4456,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1538 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0x852390", Frameless: false}]
+              InjectionPoints: [{PC: "0x852540", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1539 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0x852434", Frameless: false}]
+              InjectionPoints: [{PC: "0x8525e4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4478,7 +4478,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1351 EventRootType Probe[main.testRuneArray]
-              InjectionPoints: [{PC: "0x84a720", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a810", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4513,11 +4513,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1501 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x851938", Frameless: false}]
+              InjectionPoints: [{PC: "0x851ae8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1502 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x8519c4", Frameless: false}]
+              InjectionPoints: [{PC: "0x851b74", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -4563,7 +4563,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1372 EventRootType Probe[main.testSingleBool]
-              InjectionPoints: [{PC: "0x84aba0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ac90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4585,7 +4585,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1370 EventRootType Probe[main.testSingleByte]
-              InjectionPoints: [{PC: "0x84ab80", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ac70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4607,7 +4607,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1383 EventRootType Probe[main.testSingleFloat32]
-              InjectionPoints: [{PC: "0x84ac50", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ad40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4625,7 +4625,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1384 EventRootType Probe[main.testSingleFloat64]
-              InjectionPoints: [{PC: "0x84ac60", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ad50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4643,7 +4643,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1373 EventRootType Probe[main.testSingleInt]
-              InjectionPoints: [{PC: "0x84abb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84aca0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4665,7 +4665,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1375 EventRootType Probe[main.testSingleInt16]
-              InjectionPoints: [{PC: "0x84abd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84acc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}
@@ -4688,7 +4688,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1376 EventRootType Probe[main.testSingleInt32]
-              InjectionPoints: [{PC: "0x84abe0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84acd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4710,7 +4710,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1377 EventRootType Probe[main.testSingleInt64]
-              InjectionPoints: [{PC: "0x84abf0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ace0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4739,7 +4739,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1374 EventRootType Probe[main.testSingleInt8]
-              InjectionPoints: [{PC: "0x84abc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84acb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}{x}{x}
@@ -4770,7 +4770,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1371 EventRootType Probe[main.testSingleRune]
-              InjectionPoints: [{PC: "0x84ab90", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ac80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4792,7 +4792,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1583 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0x853b10", Frameless: true}]
+              InjectionPoints: [{PC: "0x853f90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4814,7 +4814,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1378 EventRootType Probe[main.testSingleUint]
-              InjectionPoints: [{PC: "0x84ac00", Frameless: true}]
+              InjectionPoints: [{PC: "0x84acf0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4836,7 +4836,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1380 EventRootType Probe[main.testSingleUint16]
-              InjectionPoints: [{PC: "0x84ac20", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ad10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4858,7 +4858,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1381 EventRootType Probe[main.testSingleUint32]
-              InjectionPoints: [{PC: "0x84ac30", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ad20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4880,7 +4880,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1382 EventRootType Probe[main.testSingleUint64]
-              InjectionPoints: [{PC: "0x84ac40", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ad30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4902,7 +4902,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1379 EventRootType Probe[main.testSingleUint8]
-              InjectionPoints: [{PC: "0x84ac10", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ad00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4924,7 +4924,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1579 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0x853770", Frameless: true}]
+              InjectionPoints: [{PC: "0x853920", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -4946,7 +4946,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1570 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0x8536f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8538a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -4968,7 +4968,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1431 EventRootType Probe[main.testSmallMap]
-              InjectionPoints: [{PC: "0x84f350", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f500", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -4989,11 +4989,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1515 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x851a08", Frameless: false}]
+              InjectionPoints: [{PC: "0x851bb8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1516 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x851a90", Frameless: false}]
+              InjectionPoints: [{PC: "0x851c40", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -5014,11 +5014,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1560 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0x852f88", Frameless: false}]
+              InjectionPoints: [{PC: "0x853138", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1561 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0x852fec", Frameless: false}]
+              InjectionPoints: [{PC: "0x85319c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5040,7 +5040,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1352 EventRootType Probe[main.testStringArray]
-              InjectionPoints: [{PC: "0x84a730", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a820", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5062,7 +5062,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1462 EventRootType Probe[main.testStringPointer]
-              InjectionPoints: [{PC: "0x850db0", Frameless: true}]
+              InjectionPoints: [{PC: "0x850f60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}'
@@ -5084,7 +5084,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1574 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0x853730", Frameless: true}]
+              InjectionPoints: [{PC: "0x8538e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5106,7 +5106,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1395 EventRootType Probe[main.testStringType1]
-              InjectionPoints: [{PC: "0x84b2a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84b390", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5128,7 +5128,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1396 EventRootType Probe[main.testStringType2]
-              InjectionPoints: [{PC: "0x84b2b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84b3a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5150,11 +5150,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1602 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x853e10", Frameless: true}]
+              InjectionPoints: [{PC: "0x854290", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1603 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0x853e2c", Frameless: true}]
+              InjectionPoints: [{PC: "0x8542ac", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5181,7 +5181,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1571 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0x853700", Frameless: true}]
+              InjectionPoints: [{PC: "0x8538b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5208,7 +5208,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1425 EventRootType Probe[main.testStructWithAny]
-              InjectionPoints: [{PC: "0x84ed40", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ee30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5229,11 +5229,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1564 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0x85310c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8532bc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1565 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0x85319c", Frameless: false}]
+              InjectionPoints: [{PC: "0x85334c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5255,11 +5255,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1598 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0x853d20", Frameless: true}]
+              InjectionPoints: [{PC: "0x8541a0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1599 EventRootType Probe[main.testStructWithCyclicMaps]Return
-              InjectionPoints: [{PC: "0x853d38", Frameless: true}]
+              InjectionPoints: [{PC: "0x8541b8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5280,7 +5280,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1597 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0x853d10", Frameless: true}]
+              InjectionPoints: [{PC: "0x854190", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5307,7 +5307,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1426 EventRootType Probe[main.testStructWithMap]
-              InjectionPoints: [{PC: "0x84f300", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f4b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s} {@duration}'
@@ -5340,7 +5340,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1580 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0x853780", Frameless: true}]
+              InjectionPoints: [{PC: "0x853930", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5380,7 +5380,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1596 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0x853ba0", Frameless: true}]
+              InjectionPoints: [{PC: "0x854020", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5413,11 +5413,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1503 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x851938", Frameless: false}]
+              InjectionPoints: [{PC: "0x851ae8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1504 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x8519c4", Frameless: false}]
+              InjectionPoints: [{PC: "0x851b74", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{nonexistentVariable}'
@@ -5438,11 +5438,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1505 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x851938", Frameless: false}]
+              InjectionPoints: [{PC: "0x851ae8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1506 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x8519c4", Frameless: false}]
+              InjectionPoints: [{PC: "0x851b74", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{unsupportedExpression}'
@@ -5465,11 +5465,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1507 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x851938", Frameless: false}]
+              InjectionPoints: [{PC: "0x851ae8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1508 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x8519c4", Frameless: false}]
+              InjectionPoints: [{PC: "0x851b74", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -5501,7 +5501,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1584 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0x853b20", Frameless: true}]
+              InjectionPoints: [{PC: "0x853fa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5533,11 +5533,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1585 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x853b30", Frameless: true}]
+              InjectionPoints: [{PC: "0x853fb0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1586 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0x853b48", Frameless: true}]
+              InjectionPoints: [{PC: "0x853fc8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5567,11 +5567,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1587 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x853b30", Frameless: true}]
+              InjectionPoints: [{PC: "0x853fb0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1588 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0x853b48", Frameless: true}]
+              InjectionPoints: [{PC: "0x853fc8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5603,7 +5603,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1589 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x853b50", Frameless: true}]
+              InjectionPoints: [{PC: "0x853fd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5633,7 +5633,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1590 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x853b50", Frameless: true}]
+              InjectionPoints: [{PC: "0x853fd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5665,7 +5665,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1385 EventRootType Probe[main.testTypeAlias]
-              InjectionPoints: [{PC: "0x84ac70", Frameless: true}]
+              InjectionPoints: [{PC: "0x84ad60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5687,7 +5687,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1361 EventRootType Probe[main.testUint16Array]
-              InjectionPoints: [{PC: "0x84a7c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a8b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5709,7 +5709,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1362 EventRootType Probe[main.testUint32Array]
-              InjectionPoints: [{PC: "0x84a7d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a8c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5731,7 +5731,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1363 EventRootType Probe[main.testUint64Array]
-              InjectionPoints: [{PC: "0x84a7e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a8d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5753,7 +5753,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1360 EventRootType Probe[main.testUint8Array]
-              InjectionPoints: [{PC: "0x84a7b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a8a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5775,7 +5775,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1359 EventRootType Probe[main.testUintArray]
-              InjectionPoints: [{PC: "0x84a7a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a890", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5797,7 +5797,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1461 EventRootType Probe[main.testUintPointer]
-              InjectionPoints: [{PC: "0x850d40", Frameless: true}]
+              InjectionPoints: [{PC: "0x850ef0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5819,7 +5819,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1568 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0x8536d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x853880", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5841,7 +5841,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1594 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0x853b80", Frameless: true}]
+              InjectionPoints: [{PC: "0x854000", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5863,7 +5863,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1460 EventRootType Probe[main.testUnsafePointer]
-              InjectionPoints: [{PC: "0x850d20", Frameless: true}]
+              InjectionPoints: [{PC: "0x850ed0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5885,7 +5885,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1369 EventRootType Probe[main.testVeryLargeArray]
-              InjectionPoints: [{PC: "0x84a850", Frameless: true}]
+              InjectionPoints: [{PC: "0x84a940", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5907,7 +5907,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1577 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x853760", Frameless: true}]
+              InjectionPoints: [{PC: "0x853910", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5929,7 +5929,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1578 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x853760", Frameless: true}]
+              InjectionPoints: [{PC: "0x853910", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5952,14 +5952,14 @@ Probes:
             - Kind: Entry
               Type: 1675 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
-                - PC: "0x84eb78"
+                - PC: "0x84ec68"
                   Frameless: false
-                - PC: "0x85638c"
+                - PC: "0x85680c"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1676 EventRootType Probe[main.firstBehavior.DoSomething]Return
-              InjectionPoints: [{PC: "0x84ebb0", Frameless: false}]
+              InjectionPoints: [{PC: "0x84eca0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testWhollyInlinedSubroutine
@@ -5981,11 +5981,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1566 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0x8531d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x853388", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1567 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x853240", Frameless: false}]
+              InjectionPoints: [{PC: "0x8533f0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -6002,481 +6002,481 @@ Probes:
 Subprograms:
     - ID: 1
       Name: main.testByteArray
-      OutOfLinePCRanges: [0x84a710..0x84a720]
+      OutOfLinePCRanges: [0x84a800..0x84a810]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 108 ArrayType [2]uint8
           Locations:
-            - Range: 0x84a710..0x84a720
+            - Range: 0x84a800..0x84a810
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 2
       Name: main.testRuneArray
-      OutOfLinePCRanges: [0x84a720..0x84a730]
+      OutOfLinePCRanges: [0x84a810..0x84a820]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 109 ArrayType [2]int32
           Locations:
-            - Range: 0x84a720..0x84a730
+            - Range: 0x84a810..0x84a820
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 3
       Name: main.testStringArray
-      OutOfLinePCRanges: [0x84a730..0x84a740]
+      OutOfLinePCRanges: [0x84a820..0x84a830]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 110 ArrayType [2]string
           Locations:
-            - Range: 0x84a730..0x84a740
+            - Range: 0x84a820..0x84a830
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 4
       Name: main.testBoolArray
-      OutOfLinePCRanges: [0x84a740..0x84a750]
+      OutOfLinePCRanges: [0x84a830..0x84a840]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 111 ArrayType [2]bool
           Locations:
-            - Range: 0x84a740..0x84a750
+            - Range: 0x84a830..0x84a840
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 5
       Name: main.testIntArray
-      OutOfLinePCRanges: [0x84a750..0x84a760]
+      OutOfLinePCRanges: [0x84a840..0x84a850]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 112 ArrayType [2]int
           Locations:
-            - Range: 0x84a750..0x84a760
+            - Range: 0x84a840..0x84a850
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 6
       Name: main.testInt8Array
-      OutOfLinePCRanges: [0x84a760..0x84a770]
+      OutOfLinePCRanges: [0x84a850..0x84a860]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 113 ArrayType [2]int8
           Locations:
-            - Range: 0x84a760..0x84a770
+            - Range: 0x84a850..0x84a860
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 7
       Name: main.testInt16Array
-      OutOfLinePCRanges: [0x84a770..0x84a780]
+      OutOfLinePCRanges: [0x84a860..0x84a870]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 114 ArrayType [2]int16
           Locations:
-            - Range: 0x84a770..0x84a780
+            - Range: 0x84a860..0x84a870
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 8
       Name: main.testInt32Array
-      OutOfLinePCRanges: [0x84a780..0x84a790]
+      OutOfLinePCRanges: [0x84a870..0x84a880]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 109 ArrayType [2]int32
           Locations:
-            - Range: 0x84a780..0x84a790
+            - Range: 0x84a870..0x84a880
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 9
       Name: main.testInt64Array
-      OutOfLinePCRanges: [0x84a790..0x84a7a0]
+      OutOfLinePCRanges: [0x84a880..0x84a890]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 115 ArrayType [2]int64
           Locations:
-            - Range: 0x84a790..0x84a7a0
+            - Range: 0x84a880..0x84a890
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 10
       Name: main.testUintArray
-      OutOfLinePCRanges: [0x84a7a0..0x84a7b0]
+      OutOfLinePCRanges: [0x84a890..0x84a8a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 116 ArrayType [2]uint
           Locations:
-            - Range: 0x84a7a0..0x84a7b0
+            - Range: 0x84a890..0x84a8a0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 11
       Name: main.testUint8Array
-      OutOfLinePCRanges: [0x84a7b0..0x84a7c0]
+      OutOfLinePCRanges: [0x84a8a0..0x84a8b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 108 ArrayType [2]uint8
           Locations:
-            - Range: 0x84a7b0..0x84a7c0
+            - Range: 0x84a8a0..0x84a8b0
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 12
       Name: main.testUint16Array
-      OutOfLinePCRanges: [0x84a7c0..0x84a7d0]
+      OutOfLinePCRanges: [0x84a8b0..0x84a8c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 117 ArrayType [2]uint16
           Locations:
-            - Range: 0x84a7c0..0x84a7d0
+            - Range: 0x84a8b0..0x84a8c0
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 13
       Name: main.testUint32Array
-      OutOfLinePCRanges: [0x84a7d0..0x84a7e0]
+      OutOfLinePCRanges: [0x84a8c0..0x84a8d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 118 ArrayType [2]uint32
           Locations:
-            - Range: 0x84a7d0..0x84a7e0
+            - Range: 0x84a8c0..0x84a8d0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 14
       Name: main.testUint64Array
-      OutOfLinePCRanges: [0x84a7e0..0x84a7f0]
+      OutOfLinePCRanges: [0x84a8d0..0x84a8e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 55 ArrayType [2]uint64
           Locations:
-            - Range: 0x84a7e0..0x84a7f0
+            - Range: 0x84a8d0..0x84a8e0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 15
       Name: main.testArrayOfArrays
-      OutOfLinePCRanges: [0x84a7f0..0x84a800]
+      OutOfLinePCRanges: [0x84a8e0..0x84a8f0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 119 ArrayType [2][2]int
           Locations:
-            - Range: 0x84a7f0..0x84a800
+            - Range: 0x84a8e0..0x84a8f0
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 16
       Name: main.testArrayOfStrings
-      OutOfLinePCRanges: [0x84a800..0x84a810]
+      OutOfLinePCRanges: [0x84a8f0..0x84a900]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 110 ArrayType [2]string
           Locations:
-            - Range: 0x84a800..0x84a810
+            - Range: 0x84a8f0..0x84a900
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 17
       Name: main.testArrayOfArraysOfArrays
-      OutOfLinePCRanges: [0x84a810..0x84a820]
+      OutOfLinePCRanges: [0x84a900..0x84a910]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 120 ArrayType [2][2][2]int
           Locations:
-            - Range: 0x84a810..0x84a820
+            - Range: 0x84a900..0x84a910
               Pieces: [{Size: 64, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 18
       Name: main.testArrayOfStructs
-      OutOfLinePCRanges: [0x84a820..0x84a830]
+      OutOfLinePCRanges: [0x84a910..0x84a920]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 121 ArrayType [2]main.nestedStruct
           Locations:
-            - Range: 0x84a820..0x84a830
+            - Range: 0x84a910..0x84a920
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 19
       Name: main.testArrayEmptyStructs
-      OutOfLinePCRanges: [0x84a830..0x84a840]
+      OutOfLinePCRanges: [0x84a920..0x84a930]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 123 ArrayType [2]struct {}
           Locations:
-            - Range: 0x84a830..0x84a840
+            - Range: 0x84a920..0x84a930
               Pieces: [{Size: 0, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 20
       Name: main.testVeryLargeArray
-      OutOfLinePCRanges: [0x84a850..0x84a860]
+      OutOfLinePCRanges: [0x84a940..0x84a950]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 125 ArrayType [100]uint
           Locations:
-            - Range: 0x84a850..0x84a860
+            - Range: 0x84a940..0x84a950
               Pieces: [{Size: 800, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 21
       Name: main.testSingleByte
-      OutOfLinePCRanges: [0x84ab80..0x84ab90]
+      OutOfLinePCRanges: [0x84ac70..0x84ac80]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x84ab80..0x84ab90
+            - Range: 0x84ac70..0x84ac80
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 22
       Name: main.testSingleRune
-      OutOfLinePCRanges: [0x84ab90..0x84aba0]
+      OutOfLinePCRanges: [0x84ac80..0x84ac90]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x84ab90..0x84aba0
+            - Range: 0x84ac80..0x84ac90
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 23
       Name: main.testSingleBool
-      OutOfLinePCRanges: [0x84aba0..0x84abb0]
+      OutOfLinePCRanges: [0x84ac90..0x84aca0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x84aba0..0x84abb0
+            - Range: 0x84ac90..0x84aca0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 24
       Name: main.testSingleInt
-      OutOfLinePCRanges: [0x84abb0..0x84abc0]
+      OutOfLinePCRanges: [0x84aca0..0x84acb0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0x84abb0..0x84abc0
+            - Range: 0x84aca0..0x84acb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 25
       Name: main.testSingleInt8
-      OutOfLinePCRanges: [0x84abc0..0x84abd0]
+      OutOfLinePCRanges: [0x84acb0..0x84acc0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType int8
           Locations:
-            - Range: 0x84abc0..0x84abd0
+            - Range: 0x84acb0..0x84acc0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 26
       Name: main.testSingleInt16
-      OutOfLinePCRanges: [0x84abd0..0x84abe0]
+      OutOfLinePCRanges: [0x84acc0..0x84acd0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 95 BaseType int16
           Locations:
-            - Range: 0x84abd0..0x84abe0
+            - Range: 0x84acc0..0x84acd0
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 27
       Name: main.testSingleInt32
-      OutOfLinePCRanges: [0x84abe0..0x84abf0]
+      OutOfLinePCRanges: [0x84acd0..0x84ace0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x84abe0..0x84abf0
+            - Range: 0x84acd0..0x84ace0
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 28
       Name: main.testSingleInt64
-      OutOfLinePCRanges: [0x84abf0..0x84ac00]
+      OutOfLinePCRanges: [0x84ace0..0x84acf0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 BaseType int64
           Locations:
-            - Range: 0x84abf0..0x84ac00
+            - Range: 0x84ace0..0x84acf0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 29
       Name: main.testSingleUint
-      OutOfLinePCRanges: [0x84ac00..0x84ac10]
+      OutOfLinePCRanges: [0x84acf0..0x84ad00]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 BaseType uint
           Locations:
-            - Range: 0x84ac00..0x84ac10
+            - Range: 0x84acf0..0x84ad00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 30
       Name: main.testSingleUint8
-      OutOfLinePCRanges: [0x84ac10..0x84ac20]
+      OutOfLinePCRanges: [0x84ad00..0x84ad10]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x84ac10..0x84ac20
+            - Range: 0x84ad00..0x84ad10
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 31
       Name: main.testSingleUint16
-      OutOfLinePCRanges: [0x84ac20..0x84ac30]
+      OutOfLinePCRanges: [0x84ad10..0x84ad20]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType uint16
           Locations:
-            - Range: 0x84ac20..0x84ac30
+            - Range: 0x84ad10..0x84ad20
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 32
       Name: main.testSingleUint32
-      OutOfLinePCRanges: [0x84ac30..0x84ac40]
+      OutOfLinePCRanges: [0x84ad20..0x84ad30]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint32
           Locations:
-            - Range: 0x84ac30..0x84ac40
+            - Range: 0x84ad20..0x84ad30
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 33
       Name: main.testSingleUint64
-      OutOfLinePCRanges: [0x84ac40..0x84ac50]
+      OutOfLinePCRanges: [0x84ad30..0x84ad40]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0x84ac40..0x84ac50
+            - Range: 0x84ad30..0x84ad40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 34
       Name: main.testSingleFloat32
-      OutOfLinePCRanges: [0x84ac50..0x84ac60]
+      OutOfLinePCRanges: [0x84ad40..0x84ad50]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 18 BaseType float32
           Locations:
-            - Range: 0x84ac50..0x84ac60
+            - Range: 0x84ad40..0x84ad50
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 35
       Name: main.testSingleFloat64
-      OutOfLinePCRanges: [0x84ac60..0x84ac70]
+      OutOfLinePCRanges: [0x84ad50..0x84ad60]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 19 BaseType float64
           Locations:
-            - Range: 0x84ac60..0x84ac70
+            - Range: 0x84ad50..0x84ad60
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 36
       Name: main.testTypeAlias
-      OutOfLinePCRanges: [0x84ac70..0x84ac80]
+      OutOfLinePCRanges: [0x84ad60..0x84ad70]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 126 BaseType main.typeAlias
           Locations:
-            - Range: 0x84ac70..0x84ac80
+            - Range: 0x84ad60..0x84ad70
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 37
       Name: main.testBigStruct
-      OutOfLinePCRanges: [0x84ad80..0x84ada0]
+      OutOfLinePCRanges: [0x84ae70..0x84ae90]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 127 StructureType main.bigStruct
           Locations:
-            - Range: 0x84ad80..0x84ada0
+            - Range: 0x84ae70..0x84ae90
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6495,48 +6495,48 @@ Subprograms:
       DictRegister: null
     - ID: 38
       Name: main.testErrorAtLine
-      OutOfLinePCRanges: [0x84adc0..0x84aee0]
+      OutOfLinePCRanges: [0x84aeb0..0x84afd0]
       InlinePCRanges: []
       Variables:
         - Name: shouldErr
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x84adc0..0x84ade0
+            - Range: 0x84aeb0..0x84aed0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
-          Locations: [{Range: 0x84adc0..0x84aee0, Pieces: []}]
+          Locations: [{Range: 0x84aeb0..0x84afd0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 8 BaseType int
-          Locations: [{Range: 0x84adc0..0x84aee0, Pieces: []}]
+          Locations: [{Range: 0x84aeb0..0x84afd0, Pieces: []}]
           Role: Local
           DictIndex: -1
         - Name: err
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0x84adf8..0x84ae18
+            - Range: 0x84aee8..0x84af08
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
-            - Range: 0x84ae18..0x84ae34
+            - Range: 0x84af08..0x84af24
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84ae34..0x84ae48
+            - Range: 0x84af24..0x84af38
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {CfaOffset: -64}
-            - Range: 0x84ae48..0x84aee0
+            - Range: 0x84af38..0x84afd0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
@@ -6547,39 +6547,39 @@ Subprograms:
       DictRegister: null
     - ID: 39
       Name: main.testDeepPtr1
-      OutOfLinePCRanges: [0x84af70..0x84af80]
+      OutOfLinePCRanges: [0x84b060..0x84b070]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 131 StructureType main.deepPtr1
           Locations:
-            - Range: 0x84af70..0x84af80
+            - Range: 0x84b060..0x84b070
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 40
       Name: main.testDeepPtr7
-      OutOfLinePCRanges: [0x84af80..0x84af90]
+      OutOfLinePCRanges: [0x84b070..0x84b080]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 134 PointerType *main.deepPtr7
           Locations:
-            - Range: 0x84af80..0x84af90
+            - Range: 0x84b070..0x84b080
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 41
       Name: main.testDeepSlice1
-      OutOfLinePCRanges: [0x84b120..0x84b130]
+      OutOfLinePCRanges: [0x84b210..0x84b220]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 136 StructureType main.deepSlice1
           Locations:
-            - Range: 0x84b120..0x84b130
+            - Range: 0x84b210..0x84b220
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6592,142 +6592,142 @@ Subprograms:
       DictRegister: null
     - ID: 42
       Name: main.testDeepSlice7
-      OutOfLinePCRanges: [0x84b130..0x84b140]
+      OutOfLinePCRanges: [0x84b220..0x84b230]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 140 PointerType *main.deepSlice7
           Locations:
-            - Range: 0x84b130..0x84b140
+            - Range: 0x84b220..0x84b230
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 43
       Name: main.testDeepMap1
-      OutOfLinePCRanges: [0x84b280..0x84b290]
+      OutOfLinePCRanges: [0x84b370..0x84b380]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 142 StructureType main.deepMap1
           Locations:
-            - Range: 0x84b280..0x84b290
+            - Range: 0x84b370..0x84b380
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 44
       Name: main.testDeepMap7
-      OutOfLinePCRanges: [0x84b290..0x84b2a0]
+      OutOfLinePCRanges: [0x84b380..0x84b390]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 148 PointerType *main.deepMap7
           Locations:
-            - Range: 0x84b290..0x84b2a0
+            - Range: 0x84b380..0x84b390
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 45
       Name: main.testStringType1
-      OutOfLinePCRanges: [0x84b2a0..0x84b2b0]
+      OutOfLinePCRanges: [0x84b390..0x84b3a0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 150 PointerType *main.stringType1
           Locations:
-            - Range: 0x84b2a0..0x84b2b0
+            - Range: 0x84b390..0x84b3a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 46
       Name: main.testStringType2
-      OutOfLinePCRanges: [0x84b2b0..0x84b2c0]
+      OutOfLinePCRanges: [0x84b3a0..0x84b3b0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 152 PointerType **main.stringType2
           Locations:
-            - Range: 0x84b2b0..0x84b2c0
+            - Range: 0x84b3a0..0x84b3b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 47
       Name: main.testLongFunctionWithChangingState
-      OutOfLinePCRanges: [0x84b2c0..0x84b4c0]
+      OutOfLinePCRanges: [0x84b3b0..0x84b5b0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 8 BaseType int
           Locations:
-            - Range: 0x84b384..0x84b394
+            - Range: 0x84b474..0x84b484
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84b430..0x84b440
+            - Range: 0x84b520..0x84b530
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: aPerArch
           Type: 8 BaseType int
           Locations:
-            - Range: 0x84b36c..0x84b370
+            - Range: 0x84b45c..0x84b460
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84b370..0x84b394
+            - Range: 0x84b460..0x84b484
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84b394..0x84b424
+            - Range: 0x84b484..0x84b514
               Pieces: [{Size: 8, Op: {CfaOffset: -160}}]
-            - Range: 0x84b424..0x84b42c
+            - Range: 0x84b514..0x84b51c
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0x84b42c..0x84b4c0
+            - Range: 0x84b51c..0x84b5b0
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
           Role: Local
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0x84b368..0x84b370
+            - Range: 0x84b458..0x84b460
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84b370..0x84b370
+            - Range: 0x84b460..0x84b460
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x84b370..0x84b394
+            - Range: 0x84b460..0x84b484
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84b394..0x84b424
+            - Range: 0x84b484..0x84b514
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0x84b424..0x84b428
+            - Range: 0x84b514..0x84b518
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0x84b428..0x84b42c
+            - Range: 0x84b518..0x84b51c
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x84b42c..0x84b440
+            - Range: 0x84b51c..0x84b530
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x84b440..0x84b4c0
+            - Range: 0x84b530..0x84b5b0
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 48
       Name: main.testManyPointers
-      OutOfLinePCRanges: [0x84b840..0x84b850]
+      OutOfLinePCRanges: [0x84b930..0x84b940]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 154 StructureType main.manyPointers
           Locations:
-            - Range: 0x84b840..0x84b850
+            - Range: 0x84b930..0x84b940
               Pieces: [{Size: 560, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 49
       Name: main.testManyStrings
-      OutOfLinePCRanges: [0x84d1b0..0x84d1c0]
+      OutOfLinePCRanges: [0x84d2a0..0x84d2b0]
       InlinePCRanges: []
       Variables:
         - Name: ss
           Type: 157 GoSliceHeaderType []string
           Locations:
-            - Range: 0x84d1b0..0x84d1c0
+            - Range: 0x84d2a0..0x84d2b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6740,13 +6740,13 @@ Subprograms:
       DictRegister: null
     - ID: 50
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0x84d450..0x84d520]
+      OutOfLinePCRanges: [0x84d540..0x84d610]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 158 StructureType main.esotericStack
           Locations:
-            - Range: 0x84d450..0x84d498
+            - Range: 0x84d540..0x84d588
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -6766,7 +6766,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x84d498..0x84d49c
+            - Range: 0x84d588..0x84d58c
               Pieces:
                 - Size: 4
                   Op: null
@@ -6786,7 +6786,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x84d49c..0x84d4a0
+            - Range: 0x84d58c..0x84d590
               Pieces:
                 - Size: 4
                   Op: null
@@ -6811,157 +6811,157 @@ Subprograms:
       DictRegister: null
     - ID: 51
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0x84d520..0x84d5a0]
+      OutOfLinePCRanges: [0x84d610..0x84d690]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 162 PointerType *main.esotericHeap
           Locations:
-            - Range: 0x84d520..0x84d558
+            - Range: 0x84d610..0x84d648
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 52
       Name: main.testInlinedBA
-      OutOfLinePCRanges: [0x84e6b0..0x84e740]
+      OutOfLinePCRanges: [0x84e7a0..0x84e830]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0x84e6b0..0x84e6e8
+            - Range: 0x84e7a0..0x84e7d8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 53
       Name: main.testInlinedBB
-      OutOfLinePCRanges: [0x84e740..0x84e800]
+      OutOfLinePCRanges: [0x84e830..0x84e8f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0x84e740..0x84e75c
+            - Range: 0x84e830..0x84e84c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: "y"
           Type: 8 BaseType int
           Locations:
-            - Range: 0x84e740..0x84e76c
+            - Range: 0x84e830..0x84e85c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: z
           Type: 8 BaseType int
           Locations:
-            - Range: 0x84e75c..0x84e76c
+            - Range: 0x84e84c..0x84e85c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84e76c..0x84e800
+            - Range: 0x84e85c..0x84e8f0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 54
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0x84e800..0x84e880]
+      OutOfLinePCRanges: [0x84e8f0..0x84e970]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0x84e800..0x84e824
+            - Range: 0x84e8f0..0x84e914
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 55
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0x84e880..0x84e9a0]
+      OutOfLinePCRanges: [0x84e970..0x84ea90]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 8 BaseType int
           Locations:
-            - Range: 0x84e8e8..0x84e8f0
+            - Range: 0x84e9d8..0x84e9e0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x84e8f0..0x84e908
+            - Range: 0x84e9e0..0x84e9f8
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x84e908..0x84e91c
+            - Range: 0x84e9f8..0x84ea0c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x84e8e4..0x84e8ec
+            - Range: 0x84e9d4..0x84e9dc
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x84e8ec..0x84e908
+            - Range: 0x84e9dc..0x84e9f8
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x84e908..0x84e918
+            - Range: 0x84e9f8..0x84ea08
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 56
       Name: main.testFrameless
-      OutOfLinePCRanges: [0x84e9a0..0x84e9b0]
+      OutOfLinePCRanges: [0x84ea90..0x84eaa0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0x84e9a0..0x84e9a8
+            - Range: 0x84ea90..0x84ea98
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x84e9a0..0x84e9a8
+            - Range: 0x84ea90..0x84ea98
               Pieces: []
-            - Range: 0x84e9a8..0x84e9a9
+            - Range: 0x84ea98..0x84ea99
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84e9a9..0x84e9b0
+            - Range: 0x84ea99..0x84eaa0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 57
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0x84e9b0..0x84ea10]
+      OutOfLinePCRanges: [0x84eaa0..0x84eb00]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 164 ArrayType [5]int
           Locations:
-            - Range: 0x84e9b0..0x84ea10
+            - Range: 0x84eaa0..0x84eb00
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x84e9b0..0x84e9f8
+            - Range: 0x84eaa0..0x84eae8
               Pieces: []
-            - Range: 0x84e9f8..0x84e9f9
+            - Range: 0x84eae8..0x84eae9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84e9f9..0x84ea10
+            - Range: 0x84eae9..0x84eb00
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 58
       Name: main.testInterface
-      OutOfLinePCRanges: [0x84ec40..0x84ec50]
+      OutOfLinePCRanges: [0x84ed30..0x84ed40]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 165 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x84ec40..0x84ec50
+            - Range: 0x84ed30..0x84ed40
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6972,19 +6972,19 @@ Subprograms:
       DictRegister: null
     - ID: 59
       Name: main.testAny
-      OutOfLinePCRanges: [0x84ec50..0x84ecc0]
+      OutOfLinePCRanges: [0x84ed40..0x84edb0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 160 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x84ec50..0x84ec80
+            - Range: 0x84ed40..0x84ed70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84ec80..0x84ec84
+            - Range: 0x84ed70..0x84ed74
               Pieces:
                 - Size: 8
                   Op: null
@@ -6995,28 +6995,28 @@ Subprograms:
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x84ec50..0x84ec94
+            - Range: 0x84ed40..0x84ed84
               Pieces: []
-            - Range: 0x84ec94..0x84ec95
+            - Range: 0x84ed84..0x84ed85
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84ec95..0x84ecc0
+            - Range: 0x84ed85..0x84edb0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 60
       Name: main.testError
-      OutOfLinePCRanges: [0x84ecc0..0x84ecd0]
+      OutOfLinePCRanges: [0x84edb0..0x84edc0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0x84ecc0..0x84ecd0
+            - Range: 0x84edb0..0x84edc0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7027,41 +7027,41 @@ Subprograms:
       DictRegister: null
     - ID: 61
       Name: main.testAnyPtr
-      OutOfLinePCRanges: [0x84ecd0..0x84ed40]
+      OutOfLinePCRanges: [0x84edc0..0x84ee30]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 166 PointerType *interface {}
           Locations:
-            - Range: 0x84ecd0..0x84ed00
+            - Range: 0x84edc0..0x84edf0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x84ecd0..0x84ed14
+            - Range: 0x84edc0..0x84ee04
               Pieces: []
-            - Range: 0x84ed14..0x84ed15
+            - Range: 0x84ee04..0x84ee05
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84ed15..0x84ed40
+            - Range: 0x84ee05..0x84ee30
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 62
       Name: main.testStructWithAny
-      OutOfLinePCRanges: [0x84ed40..0x84ed50]
+      OutOfLinePCRanges: [0x84ee30..0x84ee40]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 167 StructureType main.structWithAny
           Locations:
-            - Range: 0x84ed40..0x84ed50
+            - Range: 0x84ee30..0x84ee40
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7072,346 +7072,346 @@ Subprograms:
       DictRegister: null
     - ID: 63
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x84f300..0x84f310]
+      OutOfLinePCRanges: [0x84f4b0..0x84f4c0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 168 StructureType main.structWithMap
           Locations:
-            - Range: 0x84f300..0x84f310
+            - Range: 0x84f4b0..0x84f4c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 64
       Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x84f310..0x84f320]
+      OutOfLinePCRanges: [0x84f4c0..0x84f4d0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 174 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0x84f310..0x84f320
+            - Range: 0x84f4c0..0x84f4d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 65
       Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0x84f320..0x84f330]
+      OutOfLinePCRanges: [0x84f4d0..0x84f4e0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 179 GoMapType map[string]int
           Locations:
-            - Range: 0x84f320..0x84f330
+            - Range: 0x84f4d0..0x84f4e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 66
       Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0x84f330..0x84f340]
+      OutOfLinePCRanges: [0x84f4e0..0x84f4f0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 184 GoMapType map[string][]string
           Locations:
-            - Range: 0x84f330..0x84f340
+            - Range: 0x84f4e0..0x84f4f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 67
       Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0x84f340..0x84f350]
+      OutOfLinePCRanges: [0x84f4f0..0x84f500]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 189 GoMapType map[[4]string][2]int
           Locations:
-            - Range: 0x84f340..0x84f350
+            - Range: 0x84f4f0..0x84f500
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 68
       Name: main.testSmallMap
-      OutOfLinePCRanges: [0x84f350..0x84f360]
+      OutOfLinePCRanges: [0x84f500..0x84f510]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 179 GoMapType map[string]int
           Locations:
-            - Range: 0x84f350..0x84f360
+            - Range: 0x84f500..0x84f510
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 69
       Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0x84f360..0x84f370]
+      OutOfLinePCRanges: [0x84f510..0x84f520]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 194 ArrayType [2]map[string]int
           Locations:
-            - Range: 0x84f360..0x84f370
+            - Range: 0x84f510..0x84f520
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 70
       Name: main.testPointerToMap
-      OutOfLinePCRanges: [0x84f370..0x84f380]
+      OutOfLinePCRanges: [0x84f520..0x84f530]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 195 PointerType *map[string]int
           Locations:
-            - Range: 0x84f370..0x84f380
+            - Range: 0x84f520..0x84f530
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 71
       Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0x84f380..0x84f390]
+      OutOfLinePCRanges: [0x84f530..0x84f540]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 169 GoMapType map[int]int
           Locations:
-            - Range: 0x84f380..0x84f390
+            - Range: 0x84f530..0x84f540
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 72
       Name: main.testMapMassive
-      OutOfLinePCRanges: [0x84f390..0x84f3a0]
+      OutOfLinePCRanges: [0x84f540..0x84f550]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 196 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x84f390..0x84f3a0
+            - Range: 0x84f540..0x84f550
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 73
       Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0x84f3a0..0x84f3b0]
+      OutOfLinePCRanges: [0x84f550..0x84f560]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 196 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x84f3a0..0x84f3b0
+            - Range: 0x84f550..0x84f560
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 74
       Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0x84f3b0..0x84f3c0]
+      OutOfLinePCRanges: [0x84f560..0x84f570]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 201 GoMapType map[bool]main.node
           Locations:
-            - Range: 0x84f3b0..0x84f3c0
+            - Range: 0x84f560..0x84f570
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 75
       Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0x84f3c0..0x84f3d0]
+      OutOfLinePCRanges: [0x84f570..0x84f580]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 206 GoMapType map[int]uint8
           Locations:
-            - Range: 0x84f3c0..0x84f3d0
+            - Range: 0x84f570..0x84f580
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 76
       Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0x84f3d0..0x84f3e0]
+      OutOfLinePCRanges: [0x84f580..0x84f590]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 206 GoMapType map[int]uint8
           Locations:
-            - Range: 0x84f3d0..0x84f3e0
+            - Range: 0x84f580..0x84f590
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 77
       Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0x84f3e0..0x84f3f0]
+      OutOfLinePCRanges: [0x84f590..0x84f5a0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 211 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x84f3e0..0x84f3f0
+            - Range: 0x84f590..0x84f5a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 78
       Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0x84f3f0..0x84f400]
+      OutOfLinePCRanges: [0x84f5a0..0x84f5b0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 211 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x84f3f0..0x84f400
+            - Range: 0x84f5a0..0x84f5b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 79
       Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0x84f400..0x84f410]
+      OutOfLinePCRanges: [0x84f5b0..0x84f5c0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 211 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x84f400..0x84f410
+            - Range: 0x84f5b0..0x84f5c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 80
       Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0x84f410..0x84f420]
+      OutOfLinePCRanges: [0x84f5c0..0x84f5d0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 216 GoMapType map[uint8][4]int
           Locations:
-            - Range: 0x84f410..0x84f420
+            - Range: 0x84f5c0..0x84f5d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 81
       Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0x84f420..0x84f430]
+      OutOfLinePCRanges: [0x84f5d0..0x84f5e0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 221 GoMapType map[[4]int]uint8
           Locations:
-            - Range: 0x84f420..0x84f430
+            - Range: 0x84f5d0..0x84f5e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 82
       Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0x84f430..0x84f440]
+      OutOfLinePCRanges: [0x84f5e0..0x84f5f0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 226 GoMapType map[[4]int][4]int
           Locations:
-            - Range: 0x84f430..0x84f440
+            - Range: 0x84f5e0..0x84f5f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 83
       Name: main.testMapEmptyKey
-      OutOfLinePCRanges: [0x84f440..0x84f450]
+      OutOfLinePCRanges: [0x84f5f0..0x84f600]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 231 GoMapType map[struct {}]int
           Locations:
-            - Range: 0x84f440..0x84f450
+            - Range: 0x84f5f0..0x84f600
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 84
       Name: main.testMapEmptyValue
-      OutOfLinePCRanges: [0x84f450..0x84f460]
+      OutOfLinePCRanges: [0x84f600..0x84f610]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 236 GoMapType map[int]struct {}
           Locations:
-            - Range: 0x84f450..0x84f460
+            - Range: 0x84f600..0x84f610
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 85
       Name: main.testMapEmptyKeyAndValue
-      OutOfLinePCRanges: [0x84f460..0x84f470]
+      OutOfLinePCRanges: [0x84f610..0x84f620]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 241 GoMapType map[struct {}]struct {}
           Locations:
-            - Range: 0x84f460..0x84f470
+            - Range: 0x84f610..0x84f620
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 86
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x850880..0x850890]
+      OutOfLinePCRanges: [0x850a30..0x850a40]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x850880..0x850890
+            - Range: 0x850a30..0x850a40
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x850880..0x850890
+            - Range: 0x850a30..0x850a40
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: "y"
           Type: 18 BaseType float32
           Locations:
-            - Range: 0x850880..0x850890
+            - Range: 0x850a30..0x850a40
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 87
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0x8508a0..0x8508b0]
+      OutOfLinePCRanges: [0x850a50..0x850a60]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x8508a0..0x8508b0
+            - Range: 0x850a50..0x850a60
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x8508a0..0x8508b0
+            - Range: 0x850a50..0x850a60
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -7422,48 +7422,48 @@ Subprograms:
         - Name: "y"
           Type: 18 BaseType float32
           Locations:
-            - Range: 0x8508a0..0x8508b0
+            - Range: 0x850a50..0x850a60
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 88
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x850960..0x850970]
+      OutOfLinePCRanges: [0x850b10..0x850b20]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x850960..0x850970
+            - Range: 0x850b10..0x850b20
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x850960..0x850970
+            - Range: 0x850b10..0x850b20
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x850960..0x850970
+            - Range: 0x850b10..0x850b20
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 11 BaseType uint
           Locations:
-            - Range: 0x850960..0x850970
+            - Range: 0x850b10..0x850b20
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x850960..0x850970
+            - Range: 0x850b10..0x850b20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7474,63 +7474,63 @@ Subprograms:
       DictRegister: null
     - ID: 89
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0x850b00..0x850b40]
+      OutOfLinePCRanges: [0x850cb0..0x850cf0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0x850b00..0x850b3c
+            - Range: 0x850cb0..0x850cec
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0x850b00..0x850b3c
+            - Range: 0x850cb0..0x850cec
               Pieces: []
-            - Range: 0x850b3c..0x850b3d
+            - Range: 0x850cec..0x850ced
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x850b3d..0x850b40
+            - Range: 0x850ced..0x850cf0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 90
       Name: main.testChannel
-      OutOfLinePCRanges: [0x850b40..0x850b50]
+      OutOfLinePCRanges: [0x850cf0..0x850d00]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 246 GoChannelType chan bool
           Locations:
-            - Range: 0x850b40..0x850b50
+            - Range: 0x850cf0..0x850d00
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 91
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x850cf0..0x850d00]
+      OutOfLinePCRanges: [0x850ea0..0x850eb0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 247 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x850cf0..0x850d00
+            - Range: 0x850ea0..0x850eb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 92
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x850d00..0x850d10]
+      OutOfLinePCRanges: [0x850eb0..0x850ec0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 249 StructureType main.node
           Locations:
-            - Range: 0x850d00..0x850d10
+            - Range: 0x850eb0..0x850ec0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7541,273 +7541,273 @@ Subprograms:
       DictRegister: null
     - ID: 93
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x850d10..0x850d20]
+      OutOfLinePCRanges: [0x850ec0..0x850ed0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 250 PointerType *main.node
           Locations:
-            - Range: 0x850d10..0x850d20
+            - Range: 0x850ec0..0x850ed0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 94
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x850d20..0x850d30]
+      OutOfLinePCRanges: [0x850ed0..0x850ee0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0x850d20..0x850d30
+            - Range: 0x850ed0..0x850ee0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 95
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x850d40..0x850d50]
+      OutOfLinePCRanges: [0x850ef0..0x850f00]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 106 PointerType *uint
           Locations:
-            - Range: 0x850d40..0x850d50
+            - Range: 0x850ef0..0x850f00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 96
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x850db0..0x850dc0]
+      OutOfLinePCRanges: [0x850f60..0x850f70]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 94 PointerType *string
           Locations:
-            - Range: 0x850db0..0x850dc0
+            - Range: 0x850f60..0x850f70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 97
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x850dd0..0x850de0]
+      OutOfLinePCRanges: [0x850f80..0x850f90]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 12 PointerType *bool
           Locations:
-            - Range: 0x850dd0..0x850de0
+            - Range: 0x850f80..0x850f90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 11 BaseType uint
           Locations:
-            - Range: 0x850dd0..0x850de0
+            - Range: 0x850f80..0x850f90
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 98
       Name: main.testCycle
-      OutOfLinePCRanges: [0x850df0..0x850e00]
+      OutOfLinePCRanges: [0x850fa0..0x850fb0]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 251 PointerType *main.t
           Locations:
-            - Range: 0x850df0..0x850e00
+            - Range: 0x850fa0..0x850fb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 99
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0x851130..0x8511b0]
+      OutOfLinePCRanges: [0x8512e0..0x851360]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x851130..0x85114c
+            - Range: 0x8512e0..0x8512fc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x851130..0x85118c
+            - Range: 0x8512e0..0x85133c
               Pieces: []
-            - Range: 0x85118c..0x85118d
+            - Range: 0x85133c..0x85133d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x85118d..0x8511b0
+            - Range: 0x85133d..0x851360
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result
           Type: 8 BaseType int
           Locations:
-            - Range: 0x85114c..0x851158
+            - Range: 0x8512fc..0x851308
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x851158..0x8511b0
+            - Range: 0x851308..0x851360
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 100
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0x8511b0..0x851250]
+      OutOfLinePCRanges: [0x851360..0x851400]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x8511b0..0x8511d4
+            - Range: 0x851360..0x851384
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8511d4..0x851250
+            - Range: 0x851384..0x851400
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 100 PointerType *int
           Locations:
-            - Range: 0x8511b0..0x851228
+            - Range: 0x851360..0x8513d8
               Pieces: []
-            - Range: 0x851228..0x851229
+            - Range: 0x8513d8..0x8513d9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x851229..0x851250
+            - Range: 0x8513d9..0x851400
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: '&result'
           Type: 100 PointerType *int
           Locations:
-            - Range: 0x8511d8..0x8511f0
+            - Range: 0x851388..0x8513a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8511f0..0x851250
+            - Range: 0x8513a0..0x851400
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 101
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0x851250..0x851320]
+      OutOfLinePCRanges: [0x851400..0x8514d0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x851250..0x8512a8
+            - Range: 0x851400..0x851458
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x851250..0x851300
+            - Range: 0x851400..0x8514b0
               Pieces: []
-            - Range: 0x851300..0x851301
+            - Range: 0x8514b0..0x8514b1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x851301..0x851320
+            - Range: 0x8514b1..0x8514d0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 19 BaseType float64
-          Locations: [{Range: 0x851250..0x851320, Pieces: []}]
+          Locations: [{Range: 0x851400..0x8514d0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: resultInt
           Type: 8 BaseType int
           Locations:
-            - Range: 0x85126c..0x8512ac
+            - Range: 0x85141c..0x85145c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x8512ac..0x851320
+            - Range: 0x85145c..0x8514d0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: -1
         - Name: resultFloat
           Type: 19 BaseType float64
           Locations:
-            - Range: 0x85127c..0x8512ac
+            - Range: 0x85142c..0x85145c
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-            - Range: 0x8512ac..0x851320
+            - Range: 0x85145c..0x8514d0
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 102
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0x851320..0x8513a0]
+      OutOfLinePCRanges: [0x8514d0..0x851550]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x851320..0x851344
+            - Range: 0x8514d0..0x8514f4
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0x851320..0x851368
+            - Range: 0x8514d0..0x851518
               Pieces: []
-            - Range: 0x851368..0x851369
+            - Range: 0x851518..0x851519
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x851369..0x85137c
+            - Range: 0x851519..0x85152c
               Pieces: []
-            - Range: 0x85137c..0x85137d
+            - Range: 0x85152c..0x85152d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x85137d..0x8513a0
+            - Range: 0x85152d..0x851550
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 103
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0x8513a0..0x851520]
+      OutOfLinePCRanges: [0x851550..0x8516d0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 160 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x8513a0..0x8513f0
+            - Range: 0x851550..0x8515a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8513f0..0x8513f4
+            - Range: 0x8515a0..0x8515a4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x851444..0x851448
+            - Range: 0x8515f4..0x8515f8
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x851484..0x851488
+            - Range: 0x851634..0x851638
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8514c4..0x8514c8
+            - Range: 0x851674..0x851678
               Pieces:
                 - Size: 8
                   Op: null
@@ -7818,117 +7818,117 @@ Subprograms:
         - Name: failed
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x8513a0..0x8513e4
+            - Range: 0x851550..0x851594
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 160 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x8513a0..0x85140c
+            - Range: 0x851550..0x8515bc
               Pieces: []
-            - Range: 0x85140c..0x85140d
+            - Range: 0x8515bc..0x8515bd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x85140d..0x851470
+            - Range: 0x8515bd..0x851620
               Pieces: []
-            - Range: 0x851470..0x851471
+            - Range: 0x851620..0x851621
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x851471..0x8514b0
+            - Range: 0x851621..0x851660
               Pieces: []
-            - Range: 0x8514b0..0x8514b1
+            - Range: 0x851660..0x851661
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8514b1..0x8514f0
+            - Range: 0x851661..0x8516a0
               Pieces: []
-            - Range: 0x8514f0..0x8514f1
+            - Range: 0x8516a0..0x8516a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8514f1..0x851520
+            - Range: 0x8516a1..0x8516d0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0x8513a0..0x85140c
+            - Range: 0x851550..0x8515bc
               Pieces: []
-            - Range: 0x85140c..0x85140d
+            - Range: 0x8515bc..0x8515bd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x85140d..0x851470
+            - Range: 0x8515bd..0x851620
               Pieces: []
-            - Range: 0x851470..0x851471
+            - Range: 0x851620..0x851621
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x851471..0x8514b0
+            - Range: 0x851621..0x851660
               Pieces: []
-            - Range: 0x8514b0..0x8514b1
+            - Range: 0x851660..0x851661
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8514b1..0x8514f0
+            - Range: 0x851661..0x8516a0
               Pieces: []
-            - Range: 0x8514f0..0x8514f1
+            - Range: 0x8516a0..0x8516a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8514f1..0x851520
+            - Range: 0x8516a1..0x8516d0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 8 BaseType int
           Locations:
-            - Range: 0x8513f0..0x8513f8
+            - Range: 0x8515a0..0x8515a8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 104
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0x851520..0x851720]
+      OutOfLinePCRanges: [0x8516d0..0x8518d0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 160 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x851520..0x851568
+            - Range: 0x8516d0..0x851718
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x851568..0x851570
+            - Range: 0x851718..0x851720
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x851570..0x851720
+            - Range: 0x851720..0x8518d0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -7939,549 +7939,549 @@ Subprograms:
         - Name: ~r0
           Type: 160 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x851520..0x8515d4
+            - Range: 0x8516d0..0x851784
               Pieces: []
-            - Range: 0x8515d4..0x8515d5
+            - Range: 0x851784..0x851785
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8515d5..0x85161c
+            - Range: 0x851785..0x8517cc
               Pieces: []
-            - Range: 0x85161c..0x85161d
+            - Range: 0x8517cc..0x8517cd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x85161d..0x8516e0
+            - Range: 0x8517cd..0x851890
               Pieces: []
-            - Range: 0x8516e0..0x8516e1
+            - Range: 0x851890..0x851891
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8516e1..0x8516f4
+            - Range: 0x851891..0x8518a4
               Pieces: []
-            - Range: 0x8516f4..0x8516f5
+            - Range: 0x8518a4..0x8518a5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8516f5..0x851720
+            - Range: 0x8518a5..0x8518d0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 8 BaseType int
           Locations:
-            - Range: 0x851608..0x851610
+            - Range: 0x8517b8..0x8517c0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: '&result'
           Type: 100 PointerType *int
           Locations:
-            - Range: 0x8515b8..0x8515d4
+            - Range: 0x851768..0x851784
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 105
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0x851720..0x851880]
+      OutOfLinePCRanges: [0x8518d0..0x851a30]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 160 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x851720..0x85175c
+            - Range: 0x8518d0..0x85190c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x85175c..0x8517a4
+            - Range: 0x85190c..0x851954
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x8517a4..0x851824
+            - Range: 0x851954..0x8519d4
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x851824..0x85184c
+            - Range: 0x8519d4..0x8519fc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x85184c..0x851850
+            - Range: 0x8519fc..0x851a00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x851850..0x851880
+            - Range: 0x851a00..0x851a30
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 165 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x851720..0x851804
+            - Range: 0x8518d0..0x8519b4
               Pieces: []
-            - Range: 0x851804..0x851805
+            - Range: 0x8519b4..0x8519b5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x851805..0x851818
+            - Range: 0x8519b5..0x8519c8
               Pieces: []
-            - Range: 0x851818..0x851819
+            - Range: 0x8519c8..0x8519c9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x851819..0x851880
+            - Range: 0x8519c9..0x851a30
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 165 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x851720..0x85175c
+            - Range: 0x8518d0..0x85190c
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x85175c..0x8517a4
+            - Range: 0x85190c..0x851954
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8517a4..0x8517ac
+            - Range: 0x851954..0x85195c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -64}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8517ac..0x851810
+            - Range: 0x85195c..0x8519c0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -64}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x851810..0x851814
+            - Range: 0x8519c0..0x8519c4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x851814..0x851818
+            - Range: 0x8519c4..0x8519c8
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x851818..0x851880
+            - Range: 0x8519c8..0x851a30
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 106
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0x851880..0x851920]
+      OutOfLinePCRanges: [0x851a30..0x851ad0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x851880..0x85189c
+            - Range: 0x851a30..0x851a4c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 8 BaseType int
           Locations:
-            - Range: 0x851880..0x8518f8
+            - Range: 0x851a30..0x851aa8
               Pieces: []
-            - Range: 0x8518f8..0x8518f9
+            - Range: 0x851aa8..0x851aa9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8518f9..0x851920
+            - Range: 0x851aa9..0x851ad0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 107
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0x851920..0x8519f0]
+      OutOfLinePCRanges: [0x851ad0..0x851ba0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x851920..0x851970
+            - Range: 0x851ad0..0x851b20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 8 BaseType int
           Locations:
-            - Range: 0x851920..0x8519c4
+            - Range: 0x851ad0..0x851b74
               Pieces: []
-            - Range: 0x8519c4..0x8519c5
+            - Range: 0x851b74..0x851b75
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8519c5..0x8519f0
+            - Range: 0x851b75..0x851ba0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 8 BaseType int
           Locations:
-            - Range: 0x851920..0x8519c4
+            - Range: 0x851ad0..0x851b74
               Pieces: []
-            - Range: 0x8519c4..0x8519c5
+            - Range: 0x851b74..0x851b75
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x8519c5..0x8519f0
+            - Range: 0x851b75..0x851ba0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 108
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0x8519f0..0x851ab0]
+      OutOfLinePCRanges: [0x851ba0..0x851c60]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x8519f0..0x851a30
+            - Range: 0x851ba0..0x851be0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x851a30..0x851ab0
+            - Range: 0x851be0..0x851c60
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x8519f0..0x851a90
+            - Range: 0x851ba0..0x851c40
               Pieces: []
-            - Range: 0x851a90..0x851a91
+            - Range: 0x851c40..0x851c41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x851a91..0x851ab0
+            - Range: 0x851c41..0x851c60
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 8 BaseType int
           Locations:
-            - Range: 0x8519f0..0x851a90
+            - Range: 0x851ba0..0x851c40
               Pieces: []
-            - Range: 0x851a90..0x851a91
+            - Range: 0x851c40..0x851c41
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x851a91..0x851ab0
+            - Range: 0x851c41..0x851c60
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0x8519f0..0x851a90
+            - Range: 0x851ba0..0x851c40
               Pieces: []
-            - Range: 0x851a90..0x851a91
+            - Range: 0x851c40..0x851c41
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x851a91..0x851ab0
+            - Range: 0x851c41..0x851c60
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 109
       Name: main.testConflictingReturn
-      OutOfLinePCRanges: [0x851ab0..0x851ba0]
+      OutOfLinePCRanges: [0x851c60..0x851d50]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x851ab0..0x851af0
+            - Range: 0x851c60..0x851ca0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x851af0..0x851ba0
+            - Range: 0x851ca0..0x851d50
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x851ab0..0x851b74
+            - Range: 0x851c60..0x851d24
               Pieces: []
-            - Range: 0x851b74..0x851b75
+            - Range: 0x851d24..0x851d25
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x851b75..0x851ba0
+            - Range: 0x851d25..0x851d50
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x851ab0..0x851b74
+            - Range: 0x851c60..0x851d24
               Pieces: []
-            - Range: 0x851b74..0x851b75
+            - Range: 0x851d24..0x851d25
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x851b75..0x851ba0
+            - Range: 0x851d25..0x851d50
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 110
       Name: main.testReturnsNamedDeferLine
-      OutOfLinePCRanges: [0x851ba0..0x851d60]
+      OutOfLinePCRanges: [0x851d50..0x851f10]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x851ba0..0x851c04
+            - Range: 0x851d50..0x851db4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x851c04..0x851d60
+            - Range: 0x851db4..0x851f10
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x851bcc..0x851d60
+            - Range: 0x851d7c..0x851f10
               Pieces: [{Size: 16, Op: {CfaOffset: -120}}]
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x851bd0..0x851d60
+            - Range: 0x851d80..0x851f10
               Pieces: [{Size: 16, Op: {CfaOffset: -136}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 111
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0x851e40..0x851ed0]
+      OutOfLinePCRanges: [0x851ff0..0x852080]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType int8
           Locations:
-            - Range: 0x851e40..0x851eb0
+            - Range: 0x851ff0..0x852060
               Pieces: []
-            - Range: 0x851eb0..0x851eb1
+            - Range: 0x852060..0x852061
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x851eb1..0x851ed0
+            - Range: 0x852061..0x852080
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 95 BaseType int16
           Locations:
-            - Range: 0x851e40..0x851eb0
+            - Range: 0x851ff0..0x852060
               Pieces: []
-            - Range: 0x851eb0..0x851eb1
+            - Range: 0x852060..0x852061
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x851eb1..0x851ed0
+            - Range: 0x852061..0x852080
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x851e40..0x851eb0
+            - Range: 0x851ff0..0x852060
               Pieces: []
-            - Range: 0x851eb0..0x851eb1
+            - Range: 0x852060..0x852061
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x851eb1..0x851ed0
+            - Range: 0x852061..0x852080
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 14 BaseType int64
           Locations:
-            - Range: 0x851e40..0x851eb0
+            - Range: 0x851ff0..0x852060
               Pieces: []
-            - Range: 0x851eb0..0x851eb1
+            - Range: 0x852060..0x852061
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x851eb1..0x851ed0
+            - Range: 0x852061..0x852080
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x851e40..0x851eb0
+            - Range: 0x851ff0..0x852060
               Pieces: []
-            - Range: 0x851eb0..0x851eb1
+            - Range: 0x852060..0x852061
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x851eb1..0x851ed0
+            - Range: 0x852061..0x852080
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 7 BaseType uint16
           Locations:
-            - Range: 0x851e40..0x851eb0
+            - Range: 0x851ff0..0x852060
               Pieces: []
-            - Range: 0x851eb0..0x851eb1
+            - Range: 0x852060..0x852061
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x851eb1..0x851ed0
+            - Range: 0x852061..0x852080
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 3 BaseType uint32
           Locations:
-            - Range: 0x851e40..0x851eb0
+            - Range: 0x851ff0..0x852060
               Pieces: []
-            - Range: 0x851eb0..0x851eb1
+            - Range: 0x852060..0x852061
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x851eb1..0x851ed0
+            - Range: 0x852061..0x852080
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0x851e40..0x851eb0
+            - Range: 0x851ff0..0x852060
               Pieces: []
-            - Range: 0x851eb0..0x851eb1
+            - Range: 0x852060..0x852061
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x851eb1..0x851ed0
+            - Range: 0x852061..0x852080
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 112
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0x851ed0..0x851f90]
+      OutOfLinePCRanges: [0x852080..0x852140]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 19 BaseType float64
-          Locations: [{Range: 0x851ed0..0x851f90, Pieces: []}]
+          Locations: [{Range: 0x852080..0x852140, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 19 BaseType float64
-          Locations: [{Range: 0x851ed0..0x851f90, Pieces: []}]
+          Locations: [{Range: 0x852080..0x852140, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 19 BaseType float64
-          Locations: [{Range: 0x851ed0..0x851f90, Pieces: []}]
+          Locations: [{Range: 0x852080..0x852140, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 19 BaseType float64
-          Locations: [{Range: 0x851ed0..0x851f90, Pieces: []}]
+          Locations: [{Range: 0x852080..0x852140, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 19 BaseType float64
-          Locations: [{Range: 0x851ed0..0x851f90, Pieces: []}]
+          Locations: [{Range: 0x852080..0x852140, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 19 BaseType float64
-          Locations: [{Range: 0x851ed0..0x851f90, Pieces: []}]
+          Locations: [{Range: 0x852080..0x852140, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 19 BaseType float64
-          Locations: [{Range: 0x851ed0..0x851f90, Pieces: []}]
+          Locations: [{Range: 0x852080..0x852140, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 19 BaseType float64
-          Locations: [{Range: 0x851ed0..0x851f90, Pieces: []}]
+          Locations: [{Range: 0x852080..0x852140, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 19 BaseType float64
-          Locations: [{Range: 0x851ed0..0x851f90, Pieces: []}]
+          Locations: [{Range: 0x852080..0x852140, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r9
           Type: 19 BaseType float64
-          Locations: [{Range: 0x851ed0..0x851f90, Pieces: []}]
+          Locations: [{Range: 0x852080..0x852140, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r10
           Type: 19 BaseType float64
-          Locations: [{Range: 0x851ed0..0x851f90, Pieces: []}]
+          Locations: [{Range: 0x852080..0x852140, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r11
           Type: 19 BaseType float64
-          Locations: [{Range: 0x851ed0..0x851f90, Pieces: []}]
+          Locations: [{Range: 0x852080..0x852140, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r12
           Type: 19 BaseType float64
-          Locations: [{Range: 0x851ed0..0x851f90, Pieces: []}]
+          Locations: [{Range: 0x852080..0x852140, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r13
           Type: 19 BaseType float64
-          Locations: [{Range: 0x851ed0..0x851f90, Pieces: []}]
+          Locations: [{Range: 0x852080..0x852140, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r14
           Type: 19 BaseType float64
-          Locations: [{Range: 0x851ed0..0x851f90, Pieces: []}]
+          Locations: [{Range: 0x852080..0x852140, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: onlyOnAmd64_16
           Type: 19 BaseType float64
-          Locations: [{Range: 0x851ed0..0x851f90, Pieces: []}]
+          Locations: [{Range: 0x852080..0x852140, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: bothArmAndAmd64
           Type: 19 BaseType float64
           Locations:
-            - Range: 0x851ed0..0x851f6c
+            - Range: 0x852080..0x85211c
               Pieces: []
-            - Range: 0x851f6c..0x851f6d
+            - Range: 0x85211c..0x85211d
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x851f6d..0x851f90
+            - Range: 0x85211d..0x852140
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 113
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0x851f90..0x852010]
+      OutOfLinePCRanges: [0x852140..0x8521c0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 96 BaseType complex64
-          Locations: [{Range: 0x851f90..0x852010, Pieces: []}]
+          Locations: [{Range: 0x852140..0x8521c0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 97 BaseType complex128
-          Locations: [{Range: 0x851f90..0x852010, Pieces: []}]
+          Locations: [{Range: 0x852140..0x8521c0, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 114
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0x852010..0x8520e0]
+      OutOfLinePCRanges: [0x8521c0..0x852290]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 253 StructureType main.largeStruct
           Locations:
-            - Range: 0x852010..0x8520c4
+            - Range: 0x8521c0..0x852274
               Pieces: []
-            - Range: 0x8520c4..0x8520c5
+            - Range: 0x852274..0x852275
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8503,193 +8503,193 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8520c5..0x8520e0
+            - Range: 0x852275..0x852290
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 115
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0x8520e0..0x852170]
+      OutOfLinePCRanges: [0x852290..0x852320]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 254 ArrayType [3]int
           Locations:
-            - Range: 0x8520e0..0x852150
+            - Range: 0x852290..0x852300
               Pieces: []
-            - Range: 0x852150..0x852151
+            - Range: 0x852300..0x852301
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x852151..0x852170
+            - Range: 0x852301..0x852320
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 116
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0x852170..0x8521e0]
+      OutOfLinePCRanges: [0x852320..0x852390]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 255 ArrayType [1]int
           Locations:
-            - Range: 0x852170..0x8521c4
+            - Range: 0x852320..0x852374
               Pieces: []
-            - Range: 0x8521c4..0x8521c5
+            - Range: 0x852374..0x852375
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8521c5..0x8521e0
+            - Range: 0x852375..0x852390
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 117
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0x8521e0..0x852250]
+      OutOfLinePCRanges: [0x852390..0x852400]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 256 ArrayType [0]int
           Locations:
-            - Range: 0x8521e0..0x852230
+            - Range: 0x852390..0x8523e0
               Pieces: []
-            - Range: 0x852230..0x852231
+            - Range: 0x8523e0..0x8523e1
               Pieces: []
-            - Range: 0x852231..0x852250
+            - Range: 0x8523e1..0x852400
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 118
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0x852250..0x8522d0]
+      OutOfLinePCRanges: [0x852400..0x852480]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 257 StructureType main.mixedStruct
-          Locations: [{Range: 0x852250..0x8522d0, Pieces: []}]
+          Locations: [{Range: 0x852400..0x852480, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 119
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0x8522d0..0x852370]
+      OutOfLinePCRanges: [0x852480..0x852520]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x8522d0..0x85234c
+            - Range: 0x852480..0x8524fc
               Pieces: []
-            - Range: 0x85234c..0x85234d
+            - Range: 0x8524fc..0x8524fd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x85234d..0x852370
+            - Range: 0x8524fd..0x852520
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 8 BaseType int
           Locations:
-            - Range: 0x8522d0..0x85234c
+            - Range: 0x852480..0x8524fc
               Pieces: []
-            - Range: 0x85234c..0x85234d
+            - Range: 0x8524fc..0x8524fd
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x85234d..0x852370
+            - Range: 0x8524fd..0x852520
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0x8522d0..0x85234c
+            - Range: 0x852480..0x8524fc
               Pieces: []
-            - Range: 0x85234c..0x85234d
+            - Range: 0x8524fc..0x8524fd
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x85234d..0x852370
+            - Range: 0x8524fd..0x852520
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 8 BaseType int
           Locations:
-            - Range: 0x8522d0..0x85234c
+            - Range: 0x852480..0x8524fc
               Pieces: []
-            - Range: 0x85234c..0x85234d
+            - Range: 0x8524fc..0x8524fd
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x85234d..0x852370
+            - Range: 0x8524fd..0x852520
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 8 BaseType int
           Locations:
-            - Range: 0x8522d0..0x85234c
+            - Range: 0x852480..0x8524fc
               Pieces: []
-            - Range: 0x85234c..0x85234d
+            - Range: 0x8524fc..0x8524fd
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x85234d..0x852370
+            - Range: 0x8524fd..0x852520
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 8 BaseType int
           Locations:
-            - Range: 0x8522d0..0x85234c
+            - Range: 0x852480..0x8524fc
               Pieces: []
-            - Range: 0x85234c..0x85234d
+            - Range: 0x8524fc..0x8524fd
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x85234d..0x852370
+            - Range: 0x8524fd..0x852520
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 8 BaseType int
           Locations:
-            - Range: 0x8522d0..0x85234c
+            - Range: 0x852480..0x8524fc
               Pieces: []
-            - Range: 0x85234c..0x85234d
+            - Range: 0x8524fc..0x8524fd
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x85234d..0x852370
+            - Range: 0x8524fd..0x852520
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 8 BaseType int
           Locations:
-            - Range: 0x8522d0..0x85234c
+            - Range: 0x852480..0x8524fc
               Pieces: []
-            - Range: 0x85234c..0x85234d
+            - Range: 0x8524fc..0x8524fd
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x85234d..0x852370
+            - Range: 0x8524fd..0x852520
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x8522d0..0x85234c
+            - Range: 0x852480..0x8524fc
               Pieces: []
-            - Range: 0x85234c..0x85234d
+            - Range: 0x8524fc..0x8524fd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x85234d..0x852370
+            - Range: 0x8524fd..0x852520
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 120
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0x852370..0x852450]
+      OutOfLinePCRanges: [0x852520..0x852600]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 258 StructureType main.wideStruct
           Locations:
-            - Range: 0x852370..0x852434
+            - Range: 0x852520..0x8525e4
               Pieces: []
-            - Range: 0x852434..0x852435
+            - Range: 0x8525e4..0x8525e5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8713,145 +8713,145 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0x852435..0x852450
+            - Range: 0x8525e5..0x852600
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 121
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0x852450..0x8524e0]
+      OutOfLinePCRanges: [0x852600..0x852690]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852450..0x8524c0
+            - Range: 0x852600..0x852670
               Pieces: []
-            - Range: 0x8524c0..0x8524c1
+            - Range: 0x852670..0x852671
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8524c1..0x8524e0
+            - Range: 0x852671..0x852690
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 19 BaseType float64
-          Locations: [{Range: 0x852450..0x8524e0, Pieces: []}]
+          Locations: [{Range: 0x852600..0x852690, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852450..0x8524c0
+            - Range: 0x852600..0x852670
               Pieces: []
-            - Range: 0x8524c0..0x8524c1
+            - Range: 0x852670..0x852671
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x8524c1..0x8524e0
+            - Range: 0x852671..0x852690
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 19 BaseType float64
-          Locations: [{Range: 0x852450..0x8524e0, Pieces: []}]
+          Locations: [{Range: 0x852600..0x852690, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x852450..0x8524c0
+            - Range: 0x852600..0x852670
               Pieces: []
-            - Range: 0x8524c0..0x8524c1
+            - Range: 0x852670..0x852671
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8524c1..0x8524e0
+            - Range: 0x852671..0x852690
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 122
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0x8524e0..0x852570]
+      OutOfLinePCRanges: [0x852690..0x852720]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 259 StructureType main.structWithArray
           Locations:
-            - Range: 0x8524e0..0x852550
+            - Range: 0x852690..0x852700
               Pieces: []
-            - Range: 0x852550..0x852551
+            - Range: 0x852700..0x852701
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x852551..0x852570
+            - Range: 0x852701..0x852720
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 123
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0x852570..0x8525e0]
+      OutOfLinePCRanges: [0x852720..0x852790]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 19 BaseType float64
-          Locations: [{Range: 0x852570..0x8525e0, Pieces: []}]
+          Locations: [{Range: 0x852720..0x852790, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 124
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0x8525e0..0x852660]
+      OutOfLinePCRanges: [0x852790..0x852810]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float32
-          Locations: [{Range: 0x8525e0..0x852660, Pieces: []}]
+          Locations: [{Range: 0x852790..0x852810, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 19 BaseType float64
-          Locations: [{Range: 0x8525e0..0x852660, Pieces: []}]
+          Locations: [{Range: 0x852790..0x852810, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 125
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0x852660..0x8526d0]
+      OutOfLinePCRanges: [0x852810..0x852880]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x852660..0x8526b8
+            - Range: 0x852810..0x852868
               Pieces: []
-            - Range: 0x8526b8..0x8526b9
+            - Range: 0x852868..0x852869
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8526b9..0x8526d0
+            - Range: 0x852869..0x852880
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 2 BaseType uintptr
           Locations:
-            - Range: 0x852660..0x8526b8
+            - Range: 0x852810..0x852868
               Pieces: []
-            - Range: 0x8526b8..0x8526b9
+            - Range: 0x852868..0x852869
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x8526b9..0x8526d0
+            - Range: 0x852869..0x852880
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 126
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0x8526d0..0x852890]
+      OutOfLinePCRanges: [0x852880..0x852a40]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 253 StructureType main.largeStruct
           Locations:
-            - Range: 0x8526d0..0x85273c
+            - Range: 0x852880..0x8528ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8873,7 +8873,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x85273c..0x852750
+            - Range: 0x8528ec..0x852900
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8895,7 +8895,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x852750..0x852754
+            - Range: 0x852900..0x852904
               Pieces:
                 - Size: 8
                   Op: null
@@ -8922,9 +8922,9 @@ Subprograms:
         - Name: ~r0
           Type: 253 StructureType main.largeStruct
           Locations:
-            - Range: 0x8526d0..0x852848
+            - Range: 0x852880..0x8529f8
               Pieces: []
-            - Range: 0x852848..0x852849
+            - Range: 0x8529f8..0x8529f9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8946,44 +8946,44 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x852849..0x852890
+            - Range: 0x8529f9..0x852a40
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 127
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0x852890..0x852960]
+      OutOfLinePCRanges: [0x852a40..0x852b10]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 254 ArrayType [3]int
           Locations:
-            - Range: 0x852890..0x852960
+            - Range: 0x852a40..0x852b10
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 254 ArrayType [3]int
           Locations:
-            - Range: 0x852890..0x852944
+            - Range: 0x852a40..0x852af4
               Pieces: []
-            - Range: 0x852944..0x852945
+            - Range: 0x852af4..0x852af5
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x852945..0x852960
+            - Range: 0x852af5..0x852b10
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 128
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0x852960..0x852b90]
+      OutOfLinePCRanges: [0x852b10..0x852d40]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 253 StructureType main.largeStruct
           Locations:
-            - Range: 0x852960..0x8529d0
+            - Range: 0x852b10..0x852b80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9005,7 +9005,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8529d0..0x8529e4
+            - Range: 0x852b80..0x852b94
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9027,7 +9027,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8529e4..0x8529e8
+            - Range: 0x852b94..0x852b98
               Pieces:
                 - Size: 8
                   Op: null
@@ -9054,16 +9054,16 @@ Subprograms:
         - Name: s2
           Type: 253 StructureType main.largeStruct
           Locations:
-            - Range: 0x852960..0x852b90
+            - Range: 0x852b10..0x852d40
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 253 StructureType main.largeStruct
           Locations:
-            - Range: 0x852960..0x852b50
+            - Range: 0x852b10..0x852d00
               Pieces: []
-            - Range: 0x852b50..0x852b51
+            - Range: 0x852d00..0x852d01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9085,196 +9085,196 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x852b51..0x852b90
+            - Range: 0x852d01..0x852d40
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 129
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0x852b90..0x852d60]
+      OutOfLinePCRanges: [0x852d40..0x852f10]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852b90..0x852c08
+            - Range: 0x852d40..0x852db8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x852c08..0x852d60
+            - Range: 0x852db8..0x852f10
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852b90..0x852bf4
+            - Range: 0x852d40..0x852da4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x852bf4..0x852d60
+            - Range: 0x852da4..0x852f10
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852b90..0x852c08
+            - Range: 0x852d40..0x852db8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x852c08..0x852d60
+            - Range: 0x852db8..0x852f10
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852b90..0x852c08
+            - Range: 0x852d40..0x852db8
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x852c08..0x852d60
+            - Range: 0x852db8..0x852f10
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852b90..0x852c08
+            - Range: 0x852d40..0x852db8
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x852c08..0x852d60
+            - Range: 0x852db8..0x852f10
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852b90..0x852c08
+            - Range: 0x852d40..0x852db8
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x852c08..0x852d60
+            - Range: 0x852db8..0x852f10
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852b90..0x852c08
+            - Range: 0x852d40..0x852db8
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x852c08..0x852d60
+            - Range: 0x852db8..0x852f10
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852b90..0x852c08
+            - Range: 0x852d40..0x852db8
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x852c08..0x852d60
+            - Range: 0x852db8..0x852f10
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852b90..0x852c08
+            - Range: 0x852d40..0x852db8
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0x852c08..0x852d60
+            - Range: 0x852db8..0x852f10
               Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 112 ArrayType [2]int
           Locations:
-            - Range: 0x852b90..0x852d18
+            - Range: 0x852d40..0x852ec8
               Pieces: []
-            - Range: 0x852d18..0x852d19
+            - Range: 0x852ec8..0x852ec9
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-            - Range: 0x852d19..0x852d60
+            - Range: 0x852ec9..0x852f10
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 130
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0x852d60..0x852f70]
+      OutOfLinePCRanges: [0x852f10..0x853120]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852d60..0x852de8
+            - Range: 0x852f10..0x852f98
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x852de8..0x852f70
+            - Range: 0x852f98..0x853120
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852d60..0x852dd4
+            - Range: 0x852f10..0x852f84
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x852dd4..0x852f70
+            - Range: 0x852f84..0x853120
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852d60..0x852de8
+            - Range: 0x852f10..0x852f98
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x852de8..0x852f70
+            - Range: 0x852f98..0x853120
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852d60..0x852de8
+            - Range: 0x852f10..0x852f98
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x852de8..0x852f70
+            - Range: 0x852f98..0x853120
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852d60..0x852de8
+            - Range: 0x852f10..0x852f98
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x852de8..0x852f70
+            - Range: 0x852f98..0x853120
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852d60..0x852de8
+            - Range: 0x852f10..0x852f98
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x852de8..0x852f70
+            - Range: 0x852f98..0x853120
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852d60..0x852de8
+            - Range: 0x852f10..0x852f98
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x852de8..0x852f70
+            - Range: 0x852f98..0x853120
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852d60..0x852de8
+            - Range: 0x852f10..0x852f98
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x852de8..0x852f70
+            - Range: 0x852f98..0x853120
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x852d60..0x852de8
+            - Range: 0x852f10..0x852f98
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x852de8..0x852f70
+            - Range: 0x852f98..0x853120
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 72}
@@ -9285,9 +9285,9 @@ Subprograms:
         - Name: ~r0
           Type: 253 StructureType main.largeStruct
           Locations:
-            - Range: 0x852d60..0x852f2c
+            - Range: 0x852f10..0x8530dc
               Pieces: []
-            - Range: 0x852f2c..0x852f2d
+            - Range: 0x8530dc..0x8530dd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9309,196 +9309,196 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x852f2d..0x852f70
+            - Range: 0x8530dd..0x853120
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 131
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0x852f70..0x853010]
+      OutOfLinePCRanges: [0x853120..0x8531c0]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 164 ArrayType [5]int
           Locations:
-            - Range: 0x852f70..0x853010
+            - Range: 0x853120..0x8531c0
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852f70..0x852fec
+            - Range: 0x853120..0x85319c
               Pieces: []
-            - Range: 0x852fec..0x852fed
+            - Range: 0x85319c..0x85319d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x852fed..0x853010
+            - Range: 0x85319d..0x8531c0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852f70..0x852fec
+            - Range: 0x853120..0x85319c
               Pieces: []
-            - Range: 0x852fec..0x852fed
+            - Range: 0x85319c..0x85319d
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x852fed..0x853010
+            - Range: 0x85319d..0x8531c0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852f70..0x852fec
+            - Range: 0x853120..0x85319c
               Pieces: []
-            - Range: 0x852fec..0x852fed
+            - Range: 0x85319c..0x85319d
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x852fed..0x853010
+            - Range: 0x85319d..0x8531c0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 132
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0x853010..0x8530f0]
+      OutOfLinePCRanges: [0x8531c0..0x8532a0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 112 ArrayType [2]int
           Locations:
-            - Range: 0x853010..0x8530f0
+            - Range: 0x8531c0..0x8532a0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 254 ArrayType [3]int
           Locations:
-            - Range: 0x853010..0x8530f0
+            - Range: 0x8531c0..0x8532a0
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x853010..0x8530d4
+            - Range: 0x8531c0..0x853284
               Pieces: []
-            - Range: 0x8530d4..0x8530d5
+            - Range: 0x853284..0x853285
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8530d5..0x8530f0
+            - Range: 0x853285..0x8532a0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 112 ArrayType [2]int
           Locations:
-            - Range: 0x853010..0x8530d4
+            - Range: 0x8531c0..0x853284
               Pieces: []
-            - Range: 0x8530d4..0x8530d5
+            - Range: 0x853284..0x853285
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
-            - Range: 0x8530d5..0x8530f0
+            - Range: 0x853285..0x8532a0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 133
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0x8530f0..0x8531c0]
+      OutOfLinePCRanges: [0x8532a0..0x853370]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 259 StructureType main.structWithArray
           Locations:
-            - Range: 0x8530f0..0x8531c0
+            - Range: 0x8532a0..0x853370
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x8530f0..0x85319c
+            - Range: 0x8532a0..0x85334c
               Pieces: []
-            - Range: 0x85319c..0x85319d
+            - Range: 0x85334c..0x85334d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x85319d..0x8531c0
+            - Range: 0x85334d..0x853370
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 259 StructureType main.structWithArray
           Locations:
-            - Range: 0x8530f0..0x85319c
+            - Range: 0x8532a0..0x85334c
               Pieces: []
-            - Range: 0x85319c..0x85319d
+            - Range: 0x85334c..0x85334d
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x85319d..0x8531c0
+            - Range: 0x85334d..0x853370
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0x853170..0x8531c0
+            - Range: 0x853320..0x853370
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 134
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0x8531c0..0x853260]
+      OutOfLinePCRanges: [0x853370..0x853410]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 256 ArrayType [0]int
-          Locations: [{Range: 0x8531c0..0x853260, Pieces: []}]
+          Locations: [{Range: 0x853370..0x853410, Pieces: []}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0x8531c0..0x853200
+            - Range: 0x853370..0x8533b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x853200..0x85321c
+            - Range: 0x8533b0..0x8533cc
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x85321c..0x853224
+            - Range: 0x8533cc..0x8533d4
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x853224..0x853260
+            - Range: 0x8533d4..0x853410
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x8531c0..0x853240
+            - Range: 0x853370..0x8533f0
               Pieces: []
-            - Range: 0x853240..0x853241
+            - Range: 0x8533f0..0x8533f1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x853241..0x853260
+            - Range: 0x8533f1..0x853410
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 256 ArrayType [0]int
           Locations:
-            - Range: 0x8531c0..0x853240
+            - Range: 0x853370..0x8533f0
               Pieces: []
-            - Range: 0x853240..0x853241
+            - Range: 0x8533f0..0x8533f1
               Pieces: []
-            - Range: 0x853241..0x853260
+            - Range: 0x8533f1..0x853410
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 135
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0x8536d0..0x8536e0]
+      OutOfLinePCRanges: [0x853880..0x853890]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 260 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8536d0..0x8536e0
+            - Range: 0x853880..0x853890
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9511,13 +9511,13 @@ Subprograms:
       DictRegister: null
     - ID: 136
       Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x8536e0..0x8536f0]
+      OutOfLinePCRanges: [0x853890..0x8538a0]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 260 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8536e0..0x8536f0
+            - Range: 0x853890..0x8538a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9530,13 +9530,13 @@ Subprograms:
       DictRegister: null
     - ID: 137
       Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x8536f0..0x853700]
+      OutOfLinePCRanges: [0x8538a0..0x8538b0]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 261 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0x8536f0..0x853700
+            - Range: 0x8538a0..0x8538b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9549,13 +9549,13 @@ Subprograms:
       DictRegister: null
     - ID: 138
       Name: main.testStructSlice
-      OutOfLinePCRanges: [0x853700..0x853710]
+      OutOfLinePCRanges: [0x8538b0..0x8538c0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 263 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x853700..0x853710
+            - Range: 0x8538b0..0x8538c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9568,20 +9568,20 @@ Subprograms:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0x853700..0x853710
+            - Range: 0x8538b0..0x8538c0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 139
       Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x853710..0x853720]
+      OutOfLinePCRanges: [0x8538c0..0x8538d0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 263 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x853710..0x853720
+            - Range: 0x8538c0..0x8538d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9594,20 +9594,20 @@ Subprograms:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0x853710..0x853720
+            - Range: 0x8538c0..0x8538d0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 140
       Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x853720..0x853730]
+      OutOfLinePCRanges: [0x8538d0..0x8538e0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 263 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x853720..0x853730
+            - Range: 0x8538d0..0x8538e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9620,20 +9620,20 @@ Subprograms:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0x853720..0x853730
+            - Range: 0x8538d0..0x8538e0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 141
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0x853730..0x853740]
+      OutOfLinePCRanges: [0x8538e0..0x8538f0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 157 GoSliceHeaderType []string
           Locations:
-            - Range: 0x853730..0x853740
+            - Range: 0x8538e0..0x8538f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9646,20 +9646,20 @@ Subprograms:
       DictRegister: null
     - ID: 142
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x853740..0x853750]
+      OutOfLinePCRanges: [0x8538f0..0x853900]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 17 BaseType int8
           Locations:
-            - Range: 0x853740..0x853750
+            - Range: 0x8538f0..0x853900
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 266 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x853740..0x853750
+            - Range: 0x8538f0..0x853900
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -9672,20 +9672,20 @@ Subprograms:
         - Name: x
           Type: 11 BaseType uint
           Locations:
-            - Range: 0x853740..0x853750
+            - Range: 0x8538f0..0x853900
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 143
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x853750..0x853760]
+      OutOfLinePCRanges: [0x853900..0x853910]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 267 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x853750..0x853760
+            - Range: 0x853900..0x853910
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9698,13 +9698,13 @@ Subprograms:
       DictRegister: null
     - ID: 144
       Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x853760..0x853770]
+      OutOfLinePCRanges: [0x853910..0x853920]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 260 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x853760..0x853770
+            - Range: 0x853910..0x853920
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9717,13 +9717,13 @@ Subprograms:
       DictRegister: null
     - ID: 145
       Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0x853770..0x853780]
+      OutOfLinePCRanges: [0x853920..0x853930]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 268 GoSliceHeaderType []struct {}
           Locations:
-            - Range: 0x853770..0x853780
+            - Range: 0x853920..0x853930
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9736,13 +9736,13 @@ Subprograms:
       DictRegister: null
     - ID: 146
       Name: main.testSubslices
-      OutOfLinePCRanges: [0x853780..0x853790]
+      OutOfLinePCRanges: [0x853930..0x853940]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 260 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x853780..0x853790
+            - Range: 0x853930..0x853940
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9755,7 +9755,7 @@ Subprograms:
         - Name: bs
           Type: 260 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x853780..0x853790
+            - Range: 0x853930..0x853940
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9768,7 +9768,7 @@ Subprograms:
         - Name: cs
           Type: 260 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x853780..0x853790
+            - Range: 0x853930..0x853940
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -9781,34 +9781,34 @@ Subprograms:
       DictRegister: null
     - ID: 147
       Name: main.stackC
-      OutOfLinePCRanges: [0x853aa0..0x853b10]
+      OutOfLinePCRanges: [0x853f20..0x853f90]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x853aa0..0x853aec
+            - Range: 0x853f20..0x853f6c
               Pieces: []
-            - Range: 0x853aec..0x853aed
+            - Range: 0x853f6c..0x853f6d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x853aed..0x853b10
+            - Range: 0x853f6d..0x853f90
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 148
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x853b10..0x853b20]
+      OutOfLinePCRanges: [0x853f90..0x853fa0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x853b10..0x853b20
+            - Range: 0x853f90..0x853fa0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9819,13 +9819,13 @@ Subprograms:
       DictRegister: null
     - ID: 149
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x853b20..0x853b30]
+      OutOfLinePCRanges: [0x853fa0..0x853fb0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x853b20..0x853b30
+            - Range: 0x853fa0..0x853fb0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9836,7 +9836,7 @@ Subprograms:
         - Name: "y"
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x853b20..0x853b30
+            - Range: 0x853fa0..0x853fb0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9847,7 +9847,7 @@ Subprograms:
         - Name: z
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x853b20..0x853b30
+            - Range: 0x853fa0..0x853fb0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9858,13 +9858,13 @@ Subprograms:
       DictRegister: null
     - ID: 150
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x853b30..0x853b50]
+      OutOfLinePCRanges: [0x853fb0..0x853fd0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 270 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x853b30..0x853b50
+            - Range: 0x853fb0..0x853fd0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9883,39 +9883,39 @@ Subprograms:
       DictRegister: null
     - ID: 151
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x853b50..0x853b60]
+      OutOfLinePCRanges: [0x853fd0..0x853fe0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 271 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x853b50..0x853b60
+            - Range: 0x853fd0..0x853fe0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 152
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x853b60..0x853b70]
+      OutOfLinePCRanges: [0x853fe0..0x853ff0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 272 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x853b60..0x853b70
+            - Range: 0x853fe0..0x853ff0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 153
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0x853b70..0x853b80]
+      OutOfLinePCRanges: [0x853ff0..0x854000]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x853b70..0x853b80
+            - Range: 0x853ff0..0x854000
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9926,13 +9926,13 @@ Subprograms:
       DictRegister: null
     - ID: 154
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x853b80..0x853b90]
+      OutOfLinePCRanges: [0x854000..0x854010]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x853b80..0x853b90
+            - Range: 0x854000..0x854010
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9943,13 +9943,13 @@ Subprograms:
       DictRegister: null
     - ID: 155
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0x853b90..0x853ba0]
+      OutOfLinePCRanges: [0x854010..0x854020]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x853b90..0x853ba0
+            - Range: 0x854010..0x854020
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9960,13 +9960,13 @@ Subprograms:
       DictRegister: null
     - ID: 156
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0x853ba0..0x853bb0]
+      OutOfLinePCRanges: [0x854020..0x854030]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x853ba0..0x853bb0
+            - Range: 0x854020..0x854030
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9977,7 +9977,7 @@ Subprograms:
         - Name: b
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x853ba0..0x853bb0
+            - Range: 0x854020..0x854030
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9988,7 +9988,7 @@ Subprograms:
         - Name: c
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x853ba0..0x853bb0
+            - Range: 0x854020..0x854030
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9999,26 +9999,26 @@ Subprograms:
       DictRegister: null
     - ID: 157
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x853d10..0x853d20]
+      OutOfLinePCRanges: [0x854190..0x8541a0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 274 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x853d10..0x853d20
+            - Range: 0x854190..0x8541a0
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 158
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x853d20..0x853d40]
+      OutOfLinePCRanges: [0x8541a0..0x8541c0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 287 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x853d20..0x853d40
+            - Range: 0x8541a0..0x8541c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10037,13 +10037,13 @@ Subprograms:
       DictRegister: null
     - ID: 159
       Name: main.testStruct
-      OutOfLinePCRanges: [0x853e10..0x853e30]
+      OutOfLinePCRanges: [0x854290..0x8542b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 318 StructureType main.aStruct
           Locations:
-            - Range: 0x853e10..0x853e30
+            - Range: 0x854290..0x8542b0
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -10064,93 +10064,93 @@ Subprograms:
       DictRegister: null
     - ID: 160
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0x853eb0..0x853ec0]
+      OutOfLinePCRanges: [0x854330..0x854340]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 319 PointerType *main.anotherStruct
           Locations:
-            - Range: 0x853eb0..0x853ec0
+            - Range: 0x854330..0x854340
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 161
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0x853ec0..0x853ed0]
+      OutOfLinePCRanges: [0x854340..0x854350]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 321 StructureType main.tenStrings
           Locations:
-            - Range: 0x853ec0..0x853ed0
+            - Range: 0x854340..0x854350
               Pieces: [{Size: 160, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 162
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x853f10..0x853f20]
+      OutOfLinePCRanges: [0x854390..0x8543a0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 322 StructureType main.emptyStruct
-          Locations: [{Range: 0x853f10..0x853f20, Pieces: []}]
+          Locations: [{Range: 0x854390..0x8543a0, Pieces: []}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 163
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x853f20..0x853f30]
+      OutOfLinePCRanges: [0x8543a0..0x8543b0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 323 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x853f20..0x853f30
+            - Range: 0x8543a0..0x8543b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 164
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0x855830..0x855840]
+      OutOfLinePCRanges: [0x855cb0..0x855cc0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0x855830..0x855840
+            - Range: 0x855cb0..0x855cc0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 325 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x855830..0x855834
+            - Range: 0x855cb0..0x855cb4
               Pieces: []
-            - Range: 0x855834..0x855835
+            - Range: 0x855cb4..0x855cb5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x855835..0x855840
+            - Range: 0x855cb5..0x855cc0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 165
       Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0x855840..0x855850]
+      OutOfLinePCRanges: [0x855cc0..0x855cd0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x855840..0x85584c
+            - Range: 0x855cc0..0x855ccc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x85584c..0x855850
+            - Range: 0x855ccc..0x855cd0
               Pieces:
                 - Size: 8
                   Op: null
@@ -10161,58 +10161,58 @@ Subprograms:
         - Name: ~r0
           Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x855840..0x85584c
+            - Range: 0x855cc0..0x855ccc
               Pieces: []
-            - Range: 0x85584c..0x85584d
+            - Range: 0x855ccc..0x855ccd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x85584d..0x855850
+            - Range: 0x855ccd..0x855cd0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 166
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0x855850..0x855860]
+      OutOfLinePCRanges: [0x855cd0..0x855ce0]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 325 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x855850..0x855860
+            - Range: 0x855cd0..0x855ce0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0x855850..0x855854
+            - Range: 0x855cd0..0x855cd4
               Pieces: []
-            - Range: 0x855854..0x855855
+            - Range: 0x855cd4..0x855cd5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x855855..0x855860
+            - Range: 0x855cd5..0x855ce0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 167
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0x855860..0x855870]
+      OutOfLinePCRanges: [0x855ce0..0x855cf0]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x855860..0x85586c
+            - Range: 0x855ce0..0x855cec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x85586c..0x855870
+            - Range: 0x855cec..0x855cf0
               Pieces:
                 - Size: 8
                   Op: null
@@ -10223,28 +10223,28 @@ Subprograms:
         - Name: ~r0
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x855860..0x85586c
+            - Range: 0x855ce0..0x855cec
               Pieces: []
-            - Range: 0x85586c..0x85586d
+            - Range: 0x855cec..0x855ced
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x85586d..0x855870
+            - Range: 0x855ced..0x855cf0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 168
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0x8558d0..0x8559f0]
+      OutOfLinePCRanges: [0x855d50..0x855e70]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 328 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x8558d0..0x8558fc
+            - Range: 0x855d50..0x855d7c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10252,7 +10252,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8558fc..0x85590c
+            - Range: 0x855d7c..0x855d8c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10260,7 +10260,7 @@ Subprograms:
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: null
-            - Range: 0x85590c..0x8559f0
+            - Range: 0x855d8c..0x855e70
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10273,18 +10273,18 @@ Subprograms:
         - Name: pred
           Type: 330 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0x8558d0..0x85590c
+            - Range: 0x855d50..0x855d8c
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x85590c..0x8559f0
+            - Range: 0x855d8c..0x855e70
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 328 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x8558d0..0x8559bc
+            - Range: 0x855d50..0x855e3c
               Pieces: []
-            - Range: 0x8559bc..0x8559bd
+            - Range: 0x855e3c..0x855e3d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10292,14 +10292,14 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x8559bd..0x8559f0
+            - Range: 0x855e3d..0x855e70
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
           Type: 328 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x85590c..0x855928
+            - Range: 0x855d8c..0x855da8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10307,7 +10307,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x855928..0x85592c
+            - Range: 0x855da8..0x855dac
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10315,7 +10315,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x85592c..0x855930
+            - Range: 0x855dac..0x855db0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10323,7 +10323,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x855930..0x855930
+            - Range: 0x855db0..0x855db0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10331,7 +10331,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x855930..0x85595c
+            - Range: 0x855db0..0x855ddc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10339,7 +10339,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x85595c..0x8559b0
+            - Range: 0x855ddc..0x855e30
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10347,7 +10347,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x8559b0..0x8559f0
+            - Range: 0x855e30..0x855e70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10360,215 +10360,215 @@ Subprograms:
         - Name: item
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0x85594c..0x85595c
+            - Range: 0x855dcc..0x855ddc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x85595c..0x8559b0
+            - Range: 0x855ddc..0x855e30
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
     - ID: 169
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x8559f0..0x855a40]
+      OutOfLinePCRanges: [0x855e70..0x855ec0]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 325 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x8559f0..0x855a18
+            - Range: 0x855e70..0x855e98
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
           Type: 331 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0x8559f0..0x855a18
+            - Range: 0x855e70..0x855e98
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x8559f0..0x855a18
+            - Range: 0x855e70..0x855e98
               Pieces: []
-            - Range: 0x855a18..0x855a19
+            - Range: 0x855e98..0x855e99
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x855a19..0x855a40
+            - Range: 0x855e99..0x855ec0
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
     - ID: 170
       Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0x855cb0..0x855cc0]
+      OutOfLinePCRanges: [0x856130..0x856140]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 329 PointerType *go.shape.int
           Locations:
-            - Range: 0x855cb0..0x855cc0
+            - Range: 0x856130..0x856140
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 329 PointerType *go.shape.int
           Locations:
-            - Range: 0x855cb0..0x855cb4
+            - Range: 0x856130..0x856134
               Pieces: []
-            - Range: 0x855cb4..0x855cb5
+            - Range: 0x856134..0x856135
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x855cb5..0x855cc0
+            - Range: 0x856135..0x856140
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 171
       Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0x855cc0..0x855cd0]
+      OutOfLinePCRanges: [0x856140..0x856150]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 332 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0x855cc0..0x855cd0
+            - Range: 0x856140..0x856150
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 332 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0x855cc0..0x855cc4
+            - Range: 0x856140..0x856144
               Pieces: []
-            - Range: 0x855cc4..0x855cc5
+            - Range: 0x856144..0x856145
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x855cc5..0x855cd0
+            - Range: 0x856145..0x856150
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 172
       Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0x855cd0..0x855ce0]
+      OutOfLinePCRanges: [0x856150..0x856160]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 334 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0x855cd0..0x855ce0
+            - Range: 0x856150..0x856160
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 334 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0x855cd0..0x855cd4
+            - Range: 0x856150..0x856154
               Pieces: []
-            - Range: 0x855cd4..0x855cd5
+            - Range: 0x856154..0x856155
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x855cd5..0x855ce0
+            - Range: 0x856155..0x856160
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 173
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0x855ce0..0x855cf0]
+      OutOfLinePCRanges: [0x856160..0x856170]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 336 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0x855ce0..0x855cf0
+            - Range: 0x856160..0x856170
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x855ce0..0x855ce8
+            - Range: 0x856160..0x856168
               Pieces: []
-            - Range: 0x855ce8..0x855ce9
+            - Range: 0x856168..0x856169
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x855ce9..0x855cf0
+            - Range: 0x856169..0x856170
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 174
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0x855d70..0x855d80]
+      OutOfLinePCRanges: [0x8561f0..0x856200]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 338 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0x855d70..0x855d80
+            - Range: 0x8561f0..0x856200
               Pieces: [{Size: 136, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0x855d70..0x855d74
+            - Range: 0x8561f0..0x8561f4
               Pieces: []
-            - Range: 0x855d74..0x855d75
+            - Range: 0x8561f4..0x8561f5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x855d75..0x855d80
+            - Range: 0x8561f5..0x856200
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 175
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0x855e10..0x855e20]
+      OutOfLinePCRanges: [0x856290..0x8562a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 339 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0x855e10..0x855e20
+            - Range: 0x856290..0x8562a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0x855e10..0x855e20
+            - Range: 0x856290..0x8562a0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
           Type: 341 BaseType go.shape.bool
           Locations:
-            - Range: 0x855e10..0x855e20
+            - Range: 0x856290..0x8562a0
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
     - ID: 176
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0x855ea0..0x855f20]
+      OutOfLinePCRanges: [0x856320..0x8563a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 342 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0x855ea0..0x855f20
+            - Range: 0x856320..0x8563a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x855ea0..0x855f20
+            - Range: 0x856320..0x8563a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10579,20 +10579,20 @@ Subprograms:
         - Name: v
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0x855ea0..0x855f20
+            - Range: 0x856320..0x8563a0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
     - ID: 177
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0x855fa0..0x855fb0]
+      OutOfLinePCRanges: [0x856420..0x856430]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x855fa0..0x855fb0
+            - Range: 0x856420..0x856430
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10603,59 +10603,59 @@ Subprograms:
         - Name: b
           Type: 341 BaseType go.shape.bool
           Locations:
-            - Range: 0x855fa0..0x855fb0
+            - Range: 0x856420..0x856430
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 341 BaseType go.shape.bool
           Locations:
-            - Range: 0x855fa0..0x855fa8
+            - Range: 0x856420..0x856428
               Pieces: []
-            - Range: 0x855fa8..0x855fa9
+            - Range: 0x856428..0x856429
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x855fa9..0x855fb0
+            - Range: 0x856429..0x856430
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x855fa0..0x855fa8
+            - Range: 0x856420..0x856428
               Pieces: []
-            - Range: 0x855fa8..0x855fa9
+            - Range: 0x856428..0x856429
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x855fa9..0x855fb0
+            - Range: 0x856429..0x856430
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 178
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x855fb0..0x855fd0]
+      OutOfLinePCRanges: [0x856430..0x856450]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0x855fb0..0x855fc0
+            - Range: 0x856430..0x856440
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x855fb0..0x855fbc
+            - Range: 0x856430..0x85643c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x855fbc..0x855fd0
+            - Range: 0x85643c..0x856450
               Pieces:
                 - Size: 8
                   Op: null
@@ -10666,73 +10666,73 @@ Subprograms:
         - Name: ~r0
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x855fb0..0x855fc0
+            - Range: 0x856430..0x856440
               Pieces: []
-            - Range: 0x855fc0..0x855fc1
+            - Range: 0x856440..0x856441
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x855fc1..0x855fd0
+            - Range: 0x856441..0x856450
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0x855fb0..0x855fc0
+            - Range: 0x856430..0x856440
               Pieces: []
-            - Range: 0x855fc0..0x855fc1
+            - Range: 0x856440..0x856441
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x855fc1..0x855fd0
+            - Range: 0x856441..0x856450
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 179
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0x855fd0..0x856020]
+      OutOfLinePCRanges: [0x856450..0x8564a0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 344 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0x855fd0..0x855ff8
+            - Range: 0x856450..0x856478
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x855fd0..0x855ff8
+            - Range: 0x856450..0x856478
               Pieces: []
-            - Range: 0x855ff8..0x855ff9
+            - Range: 0x856478..0x856479
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x855ff9..0x856020
+            - Range: 0x856479..0x8564a0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 180
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0x856020..0x856080]
+      OutOfLinePCRanges: [0x8564a0..0x856500]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 345 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0x856020..0x85604c
+            - Range: 0x8564a0..0x8564cc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x85604c..0x856050
+            - Range: 0x8564cc..0x8564d0
               Pieces:
                 - Size: 8
                   Op: null
@@ -10743,65 +10743,65 @@ Subprograms:
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x856020..0x856050
+            - Range: 0x8564a0..0x8564d0
               Pieces: []
-            - Range: 0x856050..0x856051
+            - Range: 0x8564d0..0x8564d1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x856051..0x856080
+            - Range: 0x8564d1..0x856500
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 181
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0x856080..0x856090]
+      OutOfLinePCRanges: [0x856500..0x856510]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 346 PointerType *go.shape.string
           Locations:
-            - Range: 0x856080..0x856088
+            - Range: 0x856500..0x856508
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x856080..0x856088
+            - Range: 0x856500..0x856508
               Pieces: []
-            - Range: 0x856088..0x856089
+            - Range: 0x856508..0x856509
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x856089..0x856090
+            - Range: 0x856509..0x856510
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 182
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0x856090..0x8560f0]
+      OutOfLinePCRanges: [0x856510..0x856570]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 347 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x856090..0x8560cc
+            - Range: 0x856510..0x85654c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 348 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x856090..0x8560dc
+            - Range: 0x856510..0x85655c
               Pieces: []
-            - Range: 0x8560dc..0x8560dd
+            - Range: 0x85655c..0x85655d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10815,20 +10815,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x8560dd..0x8560f0
+            - Range: 0x85655d..0x856570
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 183
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0x8560f0..0x856130]
+      OutOfLinePCRanges: [0x856570..0x8565b0]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 328 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x8560f0..0x8560fc
+            - Range: 0x856570..0x85657c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10836,7 +10836,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8560fc..0x856130
+            - Range: 0x85657c..0x8565b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10849,42 +10849,42 @@ Subprograms:
         - Name: needle
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0x8560f0..0x856130
+            - Range: 0x856570..0x8565b0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x8560f0..0x856118
+            - Range: 0x856570..0x856598
               Pieces: []
-            - Range: 0x856118..0x856119
+            - Range: 0x856598..0x856599
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x856119..0x856120
+            - Range: 0x856599..0x8565a0
               Pieces: []
-            - Range: 0x856120..0x856121
+            - Range: 0x8565a0..0x8565a1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x856121..0x856130
+            - Range: 0x8565a1..0x8565b0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0x85610c..0x85611c
+            - Range: 0x85658c..0x85659c
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Local
           DictIndex: 1
       DictRegister: 0
     - ID: 184
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0x856130..0x8561f0]
+      OutOfLinePCRanges: [0x8565b0..0x856670]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 349 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0x856130..0x856154
+            - Range: 0x8565b0..0x8565d4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10892,7 +10892,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x856154..0x856158
+            - Range: 0x8565d4..0x8565d8
               Pieces:
                 - Size: 8
                   Op: null
@@ -10905,13 +10905,13 @@ Subprograms:
         - Name: needle
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x856130..0x85618c
+            - Range: 0x8565b0..0x85660c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x85618c..0x8561f0
+            - Range: 0x85660c..0x856670
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 40}
@@ -10922,28 +10922,28 @@ Subprograms:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x856130..0x8561a8
+            - Range: 0x8565b0..0x856628
               Pieces: []
-            - Range: 0x8561a8..0x8561a9
+            - Range: 0x856628..0x856629
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8561a9..0x8561b8
+            - Range: 0x856629..0x856638
               Pieces: []
-            - Range: 0x8561b8..0x8561b9
+            - Range: 0x856638..0x856639
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8561b9..0x8561f0
+            - Range: 0x856639..0x856670
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x85616c..0x856180
+            - Range: 0x8565ec..0x856600
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x856180..0x85618c
+            - Range: 0x856600..0x85660c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10954,56 +10954,56 @@ Subprograms:
       DictRegister: 0
     - ID: 185
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0x8561f0..0x856200]
+      OutOfLinePCRanges: [0x856670..0x856680]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 350 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0x8561f0..0x8561f8
+            - Range: 0x856670..0x856678
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0x8561f0..0x856200
+            - Range: 0x856670..0x856680
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x8561f0..0x8561f8
+            - Range: 0x856670..0x856678
               Pieces: []
-            - Range: 0x8561f8..0x8561f9
+            - Range: 0x856678..0x856679
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8561f9..0x856200
+            - Range: 0x856679..0x856680
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 1
     - ID: 186
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0x856270..0x8562e0]
+      OutOfLinePCRanges: [0x8566f0..0x856760]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 351 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0x856270..0x85629c
+            - Range: 0x8566f0..0x85671c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x85629c..0x8562a8
+            - Range: 0x85671c..0x856728
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8562a8..0x8562ac
+            - Range: 0x856728..0x85672c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11014,7 +11014,7 @@ Subprograms:
         - Name: value
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x856270..0x8562ac
+            - Range: 0x8566f0..0x85672c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -11025,11 +11025,11 @@ Subprograms:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x856270..0x8562ac
+            - Range: 0x8566f0..0x85672c
               Pieces: []
-            - Range: 0x8562ac..0x8562ad
+            - Range: 0x85672c..0x85672d
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8562ad..0x8562e0
+            - Range: 0x85672d..0x856760
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11167,31 +11167,31 @@ Subprograms:
       DictRegister: 0
     - ID: 188
       Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0x84e510..0x84e580]
+      OutOfLinePCRanges: [0x84e600..0x84e670]
       InlinePCRanges:
-        - Ranges: [0x84e59c..0x84e5d4]
-          RootRanges: [0x84e580..0x84e600]
-        - Ranges: [0x84e6e8..0x84e720]
-          RootRanges: [0x84e6b0..0x84e740]
-        - Ranges: [0x84e764..0x84e79c]
-          RootRanges: [0x84e740..0x84e800]
-        - Ranges: [0x84e81c..0x84e854]
-          RootRanges: [0x84e800..0x84e880]
+        - Ranges: [0x84e68c..0x84e6c4]
+          RootRanges: [0x84e670..0x84e6f0]
+        - Ranges: [0x84e7d8..0x84e810]
+          RootRanges: [0x84e7a0..0x84e830]
+        - Ranges: [0x84e854..0x84e88c]
+          RootRanges: [0x84e830..0x84e8f0]
+        - Ranges: [0x84e90c..0x84e944]
+          RootRanges: [0x84e8f0..0x84e970]
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0x84e510..0x84e530
+            - Range: 0x84e600..0x84e620
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84e59c..0x84e5a4
+            - Range: 0x84e68c..0x84e694
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84e6e8..0x84e6f0
+            - Range: 0x84e7d8..0x84e7e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84e75c..0x84e76c
+            - Range: 0x84e84c..0x84e85c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84e76c..0x84e800
+            - Range: 0x84e85c..0x84e8f0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x84e800..0x84e824
+            - Range: 0x84e8f0..0x84e914
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -11200,37 +11200,37 @@ Subprograms:
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x84e7a8..0x84e7e0]
-          RootRanges: [0x84e740..0x84e800]
+        - Ranges: [0x84e898..0x84e8d0]
+          RootRanges: [0x84e830..0x84e8f0]
       Variables: []
       DictRegister: null
     - ID: 190
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x84e89c..0x84e8e0]
-          RootRanges: [0x84e880..0x84e9a0]
+        - Ranges: [0x84e98c..0x84e9d0]
+          RootRanges: [0x84e970..0x84ea90]
       Variables: []
       DictRegister: null
     - ID: 191
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x84e950..0x84e988]
-          RootRanges: [0x84e880..0x84e9a0]
+        - Ranges: [0x84ea40..0x84ea78]
+          RootRanges: [0x84e970..0x84ea90]
       Variables: []
       DictRegister: null
     - ID: 192
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x84e9a4..0x84e9a8]
-          RootRanges: [0x84e9a0..0x84e9b0]
+        - Ranges: [0x84ea94..0x84ea98]
+          RootRanges: [0x84ea90..0x84eaa0]
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0x84e9a0..0x84e9a8
+            - Range: 0x84ea90..0x84ea98
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -11239,38 +11239,38 @@ Subprograms:
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x84e9d4..0x84e9f8]
-          RootRanges: [0x84e9b0..0x84ea10]
-        - Ranges: [0x84ea6c..0x84ea94]
-          RootRanges: [0x84ea10..0x84eb60]
+        - Ranges: [0x84eac4..0x84eae8]
+          RootRanges: [0x84eaa0..0x84eb00]
+        - Ranges: [0x84eb5c..0x84eb84]
+          RootRanges: [0x84eb00..0x84ec50]
       Variables:
         - Name: a
           Type: 164 ArrayType [5]int
           Locations:
-            - Range: 0x84e9c0..0x84ea10
+            - Range: 0x84eab0..0x84eb00
               Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
-            - Range: 0x84ea58..0x84eb60
+            - Range: 0x84eb48..0x84ec50
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 194
       Name: main.firstBehavior.DoSomething
-      OutOfLinePCRanges: [0x84eb60..0x84ebd0]
+      OutOfLinePCRanges: [0x84ec50..0x84ecc0]
       InlinePCRanges:
-        - Ranges: [0x85638c..0x8563c0]
-          RootRanges: [0x856360..0x856410]
+        - Ranges: [0x85680c..0x856840]
+          RootRanges: [0x8567e0..0x856890]
       Variables:
         - Name: b
           Type: 356 StructureType main.firstBehavior
           Locations:
-            - Range: 0x84eb60..0x84eb8c
+            - Range: 0x84ec50..0x84ec7c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84eb8c..0x84eb90
+            - Range: 0x84ec7c..0x84ec80
               Pieces:
                 - Size: 8
                   Op: null
@@ -11281,15 +11281,15 @@ Subprograms:
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x84eb60..0x84ebb0
+            - Range: 0x84ec50..0x84eca0
               Pieces: []
-            - Range: 0x84ebb0..0x84ebb1
+            - Range: 0x84eca0..0x84eca1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84ebb1..0x84ebd0
+            - Range: 0x84eca1..0x84ecc0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11298,8 +11298,8 @@ Subprograms:
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x84f22c..0x84f238, 0x84f23c..0x84f244]
-          RootRanges: [0x84f110..0x84f290]
+        - Ranges: [0x84f454..0x84f460, 0x84f464..0x84f46c]
+          RootRanges: [0x84f3c0..0x84f4b0]
         - Ranges: [0x129ba8..0x129bac, 0x129bb0..0x129bb8]
           RootRanges: [0x129ba0..0x129bc0]
       Variables: []
@@ -11607,7 +11607,7 @@ Types:
       ID: 40
       Name: '*[]runtime.ancestorInfo'
       ByteSize: 8
-      GoRuntimeType: 488704
+      GoRuntimeType: 488960
       GoKind: 22
       Pointee: 41 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
@@ -11710,7 +11710,7 @@ Types:
       ID: 12
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 392768
+      GoRuntimeType: 392896
       GoKind: 22
       Pointee: 5 BaseType bool
     - __kind: PointerType
@@ -12133,7 +12133,7 @@ Types:
       ID: 105
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 391680
+      GoRuntimeType: 391808
       GoKind: 22
       Pointee: 15 GoInterfaceType error
     - __kind: PointerType
@@ -12154,14 +12154,14 @@ Types:
       ID: 107
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 392640
+      GoRuntimeType: 392768
       GoKind: 22
       Pointee: 18 BaseType float32
     - __kind: PointerType
       ID: 98
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 392704
+      GoRuntimeType: 392832
       GoKind: 22
       Pointee: 19 BaseType float64
     - __kind: PointerType
@@ -13020,42 +13020,42 @@ Types:
       ID: 100
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 392320
+      GoRuntimeType: 392448
       GoKind: 22
       Pointee: 8 BaseType int
     - __kind: PointerType
       ID: 103
       Name: '*int16'
       ByteSize: 8
-      GoRuntimeType: 391936
+      GoRuntimeType: 392064
       GoKind: 22
       Pointee: 95 BaseType int16
     - __kind: PointerType
       ID: 21
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 392064
+      GoRuntimeType: 392192
       GoKind: 22
       Pointee: 13 BaseType int32
     - __kind: PointerType
       ID: 99
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 392192
+      GoRuntimeType: 392320
       GoKind: 22
       Pointee: 14 BaseType int64
     - __kind: PointerType
       ID: 104
       Name: '*int8'
       ByteSize: 8
-      GoRuntimeType: 391808
+      GoRuntimeType: 391936
       GoKind: 22
       Pointee: 17 BaseType int8
     - __kind: PointerType
       ID: 166
       Name: '*interface {}'
       ByteSize: 8
-      GoRuntimeType: 392896
+      GoRuntimeType: 393024
       GoKind: 22
       Pointee: 160 GoEmptyInterfaceType interface {}
     - __kind: PointerType
@@ -13076,7 +13076,7 @@ Types:
       ID: 1047
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
-      GoRuntimeType: 900800
+      GoRuntimeType: 901184
       GoKind: 22
       Pointee: 1048 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
@@ -13101,12 +13101,12 @@ Types:
       GoKind: 22
       Pointee: 934 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 660
+      ID: 663
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
-      GoRuntimeType: 899744
+      GoRuntimeType: 900128
       GoKind: 22
-      Pointee: 661 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 664 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
       ID: 1093
       Name: '*io.PipeWriter'
@@ -14192,12 +14192,12 @@ Types:
       GoKind: 22
       Pointee: 637 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 662
+      ID: 665
       Name: '*reflect.ValueError'
       ByteSize: 8
-      GoRuntimeType: 900416
+      GoRuntimeType: 900800
       GoKind: 22
-      Pointee: 663 UnresolvedPointeeType reflect.ValueError
+      Pointee: 666 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
       ID: 757
       Name: '*regexp/syntax.Error'
@@ -14209,21 +14209,21 @@ Types:
       ID: 869
       Name: '*runtime.PanicNilError'
       ByteSize: 8
-      GoRuntimeType: 1028416
+      GoRuntimeType: 1028672
       GoKind: 22
       Pointee: 870 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
       ID: 873
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
-      GoRuntimeType: 1030208
+      GoRuntimeType: 1030464
       GoKind: 22
       Pointee: 874 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 27
       Name: '*runtime._defer'
       ByteSize: 8
-      GoRuntimeType: 392960
+      GoRuntimeType: 393088
       GoKind: 22
       Pointee: 28 UnresolvedPointeeType runtime._defer
     - __kind: PointerType
@@ -14237,21 +14237,21 @@ Types:
       ID: 871
       Name: '*runtime.boundsError'
       ByteSize: 8
-      GoRuntimeType: 1028544
+      GoRuntimeType: 1028800
       GoKind: 22
       Pointee: 872 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 63
       Name: '*runtime.cgoCallers'
       ByteSize: 8
-      GoRuntimeType: 393600
+      GoRuntimeType: 393728
       GoKind: 22
       Pointee: 64 UnresolvedPointeeType runtime.cgoCallers
     - __kind: PointerType
       ID: 48
       Name: '*runtime.coro'
       ByteSize: 8
-      GoRuntimeType: 393664
+      GoRuntimeType: 393792
       GoKind: 22
       Pointee: 49 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
@@ -14265,7 +14265,7 @@ Types:
       ID: 867
       Name: '*runtime.errorString'
       ByteSize: 8
-      GoRuntimeType: 1028032
+      GoRuntimeType: 1028288
       GoKind: 22
       Pointee: 848 GoStringHeaderType runtime.errorString
     - __kind: PointerType
@@ -14277,21 +14277,21 @@ Types:
       ID: 56
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 898976
+      GoRuntimeType: 899360
       GoKind: 22
       Pointee: 23 StructureType runtime.g
     - __kind: PointerType
       ID: 29
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 1029696
+      GoRuntimeType: 1029952
       GoKind: 22
       Pointee: 30 StructureType runtime.m
     - __kind: PointerType
       ID: 868
       Name: '*runtime.plainError'
       ByteSize: 8
-      GoRuntimeType: 1028160
+      GoRuntimeType: 1028416
       GoKind: 22
       Pointee: 851 GoStringHeaderType runtime.plainError
     - __kind: PointerType
@@ -14303,7 +14303,7 @@ Types:
       ID: 42
       Name: '*runtime.sudog'
       ByteSize: 8
-      GoRuntimeType: 394368
+      GoRuntimeType: 394496
       GoKind: 22
       Pointee: 43 UnresolvedPointeeType runtime.sudog
     - __kind: PointerType
@@ -14324,7 +14324,7 @@ Types:
       ID: 77
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1623552
+      GoRuntimeType: 1623936
       GoKind: 22
       Pointee: 78 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
@@ -14338,7 +14338,7 @@ Types:
       ID: 94
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 391744
+      GoRuntimeType: 391872
       GoKind: 22
       Pointee: 10 GoStringHeaderType string
     - __kind: PointerType
@@ -14532,21 +14532,21 @@ Types:
       ID: 997
       Name: '*time.Location'
       ByteSize: 8
-      GoRuntimeType: 1628544
+      GoRuntimeType: 1620096
       GoKind: 22
       Pointee: 998 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 665
+      ID: 661
       Name: '*time.ParseError'
       ByteSize: 8
-      GoRuntimeType: 901568
+      GoRuntimeType: 897536
       GoKind: 22
-      Pointee: 666 UnresolvedPointeeType time.ParseError
+      Pointee: 662 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 664
+      ID: 660
       Name: '*time.fileSizeError'
       ByteSize: 8
-      GoRuntimeType: 901472
+      GoRuntimeType: 897440
       GoKind: 22
       Pointee: 586 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
@@ -14558,42 +14558,42 @@ Types:
       ID: 106
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 392384
+      GoRuntimeType: 392512
       GoKind: 22
       Pointee: 11 BaseType uint
     - __kind: PointerType
       ID: 102
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 392000
+      GoRuntimeType: 392128
       GoKind: 22
       Pointee: 7 BaseType uint16
     - __kind: PointerType
       ID: 22
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 392128
+      GoRuntimeType: 392256
       GoKind: 22
       Pointee: 3 BaseType uint32
     - __kind: PointerType
       ID: 101
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 392256
+      GoRuntimeType: 392384
       GoKind: 22
       Pointee: 9 BaseType uint64
     - __kind: PointerType
       ID: 6
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 391872
+      GoRuntimeType: 392000
       GoKind: 22
       Pointee: 4 BaseType uint8
     - __kind: PointerType
       ID: 20
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 392448
+      GoRuntimeType: 392576
       GoKind: 22
       Pointee: 2 BaseType uintptr
     - __kind: PointerType
@@ -23730,7 +23730,7 @@ Types:
       ID: 90
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 701408
+      GoRuntimeType: 702848
       GoKind: 17
       Count: 10
       HasCount: true
@@ -23757,7 +23757,7 @@ Types:
       ID: 76
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 701024
+      GoRuntimeType: 702464
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23766,7 +23766,7 @@ Types:
       ID: 75
       Name: '[2][2]*runtime.traceBuf'
       ByteSize: 32
-      GoRuntimeType: 701120
+      GoRuntimeType: 702560
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23791,7 +23791,7 @@ Types:
       ID: 82
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 701312
+      GoRuntimeType: 702752
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23933,7 +23933,7 @@ Types:
       ID: 66
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 700832
+      GoRuntimeType: 702272
       GoKind: 17
       Count: 32
       HasCount: true
@@ -23951,7 +23951,7 @@ Types:
       ID: 54
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 700544
+      GoRuntimeType: 701984
       GoKind: 17
       Count: 3
       HasCount: true
@@ -24021,7 +24021,7 @@ Types:
       ID: 83
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 701216
+      GoRuntimeType: 702656
       GoKind: 17
       Count: 8
       HasCount: true
@@ -24439,7 +24439,7 @@ Types:
       ID: 266
       Name: '[]bool'
       ByteSize: 24
-      GoRuntimeType: 486912
+      GoRuntimeType: 487168
       GoKind: 23
       RawFields:
         - Name: array
@@ -24462,7 +24462,7 @@ Types:
       ID: 1020
       Name: '[]float64'
       ByteSize: 24
-      GoRuntimeType: 486784
+      GoRuntimeType: 487040
       GoKind: 23
       RawFields:
         - Name: array
@@ -24552,7 +24552,7 @@ Types:
       ID: 1301
       Name: '[]interface {}'
       ByteSize: 24
-      GoRuntimeType: 487232
+      GoRuntimeType: 487488
       GoKind: 23
       RawFields:
         - Name: array
@@ -24808,7 +24808,7 @@ Types:
       ID: 157
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 487040
+      GoRuntimeType: 487296
       GoKind: 23
       RawFields:
         - Name: array
@@ -24852,7 +24852,7 @@ Types:
       ID: 260
       Name: '[]uint'
       ByteSize: 24
-      GoRuntimeType: 486528
+      GoRuntimeType: 486784
       GoKind: 23
       RawFields:
         - Name: array
@@ -24875,7 +24875,7 @@ Types:
       ID: 267
       Name: '[]uint16'
       ByteSize: 24
-      GoRuntimeType: 485888
+      GoRuntimeType: 486144
       GoKind: 23
       RawFields:
         - Name: array
@@ -24898,7 +24898,7 @@ Types:
       ID: 39
       Name: '[]uint8'
       ByteSize: 24
-      GoRuntimeType: 485760
+      GoRuntimeType: 486016
       GoKind: 23
       RawFields:
         - Name: array
@@ -24921,7 +24921,7 @@ Types:
       ID: 44
       Name: '[]uintptr'
       ByteSize: 24
-      GoRuntimeType: 486592
+      GoRuntimeType: 486848
       GoKind: 23
       RawFields:
         - Name: array
@@ -25394,7 +25394,7 @@ Types:
       ID: 15
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1027904
+      GoRuntimeType: 1028160
       GoKind: 20
       RawFields:
         - Name: tab
@@ -25445,7 +25445,7 @@ Types:
       ID: 71
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 848896
+      GoRuntimeType: 849184
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 355
@@ -27035,7 +27035,7 @@ Types:
       ID: 160
       Name: interface {}
       ByteSize: 16
-      GoRuntimeType: 848608
+      GoRuntimeType: 848896
       GoKind: 20
       RawFields:
         - Name: _type
@@ -27089,11 +27089,11 @@ Types:
     - __kind: StructureType
       ID: 934
       Name: internal/poll.errNetClosing
-      GoRuntimeType: 1479424
+      GoRuntimeType: 1479744
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 661
+      ID: 664
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -27177,7 +27177,7 @@ Types:
       ID: 1250
       Name: internal/sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1476864
+      GoRuntimeType: 1477184
       GoKind: 25
       RawFields:
         - Name: state
@@ -30915,7 +30915,7 @@ Types:
       GoRuntimeType: 838432
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 663
+      ID: 666
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -30981,7 +30981,7 @@ Types:
       ID: 930
       Name: runtime.errorAddressString
       ByteSize: 24
-      GoRuntimeType: 1754400
+      GoRuntimeType: 1754592
       GoKind: 25
       RawFields:
         - Name: msg
@@ -31204,7 +31204,7 @@ Types:
       ID: 31
       Name: runtime.gobuf
       ByteSize: 56
-      GoRuntimeType: 1971296
+      GoRuntimeType: 1971584
       GoKind: 25
       RawFields:
         - Name: sp
@@ -31232,7 +31232,7 @@ Types:
       ID: 47
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1474304
+      GoRuntimeType: 1474624
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -31245,7 +31245,7 @@ Types:
       ID: 57
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1753440
+      GoRuntimeType: 1753632
       GoKind: 25
       RawFields:
         - Name: stack
@@ -31264,13 +31264,13 @@ Types:
       ID: 32
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 831136
+      GoRuntimeType: 831424
       GoKind: 12
     - __kind: StructureType
       ID: 91
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1474144
+      GoRuntimeType: 1474464
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -31283,7 +31283,7 @@ Types:
       ID: 79
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 1915200
+      GoRuntimeType: 1915456
       GoKind: 25
       RawFields:
         - Name: fn
@@ -31308,7 +31308,7 @@ Types:
       ID: 92
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 831040
+      GoRuntimeType: 831328
       GoKind: 2
     - __kind: StructureType
       ID: 30
@@ -31537,7 +31537,7 @@ Types:
       ID: 68
       Name: runtime.mLockProfile
       ByteSize: 64
-      GoRuntimeType: 1971584
+      GoRuntimeType: 1971872
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -31565,7 +31565,7 @@ Types:
       ID: 86
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 1840768
+      GoRuntimeType: 1840992
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -31587,7 +31587,7 @@ Types:
       ID: 73
       Name: runtime.mTraceState
       ByteSize: 56
-      GoRuntimeType: 1840544
+      GoRuntimeType: 1840768
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -31619,7 +31619,7 @@ Types:
       ID: 38
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 830752
+      GoRuntimeType: 831040
       GoKind: 12
     - __kind: StructureType
       ID: 65
@@ -31632,7 +31632,7 @@ Types:
       ID: 81
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1473984
+      GoRuntimeType: 1474304
       GoKind: 25
       RawFields:
         - Name: entries
@@ -31645,7 +31645,7 @@ Types:
       ID: 84
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1754208
+      GoRuntimeType: 1754400
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -31683,13 +31683,13 @@ Types:
       ID: 61
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 830944
+      GoRuntimeType: 831232
       GoKind: 12
     - __kind: ArrayType
       ID: 58
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 898592
+      GoRuntimeType: 898976
       GoKind: 17
       Count: 2
       HasCount: true
@@ -31698,7 +31698,7 @@ Types:
       ID: 24
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1472384
+      GoRuntimeType: 1472704
       GoKind: 25
       RawFields:
         - Name: lo
@@ -31739,7 +31739,7 @@ Types:
       ID: 53
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1473344
+      GoRuntimeType: 1473664
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -32587,14 +32587,14 @@ Types:
       ID: 1146
       Name: time.Duration
       ByteSize: 8
-      GoRuntimeType: 1915968
+      GoRuntimeType: 1913408
       GoKind: 6
     - __kind: UnresolvedPointeeType
       ID: 998
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 666
+      ID: 662
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
@@ -32617,7 +32617,7 @@ Types:
       ID: 586
       Name: time.fileSizeError
       ByteSize: 16
-      GoRuntimeType: 831520
+      GoRuntimeType: 830272
       GoKind: 24
       RawFields:
         - Name: str

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -13,11 +13,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1600 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0x80fe78", Frameless: false}]
+              InjectionPoints: [{PC: "0x8102e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1601 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0x80fea8", Frameless: false}]
+              InjectionPoints: [{PC: "0x810318", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -33,11 +33,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1439 EventRootType Probe[main.testAny]
-              InjectionPoints: [{PC: "0x80b398", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b478", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1440 EventRootType Probe[main.testAny]Return
-              InjectionPoints: [{PC: "0x80b3c0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b4a0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -59,11 +59,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1442 EventRootType Probe[main.testAnyPtr]
-              InjectionPoints: [{PC: "0x80b408", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b4e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1443 EventRootType Probe[main.testAnyPtr]Return
-              InjectionPoints: [{PC: "0x80b430", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b510", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -84,11 +84,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1571 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0x80ed7c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ef1c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1572 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0x80ee08", Frameless: false}]
+              InjectionPoints: [{PC: "0x80efa8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -110,7 +110,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1387 EventRootType Probe[main.testArrayEmptyStructs]
-              InjectionPoints: [{PC: "0x807140", Frameless: true}]
+              InjectionPoints: [{PC: "0x807220", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -132,7 +132,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1383 EventRootType Probe[main.testArrayOfArrays]
-              InjectionPoints: [{PC: "0x807100", Frameless: true}]
+              InjectionPoints: [{PC: "0x8071e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -154,7 +154,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1385 EventRootType Probe[main.testArrayOfArraysOfArrays]
-              InjectionPoints: [{PC: "0x807120", Frameless: true}]
+              InjectionPoints: [{PC: "0x807200", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -176,7 +176,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1451 EventRootType Probe[main.testArrayOfMaps]
-              InjectionPoints: [{PC: "0x80ba10", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bbb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -198,7 +198,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1384 EventRootType Probe[main.testArrayOfStrings]
-              InjectionPoints: [{PC: "0x807110", Frameless: true}]
+              InjectionPoints: [{PC: "0x8071f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -219,7 +219,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1386 EventRootType Probe[main.testArrayOfStructs]
-              InjectionPoints: [{PC: "0x807130", Frameless: true}]
+              InjectionPoints: [{PC: "0x807210", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -241,11 +241,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1473 EventRootType Probe[main.testAtomicAdd]
-              InjectionPoints: [{PC: "0x80d160", Frameless: true}]
+              InjectionPoints: [{PC: "0x80d300", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1474 EventRootType Probe[main.testAtomicAdd]Return
-              InjectionPoints: [{PC: "0x80d19c", Frameless: true}]
+              InjectionPoints: [{PC: "0x80d33c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -267,11 +267,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1405 EventRootType Probe[main.testBigStruct]
-              InjectionPoints: [{PC: "0x807680", Frameless: true}]
+              InjectionPoints: [{PC: "0x807760", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1406 EventRootType Probe[main.testBigStruct]Return
-              InjectionPoints: [{PC: "0x80768c", Frameless: true}]
+              InjectionPoints: [{PC: "0x80776c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -293,7 +293,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1372 EventRootType Probe[main.testBoolArray]
-              InjectionPoints: [{PC: "0x807050", Frameless: true}]
+              InjectionPoints: [{PC: "0x807130", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -315,7 +315,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1369 EventRootType Probe[main.testByteArray]
-              InjectionPoints: [{PC: "0x807020", Frameless: true}]
+              InjectionPoints: [{PC: "0x807100", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -342,11 +342,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1619 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x810160", Frameless: true}]
+              InjectionPoints: [{PC: "0x8105d0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1620 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0x810170", Frameless: true}]
+              InjectionPoints: [{PC: "0x8105e0", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -366,15 +366,15 @@ Probes:
             - Kind: Line
               Type: 1680 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x80acb8"
+                - PC: "0x80ad98"
                   Frameless: false
-                - PC: "0x80ad2c"
+                - PC: "0x80ae0c"
                   Frameless: false
-                - PC: "0x80ae68"
+                - PC: "0x80af48"
                   Frameless: false
-                - PC: "0x80aee4"
+                - PC: "0x80afc4"
                   Frameless: false
-                - PC: "0x80af9c"
+                - PC: "0x80b07c"
                   Frameless: false
               Condition: null
     - id: testCaptureExprLineCond
@@ -396,15 +396,15 @@ Probes:
             - Kind: Line
               Type: 1681 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x80acb8"
+                - PC: "0x80ad98"
                   Frameless: false
-                - PC: "0x80ad2c"
+                - PC: "0x80ae0c"
                   Frameless: false
-                - PC: "0x80ae68"
+                - PC: "0x80af48"
                   Frameless: false
-                - PC: "0x80aee4"
+                - PC: "0x80afc4"
                   Frameless: false
-                - PC: "0x80af9c"
+                - PC: "0x80b07c"
                   Frameless: false
               Condition:
                 Type: 5 BaseType bool
@@ -440,15 +440,15 @@ Probes:
             - Kind: Line
               Type: 1682 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x80acb8"
+                - PC: "0x80ad98"
                   Frameless: false
-                - PC: "0x80ad2c"
+                - PC: "0x80ae0c"
                   Frameless: false
-                - PC: "0x80ae68"
+                - PC: "0x80af48"
                   Frameless: false
-                - PC: "0x80aee4"
+                - PC: "0x80afc4"
                   Frameless: false
-                - PC: "0x80af9c"
+                - PC: "0x80b07c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -476,7 +476,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1470 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x80cf00", Frameless: true}]
+              InjectionPoints: [{PC: "0x80d0a0", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -495,7 +495,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1471 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x80cf00", Frameless: true}]
+              InjectionPoints: [{PC: "0x80d0a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -521,7 +521,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1627 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0x810200", Frameless: true}]
+              InjectionPoints: [{PC: "0x810670", Frameless: true}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -557,7 +557,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1475 EventRootType Probe[main.testChannel]
-              InjectionPoints: [{PC: "0x80d1a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80d340", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -587,7 +587,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1469 EventRootType Probe[main.testCombinedByte]
-              InjectionPoints: [{PC: "0x80cee0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80d080", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{w}, {x}, {y}'
@@ -616,11 +616,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1536 EventRootType Probe[main.testConflictingReturn]
-              InjectionPoints: [{PC: "0x80e078", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e218", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1537 EventRootType Probe[main.testConflictingReturn]Return
-              InjectionPoints: [{PC: "0x80e118", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e2b8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -642,7 +642,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1483 EventRootType Probe[main.testCycle]
-              InjectionPoints: [{PC: "0x80d430", Frameless: true}]
+              InjectionPoints: [{PC: "0x80d5d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{t}'
@@ -664,7 +664,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1412 EventRootType Probe[main.testDeepMap1]
-              InjectionPoints: [{PC: "0x807b20", Frameless: true}]
+              InjectionPoints: [{PC: "0x807c00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -686,7 +686,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1413 EventRootType Probe[main.testDeepMap7]
-              InjectionPoints: [{PC: "0x807b30", Frameless: true}]
+              InjectionPoints: [{PC: "0x807c10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -708,7 +708,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1408 EventRootType Probe[main.testDeepPtr1]
-              InjectionPoints: [{PC: "0x807840", Frameless: true}]
+              InjectionPoints: [{PC: "0x807920", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -730,7 +730,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1409 EventRootType Probe[main.testDeepPtr7]
-              InjectionPoints: [{PC: "0x807850", Frameless: true}]
+              InjectionPoints: [{PC: "0x807930", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -752,7 +752,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1410 EventRootType Probe[main.testDeepSlice1]
-              InjectionPoints: [{PC: "0x8079c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x807aa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -774,7 +774,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1411 EventRootType Probe[main.testDeepSlice7]
-              InjectionPoints: [{PC: "0x8079d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x807ab0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -796,7 +796,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1588 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0x80fad0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fc70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -823,7 +823,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1591 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0x80fb00", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fca0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -851,7 +851,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1614 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0x80ff30", Frameless: true}]
+              InjectionPoints: [{PC: "0x8103a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -873,7 +873,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1628 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0x810230", Frameless: true}]
+              InjectionPoints: [{PC: "0x8106a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -894,7 +894,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1629 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0x810240", Frameless: true}]
+              InjectionPoints: [{PC: "0x8106b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -916,7 +916,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1441 EventRootType Probe[main.testError]
-              InjectionPoints: [{PC: "0x80b3e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b4c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -950,7 +950,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1407 EventRootType Probe[main.testErrorAtLine]Line
-              InjectionPoints: [{PC: "0x8076cc", Frameless: false}]
+              InjectionPoints: [{PC: "0x8077ac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}, err={err}
@@ -978,11 +978,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1423 EventRootType Probe[main.testEsotericHeap]
-              InjectionPoints: [{PC: "0x809d98", Frameless: false}]
+              InjectionPoints: [{PC: "0x809e78", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1424 EventRootType Probe[main.testEsotericHeap]Return
-              InjectionPoints: [{PC: "0x809dd0", Frameless: false}]
+              InjectionPoints: [{PC: "0x809eb0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1004,11 +1004,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1421 EventRootType Probe[main.testEsotericStack]
-              InjectionPoints: [{PC: "0x809cdc", Frameless: false}]
+              InjectionPoints: [{PC: "0x809dbc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1422 EventRootType Probe[main.testEsotericStack]Return
-              InjectionPoints: [{PC: "0x809d38", Frameless: false}]
+              InjectionPoints: [{PC: "0x809e18", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1030,11 +1030,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1433 EventRootType Probe[main.testFrameless]
-              InjectionPoints: [{PC: "0x80b100", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b1e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1434 EventRootType Probe[main.testFrameless]Return
-              InjectionPoints: [{PC: "0x80b108", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b1e8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1056,11 +1056,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1435 EventRootType Probe[main.testFramelessArray]
-              InjectionPoints: [{PC: "0x80b11c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b1fc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1436 EventRootType Probe[main.testFramelessArray]Return
-              InjectionPoints: [{PC: "0x80b150", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b230", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1085,7 +1085,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1437 EventRootType Probe[main.testFramelessArray]Line
-              InjectionPoints: [{PC: "0x80b11c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b1fc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1107,11 +1107,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1666 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0x812250", Frameless: true}]
+              InjectionPoints: [{PC: "0x8126c0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1667 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x812254", Frameless: true}]
+              InjectionPoints: [{PC: "0x8126c4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1125,11 +1125,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1668 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0x812270", Frameless: false}]
+              InjectionPoints: [{PC: "0x8126e0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1669 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0x8122a0", Frameless: false}]
+              InjectionPoints: [{PC: "0x812710", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1152,11 +1152,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1662 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0x8121b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x812628", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1663 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0x8121c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x812638", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1170,11 +1170,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1664 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0x812208", Frameless: false}]
+              InjectionPoints: [{PC: "0x812678", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1665 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0x812220", Frameless: false}]
+              InjectionPoints: [{PC: "0x812690", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1197,14 +1197,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1670 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0x8122b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x812720", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1671 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0x8122d8"
+                - PC: "0x812748"
                   Frameless: true
-                - PC: "0x8122e0"
+                - PC: "0x812750"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1219,14 +1219,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1672 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0x812308", Frameless: false}]
+              InjectionPoints: [{PC: "0x812778", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1673 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0x812364"
+                - PC: "0x8127d4"
                   Frameless: false
-                - PC: "0x812374"
+                - PC: "0x8127e4"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1253,7 +1253,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1674 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0x8122b4", Frameless: true}]
+              InjectionPoints: [{PC: "0x812724", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1265,7 +1265,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1675 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0x812318", Frameless: false}]
+              InjectionPoints: [{PC: "0x812788", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1286,11 +1286,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1650 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0x811ec0", Frameless: true}]
+              InjectionPoints: [{PC: "0x812330", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1651 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0x811ec4", Frameless: true}]
+              InjectionPoints: [{PC: "0x812334", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1304,11 +1304,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1652 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0x811f50", Frameless: true}]
+              InjectionPoints: [{PC: "0x8123c0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1653 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0x811f54", Frameless: true}]
+              InjectionPoints: [{PC: "0x8123c4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1332,11 +1332,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1638 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0x811ac8", Frameless: false}]
+              InjectionPoints: [{PC: "0x811f38", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1639 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x811b9c", Frameless: false}]
+              InjectionPoints: [{PC: "0x81200c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1378,11 +1378,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1642 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x811be8", Frameless: false}]
+              InjectionPoints: [{PC: "0x812058", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1643 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x811bf8", Frameless: false}]
+              InjectionPoints: [{PC: "0x812068", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1405,11 +1405,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1676 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0x8123b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x812820", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1677 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0x8123b8", Frameless: true}]
+              InjectionPoints: [{PC: "0x812828", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1423,11 +1423,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1678 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0x812448", Frameless: false}]
+              InjectionPoints: [{PC: "0x8128b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1679 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0x81246c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8128dc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1450,11 +1450,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1634 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0x811a30", Frameless: true}]
+              InjectionPoints: [{PC: "0x811ea0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1635 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x811a34", Frameless: true}]
+              InjectionPoints: [{PC: "0x811ea4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1468,11 +1468,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1636 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0x811a40", Frameless: true}]
+              InjectionPoints: [{PC: "0x811eb0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1637 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x811a4c", Frameless: true}]
+              InjectionPoints: [{PC: "0x811ebc", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1495,11 +1495,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1654 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0x811ff0", Frameless: true}]
+              InjectionPoints: [{PC: "0x812460", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1655 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0x811ff8", Frameless: true}]
+              InjectionPoints: [{PC: "0x812468", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1513,11 +1513,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1656 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0x812098", Frameless: false}]
+              InjectionPoints: [{PC: "0x812508", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1657 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0x8120c0", Frameless: false}]
+              InjectionPoints: [{PC: "0x812530", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1540,11 +1540,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1644 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0x811e90", Frameless: true}]
+              InjectionPoints: [{PC: "0x812300", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1645 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x811e94", Frameless: true}]
+              InjectionPoints: [{PC: "0x812304", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1558,11 +1558,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1646 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0x811ea0", Frameless: true}]
+              InjectionPoints: [{PC: "0x812310", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1647 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0x811ea4", Frameless: true}]
+              InjectionPoints: [{PC: "0x812314", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1576,11 +1576,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1648 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0x811eb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x812320", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1649 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0x811eb4", Frameless: true}]
+              InjectionPoints: [{PC: "0x812324", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1603,11 +1603,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1658 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0x812170", Frameless: true}]
+              InjectionPoints: [{PC: "0x8125e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1659 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0x812178", Frameless: true}]
+              InjectionPoints: [{PC: "0x8125e8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1621,11 +1621,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1660 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x812180", Frameless: true}]
+              InjectionPoints: [{PC: "0x8125f0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1661 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x812190", Frameless: true}]
+              InjectionPoints: [{PC: "0x812600", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1648,11 +1648,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1630 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0x811a10", Frameless: true}]
+              InjectionPoints: [{PC: "0x811e80", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1631 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x811a14", Frameless: true}]
+              InjectionPoints: [{PC: "0x811e84", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1666,11 +1666,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1632 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0x811a20", Frameless: true}]
+              InjectionPoints: [{PC: "0x811e90", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1633 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x811a2c", Frameless: true}]
+              InjectionPoints: [{PC: "0x811e9c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1693,11 +1693,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1425 EventRootType Probe[main.testInlinedBA]
-              InjectionPoints: [{PC: "0x80ae48", Frameless: false}]
+              InjectionPoints: [{PC: "0x80af28", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1426 EventRootType Probe[main.testInlinedBA]Return
-              InjectionPoints: [{PC: "0x80ae9c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80af7c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1724,11 +1724,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1427 EventRootType Probe[main.testInlinedBB]
-              InjectionPoints: [{PC: "0x80aed8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80afb8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1428 EventRootType Probe[main.testInlinedBB]Return
-              InjectionPoints: [{PC: "0x80af58", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b038", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}'
@@ -1755,11 +1755,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1429 EventRootType Probe[main.testInlinedBBA]
-              InjectionPoints: [{PC: "0x80af98", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b078", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1430 EventRootType Probe[main.testInlinedBBA]Return
-              InjectionPoints: [{PC: "0x80afd0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b0b0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1781,7 +1781,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1686 EventRootType Probe[main.testInlinedBBB]
-              InjectionPoints: [{PC: "0x80af24", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b004", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBBB
@@ -1799,11 +1799,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1431 EventRootType Probe[main.testInlinedBC]
-              InjectionPoints: [{PC: "0x80b008", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b0e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1432 EventRootType Probe[main.testInlinedBC]Return
-              InjectionPoints: [{PC: "0x80b0e4", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b1c4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBC
@@ -1821,7 +1821,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1687 EventRootType Probe[main.testInlinedBCA]
-              InjectionPoints: [{PC: "0x80b00c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b0ec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1842,7 +1842,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1688 EventRootType Probe[main.testInlinedBCA]Line
-              InjectionPoints: [{PC: "0x80b00c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b0ec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1860,7 +1860,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1689 EventRootType Probe[main.testInlinedBCB]
-              InjectionPoints: [{PC: "0x80b0b0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b190", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1881,7 +1881,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1690 EventRootType Probe[main.testInlinedBCB]Line
-              InjectionPoints: [{PC: "0x80b0b0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b190", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1902,7 +1902,7 @@ Probes:
               InjectionPoints:
                 - PC: "0x12c238"
                   Frameless: true
-                - PC: "0x80b8dc"
+                - PC: "0x80baf0"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1923,20 +1923,20 @@ Probes:
             - Kind: Entry
               Type: 1683 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
-                - PC: "0x80acb8"
+                - PC: "0x80ad98"
                   Frameless: false
-                - PC: "0x80ad2c"
+                - PC: "0x80ae0c"
                   Frameless: false
-                - PC: "0x80ae68"
+                - PC: "0x80af48"
                   Frameless: false
-                - PC: "0x80aee4"
+                - PC: "0x80afc4"
                   Frameless: false
-                - PC: "0x80af9c"
+                - PC: "0x80b07c"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1684 EventRootType Probe[main.testInlinedPrint]Return
-              InjectionPoints: [{PC: "0x80acec", Frameless: false}]
+              InjectionPoints: [{PC: "0x80adcc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1962,15 +1962,15 @@ Probes:
             - Kind: Line
               Type: 1685 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x80acb8"
+                - PC: "0x80ad98"
                   Frameless: false
-                - PC: "0x80ad2c"
+                - PC: "0x80ae0c"
                   Frameless: false
-                - PC: "0x80ae68"
+                - PC: "0x80af48"
                   Frameless: false
-                - PC: "0x80aee4"
+                - PC: "0x80afc4"
                   Frameless: false
-                - PC: "0x80af9c"
+                - PC: "0x80b07c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1993,7 +1993,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1691 EventRootType Probe[main.testInlinedSq]
-              InjectionPoints: [{PC: "0x80b104", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b1e4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2018,7 +2018,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1692 EventRootType Probe[main.testInlinedSq]Line
-              InjectionPoints: [{PC: "0x80b104", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b1e4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2042,9 +2042,9 @@ Probes:
             - Kind: Entry
               Type: 1693 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
-                - PC: "0x80b134"
+                - PC: "0x80b214"
                   Frameless: false
-                - PC: "0x80b1bc"
+                - PC: "0x80b29c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2067,7 +2067,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1375 EventRootType Probe[main.testInt16Array]
-              InjectionPoints: [{PC: "0x807080", Frameless: true}]
+              InjectionPoints: [{PC: "0x807160", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2089,7 +2089,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1376 EventRootType Probe[main.testInt32Array]
-              InjectionPoints: [{PC: "0x807090", Frameless: true}]
+              InjectionPoints: [{PC: "0x807170", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2111,7 +2111,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1377 EventRootType Probe[main.testInt64Array]
-              InjectionPoints: [{PC: "0x8070a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x807180", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2133,7 +2133,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1374 EventRootType Probe[main.testInt8Array]
-              InjectionPoints: [{PC: "0x807070", Frameless: true}]
+              InjectionPoints: [{PC: "0x807150", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2155,7 +2155,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1373 EventRootType Probe[main.testIntArray]
-              InjectionPoints: [{PC: "0x807060", Frameless: true}]
+              InjectionPoints: [{PC: "0x807140", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2177,7 +2177,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1438 EventRootType Probe[main.testInterface]
-              InjectionPoints: [{PC: "0x80b370", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b450", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -2198,11 +2198,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1569 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0x80ebf0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ed90", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1570 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x80ed18", Frameless: false}]
+              InjectionPoints: [{PC: "0x80eeb8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2224,7 +2224,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1477 EventRootType Probe[main.testLinkedList]
-              InjectionPoints: [{PC: "0x80d340", Frameless: true}]
+              InjectionPoints: [{PC: "0x80d4e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -2249,7 +2249,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1416 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x807b7c", Frameless: false}]
+              InjectionPoints: [{PC: "0x807c5c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2271,7 +2271,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1417 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x807c00", Frameless: false}]
+              InjectionPoints: [{PC: "0x807ce0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2293,7 +2293,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1418 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x807c9c", Frameless: false}]
+              InjectionPoints: [{PC: "0x807d7c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2336,11 +2336,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1575 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0x80f04c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80f1ec", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1576 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0x80f18c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80f32c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2403,7 +2403,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1419 EventRootType Probe[main.testManyPointers]
-              InjectionPoints: [{PC: "0x808060", Frameless: true}]
+              InjectionPoints: [{PC: "0x808140", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2427,7 +2427,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1420 EventRootType Probe[main.testManyStrings]
-              InjectionPoints: [{PC: "0x8099d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x809ab0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{ss}'
@@ -2449,7 +2449,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1449 EventRootType Probe[main.testMapArrayToArray]
-              InjectionPoints: [{PC: "0x80b9f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bb90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2471,7 +2471,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1456 EventRootType Probe[main.testMapEmbeddedMaps]
-              InjectionPoints: [{PC: "0x80ba50", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bbf0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2493,7 +2493,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1466 EventRootType Probe[main.testMapEmptyKey]
-              InjectionPoints: [{PC: "0x80baf0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bc90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2515,7 +2515,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1468 EventRootType Probe[main.testMapEmptyKeyAndValue]
-              InjectionPoints: [{PC: "0x80bb10", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bcb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2537,7 +2537,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1467 EventRootType Probe[main.testMapEmptyValue]
-              InjectionPoints: [{PC: "0x80bb00", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bca0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2559,7 +2559,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1453 EventRootType Probe[main.testMapIntToInt]
-              InjectionPoints: [{PC: "0x80ba30", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bbd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2581,7 +2581,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1465 EventRootType Probe[main.testMapLargeKeyLargeValue]
-              InjectionPoints: [{PC: "0x80bae0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bc80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2603,7 +2603,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1464 EventRootType Probe[main.testMapLargeKeySmallValue]
-              InjectionPoints: [{PC: "0x80bad0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bc70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2627,7 +2627,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1454 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x80ba40", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bbe0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2651,7 +2651,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1455 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x80ba40", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bbe0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2673,7 +2673,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1463 EventRootType Probe[main.testMapSmallKeyLargeValue]
-              InjectionPoints: [{PC: "0x80bac0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bc60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2695,7 +2695,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1462 EventRootType Probe[main.testMapSmallKeySmallValue]
-              InjectionPoints: [{PC: "0x80bab0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bc50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2717,7 +2717,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1447 EventRootType Probe[main.testMapStringToInt]
-              InjectionPoints: [{PC: "0x80b9d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bb70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2739,7 +2739,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1448 EventRootType Probe[main.testMapStringToSlice]
-              InjectionPoints: [{PC: "0x80b9e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bb80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2761,7 +2761,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1446 EventRootType Probe[main.testMapStringToStruct]
-              InjectionPoints: [{PC: "0x80b9c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bb60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2783,7 +2783,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1457 EventRootType Probe[main.testMapWithLinkedList]
-              InjectionPoints: [{PC: "0x80ba60", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bc00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2805,7 +2805,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1460 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-              InjectionPoints: [{PC: "0x80ba90", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bc30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2827,7 +2827,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1461 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-              InjectionPoints: [{PC: "0x80baa0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bc40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2849,7 +2849,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1458 EventRootType Probe[main.testMapWithSmallValue]
-              InjectionPoints: [{PC: "0x80ba70", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bc10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2873,7 +2873,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1459 EventRootType Probe[main.testMapWithSmallValueMassive]
-              InjectionPoints: [{PC: "0x80ba80", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bc20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2895,7 +2895,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1611 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x80ff10", Frameless: true}]
+              InjectionPoints: [{PC: "0x810380", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2918,7 +2918,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1612 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x80ff10", Frameless: true}]
+              InjectionPoints: [{PC: "0x810380", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2965,11 +2965,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1577 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0x80f1f0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80f390", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1578 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0x80f378", Frameless: false}]
+              InjectionPoints: [{PC: "0x80f518", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -3035,11 +3035,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1581 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0x80f46c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80f60c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1582 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0x80f504", Frameless: false}]
+              InjectionPoints: [{PC: "0x80f6a4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3070,11 +3070,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1573 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0x80ee40", Frameless: false}]
+              InjectionPoints: [{PC: "0x80efe0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1574 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0x80efe4", Frameless: false}]
+              InjectionPoints: [{PC: "0x80f184", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3100,11 +3100,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1514 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80def8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e098", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1515 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80df78", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e118", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3140,7 +3140,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1472 EventRootType Probe[main.testMultipleSimpleParams]
-              InjectionPoints: [{PC: "0x80cfc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80d160", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -3181,11 +3181,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1508 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x80de68", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e008", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1509 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x80dec0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e060", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3209,11 +3209,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1510 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x80de68", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e008", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1511 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x80dec0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e060", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
       version: 0
@@ -3232,11 +3232,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1516 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80def8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e098", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1517 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80df78", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e118", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
       version: 0
@@ -3256,11 +3256,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1518 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80def8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e098", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1519 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80df78", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e118", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r1={result} r2={result2}
@@ -3293,11 +3293,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1512 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x80de68", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e008", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1513 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x80dec0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e060", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Parameter {i} * 2 = result {result}
@@ -3325,7 +3325,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1623 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x8101f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x810660", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3350,7 +3350,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1624 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x8101f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x810660", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3381,7 +3381,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1625 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x8101f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x810660", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3406,7 +3406,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1626 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x8101f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x810660", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3433,7 +3433,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1482 EventRootType Probe[main.testNilPointer]
-              InjectionPoints: [{PC: "0x80d410", Frameless: true}]
+              InjectionPoints: [{PC: "0x80d5b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}, {a}'
@@ -3460,7 +3460,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1595 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0x80fb40", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fce0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3487,7 +3487,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1592 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0x80fb10", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fcb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3522,7 +3522,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1594 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0x80fb30", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fcd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3554,7 +3554,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1610 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0x80ff00", Frameless: true}]
+              InjectionPoints: [{PC: "0x810370", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3576,7 +3576,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1478 EventRootType Probe[main.testPointerLoop]
-              InjectionPoints: [{PC: "0x80d350", Frameless: true}]
+              InjectionPoints: [{PC: "0x80d4f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3598,7 +3598,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1452 EventRootType Probe[main.testPointerToMap]
-              InjectionPoints: [{PC: "0x80ba20", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bbc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3620,7 +3620,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1476 EventRootType Probe[main.testPointerToSimpleStruct]
-              InjectionPoints: [{PC: "0x80d330", Frameless: true}]
+              InjectionPoints: [{PC: "0x80d4d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3644,11 +3644,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1484 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x80d758", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d8f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1485 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x80d798", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d938", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
       version: 0
@@ -3668,11 +3668,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1528 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x80dfb8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e158", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1529 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x80e03c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e1dc", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3715,11 +3715,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1494 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x80d878", Frameless: false}]
+              InjectionPoints: [{PC: "0x80da18", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1495 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x80d904", Frameless: false}]
+              InjectionPoints: [{PC: "0x80daa4", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3759,11 +3759,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1486 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x80d758", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d8f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1487 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x80d798", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d938", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3806,11 +3806,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1496 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x80d878", Frameless: false}]
+              InjectionPoints: [{PC: "0x80da18", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1497 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x80d904", Frameless: false}]
+              InjectionPoints: [{PC: "0x80daa4", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3852,11 +3852,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1530 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x80dfb8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e158", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1531 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x80e03c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e1dc", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
       version: 0
@@ -3873,11 +3873,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1532 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x80dfb8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e158", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1533 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x80e03c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e1dc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r0={@return.r0}
@@ -3899,11 +3899,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1488 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x80d758", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d8f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1489 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x80d798", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d938", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: result={@return}
@@ -3926,18 +3926,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1504 EventRootType Probe[main.testReturnsAny]
-              InjectionPoints: [{PC: "0x80db38", Frameless: false}]
+              InjectionPoints: [{PC: "0x80dcd8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1505 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
-                - PC: "0x80dbc0"
+                - PC: "0x80dd60"
                   Frameless: false
-                - PC: "0x80dc14"
+                - PC: "0x80ddb4"
                   Frameless: false
-                - PC: "0x80dcc4"
+                - PC: "0x80de64"
                   Frameless: false
-                - PC: "0x80dcd8"
+                - PC: "0x80de78"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3965,18 +3965,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1502 EventRootType Probe[main.testReturnsAnyAndError]
-              InjectionPoints: [{PC: "0x80d9c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80db68", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1503 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
-                - PC: "0x80da1c"
+                - PC: "0x80dbbc"
                   Frameless: false
-                - PC: "0x80da78"
+                - PC: "0x80dc18"
                   Frameless: false
-                - PC: "0x80dab8"
+                - PC: "0x80dc58"
                   Frameless: false
-                - PC: "0x80daf4"
+                - PC: "0x80dc94"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4003,11 +4003,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1547 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0x80e64c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e7ec", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1548 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0x80e698", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e838", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -4024,11 +4024,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1549 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0x80e6c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e868", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1550 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0x80e700", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e8a0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -4045,11 +4045,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1551 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0x80e738", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e8d8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1552 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0x80e76c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e90c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4066,11 +4066,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1555 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0x80e828", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e9c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1556 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0x80e888", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ea28", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4087,11 +4087,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1567 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0x80eb78", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ed18", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1568 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0x80ebb4", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ed54", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4108,11 +4108,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1543 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0x80e508", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e6a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1544 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0x80e550", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e6f0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4130,14 +4130,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1500 EventRootType Probe[main.testReturnsError]
-              InjectionPoints: [{PC: "0x80d948", Frameless: false}]
+              InjectionPoints: [{PC: "0x80dae8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1501 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
-                - PC: "0x80d974"
+                - PC: "0x80db14"
                   Frameless: false
-                - PC: "0x80d988"
+                - PC: "0x80db28"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4159,11 +4159,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1490 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x80d758", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d8f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1491 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x80d798", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d938", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4184,11 +4184,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1498 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x80d878", Frameless: false}]
+              InjectionPoints: [{PC: "0x80da18", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1499 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x80d904", Frameless: false}]
+              InjectionPoints: [{PC: "0x80daa4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4209,11 +4209,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1492 EventRootType Probe[main.testReturnsIntPointer]
-              InjectionPoints: [{PC: "0x80d7d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d978", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1493 EventRootType Probe[main.testReturnsIntPointer]Return
-              InjectionPoints: [{PC: "0x80d834", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d9d4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4235,14 +4235,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1506 EventRootType Probe[main.testReturnsInterface]
-              InjectionPoints: [{PC: "0x80dd18", Frameless: false}]
+              InjectionPoints: [{PC: "0x80deb8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1507 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
-                - PC: "0x80ddd0"
+                - PC: "0x80df70"
                   Frameless: false
-                - PC: "0x80dde4"
+                - PC: "0x80df84"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4264,11 +4264,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1545 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0x80e590", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e730", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1546 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0x80e60c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e7ac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4285,11 +4285,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1541 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0x80e458", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e5f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1542 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0x80e4d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e678", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4306,11 +4306,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1559 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0x80e988", Frameless: false}]
+              InjectionPoints: [{PC: "0x80eb28", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1560 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0x80e9dc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80eb7c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4327,11 +4327,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1553 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0x80e7a8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e948", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1554 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0x80e7ec", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e98c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4348,11 +4348,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1565 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0x80eb08", Frameless: false}]
+              InjectionPoints: [{PC: "0x80eca8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1566 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0x80eb48", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ece8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
@@ -4372,7 +4372,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1538 EventRootType Probe[main.testReturnsNamedDeferLine]Line
-              InjectionPoints: [{PC: "0x80e220", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e3c0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4393,11 +4393,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1563 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0x80ea98", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ec38", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1564 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0x80ead4", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ec74", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4414,11 +4414,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1539 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0x80e3c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e568", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1540 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0x80e41c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e5bc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4435,11 +4435,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1561 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0x80ea1c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ebbc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1562 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0x80ea68", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ec08", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4456,11 +4456,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1557 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0x80e8c0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ea60", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1558 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0x80e94c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80eaec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4478,7 +4478,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1370 EventRootType Probe[main.testRuneArray]
-              InjectionPoints: [{PC: "0x807030", Frameless: true}]
+              InjectionPoints: [{PC: "0x807110", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4513,11 +4513,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1520 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80def8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e098", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1521 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80df78", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e118", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -4563,7 +4563,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1391 EventRootType Probe[main.testSingleBool]
-              InjectionPoints: [{PC: "0x8074b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x807590", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4585,7 +4585,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1389 EventRootType Probe[main.testSingleByte]
-              InjectionPoints: [{PC: "0x807490", Frameless: true}]
+              InjectionPoints: [{PC: "0x807570", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4607,7 +4607,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1402 EventRootType Probe[main.testSingleFloat32]
-              InjectionPoints: [{PC: "0x807560", Frameless: true}]
+              InjectionPoints: [{PC: "0x807640", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4625,7 +4625,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1403 EventRootType Probe[main.testSingleFloat64]
-              InjectionPoints: [{PC: "0x807570", Frameless: true}]
+              InjectionPoints: [{PC: "0x807650", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4643,7 +4643,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1392 EventRootType Probe[main.testSingleInt]
-              InjectionPoints: [{PC: "0x8074c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8075a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4665,7 +4665,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1394 EventRootType Probe[main.testSingleInt16]
-              InjectionPoints: [{PC: "0x8074e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8075c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}
@@ -4688,7 +4688,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1395 EventRootType Probe[main.testSingleInt32]
-              InjectionPoints: [{PC: "0x8074f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8075d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4710,7 +4710,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1396 EventRootType Probe[main.testSingleInt64]
-              InjectionPoints: [{PC: "0x807500", Frameless: true}]
+              InjectionPoints: [{PC: "0x8075e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4739,7 +4739,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1393 EventRootType Probe[main.testSingleInt8]
-              InjectionPoints: [{PC: "0x8074d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8075b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}{x}{x}
@@ -4770,7 +4770,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1390 EventRootType Probe[main.testSingleRune]
-              InjectionPoints: [{PC: "0x8074a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x807580", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4792,7 +4792,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1602 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0x80fec0", Frameless: true}]
+              InjectionPoints: [{PC: "0x810330", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4814,7 +4814,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1397 EventRootType Probe[main.testSingleUint]
-              InjectionPoints: [{PC: "0x807510", Frameless: true}]
+              InjectionPoints: [{PC: "0x8075f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4836,7 +4836,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1399 EventRootType Probe[main.testSingleUint16]
-              InjectionPoints: [{PC: "0x807530", Frameless: true}]
+              InjectionPoints: [{PC: "0x807610", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4858,7 +4858,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1400 EventRootType Probe[main.testSingleUint32]
-              InjectionPoints: [{PC: "0x807540", Frameless: true}]
+              InjectionPoints: [{PC: "0x807620", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4880,7 +4880,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1401 EventRootType Probe[main.testSingleUint64]
-              InjectionPoints: [{PC: "0x807550", Frameless: true}]
+              InjectionPoints: [{PC: "0x807630", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4902,7 +4902,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1398 EventRootType Probe[main.testSingleUint8]
-              InjectionPoints: [{PC: "0x807520", Frameless: true}]
+              InjectionPoints: [{PC: "0x807600", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4924,7 +4924,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1598 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0x80fb60", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fd00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -4946,7 +4946,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1589 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0x80fae0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fc80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -4968,7 +4968,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1450 EventRootType Probe[main.testSmallMap]
-              InjectionPoints: [{PC: "0x80ba00", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bba0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -4989,11 +4989,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1534 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x80dfb8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e158", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1535 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x80e03c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e1dc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -5014,11 +5014,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1579 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0x80f3d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80f578", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1580 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0x80f430", Frameless: false}]
+              InjectionPoints: [{PC: "0x80f5d0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5040,7 +5040,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1371 EventRootType Probe[main.testStringArray]
-              InjectionPoints: [{PC: "0x807040", Frameless: true}]
+              InjectionPoints: [{PC: "0x807120", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5062,7 +5062,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1481 EventRootType Probe[main.testStringPointer]
-              InjectionPoints: [{PC: "0x80d3f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80d590", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}'
@@ -5084,7 +5084,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1593 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0x80fb20", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fcc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5106,7 +5106,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1414 EventRootType Probe[main.testStringType1]
-              InjectionPoints: [{PC: "0x807b40", Frameless: true}]
+              InjectionPoints: [{PC: "0x807c20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5128,7 +5128,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1415 EventRootType Probe[main.testStringType2]
-              InjectionPoints: [{PC: "0x807b50", Frameless: true}]
+              InjectionPoints: [{PC: "0x807c30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5150,11 +5150,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1621 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x810160", Frameless: true}]
+              InjectionPoints: [{PC: "0x8105d0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1622 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0x810170", Frameless: true}]
+              InjectionPoints: [{PC: "0x8105e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5181,7 +5181,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1590 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0x80faf0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fc90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5208,7 +5208,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1444 EventRootType Probe[main.testStructWithAny]
-              InjectionPoints: [{PC: "0x80b450", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b530", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5229,11 +5229,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1583 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0x80f53c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80f6dc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1584 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0x80f5c0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80f760", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5255,11 +5255,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1617 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0x8100b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x810520", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1618 EventRootType Probe[main.testStructWithCyclicMaps]Return
-              InjectionPoints: [{PC: "0x8100bc", Frameless: true}]
+              InjectionPoints: [{PC: "0x81052c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5280,7 +5280,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1616 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0x8100a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x810510", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5307,7 +5307,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1445 EventRootType Probe[main.testStructWithMap]
-              InjectionPoints: [{PC: "0x80b9b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bb50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s} {@duration}'
@@ -5340,7 +5340,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1599 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0x80fb70", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fd10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5380,7 +5380,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1615 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0x80ff40", Frameless: true}]
+              InjectionPoints: [{PC: "0x8103b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5413,11 +5413,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1522 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80def8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e098", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1523 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80df78", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e118", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{nonexistentVariable}'
@@ -5438,11 +5438,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1524 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80def8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e098", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1525 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80df78", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e118", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{unsupportedExpression}'
@@ -5465,11 +5465,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1526 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80def8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e098", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1527 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80df78", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e118", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -5501,7 +5501,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1603 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0x80fed0", Frameless: true}]
+              InjectionPoints: [{PC: "0x810340", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5533,11 +5533,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1604 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x80fee0", Frameless: true}]
+              InjectionPoints: [{PC: "0x810350", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1605 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0x80feec", Frameless: true}]
+              InjectionPoints: [{PC: "0x81035c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5567,11 +5567,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1606 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x80fee0", Frameless: true}]
+              InjectionPoints: [{PC: "0x810350", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1607 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0x80feec", Frameless: true}]
+              InjectionPoints: [{PC: "0x81035c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5603,7 +5603,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1608 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x80fef0", Frameless: true}]
+              InjectionPoints: [{PC: "0x810360", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5633,7 +5633,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1609 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x80fef0", Frameless: true}]
+              InjectionPoints: [{PC: "0x810360", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5665,7 +5665,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1404 EventRootType Probe[main.testTypeAlias]
-              InjectionPoints: [{PC: "0x807580", Frameless: true}]
+              InjectionPoints: [{PC: "0x807660", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5687,7 +5687,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1380 EventRootType Probe[main.testUint16Array]
-              InjectionPoints: [{PC: "0x8070d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8071b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5709,7 +5709,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1381 EventRootType Probe[main.testUint32Array]
-              InjectionPoints: [{PC: "0x8070e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8071c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5731,7 +5731,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1382 EventRootType Probe[main.testUint64Array]
-              InjectionPoints: [{PC: "0x8070f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8071d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5753,7 +5753,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1379 EventRootType Probe[main.testUint8Array]
-              InjectionPoints: [{PC: "0x8070c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8071a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5775,7 +5775,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1378 EventRootType Probe[main.testUintArray]
-              InjectionPoints: [{PC: "0x8070b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x807190", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5797,7 +5797,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1480 EventRootType Probe[main.testUintPointer]
-              InjectionPoints: [{PC: "0x80d380", Frameless: true}]
+              InjectionPoints: [{PC: "0x80d520", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5819,7 +5819,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1587 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0x80fac0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fc60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5841,7 +5841,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1613 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0x80ff20", Frameless: true}]
+              InjectionPoints: [{PC: "0x810390", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5863,7 +5863,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1479 EventRootType Probe[main.testUnsafePointer]
-              InjectionPoints: [{PC: "0x80d360", Frameless: true}]
+              InjectionPoints: [{PC: "0x80d500", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5885,7 +5885,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1388 EventRootType Probe[main.testVeryLargeArray]
-              InjectionPoints: [{PC: "0x807160", Frameless: true}]
+              InjectionPoints: [{PC: "0x807240", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5907,7 +5907,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1596 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x80fb50", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fcf0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5929,7 +5929,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1597 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x80fb50", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fcf0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5952,14 +5952,14 @@ Probes:
             - Kind: Entry
               Type: 1694 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
-                - PC: "0x80b2b8"
+                - PC: "0x80b398"
                   Frameless: false
-                - PC: "0x812548"
+                - PC: "0x8129b8"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1695 EventRootType Probe[main.firstBehavior.DoSomething]Return
-              InjectionPoints: [{PC: "0x80b2e0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b3c0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testWhollyInlinedSubroutine
@@ -5981,11 +5981,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1585 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0x80f5f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80f798", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1586 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x80f658", Frameless: false}]
+              InjectionPoints: [{PC: "0x80f7f8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -6002,481 +6002,481 @@ Probes:
 Subprograms:
     - ID: 1
       Name: main.testByteArray
-      OutOfLinePCRanges: [0x807020..0x807030]
+      OutOfLinePCRanges: [0x807100..0x807110]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 110 ArrayType [2]uint8
           Locations:
-            - Range: 0x807020..0x807030
+            - Range: 0x807100..0x807110
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 2
       Name: main.testRuneArray
-      OutOfLinePCRanges: [0x807030..0x807040]
+      OutOfLinePCRanges: [0x807110..0x807120]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 111 ArrayType [2]int32
           Locations:
-            - Range: 0x807030..0x807040
+            - Range: 0x807110..0x807120
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 3
       Name: main.testStringArray
-      OutOfLinePCRanges: [0x807040..0x807050]
+      OutOfLinePCRanges: [0x807120..0x807130]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 112 ArrayType [2]string
           Locations:
-            - Range: 0x807040..0x807050
+            - Range: 0x807120..0x807130
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 4
       Name: main.testBoolArray
-      OutOfLinePCRanges: [0x807050..0x807060]
+      OutOfLinePCRanges: [0x807130..0x807140]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 113 ArrayType [2]bool
           Locations:
-            - Range: 0x807050..0x807060
+            - Range: 0x807130..0x807140
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 5
       Name: main.testIntArray
-      OutOfLinePCRanges: [0x807060..0x807070]
+      OutOfLinePCRanges: [0x807140..0x807150]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 114 ArrayType [2]int
           Locations:
-            - Range: 0x807060..0x807070
+            - Range: 0x807140..0x807150
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 6
       Name: main.testInt8Array
-      OutOfLinePCRanges: [0x807070..0x807080]
+      OutOfLinePCRanges: [0x807150..0x807160]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 115 ArrayType [2]int8
           Locations:
-            - Range: 0x807070..0x807080
+            - Range: 0x807150..0x807160
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 7
       Name: main.testInt16Array
-      OutOfLinePCRanges: [0x807080..0x807090]
+      OutOfLinePCRanges: [0x807160..0x807170]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 116 ArrayType [2]int16
           Locations:
-            - Range: 0x807080..0x807090
+            - Range: 0x807160..0x807170
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 8
       Name: main.testInt32Array
-      OutOfLinePCRanges: [0x807090..0x8070a0]
+      OutOfLinePCRanges: [0x807170..0x807180]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 111 ArrayType [2]int32
           Locations:
-            - Range: 0x807090..0x8070a0
+            - Range: 0x807170..0x807180
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 9
       Name: main.testInt64Array
-      OutOfLinePCRanges: [0x8070a0..0x8070b0]
+      OutOfLinePCRanges: [0x807180..0x807190]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 117 ArrayType [2]int64
           Locations:
-            - Range: 0x8070a0..0x8070b0
+            - Range: 0x807180..0x807190
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 10
       Name: main.testUintArray
-      OutOfLinePCRanges: [0x8070b0..0x8070c0]
+      OutOfLinePCRanges: [0x807190..0x8071a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 118 ArrayType [2]uint
           Locations:
-            - Range: 0x8070b0..0x8070c0
+            - Range: 0x807190..0x8071a0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 11
       Name: main.testUint8Array
-      OutOfLinePCRanges: [0x8070c0..0x8070d0]
+      OutOfLinePCRanges: [0x8071a0..0x8071b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 110 ArrayType [2]uint8
           Locations:
-            - Range: 0x8070c0..0x8070d0
+            - Range: 0x8071a0..0x8071b0
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 12
       Name: main.testUint16Array
-      OutOfLinePCRanges: [0x8070d0..0x8070e0]
+      OutOfLinePCRanges: [0x8071b0..0x8071c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 119 ArrayType [2]uint16
           Locations:
-            - Range: 0x8070d0..0x8070e0
+            - Range: 0x8071b0..0x8071c0
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 13
       Name: main.testUint32Array
-      OutOfLinePCRanges: [0x8070e0..0x8070f0]
+      OutOfLinePCRanges: [0x8071c0..0x8071d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 120 ArrayType [2]uint32
           Locations:
-            - Range: 0x8070e0..0x8070f0
+            - Range: 0x8071c0..0x8071d0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 14
       Name: main.testUint64Array
-      OutOfLinePCRanges: [0x8070f0..0x807100]
+      OutOfLinePCRanges: [0x8071d0..0x8071e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 55 ArrayType [2]uint64
           Locations:
-            - Range: 0x8070f0..0x807100
+            - Range: 0x8071d0..0x8071e0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 15
       Name: main.testArrayOfArrays
-      OutOfLinePCRanges: [0x807100..0x807110]
+      OutOfLinePCRanges: [0x8071e0..0x8071f0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 121 ArrayType [2][2]int
           Locations:
-            - Range: 0x807100..0x807110
+            - Range: 0x8071e0..0x8071f0
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 16
       Name: main.testArrayOfStrings
-      OutOfLinePCRanges: [0x807110..0x807120]
+      OutOfLinePCRanges: [0x8071f0..0x807200]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 112 ArrayType [2]string
           Locations:
-            - Range: 0x807110..0x807120
+            - Range: 0x8071f0..0x807200
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 17
       Name: main.testArrayOfArraysOfArrays
-      OutOfLinePCRanges: [0x807120..0x807130]
+      OutOfLinePCRanges: [0x807200..0x807210]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 122 ArrayType [2][2][2]int
           Locations:
-            - Range: 0x807120..0x807130
+            - Range: 0x807200..0x807210
               Pieces: [{Size: 64, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 18
       Name: main.testArrayOfStructs
-      OutOfLinePCRanges: [0x807130..0x807140]
+      OutOfLinePCRanges: [0x807210..0x807220]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 123 ArrayType [2]main.nestedStruct
           Locations:
-            - Range: 0x807130..0x807140
+            - Range: 0x807210..0x807220
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 19
       Name: main.testArrayEmptyStructs
-      OutOfLinePCRanges: [0x807140..0x807150]
+      OutOfLinePCRanges: [0x807220..0x807230]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 125 ArrayType [2]struct {}
           Locations:
-            - Range: 0x807140..0x807150
+            - Range: 0x807220..0x807230
               Pieces: [{Size: 0, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 20
       Name: main.testVeryLargeArray
-      OutOfLinePCRanges: [0x807160..0x807170]
+      OutOfLinePCRanges: [0x807240..0x807250]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 127 ArrayType [100]uint
           Locations:
-            - Range: 0x807160..0x807170
+            - Range: 0x807240..0x807250
               Pieces: [{Size: 800, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 21
       Name: main.testSingleByte
-      OutOfLinePCRanges: [0x807490..0x8074a0]
+      OutOfLinePCRanges: [0x807570..0x807580]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x807490..0x8074a0
+            - Range: 0x807570..0x807580
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 22
       Name: main.testSingleRune
-      OutOfLinePCRanges: [0x8074a0..0x8074b0]
+      OutOfLinePCRanges: [0x807580..0x807590]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x8074a0..0x8074b0
+            - Range: 0x807580..0x807590
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 23
       Name: main.testSingleBool
-      OutOfLinePCRanges: [0x8074b0..0x8074c0]
+      OutOfLinePCRanges: [0x807590..0x8075a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x8074b0..0x8074c0
+            - Range: 0x807590..0x8075a0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 24
       Name: main.testSingleInt
-      OutOfLinePCRanges: [0x8074c0..0x8074d0]
+      OutOfLinePCRanges: [0x8075a0..0x8075b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0x8074c0..0x8074d0
+            - Range: 0x8075a0..0x8075b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 25
       Name: main.testSingleInt8
-      OutOfLinePCRanges: [0x8074d0..0x8074e0]
+      OutOfLinePCRanges: [0x8075b0..0x8075c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 18 BaseType int8
           Locations:
-            - Range: 0x8074d0..0x8074e0
+            - Range: 0x8075b0..0x8075c0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 26
       Name: main.testSingleInt16
-      OutOfLinePCRanges: [0x8074e0..0x8074f0]
+      OutOfLinePCRanges: [0x8075c0..0x8075d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 97 BaseType int16
           Locations:
-            - Range: 0x8074e0..0x8074f0
+            - Range: 0x8075c0..0x8075d0
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 27
       Name: main.testSingleInt32
-      OutOfLinePCRanges: [0x8074f0..0x807500]
+      OutOfLinePCRanges: [0x8075d0..0x8075e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x8074f0..0x807500
+            - Range: 0x8075d0..0x8075e0
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 28
       Name: main.testSingleInt64
-      OutOfLinePCRanges: [0x807500..0x807510]
+      OutOfLinePCRanges: [0x8075e0..0x8075f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 BaseType int64
           Locations:
-            - Range: 0x807500..0x807510
+            - Range: 0x8075e0..0x8075f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 29
       Name: main.testSingleUint
-      OutOfLinePCRanges: [0x807510..0x807520]
+      OutOfLinePCRanges: [0x8075f0..0x807600]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 BaseType uint
           Locations:
-            - Range: 0x807510..0x807520
+            - Range: 0x8075f0..0x807600
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 30
       Name: main.testSingleUint8
-      OutOfLinePCRanges: [0x807520..0x807530]
+      OutOfLinePCRanges: [0x807600..0x807610]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x807520..0x807530
+            - Range: 0x807600..0x807610
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 31
       Name: main.testSingleUint16
-      OutOfLinePCRanges: [0x807530..0x807540]
+      OutOfLinePCRanges: [0x807610..0x807620]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType uint16
           Locations:
-            - Range: 0x807530..0x807540
+            - Range: 0x807610..0x807620
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 32
       Name: main.testSingleUint32
-      OutOfLinePCRanges: [0x807540..0x807550]
+      OutOfLinePCRanges: [0x807620..0x807630]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint32
           Locations:
-            - Range: 0x807540..0x807550
+            - Range: 0x807620..0x807630
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 33
       Name: main.testSingleUint64
-      OutOfLinePCRanges: [0x807550..0x807560]
+      OutOfLinePCRanges: [0x807630..0x807640]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0x807550..0x807560
+            - Range: 0x807630..0x807640
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 34
       Name: main.testSingleFloat32
-      OutOfLinePCRanges: [0x807560..0x807570]
+      OutOfLinePCRanges: [0x807640..0x807650]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 19 BaseType float32
           Locations:
-            - Range: 0x807560..0x807570
+            - Range: 0x807640..0x807650
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 35
       Name: main.testSingleFloat64
-      OutOfLinePCRanges: [0x807570..0x807580]
+      OutOfLinePCRanges: [0x807650..0x807660]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType float64
           Locations:
-            - Range: 0x807570..0x807580
+            - Range: 0x807650..0x807660
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 36
       Name: main.testTypeAlias
-      OutOfLinePCRanges: [0x807580..0x807590]
+      OutOfLinePCRanges: [0x807660..0x807670]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 128 BaseType main.typeAlias
           Locations:
-            - Range: 0x807580..0x807590
+            - Range: 0x807660..0x807670
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 37
       Name: main.testBigStruct
-      OutOfLinePCRanges: [0x807680..0x807690]
+      OutOfLinePCRanges: [0x807760..0x807770]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 129 StructureType main.bigStruct
           Locations:
-            - Range: 0x807680..0x807690
+            - Range: 0x807760..0x807770
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6495,89 +6495,89 @@ Subprograms:
       DictRegister: null
     - ID: 38
       Name: main.testErrorAtLine
-      OutOfLinePCRanges: [0x8076b0..0x8077b0]
+      OutOfLinePCRanges: [0x807790..0x807890]
       InlinePCRanges: []
       Variables:
         - Name: shouldErr
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x8076b0..0x8076d0
+            - Range: 0x807790..0x8077b0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
-          Locations: [{Range: 0x8076b0..0x8077b0, Pieces: []}]
+          Locations: [{Range: 0x807790..0x807890, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 8 BaseType int
-          Locations: [{Range: 0x8076b0..0x8077b0, Pieces: []}]
+          Locations: [{Range: 0x807790..0x807890, Pieces: []}]
           Role: Local
           DictIndex: -1
         - Name: err
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0x8076c8..0x807704
+            - Range: 0x8077a8..0x8077e4
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
-            - Range: 0x807704..0x80770c
+            - Range: 0x8077e4..0x8077ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
-            - Range: 0x80770c..0x807758
+            - Range: 0x8077ec..0x807838
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -64}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x807758..0x807760
+            - Range: 0x807838..0x807840
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}, {Size: 8, Op: null}]
-            - Range: 0x807760..0x8077b0
+            - Range: 0x807840..0x807890
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}, {Size: 8, Op: null}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 39
       Name: main.testDeepPtr1
-      OutOfLinePCRanges: [0x807840..0x807850]
+      OutOfLinePCRanges: [0x807920..0x807930]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 133 StructureType main.deepPtr1
           Locations:
-            - Range: 0x807840..0x807850
+            - Range: 0x807920..0x807930
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 40
       Name: main.testDeepPtr7
-      OutOfLinePCRanges: [0x807850..0x807860]
+      OutOfLinePCRanges: [0x807930..0x807940]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 136 PointerType *main.deepPtr7
           Locations:
-            - Range: 0x807850..0x807860
+            - Range: 0x807930..0x807940
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 41
       Name: main.testDeepSlice1
-      OutOfLinePCRanges: [0x8079c0..0x8079d0]
+      OutOfLinePCRanges: [0x807aa0..0x807ab0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 138 StructureType main.deepSlice1
           Locations:
-            - Range: 0x8079c0..0x8079d0
+            - Range: 0x807aa0..0x807ab0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6590,142 +6590,142 @@ Subprograms:
       DictRegister: null
     - ID: 42
       Name: main.testDeepSlice7
-      OutOfLinePCRanges: [0x8079d0..0x8079e0]
+      OutOfLinePCRanges: [0x807ab0..0x807ac0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 142 PointerType *main.deepSlice7
           Locations:
-            - Range: 0x8079d0..0x8079e0
+            - Range: 0x807ab0..0x807ac0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 43
       Name: main.testDeepMap1
-      OutOfLinePCRanges: [0x807b20..0x807b30]
+      OutOfLinePCRanges: [0x807c00..0x807c10]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 144 StructureType main.deepMap1
           Locations:
-            - Range: 0x807b20..0x807b30
+            - Range: 0x807c00..0x807c10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 44
       Name: main.testDeepMap7
-      OutOfLinePCRanges: [0x807b30..0x807b40]
+      OutOfLinePCRanges: [0x807c10..0x807c20]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 150 PointerType *main.deepMap7
           Locations:
-            - Range: 0x807b30..0x807b40
+            - Range: 0x807c10..0x807c20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 45
       Name: main.testStringType1
-      OutOfLinePCRanges: [0x807b40..0x807b50]
+      OutOfLinePCRanges: [0x807c20..0x807c30]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 152 PointerType *main.stringType1
           Locations:
-            - Range: 0x807b40..0x807b50
+            - Range: 0x807c20..0x807c30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 46
       Name: main.testStringType2
-      OutOfLinePCRanges: [0x807b50..0x807b60]
+      OutOfLinePCRanges: [0x807c30..0x807c40]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 154 PointerType **main.stringType2
           Locations:
-            - Range: 0x807b50..0x807b60
+            - Range: 0x807c30..0x807c40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 47
       Name: main.testLongFunctionWithChangingState
-      OutOfLinePCRanges: [0x807b60..0x807d40]
+      OutOfLinePCRanges: [0x807c40..0x807e20]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 8 BaseType int
           Locations:
-            - Range: 0x807c18..0x807c28
+            - Range: 0x807cf8..0x807d08
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x807cb8..0x807cc8
+            - Range: 0x807d98..0x807da8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: aPerArch
           Type: 8 BaseType int
           Locations:
-            - Range: 0x807c00..0x807c04
+            - Range: 0x807ce0..0x807ce4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x807c04..0x807c28
+            - Range: 0x807ce4..0x807d08
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x807c28..0x807cac
+            - Range: 0x807d08..0x807d8c
               Pieces: [{Size: 8, Op: {CfaOffset: -160}}]
-            - Range: 0x807cac..0x807cb4
+            - Range: 0x807d8c..0x807d94
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0x807cb4..0x807d40
+            - Range: 0x807d94..0x807e20
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
           Role: Local
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0x807bf8..0x807c04
+            - Range: 0x807cd8..0x807ce4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x807c04..0x807c04
+            - Range: 0x807ce4..0x807ce4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x807c04..0x807c28
+            - Range: 0x807ce4..0x807d08
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x807c28..0x807cac
+            - Range: 0x807d08..0x807d8c
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0x807cac..0x807cb0
+            - Range: 0x807d8c..0x807d90
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0x807cb0..0x807cb4
+            - Range: 0x807d90..0x807d94
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x807cb4..0x807cc8
+            - Range: 0x807d94..0x807da8
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x807cc8..0x807d40
+            - Range: 0x807da8..0x807e20
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 48
       Name: main.testManyPointers
-      OutOfLinePCRanges: [0x808060..0x808070]
+      OutOfLinePCRanges: [0x808140..0x808150]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 156 StructureType main.manyPointers
           Locations:
-            - Range: 0x808060..0x808070
+            - Range: 0x808140..0x808150
               Pieces: [{Size: 560, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 49
       Name: main.testManyStrings
-      OutOfLinePCRanges: [0x8099d0..0x8099e0]
+      OutOfLinePCRanges: [0x809ab0..0x809ac0]
       InlinePCRanges: []
       Variables:
         - Name: ss
           Type: 159 GoSliceHeaderType []string
           Locations:
-            - Range: 0x8099d0..0x8099e0
+            - Range: 0x809ab0..0x809ac0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6738,13 +6738,13 @@ Subprograms:
       DictRegister: null
     - ID: 50
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0x809cc0..0x809d80]
+      OutOfLinePCRanges: [0x809da0..0x809e60]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 160 StructureType main.esotericStack
           Locations:
-            - Range: 0x809cc0..0x809cf8
+            - Range: 0x809da0..0x809dd8
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -6764,7 +6764,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x809cf8..0x809cfc
+            - Range: 0x809dd8..0x809ddc
               Pieces:
                 - Size: 4
                   Op: null
@@ -6784,7 +6784,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x809cfc..0x809d00
+            - Range: 0x809ddc..0x809de0
               Pieces:
                 - Size: 4
                   Op: null
@@ -6809,251 +6809,151 @@ Subprograms:
       DictRegister: null
     - ID: 51
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0x809d80..0x809df0]
+      OutOfLinePCRanges: [0x809e60..0x809ed0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 164 PointerType *main.esotericHeap
           Locations:
-            - Range: 0x809d80..0x809db4
+            - Range: 0x809e60..0x809e94
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 52
       Name: main.testInlinedBA
-      OutOfLinePCRanges: [0x80ae30..0x80aec0]
+      OutOfLinePCRanges: [0x80af10..0x80afa0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80ae30..0x80ae68
+            - Range: 0x80af10..0x80af48
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 53
       Name: main.testInlinedBB
-      OutOfLinePCRanges: [0x80aec0..0x80af80]
+      OutOfLinePCRanges: [0x80afa0..0x80b060]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80aec0..0x80aedc
+            - Range: 0x80afa0..0x80afbc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: "y"
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80aec0..0x80aeec
+            - Range: 0x80afa0..0x80afcc
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: z
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80aedc..0x80aeec
+            - Range: 0x80afbc..0x80afcc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80aeec..0x80af80
+            - Range: 0x80afcc..0x80b060
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 54
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0x80af80..0x80aff0]
+      OutOfLinePCRanges: [0x80b060..0x80b0d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80af80..0x80afa4
+            - Range: 0x80b060..0x80b084
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 55
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0x80aff0..0x80b100]
+      OutOfLinePCRanges: [0x80b0d0..0x80b1e0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80b00c..0x80b078
+            - Range: 0x80b0ec..0x80b158
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80b078..0x80b080
+            - Range: 0x80b158..0x80b160
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80b00c..0x80b078
+            - Range: 0x80b0ec..0x80b158
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80b078..0x80b07c
+            - Range: 0x80b158..0x80b15c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 56
       Name: main.testFrameless
-      OutOfLinePCRanges: [0x80b100..0x80b110]
+      OutOfLinePCRanges: [0x80b1e0..0x80b1f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80b100..0x80b108
+            - Range: 0x80b1e0..0x80b1e8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80b100..0x80b108
+            - Range: 0x80b1e0..0x80b1e8
               Pieces: []
-            - Range: 0x80b108..0x80b109
+            - Range: 0x80b1e8..0x80b1e9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80b109..0x80b110
+            - Range: 0x80b1e9..0x80b1f0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 57
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0x80b110..0x80b160]
+      OutOfLinePCRanges: [0x80b1f0..0x80b240]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 166 ArrayType [5]int
           Locations:
-            - Range: 0x80b110..0x80b160
+            - Range: 0x80b1f0..0x80b240
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80b110..0x80b150
+            - Range: 0x80b1f0..0x80b230
               Pieces: []
-            - Range: 0x80b150..0x80b151
+            - Range: 0x80b230..0x80b231
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80b151..0x80b160
+            - Range: 0x80b231..0x80b240
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 58
       Name: main.testInterface
-      OutOfLinePCRanges: [0x80b370..0x80b380]
+      OutOfLinePCRanges: [0x80b450..0x80b460]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 167 GoInterfaceType main.behavior
-          Locations:
-            - Range: 0x80b370..0x80b380
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 59
-      Name: main.testAny
-      OutOfLinePCRanges: [0x80b380..0x80b3e0]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 162 GoEmptyInterfaceType interface {}
-          Locations:
-            - Range: 0x80b380..0x80b3ac
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80b3ac..0x80b3b0
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-        - Name: ~r0
-          Type: 10 GoStringHeaderType string
-          Locations:
-            - Range: 0x80b380..0x80b3c0
-              Pieces: []
-            - Range: 0x80b3c0..0x80b3c1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80b3c1..0x80b3e0
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-      DictRegister: null
-    - ID: 60
-      Name: main.testError
-      OutOfLinePCRanges: [0x80b3e0..0x80b3f0]
-      InlinePCRanges: []
-      Variables:
-        - Name: e
-          Type: 15 GoInterfaceType error
-          Locations:
-            - Range: 0x80b3e0..0x80b3f0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 61
-      Name: main.testAnyPtr
-      OutOfLinePCRanges: [0x80b3f0..0x80b450]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 168 PointerType *interface {}
-          Locations:
-            - Range: 0x80b3f0..0x80b41c
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: ~r0
-          Type: 10 GoStringHeaderType string
-          Locations:
-            - Range: 0x80b3f0..0x80b430
-              Pieces: []
-            - Range: 0x80b430..0x80b431
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80b431..0x80b450
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-      DictRegister: null
-    - ID: 62
-      Name: main.testStructWithAny
-      OutOfLinePCRanges: [0x80b450..0x80b460]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 169 StructureType main.structWithAny
           Locations:
             - Range: 0x80b450..0x80b460
               Pieces:
@@ -7064,348 +6964,448 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 59
+      Name: main.testAny
+      OutOfLinePCRanges: [0x80b460..0x80b4c0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 162 GoEmptyInterfaceType interface {}
+          Locations:
+            - Range: 0x80b460..0x80b48c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x80b48c..0x80b490
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: ~r0
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0x80b460..0x80b4a0
+              Pieces: []
+            - Range: 0x80b4a0..0x80b4a1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x80b4a1..0x80b4c0
+              Pieces: []
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 60
+      Name: main.testError
+      OutOfLinePCRanges: [0x80b4c0..0x80b4d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: e
+          Type: 15 GoInterfaceType error
+          Locations:
+            - Range: 0x80b4c0..0x80b4d0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 61
+      Name: main.testAnyPtr
+      OutOfLinePCRanges: [0x80b4d0..0x80b530]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 168 PointerType *interface {}
+          Locations:
+            - Range: 0x80b4d0..0x80b4fc
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: ~r0
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0x80b4d0..0x80b510
+              Pieces: []
+            - Range: 0x80b510..0x80b511
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x80b511..0x80b530
+              Pieces: []
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 62
+      Name: main.testStructWithAny
+      OutOfLinePCRanges: [0x80b530..0x80b540]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 169 StructureType main.structWithAny
+          Locations:
+            - Range: 0x80b530..0x80b540
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 63
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x80b9b0..0x80b9c0]
+      OutOfLinePCRanges: [0x80bb50..0x80bb60]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 170 StructureType main.structWithMap
           Locations:
-            - Range: 0x80b9b0..0x80b9c0
+            - Range: 0x80bb50..0x80bb60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 64
       Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x80b9c0..0x80b9d0]
+      OutOfLinePCRanges: [0x80bb60..0x80bb70]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 176 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0x80b9c0..0x80b9d0
+            - Range: 0x80bb60..0x80bb70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 65
       Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0x80b9d0..0x80b9e0]
+      OutOfLinePCRanges: [0x80bb70..0x80bb80]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 181 GoMapType map[string]int
           Locations:
-            - Range: 0x80b9d0..0x80b9e0
+            - Range: 0x80bb70..0x80bb80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 66
       Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0x80b9e0..0x80b9f0]
+      OutOfLinePCRanges: [0x80bb80..0x80bb90]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 186 GoMapType map[string][]string
           Locations:
-            - Range: 0x80b9e0..0x80b9f0
+            - Range: 0x80bb80..0x80bb90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 67
       Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0x80b9f0..0x80ba00]
+      OutOfLinePCRanges: [0x80bb90..0x80bba0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 191 GoMapType map[[4]string][2]int
           Locations:
-            - Range: 0x80b9f0..0x80ba00
+            - Range: 0x80bb90..0x80bba0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 68
       Name: main.testSmallMap
-      OutOfLinePCRanges: [0x80ba00..0x80ba10]
+      OutOfLinePCRanges: [0x80bba0..0x80bbb0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 181 GoMapType map[string]int
           Locations:
-            - Range: 0x80ba00..0x80ba10
+            - Range: 0x80bba0..0x80bbb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 69
       Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0x80ba10..0x80ba20]
+      OutOfLinePCRanges: [0x80bbb0..0x80bbc0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 196 ArrayType [2]map[string]int
           Locations:
-            - Range: 0x80ba10..0x80ba20
+            - Range: 0x80bbb0..0x80bbc0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 70
       Name: main.testPointerToMap
-      OutOfLinePCRanges: [0x80ba20..0x80ba30]
+      OutOfLinePCRanges: [0x80bbc0..0x80bbd0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 197 PointerType *map[string]int
           Locations:
-            - Range: 0x80ba20..0x80ba30
+            - Range: 0x80bbc0..0x80bbd0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 71
       Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0x80ba30..0x80ba40]
+      OutOfLinePCRanges: [0x80bbd0..0x80bbe0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 171 GoMapType map[int]int
           Locations:
-            - Range: 0x80ba30..0x80ba40
+            - Range: 0x80bbd0..0x80bbe0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 72
       Name: main.testMapMassive
-      OutOfLinePCRanges: [0x80ba40..0x80ba50]
+      OutOfLinePCRanges: [0x80bbe0..0x80bbf0]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 198 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x80ba40..0x80ba50
+            - Range: 0x80bbe0..0x80bbf0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 73
       Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0x80ba50..0x80ba60]
+      OutOfLinePCRanges: [0x80bbf0..0x80bc00]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 198 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x80ba50..0x80ba60
+            - Range: 0x80bbf0..0x80bc00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 74
       Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0x80ba60..0x80ba70]
+      OutOfLinePCRanges: [0x80bc00..0x80bc10]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 203 GoMapType map[bool]main.node
           Locations:
-            - Range: 0x80ba60..0x80ba70
+            - Range: 0x80bc00..0x80bc10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 75
       Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0x80ba70..0x80ba80]
+      OutOfLinePCRanges: [0x80bc10..0x80bc20]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 208 GoMapType map[int]uint8
           Locations:
-            - Range: 0x80ba70..0x80ba80
+            - Range: 0x80bc10..0x80bc20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 76
       Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0x80ba80..0x80ba90]
+      OutOfLinePCRanges: [0x80bc20..0x80bc30]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 208 GoMapType map[int]uint8
           Locations:
-            - Range: 0x80ba80..0x80ba90
+            - Range: 0x80bc20..0x80bc30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 77
       Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0x80ba90..0x80baa0]
+      OutOfLinePCRanges: [0x80bc30..0x80bc40]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 213 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x80ba90..0x80baa0
+            - Range: 0x80bc30..0x80bc40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 78
       Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0x80baa0..0x80bab0]
+      OutOfLinePCRanges: [0x80bc40..0x80bc50]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 213 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x80baa0..0x80bab0
+            - Range: 0x80bc40..0x80bc50
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 79
       Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0x80bab0..0x80bac0]
+      OutOfLinePCRanges: [0x80bc50..0x80bc60]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 213 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x80bab0..0x80bac0
+            - Range: 0x80bc50..0x80bc60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 80
       Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0x80bac0..0x80bad0]
+      OutOfLinePCRanges: [0x80bc60..0x80bc70]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 218 GoMapType map[uint8][4]int
           Locations:
-            - Range: 0x80bac0..0x80bad0
+            - Range: 0x80bc60..0x80bc70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 81
       Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0x80bad0..0x80bae0]
+      OutOfLinePCRanges: [0x80bc70..0x80bc80]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 223 GoMapType map[[4]int]uint8
           Locations:
-            - Range: 0x80bad0..0x80bae0
+            - Range: 0x80bc70..0x80bc80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 82
       Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0x80bae0..0x80baf0]
+      OutOfLinePCRanges: [0x80bc80..0x80bc90]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 228 GoMapType map[[4]int][4]int
           Locations:
-            - Range: 0x80bae0..0x80baf0
+            - Range: 0x80bc80..0x80bc90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 83
       Name: main.testMapEmptyKey
-      OutOfLinePCRanges: [0x80baf0..0x80bb00]
+      OutOfLinePCRanges: [0x80bc90..0x80bca0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 233 GoMapType map[struct {}]int
           Locations:
-            - Range: 0x80baf0..0x80bb00
+            - Range: 0x80bc90..0x80bca0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 84
       Name: main.testMapEmptyValue
-      OutOfLinePCRanges: [0x80bb00..0x80bb10]
+      OutOfLinePCRanges: [0x80bca0..0x80bcb0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 238 GoMapType map[int]struct {}
           Locations:
-            - Range: 0x80bb00..0x80bb10
+            - Range: 0x80bca0..0x80bcb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 85
       Name: main.testMapEmptyKeyAndValue
-      OutOfLinePCRanges: [0x80bb10..0x80bb20]
+      OutOfLinePCRanges: [0x80bcb0..0x80bcc0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 243 GoMapType map[struct {}]struct {}
           Locations:
-            - Range: 0x80bb10..0x80bb20
+            - Range: 0x80bcb0..0x80bcc0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 86
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x80cee0..0x80cef0]
+      OutOfLinePCRanges: [0x80d080..0x80d090]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x80cee0..0x80cef0
+            - Range: 0x80d080..0x80d090
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x80cee0..0x80cef0
+            - Range: 0x80d080..0x80d090
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: "y"
           Type: 19 BaseType float32
           Locations:
-            - Range: 0x80cee0..0x80cef0
+            - Range: 0x80d080..0x80d090
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 87
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0x80cf00..0x80cf10]
+      OutOfLinePCRanges: [0x80d0a0..0x80d0b0]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x80cf00..0x80cf10
+            - Range: 0x80d0a0..0x80d0b0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80cf00..0x80cf10
+            - Range: 0x80d0a0..0x80d0b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -7416,48 +7416,48 @@ Subprograms:
         - Name: "y"
           Type: 19 BaseType float32
           Locations:
-            - Range: 0x80cf00..0x80cf10
+            - Range: 0x80d0a0..0x80d0b0
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 88
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x80cfc0..0x80cfd0]
+      OutOfLinePCRanges: [0x80d160..0x80d170]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x80cfc0..0x80cfd0
+            - Range: 0x80d160..0x80d170
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x80cfc0..0x80cfd0
+            - Range: 0x80d160..0x80d170
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x80cfc0..0x80cfd0
+            - Range: 0x80d160..0x80d170
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 11 BaseType uint
           Locations:
-            - Range: 0x80cfc0..0x80cfd0
+            - Range: 0x80d160..0x80d170
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80cfc0..0x80cfd0
+            - Range: 0x80d160..0x80d170
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7468,63 +7468,63 @@ Subprograms:
       DictRegister: null
     - ID: 89
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0x80d160..0x80d1a0]
+      OutOfLinePCRanges: [0x80d300..0x80d340]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0x80d160..0x80d19c
+            - Range: 0x80d300..0x80d33c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0x80d160..0x80d19c
+            - Range: 0x80d300..0x80d33c
               Pieces: []
-            - Range: 0x80d19c..0x80d19d
+            - Range: 0x80d33c..0x80d33d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d19d..0x80d1a0
+            - Range: 0x80d33d..0x80d340
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 90
       Name: main.testChannel
-      OutOfLinePCRanges: [0x80d1a0..0x80d1b0]
+      OutOfLinePCRanges: [0x80d340..0x80d350]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 248 GoChannelType chan bool
           Locations:
-            - Range: 0x80d1a0..0x80d1b0
+            - Range: 0x80d340..0x80d350
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 91
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x80d330..0x80d340]
+      OutOfLinePCRanges: [0x80d4d0..0x80d4e0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 249 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x80d330..0x80d340
+            - Range: 0x80d4d0..0x80d4e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 92
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x80d340..0x80d350]
+      OutOfLinePCRanges: [0x80d4e0..0x80d4f0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 251 StructureType main.node
           Locations:
-            - Range: 0x80d340..0x80d350
+            - Range: 0x80d4e0..0x80d4f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7535,267 +7535,267 @@ Subprograms:
       DictRegister: null
     - ID: 93
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x80d350..0x80d360]
+      OutOfLinePCRanges: [0x80d4f0..0x80d500]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 252 PointerType *main.node
           Locations:
-            - Range: 0x80d350..0x80d360
+            - Range: 0x80d4f0..0x80d500
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 94
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x80d360..0x80d370]
+      OutOfLinePCRanges: [0x80d500..0x80d510]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0x80d360..0x80d370
+            - Range: 0x80d500..0x80d510
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 95
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x80d380..0x80d390]
+      OutOfLinePCRanges: [0x80d520..0x80d530]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 108 PointerType *uint
           Locations:
-            - Range: 0x80d380..0x80d390
+            - Range: 0x80d520..0x80d530
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 96
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x80d3f0..0x80d400]
+      OutOfLinePCRanges: [0x80d590..0x80d5a0]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 96 PointerType *string
           Locations:
-            - Range: 0x80d3f0..0x80d400
+            - Range: 0x80d590..0x80d5a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 97
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x80d410..0x80d420]
+      OutOfLinePCRanges: [0x80d5b0..0x80d5c0]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 12 PointerType *bool
           Locations:
-            - Range: 0x80d410..0x80d420
+            - Range: 0x80d5b0..0x80d5c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 11 BaseType uint
           Locations:
-            - Range: 0x80d410..0x80d420
+            - Range: 0x80d5b0..0x80d5c0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 98
       Name: main.testCycle
-      OutOfLinePCRanges: [0x80d430..0x80d440]
+      OutOfLinePCRanges: [0x80d5d0..0x80d5e0]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 253 PointerType *main.t
           Locations:
-            - Range: 0x80d430..0x80d440
+            - Range: 0x80d5d0..0x80d5e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 99
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0x80d740..0x80d7c0]
+      OutOfLinePCRanges: [0x80d8e0..0x80d960]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80d740..0x80d75c
+            - Range: 0x80d8e0..0x80d8fc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80d740..0x80d798
+            - Range: 0x80d8e0..0x80d938
               Pieces: []
-            - Range: 0x80d798..0x80d799
+            - Range: 0x80d938..0x80d939
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d799..0x80d7c0
+            - Range: 0x80d939..0x80d960
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80d75c..0x80d768
+            - Range: 0x80d8fc..0x80d908
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d768..0x80d7c0
+            - Range: 0x80d908..0x80d960
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 100
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0x80d7c0..0x80d860]
+      OutOfLinePCRanges: [0x80d960..0x80da00]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80d7c0..0x80d7e4
+            - Range: 0x80d960..0x80d984
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d7e4..0x80d860
+            - Range: 0x80d984..0x80da00
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 101 PointerType *int
           Locations:
-            - Range: 0x80d7c0..0x80d834
+            - Range: 0x80d960..0x80d9d4
               Pieces: []
-            - Range: 0x80d834..0x80d835
+            - Range: 0x80d9d4..0x80d9d5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d835..0x80d860
+            - Range: 0x80d9d5..0x80da00
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: '&result'
           Type: 101 PointerType *int
           Locations:
-            - Range: 0x80d7e8..0x80d800
+            - Range: 0x80d988..0x80d9a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d800..0x80d860
+            - Range: 0x80d9a0..0x80da00
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 101
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0x80d860..0x80d930]
+      OutOfLinePCRanges: [0x80da00..0x80dad0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80d860..0x80d8b4
+            - Range: 0x80da00..0x80da54
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80d860..0x80d904
+            - Range: 0x80da00..0x80daa4
               Pieces: []
-            - Range: 0x80d904..0x80d905
+            - Range: 0x80daa4..0x80daa5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d905..0x80d930
+            - Range: 0x80daa5..0x80dad0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80d860..0x80d930, Pieces: []}]
+          Locations: [{Range: 0x80da00..0x80dad0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: resultInt
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80d87c..0x80d8b8
+            - Range: 0x80da1c..0x80da58
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80d8b8..0x80d930
+            - Range: 0x80da58..0x80dad0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: -1
         - Name: resultFloat
           Type: 17 BaseType float64
           Locations:
-            - Range: 0x80d88c..0x80d8b8
+            - Range: 0x80da2c..0x80da58
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-            - Range: 0x80d8b8..0x80d930
+            - Range: 0x80da58..0x80dad0
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 102
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0x80d930..0x80d9b0]
+      OutOfLinePCRanges: [0x80dad0..0x80db50]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x80d930..0x80d954
+            - Range: 0x80dad0..0x80daf4
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0x80d930..0x80d974
+            - Range: 0x80dad0..0x80db14
               Pieces: []
-            - Range: 0x80d974..0x80d975
+            - Range: 0x80db14..0x80db15
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80d975..0x80d988
+            - Range: 0x80db15..0x80db28
               Pieces: []
-            - Range: 0x80d988..0x80d989
+            - Range: 0x80db28..0x80db29
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80d989..0x80d9b0
+            - Range: 0x80db29..0x80db50
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 103
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0x80d9b0..0x80db20]
+      OutOfLinePCRanges: [0x80db50..0x80dcc0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 162 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80d9b0..0x80da00
+            - Range: 0x80db50..0x80dba0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80da00..0x80da04
+            - Range: 0x80dba0..0x80dba4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x80da8c..0x80da90
+            - Range: 0x80dc2c..0x80dc30
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80dacc..0x80dad0
+            - Range: 0x80dc6c..0x80dc70
               Pieces:
                 - Size: 8
                   Op: null
@@ -7806,117 +7806,117 @@ Subprograms:
         - Name: failed
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x80d9b0..0x80d9f4
+            - Range: 0x80db50..0x80db94
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 162 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80d9b0..0x80da1c
+            - Range: 0x80db50..0x80dbbc
               Pieces: []
-            - Range: 0x80da1c..0x80da1d
+            - Range: 0x80dbbc..0x80dbbd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80da1d..0x80da78
+            - Range: 0x80dbbd..0x80dc18
               Pieces: []
-            - Range: 0x80da78..0x80da79
+            - Range: 0x80dc18..0x80dc19
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80da79..0x80dab8
+            - Range: 0x80dc19..0x80dc58
               Pieces: []
-            - Range: 0x80dab8..0x80dab9
+            - Range: 0x80dc58..0x80dc59
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80dab9..0x80daf4
+            - Range: 0x80dc59..0x80dc94
               Pieces: []
-            - Range: 0x80daf4..0x80daf5
+            - Range: 0x80dc94..0x80dc95
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80daf5..0x80db20
+            - Range: 0x80dc95..0x80dcc0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0x80d9b0..0x80da1c
+            - Range: 0x80db50..0x80dbbc
               Pieces: []
-            - Range: 0x80da1c..0x80da1d
+            - Range: 0x80dbbc..0x80dbbd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80da1d..0x80da78
+            - Range: 0x80dbbd..0x80dc18
               Pieces: []
-            - Range: 0x80da78..0x80da79
+            - Range: 0x80dc18..0x80dc19
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80da79..0x80dab8
+            - Range: 0x80dc19..0x80dc58
               Pieces: []
-            - Range: 0x80dab8..0x80dab9
+            - Range: 0x80dc58..0x80dc59
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80dab9..0x80daf4
+            - Range: 0x80dc59..0x80dc94
               Pieces: []
-            - Range: 0x80daf4..0x80daf5
+            - Range: 0x80dc94..0x80dc95
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80daf5..0x80db20
+            - Range: 0x80dc95..0x80dcc0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80da00..0x80da08
+            - Range: 0x80dba0..0x80dba8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 104
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0x80db20..0x80dd00]
+      OutOfLinePCRanges: [0x80dcc0..0x80dea0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 162 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80db20..0x80db60
+            - Range: 0x80dcc0..0x80dd00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80db60..0x80db68
+            - Range: 0x80dd00..0x80dd08
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80db68..0x80dd00
+            - Range: 0x80dd08..0x80dea0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -7927,549 +7927,549 @@ Subprograms:
         - Name: ~r0
           Type: 162 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80db20..0x80dbc0
+            - Range: 0x80dcc0..0x80dd60
               Pieces: []
-            - Range: 0x80dbc0..0x80dbc1
+            - Range: 0x80dd60..0x80dd61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80dbc1..0x80dc14
+            - Range: 0x80dd61..0x80ddb4
               Pieces: []
-            - Range: 0x80dc14..0x80dc15
+            - Range: 0x80ddb4..0x80ddb5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80dc15..0x80dcc4
+            - Range: 0x80ddb5..0x80de64
               Pieces: []
-            - Range: 0x80dcc4..0x80dcc5
+            - Range: 0x80de64..0x80de65
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80dcc5..0x80dcd8
+            - Range: 0x80de65..0x80de78
               Pieces: []
-            - Range: 0x80dcd8..0x80dcd9
+            - Range: 0x80de78..0x80de79
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80dcd9..0x80dd00
+            - Range: 0x80de79..0x80dea0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80dbac..0x80dbb4
+            - Range: 0x80dd4c..0x80dd54
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: '&result'
           Type: 101 PointerType *int
           Locations:
-            - Range: 0x80dbf8..0x80dc14
+            - Range: 0x80dd98..0x80ddb4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 105
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0x80dd00..0x80de50]
+      OutOfLinePCRanges: [0x80dea0..0x80dff0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 162 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80dd00..0x80dd3c
+            - Range: 0x80dea0..0x80dedc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80dd3c..0x80dd7c
+            - Range: 0x80dedc..0x80df1c
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x80dd7c..0x80ddf0
+            - Range: 0x80df1c..0x80df90
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x80ddf0..0x80de18
+            - Range: 0x80df90..0x80dfb8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80de18..0x80de1c
+            - Range: 0x80dfb8..0x80dfbc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80de1c..0x80de50
+            - Range: 0x80dfbc..0x80dff0
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 167 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x80dd00..0x80ddd0
+            - Range: 0x80dea0..0x80df70
               Pieces: []
-            - Range: 0x80ddd0..0x80ddd1
+            - Range: 0x80df70..0x80df71
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80ddd1..0x80dde4
+            - Range: 0x80df71..0x80df84
               Pieces: []
-            - Range: 0x80dde4..0x80dde5
+            - Range: 0x80df84..0x80df85
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80dde5..0x80de50
+            - Range: 0x80df85..0x80dff0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 167 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x80dd00..0x80dd3c
+            - Range: 0x80dea0..0x80dedc
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80dd3c..0x80dd7c
+            - Range: 0x80dedc..0x80df1c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80dd7c..0x80dd84
+            - Range: 0x80df1c..0x80df24
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80dd84..0x80dddc
+            - Range: 0x80df24..0x80df7c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80dddc..0x80dde0
+            - Range: 0x80df7c..0x80df80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80dde0..0x80dde4
+            - Range: 0x80df80..0x80df84
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x80dde4..0x80de50
+            - Range: 0x80df84..0x80dff0
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 106
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0x80de50..0x80dee0]
+      OutOfLinePCRanges: [0x80dff0..0x80e080]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80de50..0x80de6c
+            - Range: 0x80dff0..0x80e00c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80de50..0x80dec0
+            - Range: 0x80dff0..0x80e060
               Pieces: []
-            - Range: 0x80dec0..0x80dec1
+            - Range: 0x80e060..0x80e061
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80dec1..0x80dee0
+            - Range: 0x80e061..0x80e080
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 107
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0x80dee0..0x80dfa0]
+      OutOfLinePCRanges: [0x80e080..0x80e140]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80dee0..0x80df2c
+            - Range: 0x80e080..0x80e0cc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80dee0..0x80df78
+            - Range: 0x80e080..0x80e118
               Pieces: []
-            - Range: 0x80df78..0x80df79
+            - Range: 0x80e118..0x80e119
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80df79..0x80dfa0
+            - Range: 0x80e119..0x80e140
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80dee0..0x80df78
+            - Range: 0x80e080..0x80e118
               Pieces: []
-            - Range: 0x80df78..0x80df79
+            - Range: 0x80e118..0x80e119
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80df79..0x80dfa0
+            - Range: 0x80e119..0x80e140
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 108
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0x80dfa0..0x80e060]
+      OutOfLinePCRanges: [0x80e140..0x80e200]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80dfa0..0x80dfdc
+            - Range: 0x80e140..0x80e17c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80dfdc..0x80e060
+            - Range: 0x80e17c..0x80e200
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80dfa0..0x80e03c
+            - Range: 0x80e140..0x80e1dc
               Pieces: []
-            - Range: 0x80e03c..0x80e03d
+            - Range: 0x80e1dc..0x80e1dd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e03d..0x80e060
+            - Range: 0x80e1dd..0x80e200
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80dfa0..0x80e03c
+            - Range: 0x80e140..0x80e1dc
               Pieces: []
-            - Range: 0x80e03c..0x80e03d
+            - Range: 0x80e1dc..0x80e1dd
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80e03d..0x80e060
+            - Range: 0x80e1dd..0x80e200
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80dfa0..0x80e03c
+            - Range: 0x80e140..0x80e1dc
               Pieces: []
-            - Range: 0x80e03c..0x80e03d
+            - Range: 0x80e1dc..0x80e1dd
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80e03d..0x80e060
+            - Range: 0x80e1dd..0x80e200
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 109
       Name: main.testConflictingReturn
-      OutOfLinePCRanges: [0x80e060..0x80e140]
+      OutOfLinePCRanges: [0x80e200..0x80e2e0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80e060..0x80e09c
+            - Range: 0x80e200..0x80e23c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e09c..0x80e140
+            - Range: 0x80e23c..0x80e2e0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80e060..0x80e118
+            - Range: 0x80e200..0x80e2b8
               Pieces: []
-            - Range: 0x80e118..0x80e119
+            - Range: 0x80e2b8..0x80e2b9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e119..0x80e140
+            - Range: 0x80e2b9..0x80e2e0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80e060..0x80e118
+            - Range: 0x80e200..0x80e2b8
               Pieces: []
-            - Range: 0x80e118..0x80e119
+            - Range: 0x80e2b8..0x80e2b9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80e119..0x80e140
+            - Range: 0x80e2b9..0x80e2e0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 110
       Name: main.testReturnsNamedDeferLine
-      OutOfLinePCRanges: [0x80e140..0x80e2f0]
+      OutOfLinePCRanges: [0x80e2e0..0x80e490]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80e140..0x80e1a8
+            - Range: 0x80e2e0..0x80e348
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e1a8..0x80e2f0
+            - Range: 0x80e348..0x80e490
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80e16c..0x80e2f0
+            - Range: 0x80e30c..0x80e490
               Pieces: [{Size: 16, Op: {CfaOffset: -120}}]
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80e170..0x80e2f0
+            - Range: 0x80e310..0x80e490
               Pieces: [{Size: 16, Op: {CfaOffset: -136}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 111
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0x80e3b0..0x80e440]
+      OutOfLinePCRanges: [0x80e550..0x80e5e0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType int8
           Locations:
-            - Range: 0x80e3b0..0x80e41c
+            - Range: 0x80e550..0x80e5bc
               Pieces: []
-            - Range: 0x80e41c..0x80e41d
+            - Range: 0x80e5bc..0x80e5bd
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e41d..0x80e440
+            - Range: 0x80e5bd..0x80e5e0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 97 BaseType int16
           Locations:
-            - Range: 0x80e3b0..0x80e41c
+            - Range: 0x80e550..0x80e5bc
               Pieces: []
-            - Range: 0x80e41c..0x80e41d
+            - Range: 0x80e5bc..0x80e5bd
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80e41d..0x80e440
+            - Range: 0x80e5bd..0x80e5e0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x80e3b0..0x80e41c
+            - Range: 0x80e550..0x80e5bc
               Pieces: []
-            - Range: 0x80e41c..0x80e41d
+            - Range: 0x80e5bc..0x80e5bd
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80e41d..0x80e440
+            - Range: 0x80e5bd..0x80e5e0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 14 BaseType int64
           Locations:
-            - Range: 0x80e3b0..0x80e41c
+            - Range: 0x80e550..0x80e5bc
               Pieces: []
-            - Range: 0x80e41c..0x80e41d
+            - Range: 0x80e5bc..0x80e5bd
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80e41d..0x80e440
+            - Range: 0x80e5bd..0x80e5e0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x80e3b0..0x80e41c
+            - Range: 0x80e550..0x80e5bc
               Pieces: []
-            - Range: 0x80e41c..0x80e41d
+            - Range: 0x80e5bc..0x80e5bd
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80e41d..0x80e440
+            - Range: 0x80e5bd..0x80e5e0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 7 BaseType uint16
           Locations:
-            - Range: 0x80e3b0..0x80e41c
+            - Range: 0x80e550..0x80e5bc
               Pieces: []
-            - Range: 0x80e41c..0x80e41d
+            - Range: 0x80e5bc..0x80e5bd
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80e41d..0x80e440
+            - Range: 0x80e5bd..0x80e5e0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 3 BaseType uint32
           Locations:
-            - Range: 0x80e3b0..0x80e41c
+            - Range: 0x80e550..0x80e5bc
               Pieces: []
-            - Range: 0x80e41c..0x80e41d
+            - Range: 0x80e5bc..0x80e5bd
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80e41d..0x80e440
+            - Range: 0x80e5bd..0x80e5e0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0x80e3b0..0x80e41c
+            - Range: 0x80e550..0x80e5bc
               Pieces: []
-            - Range: 0x80e41c..0x80e41d
+            - Range: 0x80e5bc..0x80e5bd
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80e41d..0x80e440
+            - Range: 0x80e5bd..0x80e5e0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 112
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0x80e440..0x80e4f0]
+      OutOfLinePCRanges: [0x80e5e0..0x80e690]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80e440..0x80e4f0, Pieces: []}]
+          Locations: [{Range: 0x80e5e0..0x80e690, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80e440..0x80e4f0, Pieces: []}]
+          Locations: [{Range: 0x80e5e0..0x80e690, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80e440..0x80e4f0, Pieces: []}]
+          Locations: [{Range: 0x80e5e0..0x80e690, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80e440..0x80e4f0, Pieces: []}]
+          Locations: [{Range: 0x80e5e0..0x80e690, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80e440..0x80e4f0, Pieces: []}]
+          Locations: [{Range: 0x80e5e0..0x80e690, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80e440..0x80e4f0, Pieces: []}]
+          Locations: [{Range: 0x80e5e0..0x80e690, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80e440..0x80e4f0, Pieces: []}]
+          Locations: [{Range: 0x80e5e0..0x80e690, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80e440..0x80e4f0, Pieces: []}]
+          Locations: [{Range: 0x80e5e0..0x80e690, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80e440..0x80e4f0, Pieces: []}]
+          Locations: [{Range: 0x80e5e0..0x80e690, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r9
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80e440..0x80e4f0, Pieces: []}]
+          Locations: [{Range: 0x80e5e0..0x80e690, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r10
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80e440..0x80e4f0, Pieces: []}]
+          Locations: [{Range: 0x80e5e0..0x80e690, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r11
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80e440..0x80e4f0, Pieces: []}]
+          Locations: [{Range: 0x80e5e0..0x80e690, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r12
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80e440..0x80e4f0, Pieces: []}]
+          Locations: [{Range: 0x80e5e0..0x80e690, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r13
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80e440..0x80e4f0, Pieces: []}]
+          Locations: [{Range: 0x80e5e0..0x80e690, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r14
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80e440..0x80e4f0, Pieces: []}]
+          Locations: [{Range: 0x80e5e0..0x80e690, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: onlyOnAmd64_16
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80e440..0x80e4f0, Pieces: []}]
+          Locations: [{Range: 0x80e5e0..0x80e690, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: bothArmAndAmd64
           Type: 17 BaseType float64
           Locations:
-            - Range: 0x80e440..0x80e4d8
+            - Range: 0x80e5e0..0x80e678
               Pieces: []
-            - Range: 0x80e4d8..0x80e4d9
+            - Range: 0x80e678..0x80e679
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x80e4d9..0x80e4f0
+            - Range: 0x80e679..0x80e690
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 113
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0x80e4f0..0x80e570]
+      OutOfLinePCRanges: [0x80e690..0x80e710]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 98 BaseType complex64
-          Locations: [{Range: 0x80e4f0..0x80e570, Pieces: []}]
+          Locations: [{Range: 0x80e690..0x80e710, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 99 BaseType complex128
-          Locations: [{Range: 0x80e4f0..0x80e570, Pieces: []}]
+          Locations: [{Range: 0x80e690..0x80e710, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 114
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0x80e570..0x80e630]
+      OutOfLinePCRanges: [0x80e710..0x80e7d0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 255 StructureType main.largeStruct
           Locations:
-            - Range: 0x80e570..0x80e60c
+            - Range: 0x80e710..0x80e7ac
               Pieces: []
-            - Range: 0x80e60c..0x80e60d
+            - Range: 0x80e7ac..0x80e7ad
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8491,193 +8491,193 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80e60d..0x80e630
+            - Range: 0x80e7ad..0x80e7d0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 115
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0x80e630..0x80e6b0]
+      OutOfLinePCRanges: [0x80e7d0..0x80e850]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 256 ArrayType [3]int
           Locations:
-            - Range: 0x80e630..0x80e698
+            - Range: 0x80e7d0..0x80e838
               Pieces: []
-            - Range: 0x80e698..0x80e699
+            - Range: 0x80e838..0x80e839
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x80e699..0x80e6b0
+            - Range: 0x80e839..0x80e850
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 116
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0x80e6b0..0x80e720]
+      OutOfLinePCRanges: [0x80e850..0x80e8c0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 257 ArrayType [1]int
           Locations:
-            - Range: 0x80e6b0..0x80e700
+            - Range: 0x80e850..0x80e8a0
               Pieces: []
-            - Range: 0x80e700..0x80e701
+            - Range: 0x80e8a0..0x80e8a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e701..0x80e720
+            - Range: 0x80e8a1..0x80e8c0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 117
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0x80e720..0x80e790]
+      OutOfLinePCRanges: [0x80e8c0..0x80e930]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 258 ArrayType [0]int
           Locations:
-            - Range: 0x80e720..0x80e76c
+            - Range: 0x80e8c0..0x80e90c
               Pieces: []
-            - Range: 0x80e76c..0x80e76d
+            - Range: 0x80e90c..0x80e90d
               Pieces: []
-            - Range: 0x80e76d..0x80e790
+            - Range: 0x80e90d..0x80e930
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 118
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0x80e790..0x80e810]
+      OutOfLinePCRanges: [0x80e930..0x80e9b0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 259 StructureType main.mixedStruct
-          Locations: [{Range: 0x80e790..0x80e810, Pieces: []}]
+          Locations: [{Range: 0x80e930..0x80e9b0, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 119
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0x80e810..0x80e8a0]
+      OutOfLinePCRanges: [0x80e9b0..0x80ea40]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80e810..0x80e888
+            - Range: 0x80e9b0..0x80ea28
               Pieces: []
-            - Range: 0x80e888..0x80e889
+            - Range: 0x80ea28..0x80ea29
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e889..0x80e8a0
+            - Range: 0x80ea29..0x80ea40
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80e810..0x80e888
+            - Range: 0x80e9b0..0x80ea28
               Pieces: []
-            - Range: 0x80e888..0x80e889
+            - Range: 0x80ea28..0x80ea29
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80e889..0x80e8a0
+            - Range: 0x80ea29..0x80ea40
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80e810..0x80e888
+            - Range: 0x80e9b0..0x80ea28
               Pieces: []
-            - Range: 0x80e888..0x80e889
+            - Range: 0x80ea28..0x80ea29
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80e889..0x80e8a0
+            - Range: 0x80ea29..0x80ea40
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80e810..0x80e888
+            - Range: 0x80e9b0..0x80ea28
               Pieces: []
-            - Range: 0x80e888..0x80e889
+            - Range: 0x80ea28..0x80ea29
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80e889..0x80e8a0
+            - Range: 0x80ea29..0x80ea40
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80e810..0x80e888
+            - Range: 0x80e9b0..0x80ea28
               Pieces: []
-            - Range: 0x80e888..0x80e889
+            - Range: 0x80ea28..0x80ea29
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80e889..0x80e8a0
+            - Range: 0x80ea29..0x80ea40
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80e810..0x80e888
+            - Range: 0x80e9b0..0x80ea28
               Pieces: []
-            - Range: 0x80e888..0x80e889
+            - Range: 0x80ea28..0x80ea29
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80e889..0x80e8a0
+            - Range: 0x80ea29..0x80ea40
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80e810..0x80e888
+            - Range: 0x80e9b0..0x80ea28
               Pieces: []
-            - Range: 0x80e888..0x80e889
+            - Range: 0x80ea28..0x80ea29
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80e889..0x80e8a0
+            - Range: 0x80ea29..0x80ea40
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80e810..0x80e888
+            - Range: 0x80e9b0..0x80ea28
               Pieces: []
-            - Range: 0x80e888..0x80e889
+            - Range: 0x80ea28..0x80ea29
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80e889..0x80e8a0
+            - Range: 0x80ea29..0x80ea40
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80e810..0x80e888
+            - Range: 0x80e9b0..0x80ea28
               Pieces: []
-            - Range: 0x80e888..0x80e889
+            - Range: 0x80ea28..0x80ea29
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80e889..0x80e8a0
+            - Range: 0x80ea29..0x80ea40
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 120
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0x80e8a0..0x80e970]
+      OutOfLinePCRanges: [0x80ea40..0x80eb10]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 260 StructureType main.wideStruct
           Locations:
-            - Range: 0x80e8a0..0x80e94c
+            - Range: 0x80ea40..0x80eaec
               Pieces: []
-            - Range: 0x80e94c..0x80e94d
+            - Range: 0x80eaec..0x80eaed
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8701,145 +8701,145 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0x80e94d..0x80e970
+            - Range: 0x80eaed..0x80eb10
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 121
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0x80e970..0x80ea00]
+      OutOfLinePCRanges: [0x80eb10..0x80eba0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80e970..0x80e9dc
+            - Range: 0x80eb10..0x80eb7c
               Pieces: []
-            - Range: 0x80e9dc..0x80e9dd
+            - Range: 0x80eb7c..0x80eb7d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e9dd..0x80ea00
+            - Range: 0x80eb7d..0x80eba0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80e970..0x80ea00, Pieces: []}]
+          Locations: [{Range: 0x80eb10..0x80eba0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80e970..0x80e9dc
+            - Range: 0x80eb10..0x80eb7c
               Pieces: []
-            - Range: 0x80e9dc..0x80e9dd
+            - Range: 0x80eb7c..0x80eb7d
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80e9dd..0x80ea00
+            - Range: 0x80eb7d..0x80eba0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80e970..0x80ea00, Pieces: []}]
+          Locations: [{Range: 0x80eb10..0x80eba0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80e970..0x80e9dc
+            - Range: 0x80eb10..0x80eb7c
               Pieces: []
-            - Range: 0x80e9dc..0x80e9dd
+            - Range: 0x80eb7c..0x80eb7d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80e9dd..0x80ea00
+            - Range: 0x80eb7d..0x80eba0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 122
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0x80ea00..0x80ea80]
+      OutOfLinePCRanges: [0x80eba0..0x80ec20]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 261 StructureType main.structWithArray
           Locations:
-            - Range: 0x80ea00..0x80ea68
+            - Range: 0x80eba0..0x80ec08
               Pieces: []
-            - Range: 0x80ea68..0x80ea69
+            - Range: 0x80ec08..0x80ec09
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x80ea69..0x80ea80
+            - Range: 0x80ec09..0x80ec20
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 123
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0x80ea80..0x80eaf0]
+      OutOfLinePCRanges: [0x80ec20..0x80ec90]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80ea80..0x80eaf0, Pieces: []}]
+          Locations: [{Range: 0x80ec20..0x80ec90, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 124
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0x80eaf0..0x80eb60]
+      OutOfLinePCRanges: [0x80ec90..0x80ed00]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 19 BaseType float32
-          Locations: [{Range: 0x80eaf0..0x80eb60, Pieces: []}]
+          Locations: [{Range: 0x80ec90..0x80ed00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80eaf0..0x80eb60, Pieces: []}]
+          Locations: [{Range: 0x80ec90..0x80ed00, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 125
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0x80eb60..0x80ebd0]
+      OutOfLinePCRanges: [0x80ed00..0x80ed70]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x80eb60..0x80ebb4
+            - Range: 0x80ed00..0x80ed54
               Pieces: []
-            - Range: 0x80ebb4..0x80ebb5
+            - Range: 0x80ed54..0x80ed55
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ebb5..0x80ebd0
+            - Range: 0x80ed55..0x80ed70
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 2 BaseType uintptr
           Locations:
-            - Range: 0x80eb60..0x80ebb4
+            - Range: 0x80ed00..0x80ed54
               Pieces: []
-            - Range: 0x80ebb4..0x80ebb5
+            - Range: 0x80ed54..0x80ed55
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80ebb5..0x80ebd0
+            - Range: 0x80ed55..0x80ed70
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 126
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0x80ebd0..0x80ed60]
+      OutOfLinePCRanges: [0x80ed70..0x80ef00]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 255 StructureType main.largeStruct
           Locations:
-            - Range: 0x80ebd0..0x80ec28
+            - Range: 0x80ed70..0x80edc8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8861,7 +8861,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80ec28..0x80ec30
+            - Range: 0x80edc8..0x80edd0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8883,7 +8883,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80ec30..0x80ec38
+            - Range: 0x80edd0..0x80edd8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8905,7 +8905,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80ec38..0x80ec3c
+            - Range: 0x80edd8..0x80eddc
               Pieces:
                 - Size: 8
                   Op: null
@@ -8932,9 +8932,9 @@ Subprograms:
         - Name: ~r0
           Type: 255 StructureType main.largeStruct
           Locations:
-            - Range: 0x80ebd0..0x80ed18
+            - Range: 0x80ed70..0x80eeb8
               Pieces: []
-            - Range: 0x80ed18..0x80ed19
+            - Range: 0x80eeb8..0x80eeb9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8956,44 +8956,44 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80ed19..0x80ed60
+            - Range: 0x80eeb9..0x80ef00
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 127
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0x80ed60..0x80ee20]
+      OutOfLinePCRanges: [0x80ef00..0x80efc0]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 256 ArrayType [3]int
           Locations:
-            - Range: 0x80ed60..0x80ee20
+            - Range: 0x80ef00..0x80efc0
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 256 ArrayType [3]int
           Locations:
-            - Range: 0x80ed60..0x80ee08
+            - Range: 0x80ef00..0x80efa8
               Pieces: []
-            - Range: 0x80ee08..0x80ee09
+            - Range: 0x80efa8..0x80efa9
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x80ee09..0x80ee20
+            - Range: 0x80efa9..0x80efc0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 128
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0x80ee20..0x80f030]
+      OutOfLinePCRanges: [0x80efc0..0x80f1d0]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 255 StructureType main.largeStruct
           Locations:
-            - Range: 0x80ee20..0x80ee7c
+            - Range: 0x80efc0..0x80f01c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9015,7 +9015,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80ee7c..0x80ee84
+            - Range: 0x80f01c..0x80f024
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9037,7 +9037,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80ee84..0x80ee8c
+            - Range: 0x80f024..0x80f02c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9059,7 +9059,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80ee8c..0x80ee90
+            - Range: 0x80f02c..0x80f030
               Pieces:
                 - Size: 8
                   Op: null
@@ -9086,16 +9086,16 @@ Subprograms:
         - Name: s2
           Type: 255 StructureType main.largeStruct
           Locations:
-            - Range: 0x80ee20..0x80f030
+            - Range: 0x80efc0..0x80f1d0
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 255 StructureType main.largeStruct
           Locations:
-            - Range: 0x80ee20..0x80efe4
+            - Range: 0x80efc0..0x80f184
               Pieces: []
-            - Range: 0x80efe4..0x80efe5
+            - Range: 0x80f184..0x80f185
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9117,196 +9117,196 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80efe5..0x80f030
+            - Range: 0x80f185..0x80f1d0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 129
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0x80f030..0x80f1d0]
+      OutOfLinePCRanges: [0x80f1d0..0x80f370]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f030..0x80f0a4
+            - Range: 0x80f1d0..0x80f244
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80f0a4..0x80f1d0
+            - Range: 0x80f244..0x80f370
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f030..0x80f094
+            - Range: 0x80f1d0..0x80f234
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80f094..0x80f1d0
+            - Range: 0x80f234..0x80f370
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f030..0x80f09c
+            - Range: 0x80f1d0..0x80f23c
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80f09c..0x80f1d0
+            - Range: 0x80f23c..0x80f370
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f030..0x80f0a4
+            - Range: 0x80f1d0..0x80f244
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80f0a4..0x80f1d0
+            - Range: 0x80f244..0x80f370
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f030..0x80f0a4
+            - Range: 0x80f1d0..0x80f244
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80f0a4..0x80f1d0
+            - Range: 0x80f244..0x80f370
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f030..0x80f0a4
+            - Range: 0x80f1d0..0x80f244
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80f0a4..0x80f1d0
+            - Range: 0x80f244..0x80f370
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f030..0x80f0a4
+            - Range: 0x80f1d0..0x80f244
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80f0a4..0x80f1d0
+            - Range: 0x80f244..0x80f370
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f030..0x80f0a4
+            - Range: 0x80f1d0..0x80f244
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80f0a4..0x80f1d0
+            - Range: 0x80f244..0x80f370
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f030..0x80f0a4
+            - Range: 0x80f1d0..0x80f244
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0x80f0a4..0x80f1d0
+            - Range: 0x80f244..0x80f370
               Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 114 ArrayType [2]int
           Locations:
-            - Range: 0x80f030..0x80f18c
+            - Range: 0x80f1d0..0x80f32c
               Pieces: []
-            - Range: 0x80f18c..0x80f18d
+            - Range: 0x80f32c..0x80f32d
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-            - Range: 0x80f18d..0x80f1d0
+            - Range: 0x80f32d..0x80f370
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 130
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0x80f1d0..0x80f3c0]
+      OutOfLinePCRanges: [0x80f370..0x80f560]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f1d0..0x80f254
+            - Range: 0x80f370..0x80f3f4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80f254..0x80f3c0
+            - Range: 0x80f3f4..0x80f560
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f1d0..0x80f244
+            - Range: 0x80f370..0x80f3e4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80f244..0x80f3c0
+            - Range: 0x80f3e4..0x80f560
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f1d0..0x80f24c
+            - Range: 0x80f370..0x80f3ec
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80f24c..0x80f3c0
+            - Range: 0x80f3ec..0x80f560
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f1d0..0x80f254
+            - Range: 0x80f370..0x80f3f4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80f254..0x80f3c0
+            - Range: 0x80f3f4..0x80f560
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f1d0..0x80f254
+            - Range: 0x80f370..0x80f3f4
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80f254..0x80f3c0
+            - Range: 0x80f3f4..0x80f560
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f1d0..0x80f254
+            - Range: 0x80f370..0x80f3f4
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80f254..0x80f3c0
+            - Range: 0x80f3f4..0x80f560
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f1d0..0x80f254
+            - Range: 0x80f370..0x80f3f4
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80f254..0x80f3c0
+            - Range: 0x80f3f4..0x80f560
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f1d0..0x80f254
+            - Range: 0x80f370..0x80f3f4
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80f254..0x80f3c0
+            - Range: 0x80f3f4..0x80f560
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80f1d0..0x80f254
+            - Range: 0x80f370..0x80f3f4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80f254..0x80f3c0
+            - Range: 0x80f3f4..0x80f560
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 72}
@@ -9317,9 +9317,9 @@ Subprograms:
         - Name: ~r0
           Type: 255 StructureType main.largeStruct
           Locations:
-            - Range: 0x80f1d0..0x80f378
+            - Range: 0x80f370..0x80f518
               Pieces: []
-            - Range: 0x80f378..0x80f379
+            - Range: 0x80f518..0x80f519
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9341,196 +9341,196 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80f379..0x80f3c0
+            - Range: 0x80f519..0x80f560
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 131
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0x80f3c0..0x80f450]
+      OutOfLinePCRanges: [0x80f560..0x80f5f0]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 166 ArrayType [5]int
           Locations:
-            - Range: 0x80f3c0..0x80f450
+            - Range: 0x80f560..0x80f5f0
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f3c0..0x80f430
+            - Range: 0x80f560..0x80f5d0
               Pieces: []
-            - Range: 0x80f430..0x80f431
+            - Range: 0x80f5d0..0x80f5d1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80f431..0x80f450
+            - Range: 0x80f5d1..0x80f5f0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f3c0..0x80f430
+            - Range: 0x80f560..0x80f5d0
               Pieces: []
-            - Range: 0x80f430..0x80f431
+            - Range: 0x80f5d0..0x80f5d1
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80f431..0x80f450
+            - Range: 0x80f5d1..0x80f5f0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f3c0..0x80f430
+            - Range: 0x80f560..0x80f5d0
               Pieces: []
-            - Range: 0x80f430..0x80f431
+            - Range: 0x80f5d0..0x80f5d1
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80f431..0x80f450
+            - Range: 0x80f5d1..0x80f5f0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 132
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0x80f450..0x80f520]
+      OutOfLinePCRanges: [0x80f5f0..0x80f6c0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 114 ArrayType [2]int
           Locations:
-            - Range: 0x80f450..0x80f520
+            - Range: 0x80f5f0..0x80f6c0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 256 ArrayType [3]int
           Locations:
-            - Range: 0x80f450..0x80f520
+            - Range: 0x80f5f0..0x80f6c0
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f450..0x80f504
+            - Range: 0x80f5f0..0x80f6a4
               Pieces: []
-            - Range: 0x80f504..0x80f505
+            - Range: 0x80f6a4..0x80f6a5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80f505..0x80f520
+            - Range: 0x80f6a5..0x80f6c0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 114 ArrayType [2]int
           Locations:
-            - Range: 0x80f450..0x80f504
+            - Range: 0x80f5f0..0x80f6a4
               Pieces: []
-            - Range: 0x80f504..0x80f505
+            - Range: 0x80f6a4..0x80f6a5
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
-            - Range: 0x80f505..0x80f520
+            - Range: 0x80f6a5..0x80f6c0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 133
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0x80f520..0x80f5e0]
+      OutOfLinePCRanges: [0x80f6c0..0x80f780]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 261 StructureType main.structWithArray
           Locations:
-            - Range: 0x80f520..0x80f5e0
+            - Range: 0x80f6c0..0x80f780
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f520..0x80f5c0
+            - Range: 0x80f6c0..0x80f760
               Pieces: []
-            - Range: 0x80f5c0..0x80f5c1
+            - Range: 0x80f760..0x80f761
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80f5c1..0x80f5e0
+            - Range: 0x80f761..0x80f780
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 261 StructureType main.structWithArray
           Locations:
-            - Range: 0x80f520..0x80f5c0
+            - Range: 0x80f6c0..0x80f760
               Pieces: []
-            - Range: 0x80f5c0..0x80f5c1
+            - Range: 0x80f760..0x80f761
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x80f5c1..0x80f5e0
+            - Range: 0x80f761..0x80f780
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f598..0x80f5e0
+            - Range: 0x80f738..0x80f780
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 134
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0x80f5e0..0x80f680]
+      OutOfLinePCRanges: [0x80f780..0x80f820]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 258 ArrayType [0]int
-          Locations: [{Range: 0x80f5e0..0x80f680, Pieces: []}]
+          Locations: [{Range: 0x80f780..0x80f820, Pieces: []}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f5e0..0x80f61c
+            - Range: 0x80f780..0x80f7bc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80f61c..0x80f634
+            - Range: 0x80f7bc..0x80f7d4
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x80f634..0x80f63c
+            - Range: 0x80f7d4..0x80f7dc
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x80f63c..0x80f680
+            - Range: 0x80f7dc..0x80f820
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f5e0..0x80f658
+            - Range: 0x80f780..0x80f7f8
               Pieces: []
-            - Range: 0x80f658..0x80f659
+            - Range: 0x80f7f8..0x80f7f9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80f659..0x80f680
+            - Range: 0x80f7f9..0x80f820
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 258 ArrayType [0]int
           Locations:
-            - Range: 0x80f5e0..0x80f658
+            - Range: 0x80f780..0x80f7f8
               Pieces: []
-            - Range: 0x80f658..0x80f659
+            - Range: 0x80f7f8..0x80f7f9
               Pieces: []
-            - Range: 0x80f659..0x80f680
+            - Range: 0x80f7f9..0x80f820
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 135
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0x80fac0..0x80fad0]
+      OutOfLinePCRanges: [0x80fc60..0x80fc70]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 262 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80fac0..0x80fad0
+            - Range: 0x80fc60..0x80fc70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9543,13 +9543,13 @@ Subprograms:
       DictRegister: null
     - ID: 136
       Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x80fad0..0x80fae0]
+      OutOfLinePCRanges: [0x80fc70..0x80fc80]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 262 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80fad0..0x80fae0
+            - Range: 0x80fc70..0x80fc80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9562,13 +9562,13 @@ Subprograms:
       DictRegister: null
     - ID: 137
       Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x80fae0..0x80faf0]
+      OutOfLinePCRanges: [0x80fc80..0x80fc90]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 263 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0x80fae0..0x80faf0
+            - Range: 0x80fc80..0x80fc90
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9581,13 +9581,13 @@ Subprograms:
       DictRegister: null
     - ID: 138
       Name: main.testStructSlice
-      OutOfLinePCRanges: [0x80faf0..0x80fb00]
+      OutOfLinePCRanges: [0x80fc90..0x80fca0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 265 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x80faf0..0x80fb00
+            - Range: 0x80fc90..0x80fca0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9600,20 +9600,20 @@ Subprograms:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80faf0..0x80fb00
+            - Range: 0x80fc90..0x80fca0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 139
       Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x80fb00..0x80fb10]
+      OutOfLinePCRanges: [0x80fca0..0x80fcb0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 265 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x80fb00..0x80fb10
+            - Range: 0x80fca0..0x80fcb0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9626,20 +9626,20 @@ Subprograms:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80fb00..0x80fb10
+            - Range: 0x80fca0..0x80fcb0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 140
       Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x80fb10..0x80fb20]
+      OutOfLinePCRanges: [0x80fcb0..0x80fcc0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 265 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x80fb10..0x80fb20
+            - Range: 0x80fcb0..0x80fcc0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9652,20 +9652,20 @@ Subprograms:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80fb10..0x80fb20
+            - Range: 0x80fcb0..0x80fcc0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 141
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0x80fb20..0x80fb30]
+      OutOfLinePCRanges: [0x80fcc0..0x80fcd0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 159 GoSliceHeaderType []string
           Locations:
-            - Range: 0x80fb20..0x80fb30
+            - Range: 0x80fcc0..0x80fcd0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9678,20 +9678,20 @@ Subprograms:
       DictRegister: null
     - ID: 142
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x80fb30..0x80fb40]
+      OutOfLinePCRanges: [0x80fcd0..0x80fce0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 18 BaseType int8
           Locations:
-            - Range: 0x80fb30..0x80fb40
+            - Range: 0x80fcd0..0x80fce0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 268 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x80fb30..0x80fb40
+            - Range: 0x80fcd0..0x80fce0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -9704,20 +9704,20 @@ Subprograms:
         - Name: x
           Type: 11 BaseType uint
           Locations:
-            - Range: 0x80fb30..0x80fb40
+            - Range: 0x80fcd0..0x80fce0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 143
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x80fb40..0x80fb50]
+      OutOfLinePCRanges: [0x80fce0..0x80fcf0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 269 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x80fb40..0x80fb50
+            - Range: 0x80fce0..0x80fcf0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9730,13 +9730,13 @@ Subprograms:
       DictRegister: null
     - ID: 144
       Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x80fb50..0x80fb60]
+      OutOfLinePCRanges: [0x80fcf0..0x80fd00]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 262 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80fb50..0x80fb60
+            - Range: 0x80fcf0..0x80fd00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9749,13 +9749,13 @@ Subprograms:
       DictRegister: null
     - ID: 145
       Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0x80fb60..0x80fb70]
+      OutOfLinePCRanges: [0x80fd00..0x80fd10]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 270 GoSliceHeaderType []struct {}
           Locations:
-            - Range: 0x80fb60..0x80fb70
+            - Range: 0x80fd00..0x80fd10
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9768,13 +9768,13 @@ Subprograms:
       DictRegister: null
     - ID: 146
       Name: main.testSubslices
-      OutOfLinePCRanges: [0x80fb70..0x80fb80]
+      OutOfLinePCRanges: [0x80fd10..0x80fd20]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 262 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80fb70..0x80fb80
+            - Range: 0x80fd10..0x80fd20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9787,7 +9787,7 @@ Subprograms:
         - Name: bs
           Type: 262 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80fb70..0x80fb80
+            - Range: 0x80fd10..0x80fd20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9800,7 +9800,7 @@ Subprograms:
         - Name: cs
           Type: 262 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80fb70..0x80fb80
+            - Range: 0x80fd10..0x80fd20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -9813,34 +9813,34 @@ Subprograms:
       DictRegister: null
     - ID: 147
       Name: main.stackC
-      OutOfLinePCRanges: [0x80fe60..0x80fec0]
+      OutOfLinePCRanges: [0x8102d0..0x810330]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80fe60..0x80fea8
+            - Range: 0x8102d0..0x810318
               Pieces: []
-            - Range: 0x80fea8..0x80fea9
+            - Range: 0x810318..0x810319
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80fea9..0x80fec0
+            - Range: 0x810319..0x810330
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 148
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x80fec0..0x80fed0]
+      OutOfLinePCRanges: [0x810330..0x810340]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80fec0..0x80fed0
+            - Range: 0x810330..0x810340
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9851,13 +9851,13 @@ Subprograms:
       DictRegister: null
     - ID: 149
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x80fed0..0x80fee0]
+      OutOfLinePCRanges: [0x810340..0x810350]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80fed0..0x80fee0
+            - Range: 0x810340..0x810350
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9868,7 +9868,7 @@ Subprograms:
         - Name: "y"
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80fed0..0x80fee0
+            - Range: 0x810340..0x810350
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9879,7 +9879,7 @@ Subprograms:
         - Name: z
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80fed0..0x80fee0
+            - Range: 0x810340..0x810350
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9890,13 +9890,13 @@ Subprograms:
       DictRegister: null
     - ID: 150
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x80fee0..0x80fef0]
+      OutOfLinePCRanges: [0x810350..0x810360]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 272 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x80fee0..0x80fef0
+            - Range: 0x810350..0x810360
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9915,39 +9915,39 @@ Subprograms:
       DictRegister: null
     - ID: 151
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x80fef0..0x80ff00]
+      OutOfLinePCRanges: [0x810360..0x810370]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 273 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x80fef0..0x80ff00
+            - Range: 0x810360..0x810370
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 152
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x80ff00..0x80ff10]
+      OutOfLinePCRanges: [0x810370..0x810380]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 274 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x80ff00..0x80ff10
+            - Range: 0x810370..0x810380
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 153
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0x80ff10..0x80ff20]
+      OutOfLinePCRanges: [0x810380..0x810390]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80ff10..0x80ff20
+            - Range: 0x810380..0x810390
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9958,13 +9958,13 @@ Subprograms:
       DictRegister: null
     - ID: 154
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x80ff20..0x80ff30]
+      OutOfLinePCRanges: [0x810390..0x8103a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80ff20..0x80ff30
+            - Range: 0x810390..0x8103a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9975,13 +9975,13 @@ Subprograms:
       DictRegister: null
     - ID: 155
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0x80ff30..0x80ff40]
+      OutOfLinePCRanges: [0x8103a0..0x8103b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80ff30..0x80ff40
+            - Range: 0x8103a0..0x8103b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9992,13 +9992,13 @@ Subprograms:
       DictRegister: null
     - ID: 156
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0x80ff40..0x80ff50]
+      OutOfLinePCRanges: [0x8103b0..0x8103c0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80ff40..0x80ff50
+            - Range: 0x8103b0..0x8103c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10009,7 +10009,7 @@ Subprograms:
         - Name: b
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80ff40..0x80ff50
+            - Range: 0x8103b0..0x8103c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10020,7 +10020,7 @@ Subprograms:
         - Name: c
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80ff40..0x80ff50
+            - Range: 0x8103b0..0x8103c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -10031,26 +10031,26 @@ Subprograms:
       DictRegister: null
     - ID: 157
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x8100a0..0x8100b0]
+      OutOfLinePCRanges: [0x810510..0x810520]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 276 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x8100a0..0x8100b0
+            - Range: 0x810510..0x810520
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 158
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x8100b0..0x8100c0]
+      OutOfLinePCRanges: [0x810520..0x810530]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 289 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x8100b0..0x8100c0
+            - Range: 0x810520..0x810530
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10069,13 +10069,13 @@ Subprograms:
       DictRegister: null
     - ID: 159
       Name: main.testStruct
-      OutOfLinePCRanges: [0x810160..0x810180]
+      OutOfLinePCRanges: [0x8105d0..0x8105f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 320 StructureType main.aStruct
           Locations:
-            - Range: 0x810160..0x810180
+            - Range: 0x8105d0..0x8105f0
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -10096,93 +10096,93 @@ Subprograms:
       DictRegister: null
     - ID: 160
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0x8101f0..0x810200]
+      OutOfLinePCRanges: [0x810660..0x810670]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 321 PointerType *main.anotherStruct
           Locations:
-            - Range: 0x8101f0..0x810200
+            - Range: 0x810660..0x810670
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 161
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0x810200..0x810210]
+      OutOfLinePCRanges: [0x810670..0x810680]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 323 StructureType main.tenStrings
           Locations:
-            - Range: 0x810200..0x810210
+            - Range: 0x810670..0x810680
               Pieces: [{Size: 160, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 162
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x810230..0x810240]
+      OutOfLinePCRanges: [0x8106a0..0x8106b0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 324 StructureType main.emptyStruct
-          Locations: [{Range: 0x810230..0x810240, Pieces: []}]
+          Locations: [{Range: 0x8106a0..0x8106b0, Pieces: []}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 163
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x810240..0x810250]
+      OutOfLinePCRanges: [0x8106b0..0x8106c0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 325 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x810240..0x810250
+            - Range: 0x8106b0..0x8106c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 164
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0x811a10..0x811a20]
+      OutOfLinePCRanges: [0x811e80..0x811e90]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0x811a10..0x811a20
+            - Range: 0x811e80..0x811e90
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x811a10..0x811a14
+            - Range: 0x811e80..0x811e84
               Pieces: []
-            - Range: 0x811a14..0x811a15
+            - Range: 0x811e84..0x811e85
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x811a15..0x811a20
+            - Range: 0x811e85..0x811e90
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 165
       Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0x811a20..0x811a30]
+      OutOfLinePCRanges: [0x811e90..0x811ea0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x811a20..0x811a2c
+            - Range: 0x811e90..0x811e9c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x811a2c..0x811a30
+            - Range: 0x811e9c..0x811ea0
               Pieces:
                 - Size: 8
                   Op: null
@@ -10193,58 +10193,58 @@ Subprograms:
         - Name: ~r0
           Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x811a20..0x811a2c
+            - Range: 0x811e90..0x811e9c
               Pieces: []
-            - Range: 0x811a2c..0x811a2d
+            - Range: 0x811e9c..0x811e9d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x811a2d..0x811a30
+            - Range: 0x811e9d..0x811ea0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 166
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0x811a30..0x811a40]
+      OutOfLinePCRanges: [0x811ea0..0x811eb0]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x811a30..0x811a40
+            - Range: 0x811ea0..0x811eb0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0x811a30..0x811a34
+            - Range: 0x811ea0..0x811ea4
               Pieces: []
-            - Range: 0x811a34..0x811a35
+            - Range: 0x811ea4..0x811ea5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x811a35..0x811a40
+            - Range: 0x811ea5..0x811eb0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 167
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0x811a40..0x811a50]
+      OutOfLinePCRanges: [0x811eb0..0x811ec0]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x811a40..0x811a4c
+            - Range: 0x811eb0..0x811ebc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x811a4c..0x811a50
+            - Range: 0x811ebc..0x811ec0
               Pieces:
                 - Size: 8
                   Op: null
@@ -10255,28 +10255,28 @@ Subprograms:
         - Name: ~r0
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x811a40..0x811a4c
+            - Range: 0x811eb0..0x811ebc
               Pieces: []
-            - Range: 0x811a4c..0x811a4d
+            - Range: 0x811ebc..0x811ebd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x811a4d..0x811a50
+            - Range: 0x811ebd..0x811ec0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 168
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0x811ab0..0x811bd0]
+      OutOfLinePCRanges: [0x811f20..0x812040]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 330 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x811ab0..0x811adc
+            - Range: 0x811f20..0x811f4c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10284,7 +10284,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x811adc..0x811aec
+            - Range: 0x811f4c..0x811f5c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10292,7 +10292,7 @@ Subprograms:
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: null
-            - Range: 0x811aec..0x811bd0
+            - Range: 0x811f5c..0x812040
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10305,18 +10305,18 @@ Subprograms:
         - Name: pred
           Type: 332 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0x811ab0..0x811aec
+            - Range: 0x811f20..0x811f5c
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x811aec..0x811bd0
+            - Range: 0x811f5c..0x812040
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 330 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x811ab0..0x811b9c
+            - Range: 0x811f20..0x81200c
               Pieces: []
-            - Range: 0x811b9c..0x811b9d
+            - Range: 0x81200c..0x81200d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10324,14 +10324,14 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x811b9d..0x811bd0
+            - Range: 0x81200d..0x812040
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
           Type: 330 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x811adc..0x811aec
+            - Range: 0x811f4c..0x811f5c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10339,7 +10339,7 @@ Subprograms:
                   Op: null
                 - Size: 8
                   Op: null
-            - Range: 0x811aec..0x811b08
+            - Range: 0x811f5c..0x811f78
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10347,7 +10347,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x811b08..0x811b0c
+            - Range: 0x811f78..0x811f7c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10355,7 +10355,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x811b0c..0x811b10
+            - Range: 0x811f7c..0x811f80
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10363,7 +10363,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x811b10..0x811b10
+            - Range: 0x811f80..0x811f80
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10371,7 +10371,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x811b10..0x811b3c
+            - Range: 0x811f80..0x811fac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10379,7 +10379,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x811b3c..0x811b90
+            - Range: 0x811fac..0x812000
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10387,7 +10387,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x811b90..0x811bd0
+            - Range: 0x812000..0x812040
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10400,215 +10400,215 @@ Subprograms:
         - Name: item
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0x811b2c..0x811b3c
+            - Range: 0x811f9c..0x811fac
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x811b3c..0x811b90
+            - Range: 0x811fac..0x812000
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
     - ID: 169
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x811bd0..0x811c20]
+      OutOfLinePCRanges: [0x812040..0x812090]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x811bd0..0x811bf8
+            - Range: 0x812040..0x812068
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
           Type: 333 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0x811bd0..0x811bf8
+            - Range: 0x812040..0x812068
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x811bd0..0x811bf8
+            - Range: 0x812040..0x812068
               Pieces: []
-            - Range: 0x811bf8..0x811bf9
+            - Range: 0x812068..0x812069
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x811bf9..0x811c20
+            - Range: 0x812069..0x812090
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
     - ID: 170
       Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0x811e90..0x811ea0]
+      OutOfLinePCRanges: [0x812300..0x812310]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 331 PointerType *go.shape.int
           Locations:
-            - Range: 0x811e90..0x811ea0
+            - Range: 0x812300..0x812310
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 331 PointerType *go.shape.int
           Locations:
-            - Range: 0x811e90..0x811e94
+            - Range: 0x812300..0x812304
               Pieces: []
-            - Range: 0x811e94..0x811e95
+            - Range: 0x812304..0x812305
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x811e95..0x811ea0
+            - Range: 0x812305..0x812310
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 171
       Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0x811ea0..0x811eb0]
+      OutOfLinePCRanges: [0x812310..0x812320]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 334 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0x811ea0..0x811eb0
+            - Range: 0x812310..0x812320
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 334 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0x811ea0..0x811ea4
+            - Range: 0x812310..0x812314
               Pieces: []
-            - Range: 0x811ea4..0x811ea5
+            - Range: 0x812314..0x812315
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x811ea5..0x811eb0
+            - Range: 0x812315..0x812320
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 172
       Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0x811eb0..0x811ec0]
+      OutOfLinePCRanges: [0x812320..0x812330]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 336 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0x811eb0..0x811ec0
+            - Range: 0x812320..0x812330
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 336 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0x811eb0..0x811eb4
+            - Range: 0x812320..0x812324
               Pieces: []
-            - Range: 0x811eb4..0x811eb5
+            - Range: 0x812324..0x812325
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x811eb5..0x811ec0
+            - Range: 0x812325..0x812330
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 173
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0x811ec0..0x811ed0]
+      OutOfLinePCRanges: [0x812330..0x812340]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 338 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0x811ec0..0x811ed0
+            - Range: 0x812330..0x812340
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x811ec0..0x811ec4
+            - Range: 0x812330..0x812334
               Pieces: []
-            - Range: 0x811ec4..0x811ec5
+            - Range: 0x812334..0x812335
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x811ec5..0x811ed0
+            - Range: 0x812335..0x812340
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 174
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0x811f50..0x811f60]
+      OutOfLinePCRanges: [0x8123c0..0x8123d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 340 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0x811f50..0x811f60
+            - Range: 0x8123c0..0x8123d0
               Pieces: [{Size: 136, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0x811f50..0x811f54
+            - Range: 0x8123c0..0x8123c4
               Pieces: []
-            - Range: 0x811f54..0x811f55
+            - Range: 0x8123c4..0x8123c5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x811f55..0x811f60
+            - Range: 0x8123c5..0x8123d0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 175
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0x811ff0..0x812000]
+      OutOfLinePCRanges: [0x812460..0x812470]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 341 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0x811ff0..0x812000
+            - Range: 0x812460..0x812470
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0x811ff0..0x812000
+            - Range: 0x812460..0x812470
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
           Type: 343 BaseType go.shape.bool
           Locations:
-            - Range: 0x811ff0..0x812000
+            - Range: 0x812460..0x812470
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
     - ID: 176
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0x812080..0x8120f0]
+      OutOfLinePCRanges: [0x8124f0..0x812560]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 344 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0x812080..0x8120f0
+            - Range: 0x8124f0..0x812560
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x812080..0x8120f0
+            - Range: 0x8124f0..0x812560
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10619,20 +10619,20 @@ Subprograms:
         - Name: v
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0x812080..0x8120f0
+            - Range: 0x8124f0..0x812560
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
     - ID: 177
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0x812170..0x812180]
+      OutOfLinePCRanges: [0x8125e0..0x8125f0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x812170..0x812180
+            - Range: 0x8125e0..0x8125f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10643,59 +10643,59 @@ Subprograms:
         - Name: b
           Type: 343 BaseType go.shape.bool
           Locations:
-            - Range: 0x812170..0x812180
+            - Range: 0x8125e0..0x8125f0
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 343 BaseType go.shape.bool
           Locations:
-            - Range: 0x812170..0x812178
+            - Range: 0x8125e0..0x8125e8
               Pieces: []
-            - Range: 0x812178..0x812179
+            - Range: 0x8125e8..0x8125e9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x812179..0x812180
+            - Range: 0x8125e9..0x8125f0
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x812170..0x812178
+            - Range: 0x8125e0..0x8125e8
               Pieces: []
-            - Range: 0x812178..0x812179
+            - Range: 0x8125e8..0x8125e9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x812179..0x812180
+            - Range: 0x8125e9..0x8125f0
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 178
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x812180..0x8121a0]
+      OutOfLinePCRanges: [0x8125f0..0x812610]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0x812180..0x812190
+            - Range: 0x8125f0..0x812600
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x812180..0x81218c
+            - Range: 0x8125f0..0x8125fc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x81218c..0x8121a0
+            - Range: 0x8125fc..0x812610
               Pieces:
                 - Size: 8
                   Op: null
@@ -10706,73 +10706,73 @@ Subprograms:
         - Name: ~r0
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x812180..0x812190
+            - Range: 0x8125f0..0x812600
               Pieces: []
-            - Range: 0x812190..0x812191
+            - Range: 0x812600..0x812601
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x812191..0x8121a0
+            - Range: 0x812601..0x812610
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0x812180..0x812190
+            - Range: 0x8125f0..0x812600
               Pieces: []
-            - Range: 0x812190..0x812191
+            - Range: 0x812600..0x812601
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x812191..0x8121a0
+            - Range: 0x812601..0x812610
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 179
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0x8121a0..0x8121f0]
+      OutOfLinePCRanges: [0x812610..0x812660]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 346 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0x8121a0..0x8121c8
+            - Range: 0x812610..0x812638
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x8121a0..0x8121c8
+            - Range: 0x812610..0x812638
               Pieces: []
-            - Range: 0x8121c8..0x8121c9
+            - Range: 0x812638..0x812639
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8121c9..0x8121f0
+            - Range: 0x812639..0x812660
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 180
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0x8121f0..0x812250]
+      OutOfLinePCRanges: [0x812660..0x8126c0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 347 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0x8121f0..0x81221c
+            - Range: 0x812660..0x81268c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x81221c..0x812220
+            - Range: 0x81268c..0x812690
               Pieces:
                 - Size: 8
                   Op: null
@@ -10783,65 +10783,65 @@ Subprograms:
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x8121f0..0x812220
+            - Range: 0x812660..0x812690
               Pieces: []
-            - Range: 0x812220..0x812221
+            - Range: 0x812690..0x812691
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x812221..0x812250
+            - Range: 0x812691..0x8126c0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 181
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0x812250..0x812260]
+      OutOfLinePCRanges: [0x8126c0..0x8126d0]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 348 PointerType *go.shape.string
           Locations:
-            - Range: 0x812250..0x812254
+            - Range: 0x8126c0..0x8126c4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x812250..0x812254
+            - Range: 0x8126c0..0x8126c4
               Pieces: []
-            - Range: 0x812254..0x812255
+            - Range: 0x8126c4..0x8126c5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x812255..0x812260
+            - Range: 0x8126c5..0x8126d0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 182
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0x812260..0x8122b0]
+      OutOfLinePCRanges: [0x8126d0..0x812720]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 349 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x812260..0x81229c
+            - Range: 0x8126d0..0x81270c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 350 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x812260..0x8122a0
+            - Range: 0x8126d0..0x812710
               Pieces: []
-            - Range: 0x8122a0..0x8122a1
+            - Range: 0x812710..0x812711
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10855,20 +10855,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x8122a1..0x8122b0
+            - Range: 0x812711..0x812720
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 183
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0x8122b0..0x8122f0]
+      OutOfLinePCRanges: [0x812720..0x812760]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 330 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x8122b0..0x8122bc
+            - Range: 0x812720..0x81272c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10876,7 +10876,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8122bc..0x8122f0
+            - Range: 0x81272c..0x812760
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10889,42 +10889,42 @@ Subprograms:
         - Name: needle
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0x8122b0..0x8122f0
+            - Range: 0x812720..0x812760
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x8122b0..0x8122d8
+            - Range: 0x812720..0x812748
               Pieces: []
-            - Range: 0x8122d8..0x8122d9
+            - Range: 0x812748..0x812749
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8122d9..0x8122e0
+            - Range: 0x812749..0x812750
               Pieces: []
-            - Range: 0x8122e0..0x8122e1
+            - Range: 0x812750..0x812751
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8122e1..0x8122f0
+            - Range: 0x812751..0x812760
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0x8122cc..0x8122dc
+            - Range: 0x81273c..0x81274c
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Local
           DictIndex: 1
       DictRegister: 0
     - ID: 184
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0x8122f0..0x8123b0]
+      OutOfLinePCRanges: [0x812760..0x812820]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 351 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0x8122f0..0x812314
+            - Range: 0x812760..0x812784
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10932,7 +10932,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x812314..0x812318
+            - Range: 0x812784..0x812788
               Pieces:
                 - Size: 8
                   Op: null
@@ -10945,13 +10945,13 @@ Subprograms:
         - Name: needle
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8122f0..0x812348
+            - Range: 0x812760..0x8127b8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x812348..0x8123b0
+            - Range: 0x8127b8..0x812820
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 40}
@@ -10962,22 +10962,22 @@ Subprograms:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x8122f0..0x812364
+            - Range: 0x812760..0x8127d4
               Pieces: []
-            - Range: 0x812364..0x812365
+            - Range: 0x8127d4..0x8127d5
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x812365..0x812374
+            - Range: 0x8127d5..0x8127e4
               Pieces: []
-            - Range: 0x812374..0x812375
+            - Range: 0x8127e4..0x8127e5
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x812375..0x8123b0
+            - Range: 0x8127e5..0x812820
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x812330..0x812348
+            - Range: 0x8127a0..0x8127b8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10988,56 +10988,56 @@ Subprograms:
       DictRegister: 0
     - ID: 185
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0x8123b0..0x8123c0]
+      OutOfLinePCRanges: [0x812820..0x812830]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 352 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0x8123b0..0x8123b8
+            - Range: 0x812820..0x812828
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0x8123b0..0x8123c0
+            - Range: 0x812820..0x812830
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x8123b0..0x8123b8
+            - Range: 0x812820..0x812828
               Pieces: []
-            - Range: 0x8123b8..0x8123b9
+            - Range: 0x812828..0x812829
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8123b9..0x8123c0
+            - Range: 0x812829..0x812830
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 1
     - ID: 186
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0x812430..0x8124a0]
+      OutOfLinePCRanges: [0x8128a0..0x812910]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 353 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0x812430..0x81245c
+            - Range: 0x8128a0..0x8128cc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x81245c..0x812468
+            - Range: 0x8128cc..0x8128d8
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x812468..0x81246c
+            - Range: 0x8128d8..0x8128dc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11048,7 +11048,7 @@ Subprograms:
         - Name: value
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x812430..0x81246c
+            - Range: 0x8128a0..0x8128dc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -11059,11 +11059,11 @@ Subprograms:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x812430..0x81246c
+            - Range: 0x8128a0..0x8128dc
               Pieces: []
-            - Range: 0x81246c..0x81246d
+            - Range: 0x8128dc..0x8128dd
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x81246d..0x8124a0
+            - Range: 0x8128dd..0x812910
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11209,31 +11209,31 @@ Subprograms:
       DictRegister: 0
     - ID: 188
       Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0x80aca0..0x80ad10]
+      OutOfLinePCRanges: [0x80ad80..0x80adf0]
       InlinePCRanges:
-        - Ranges: [0x80ad2c..0x80ad60]
-          RootRanges: [0x80ad10..0x80ad80]
-        - Ranges: [0x80ae68..0x80ae9c]
-          RootRanges: [0x80ae30..0x80aec0]
-        - Ranges: [0x80aee4..0x80af18]
-          RootRanges: [0x80aec0..0x80af80]
-        - Ranges: [0x80af9c..0x80afd0]
-          RootRanges: [0x80af80..0x80aff0]
+        - Ranges: [0x80ae0c..0x80ae40]
+          RootRanges: [0x80adf0..0x80ae60]
+        - Ranges: [0x80af48..0x80af7c]
+          RootRanges: [0x80af10..0x80afa0]
+        - Ranges: [0x80afc4..0x80aff8]
+          RootRanges: [0x80afa0..0x80b060]
+        - Ranges: [0x80b07c..0x80b0b0]
+          RootRanges: [0x80b060..0x80b0d0]
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80aca0..0x80acc0
+            - Range: 0x80ad80..0x80ada0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ad2c..0x80ad34
+            - Range: 0x80ae0c..0x80ae14
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ae68..0x80ae70
+            - Range: 0x80af48..0x80af50
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80aedc..0x80aeec
+            - Range: 0x80afbc..0x80afcc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80aeec..0x80af80
+            - Range: 0x80afcc..0x80b060
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x80af80..0x80afa4
+            - Range: 0x80b060..0x80b084
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -11242,37 +11242,37 @@ Subprograms:
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x80af24..0x80af58]
-          RootRanges: [0x80aec0..0x80af80]
+        - Ranges: [0x80b004..0x80b038]
+          RootRanges: [0x80afa0..0x80b060]
       Variables: []
       DictRegister: null
     - ID: 190
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x80b00c..0x80b040, 0x80b048..0x80b04c]
-          RootRanges: [0x80aff0..0x80b100]
+        - Ranges: [0x80b0ec..0x80b120, 0x80b128..0x80b12c]
+          RootRanges: [0x80b0d0..0x80b1e0]
       Variables: []
       DictRegister: null
     - ID: 191
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x80b0b0..0x80b0e4]
-          RootRanges: [0x80aff0..0x80b100]
+        - Ranges: [0x80b190..0x80b1c4]
+          RootRanges: [0x80b0d0..0x80b1e0]
       Variables: []
       DictRegister: null
     - ID: 192
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x80b104..0x80b108]
-          RootRanges: [0x80b100..0x80b110]
+        - Ranges: [0x80b1e4..0x80b1e8]
+          RootRanges: [0x80b1e0..0x80b1f0]
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80b100..0x80b108
+            - Range: 0x80b1e0..0x80b1e8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -11281,32 +11281,32 @@ Subprograms:
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x80b134..0x80b150]
-          RootRanges: [0x80b110..0x80b160]
-        - Ranges: [0x80b1bc..0x80b1dc]
-          RootRanges: [0x80b160..0x80b2a0]
+        - Ranges: [0x80b214..0x80b230]
+          RootRanges: [0x80b1f0..0x80b240]
+        - Ranges: [0x80b29c..0x80b2bc]
+          RootRanges: [0x80b240..0x80b380]
       Variables:
         - Name: a
           Type: 166 ArrayType [5]int
           Locations:
-            - Range: 0x80b120..0x80b160
+            - Range: 0x80b200..0x80b240
               Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
-            - Range: 0x80b1a8..0x80b2a0
+            - Range: 0x80b288..0x80b380
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 194
       Name: main.firstBehavior.DoSomething
-      OutOfLinePCRanges: [0x80b2a0..0x80b300]
+      OutOfLinePCRanges: [0x80b380..0x80b3e0]
       InlinePCRanges:
-        - Ranges: [0x812548..0x81256c]
-          RootRanges: [0x812520..0x8125b0]
+        - Ranges: [0x8129b8..0x8129dc]
+          RootRanges: [0x812990..0x812a20]
       Variables:
         - Name: b
           Type: 358 StructureType main.firstBehavior
           Locations:
-            - Range: 0x80b2a0..0x80b2c4
+            - Range: 0x80b380..0x80b3a4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11317,15 +11317,15 @@ Subprograms:
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80b2a0..0x80b2e0
+            - Range: 0x80b380..0x80b3c0
               Pieces: []
-            - Range: 0x80b2e0..0x80b2e1
+            - Range: 0x80b3c0..0x80b3c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80b2e1..0x80b300
+            - Range: 0x80b3c1..0x80b3e0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11334,8 +11334,8 @@ Subprograms:
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x80b8dc..0x80b8e8, 0x80b8ec..0x80b8f4]
-          RootRanges: [0x80b7c0..0x80b940]
+        - Ranges: [0x80baf0..0x80bafc, 0x80bb00..0x80bb08]
+          RootRanges: [0x80ba60..0x80bb50]
         - Ranges: [0x12c238..0x12c23c, 0x12c240..0x12c248]
           RootRanges: [0x12c230..0x12c250]
       Variables: []
@@ -11654,7 +11654,7 @@ Types:
       ID: 40
       Name: '*[]runtime.ancestorInfo'
       ByteSize: 8
-      GoRuntimeType: 492192
+      GoRuntimeType: 492448
       GoKind: 22
       Pointee: 41 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
@@ -11757,7 +11757,7 @@ Types:
       ID: 12
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 395488
+      GoRuntimeType: 395616
       GoKind: 22
       Pointee: 5 BaseType bool
     - __kind: PointerType
@@ -12194,7 +12194,7 @@ Types:
       ID: 107
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 394400
+      GoRuntimeType: 394528
       GoKind: 22
       Pointee: 15 GoInterfaceType error
     - __kind: PointerType
@@ -12215,14 +12215,14 @@ Types:
       ID: 109
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 395360
+      GoRuntimeType: 395488
       GoKind: 22
       Pointee: 19 BaseType float32
     - __kind: PointerType
       ID: 100
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 395424
+      GoRuntimeType: 395552
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
@@ -13081,42 +13081,42 @@ Types:
       ID: 101
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 395040
+      GoRuntimeType: 395168
       GoKind: 22
       Pointee: 8 BaseType int
     - __kind: PointerType
       ID: 105
       Name: '*int16'
       ByteSize: 8
-      GoRuntimeType: 394656
+      GoRuntimeType: 394784
       GoKind: 22
       Pointee: 97 BaseType int16
     - __kind: PointerType
       ID: 21
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 394784
+      GoRuntimeType: 394912
       GoKind: 22
       Pointee: 13 BaseType int32
     - __kind: PointerType
       ID: 103
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 394912
+      GoRuntimeType: 395040
       GoKind: 22
       Pointee: 14 BaseType int64
     - __kind: PointerType
       ID: 106
       Name: '*int8'
       ByteSize: 8
-      GoRuntimeType: 394528
+      GoRuntimeType: 394656
       GoKind: 22
       Pointee: 18 BaseType int8
     - __kind: PointerType
       ID: 168
       Name: '*interface {}'
       ByteSize: 8
-      GoRuntimeType: 395616
+      GoRuntimeType: 395744
       GoKind: 22
       Pointee: 162 GoEmptyInterfaceType interface {}
     - __kind: PointerType
@@ -13144,7 +13144,7 @@ Types:
       ID: 1066
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
-      GoRuntimeType: 905408
+      GoRuntimeType: 905792
       GoKind: 22
       Pointee: 1067 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
@@ -13169,12 +13169,12 @@ Types:
       GoKind: 22
       Pointee: 951 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 670
+      ID: 673
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
-      GoRuntimeType: 904352
+      GoRuntimeType: 904736
       GoKind: 22
-      Pointee: 671 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 674 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
       ID: 733
       Name: '*internal/runtime/cgroup.stringError'
@@ -14279,12 +14279,12 @@ Types:
       GoKind: 22
       Pointee: 645 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 672
+      ID: 675
       Name: '*reflect.ValueError'
       ByteSize: 8
-      GoRuntimeType: 905024
+      GoRuntimeType: 905408
       GoKind: 22
-      Pointee: 673 UnresolvedPointeeType reflect.ValueError
+      Pointee: 676 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
       ID: 770
       Name: '*regexp/syntax.Error'
@@ -14296,21 +14296,21 @@ Types:
       ID: 882
       Name: '*runtime.PanicNilError'
       ByteSize: 8
-      GoRuntimeType: 1032640
+      GoRuntimeType: 1032896
       GoKind: 22
       Pointee: 883 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
       ID: 886
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
-      GoRuntimeType: 1034432
+      GoRuntimeType: 1034688
       GoKind: 22
       Pointee: 887 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 27
       Name: '*runtime._defer'
       ByteSize: 8
-      GoRuntimeType: 395680
+      GoRuntimeType: 395808
       GoKind: 22
       Pointee: 28 UnresolvedPointeeType runtime._defer
     - __kind: PointerType
@@ -14324,21 +14324,21 @@ Types:
       ID: 884
       Name: '*runtime.boundsError'
       ByteSize: 8
-      GoRuntimeType: 1032768
+      GoRuntimeType: 1033024
       GoKind: 22
       Pointee: 885 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 66
       Name: '*runtime.cgoCallers'
       ByteSize: 8
-      GoRuntimeType: 396320
+      GoRuntimeType: 396448
       GoKind: 22
       Pointee: 67 UnresolvedPointeeType runtime.cgoCallers
     - __kind: PointerType
       ID: 48
       Name: '*runtime.coro'
       ByteSize: 8
-      GoRuntimeType: 396384
+      GoRuntimeType: 396512
       GoKind: 22
       Pointee: 49 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
@@ -14352,7 +14352,7 @@ Types:
       ID: 880
       Name: '*runtime.errorString'
       ByteSize: 8
-      GoRuntimeType: 1032256
+      GoRuntimeType: 1032512
       GoKind: 22
       Pointee: 861 GoStringHeaderType runtime.errorString
     - __kind: PointerType
@@ -14364,7 +14364,7 @@ Types:
       ID: 56
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 903392
+      GoRuntimeType: 903776
       GoKind: 22
       Pointee: 23 StructureType runtime.g
     - __kind: PointerType
@@ -14378,14 +14378,14 @@ Types:
       ID: 65
       Name: '*runtime.p'
       ByteSize: 8
-      GoRuntimeType: 1033792
+      GoRuntimeType: 1034048
       GoKind: 22
       Pointee: 365 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 881
       Name: '*runtime.plainError'
       ByteSize: 8
-      GoRuntimeType: 1032384
+      GoRuntimeType: 1032640
       GoKind: 22
       Pointee: 864 GoStringHeaderType runtime.plainError
     - __kind: PointerType
@@ -14397,7 +14397,7 @@ Types:
       ID: 42
       Name: '*runtime.sudog'
       ByteSize: 8
-      GoRuntimeType: 397024
+      GoRuntimeType: 397152
       GoKind: 22
       Pointee: 43 UnresolvedPointeeType runtime.sudog
     - __kind: PointerType
@@ -14408,12 +14408,12 @@ Types:
       GoKind: 22
       Pointee: 51 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 668
+      ID: 671
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
-      GoRuntimeType: 904064
+      GoRuntimeType: 904448
       GoKind: 22
-      Pointee: 669 StructureType runtime.synctestDeadlockError
+      Pointee: 672 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 45
       Name: '*runtime.timer'
@@ -14425,7 +14425,7 @@ Types:
       ID: 80
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1628608
+      GoRuntimeType: 1628992
       GoKind: 22
       Pointee: 81 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
@@ -14439,7 +14439,7 @@ Types:
       ID: 96
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 394464
+      GoRuntimeType: 394592
       GoKind: 22
       Pointee: 10 GoStringHeaderType string
     - __kind: PointerType
@@ -14635,21 +14635,21 @@ Types:
       ID: 1014
       Name: '*time.Location'
       ByteSize: 8
-      GoRuntimeType: 1633600
+      GoRuntimeType: 1624960
       GoKind: 22
       Pointee: 1015 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 675
+      ID: 669
       Name: '*time.ParseError'
       ByteSize: 8
-      GoRuntimeType: 906176
+      GoRuntimeType: 901856
       GoKind: 22
-      Pointee: 676 UnresolvedPointeeType time.ParseError
+      Pointee: 670 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 674
+      ID: 668
       Name: '*time.fileSizeError'
       ByteSize: 8
-      GoRuntimeType: 906080
+      GoRuntimeType: 901760
       GoKind: 22
       Pointee: 591 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
@@ -14661,42 +14661,42 @@ Types:
       ID: 108
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 395104
+      GoRuntimeType: 395232
       GoKind: 22
       Pointee: 11 BaseType uint
     - __kind: PointerType
       ID: 104
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 394720
+      GoRuntimeType: 394848
       GoKind: 22
       Pointee: 7 BaseType uint16
     - __kind: PointerType
       ID: 22
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 394848
+      GoRuntimeType: 394976
       GoKind: 22
       Pointee: 3 BaseType uint32
     - __kind: PointerType
       ID: 102
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 394976
+      GoRuntimeType: 395104
       GoKind: 22
       Pointee: 9 BaseType uint64
     - __kind: PointerType
       ID: 6
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 394592
+      GoRuntimeType: 394720
       GoKind: 22
       Pointee: 4 BaseType uint8
     - __kind: PointerType
       ID: 20
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 395168
+      GoRuntimeType: 395296
       GoKind: 22
       Pointee: 2 BaseType uintptr
     - __kind: PointerType
@@ -23837,7 +23837,7 @@ Types:
       ID: 93
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 705120
+      GoRuntimeType: 706560
       GoKind: 17
       Count: 10
       HasCount: true
@@ -23864,7 +23864,7 @@ Types:
       ID: 79
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 704736
+      GoRuntimeType: 706176
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23873,7 +23873,7 @@ Types:
       ID: 78
       Name: '[2][2]*runtime.traceBuf'
       ByteSize: 32
-      GoRuntimeType: 704832
+      GoRuntimeType: 706272
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23898,7 +23898,7 @@ Types:
       ID: 85
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 705024
+      GoRuntimeType: 706464
       GoKind: 17
       Count: 2
       HasCount: true
@@ -24040,7 +24040,7 @@ Types:
       ID: 69
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 704544
+      GoRuntimeType: 705984
       GoKind: 17
       Count: 32
       HasCount: true
@@ -24058,7 +24058,7 @@ Types:
       ID: 54
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 703968
+      GoRuntimeType: 705408
       GoKind: 17
       Count: 3
       HasCount: true
@@ -24128,7 +24128,7 @@ Types:
       ID: 86
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 704928
+      GoRuntimeType: 706368
       GoKind: 17
       Count: 8
       HasCount: true
@@ -24229,7 +24229,7 @@ Types:
       ID: 63
       Name: '[]*runtime.p'
       ByteSize: 24
-      GoRuntimeType: 491744
+      GoRuntimeType: 492000
       GoKind: 23
       RawFields:
         - Name: array
@@ -24569,7 +24569,7 @@ Types:
       ID: 268
       Name: '[]bool'
       ByteSize: 24
-      GoRuntimeType: 490144
+      GoRuntimeType: 490400
       GoKind: 23
       RawFields:
         - Name: array
@@ -24592,7 +24592,7 @@ Types:
       ID: 1039
       Name: '[]float64'
       ByteSize: 24
-      GoRuntimeType: 490016
+      GoRuntimeType: 490272
       GoKind: 23
       RawFields:
         - Name: array
@@ -24682,7 +24682,7 @@ Types:
       ID: 1320
       Name: '[]interface {}'
       ByteSize: 24
-      GoRuntimeType: 490464
+      GoRuntimeType: 490720
       GoKind: 23
       RawFields:
         - Name: array
@@ -24938,7 +24938,7 @@ Types:
       ID: 159
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 490272
+      GoRuntimeType: 490528
       GoKind: 23
       RawFields:
         - Name: array
@@ -24982,7 +24982,7 @@ Types:
       ID: 262
       Name: '[]uint'
       ByteSize: 24
-      GoRuntimeType: 489760
+      GoRuntimeType: 490016
       GoKind: 23
       RawFields:
         - Name: array
@@ -25005,7 +25005,7 @@ Types:
       ID: 269
       Name: '[]uint16'
       ByteSize: 24
-      GoRuntimeType: 489120
+      GoRuntimeType: 489376
       GoKind: 23
       RawFields:
         - Name: array
@@ -25028,7 +25028,7 @@ Types:
       ID: 39
       Name: '[]uint8'
       ByteSize: 24
-      GoRuntimeType: 488992
+      GoRuntimeType: 489248
       GoKind: 23
       RawFields:
         - Name: array
@@ -25051,7 +25051,7 @@ Types:
       ID: 44
       Name: '[]uintptr'
       ByteSize: 24
-      GoRuntimeType: 489824
+      GoRuntimeType: 490080
       GoKind: 23
       RawFields:
         - Name: array
@@ -25534,7 +25534,7 @@ Types:
       ID: 15
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1032128
+      GoRuntimeType: 1032384
       GoKind: 20
       RawFields:
         - Name: tab
@@ -25585,7 +25585,7 @@ Types:
       ID: 74
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 852352
+      GoRuntimeType: 852640
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 357
@@ -27175,7 +27175,7 @@ Types:
       ID: 162
       Name: interface {}
       ByteSize: 16
-      GoRuntimeType: 852064
+      GoRuntimeType: 852352
       GoKind: 20
       RawFields:
         - Name: _type
@@ -27233,11 +27233,11 @@ Types:
     - __kind: StructureType
       ID: 951
       Name: internal/poll.errNetClosing
-      GoRuntimeType: 1484736
+      GoRuntimeType: 1485056
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 671
+      ID: 674
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -27350,7 +27350,7 @@ Types:
       ID: 1269
       Name: internal/sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1482176
+      GoRuntimeType: 1482496
       GoKind: 25
       RawFields:
         - Name: state
@@ -31169,7 +31169,7 @@ Types:
       GoRuntimeType: 841888
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 673
+      ID: 676
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -31235,7 +31235,7 @@ Types:
       ID: 947
       Name: runtime.errorAddressString
       ByteSize: 24
-      GoRuntimeType: 1762528
+      GoRuntimeType: 1762720
       GoKind: 25
       RawFields:
         - Name: msg
@@ -31467,7 +31467,7 @@ Types:
       ID: 31
       Name: runtime.gobuf
       ByteSize: 48
-      GoRuntimeType: 1923392
+      GoRuntimeType: 1923648
       GoKind: 25
       RawFields:
         - Name: sp
@@ -31492,7 +31492,7 @@ Types:
       ID: 47
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1479296
+      GoRuntimeType: 1479616
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -31505,7 +31505,7 @@ Types:
       ID: 57
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1761376
+      GoRuntimeType: 1761568
       GoKind: 25
       RawFields:
         - Name: stack
@@ -31524,13 +31524,13 @@ Types:
       ID: 32
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 834496
+      GoRuntimeType: 834784
       GoKind: 12
     - __kind: StructureType
       ID: 94
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1479136
+      GoRuntimeType: 1479456
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -31543,7 +31543,7 @@ Types:
       ID: 82
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 1924160
+      GoRuntimeType: 1924416
       GoKind: 25
       RawFields:
         - Name: fn
@@ -31568,7 +31568,7 @@ Types:
       ID: 95
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 834400
+      GoRuntimeType: 834688
       GoKind: 2
     - __kind: StructureType
       ID: 30
@@ -31794,7 +31794,7 @@ Types:
       ID: 71
       Name: runtime.mLockProfile
       ByteSize: 56
-      GoRuntimeType: 1923904
+      GoRuntimeType: 1924160
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -31819,7 +31819,7 @@ Types:
       ID: 89
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 1849536
+      GoRuntimeType: 1849760
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -31841,7 +31841,7 @@ Types:
       ID: 76
       Name: runtime.mTraceState
       ByteSize: 56
-      GoRuntimeType: 1849312
+      GoRuntimeType: 1849536
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -31863,7 +31863,7 @@ Types:
       ID: 70
       Name: runtime.mWaitList
       ByteSize: 16
-      GoRuntimeType: 1478816
+      GoRuntimeType: 1479136
       GoKind: 25
       RawFields:
         - Name: next
@@ -31876,7 +31876,7 @@ Types:
       ID: 38
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 834112
+      GoRuntimeType: 834400
       GoKind: 12
     - __kind: StructureType
       ID: 68
@@ -31893,7 +31893,7 @@ Types:
       ID: 84
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1478976
+      GoRuntimeType: 1479296
       GoKind: 25
       RawFields:
         - Name: entries
@@ -31906,7 +31906,7 @@ Types:
       ID: 87
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1762336
+      GoRuntimeType: 1762528
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -31944,13 +31944,13 @@ Types:
       ID: 61
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 834304
+      GoRuntimeType: 834592
       GoKind: 12
     - __kind: ArrayType
       ID: 58
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 902912
+      GoRuntimeType: 903296
       GoKind: 17
       Count: 2
       HasCount: true
@@ -31959,7 +31959,7 @@ Types:
       ID: 24
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1477056
+      GoRuntimeType: 1477376
       GoKind: 25
       RawFields:
         - Name: lo
@@ -31977,7 +31977,7 @@ Types:
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 669
+      ID: 672
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1603648
@@ -32013,7 +32013,7 @@ Types:
       ID: 53
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1478016
+      GoRuntimeType: 1478336
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -32861,14 +32861,14 @@ Types:
       ID: 1163
       Name: time.Duration
       ByteSize: 8
-      GoRuntimeType: 1924928
+      GoRuntimeType: 1921856
       GoKind: 6
     - __kind: UnresolvedPointeeType
       ID: 1015
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 676
+      ID: 670
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
@@ -32891,7 +32891,7 @@ Types:
       ID: 591
       Name: time.fileSizeError
       ByteSize: 16
-      GoRuntimeType: 834880
+      GoRuntimeType: 833632
       GoKind: 24
       RawFields:
         - Name: str

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
@@ -13,11 +13,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1600 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0x80c6f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80cb58", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1601 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0x80c728", Frameless: false}]
+              InjectionPoints: [{PC: "0x80cb88", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -33,11 +33,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1439 EventRootType Probe[main.testAny]
-              InjectionPoints: [{PC: "0x807c28", Frameless: false}]
+              InjectionPoints: [{PC: "0x807d08", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1440 EventRootType Probe[main.testAny]Return
-              InjectionPoints: [{PC: "0x807c50", Frameless: false}]
+              InjectionPoints: [{PC: "0x807d30", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -59,11 +59,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1442 EventRootType Probe[main.testAnyPtr]
-              InjectionPoints: [{PC: "0x807c98", Frameless: false}]
+              InjectionPoints: [{PC: "0x807d78", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1443 EventRootType Probe[main.testAnyPtr]Return
-              InjectionPoints: [{PC: "0x807cc0", Frameless: false}]
+              InjectionPoints: [{PC: "0x807da0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -84,11 +84,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1571 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0x80b5ec", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b78c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1572 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0x80b680", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b820", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -110,7 +110,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1388 EventRootType Probe[main.testArrayEmptyStructs]
-              InjectionPoints: [{PC: "0x803800", Frameless: true}]
+              InjectionPoints: [{PC: "0x8038e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -132,7 +132,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1384 EventRootType Probe[main.testArrayOfArrays]
-              InjectionPoints: [{PC: "0x8037c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8038a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -154,7 +154,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1386 EventRootType Probe[main.testArrayOfArraysOfArrays]
-              InjectionPoints: [{PC: "0x8037e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8038c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -176,7 +176,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1451 EventRootType Probe[main.testArrayOfMaps]
-              InjectionPoints: [{PC: "0x8082e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x808480", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -198,7 +198,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1385 EventRootType Probe[main.testArrayOfStrings]
-              InjectionPoints: [{PC: "0x8037d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8038b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -219,7 +219,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1387 EventRootType Probe[main.testArrayOfStructs]
-              InjectionPoints: [{PC: "0x8037f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8038d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -241,11 +241,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1473 EventRootType Probe[main.testAtomicAdd]
-              InjectionPoints: [{PC: "0x8099d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x809b70", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1474 EventRootType Probe[main.testAtomicAdd]Return
-              InjectionPoints: [{PC: "0x809a0c", Frameless: true}]
+              InjectionPoints: [{PC: "0x809bac", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -267,7 +267,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1406 EventRootType Probe[main.testBigStruct]
-              InjectionPoints: [{PC: "0x803d50", Frameless: true}]
+              InjectionPoints: [{PC: "0x803e30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -289,7 +289,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1373 EventRootType Probe[main.testBoolArray]
-              InjectionPoints: [{PC: "0x803710", Frameless: true}]
+              InjectionPoints: [{PC: "0x8037f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -311,7 +311,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1370 EventRootType Probe[main.testByteArray]
-              InjectionPoints: [{PC: "0x8036e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8037c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -338,7 +338,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1616 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x80c9c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ce20", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -358,15 +358,15 @@ Probes:
             - Kind: Line
               Type: 1675 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x807548"
+                - PC: "0x807628"
                   Frameless: false
-                - PC: "0x8075bc"
+                - PC: "0x80769c"
                   Frameless: false
-                - PC: "0x8076f0"
+                - PC: "0x8077d0"
                   Frameless: false
-                - PC: "0x807774"
+                - PC: "0x807854"
                   Frameless: false
-                - PC: "0x80782c"
+                - PC: "0x80790c"
                   Frameless: false
               Condition: null
     - id: testCaptureExprLineCond
@@ -388,15 +388,15 @@ Probes:
             - Kind: Line
               Type: 1676 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x807548"
+                - PC: "0x807628"
                   Frameless: false
-                - PC: "0x8075bc"
+                - PC: "0x80769c"
                   Frameless: false
-                - PC: "0x8076f0"
+                - PC: "0x8077d0"
                   Frameless: false
-                - PC: "0x807774"
+                - PC: "0x807854"
                   Frameless: false
-                - PC: "0x80782c"
+                - PC: "0x80790c"
                   Frameless: false
               Condition:
                 Type: 5 BaseType bool
@@ -432,15 +432,15 @@ Probes:
             - Kind: Line
               Type: 1677 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x807548"
+                - PC: "0x807628"
                   Frameless: false
-                - PC: "0x8075bc"
+                - PC: "0x80769c"
                   Frameless: false
-                - PC: "0x8076f0"
+                - PC: "0x8077d0"
                   Frameless: false
-                - PC: "0x807774"
+                - PC: "0x807854"
                   Frameless: false
-                - PC: "0x80782c"
+                - PC: "0x80790c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -468,7 +468,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1470 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x809770", Frameless: true}]
+              InjectionPoints: [{PC: "0x809910", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -487,7 +487,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1471 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x809770", Frameless: true}]
+              InjectionPoints: [{PC: "0x809910", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -513,7 +513,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1622 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0x80ca30", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ce90", Frameless: true}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -549,7 +549,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1475 EventRootType Probe[main.testChannel]
-              InjectionPoints: [{PC: "0x809a10", Frameless: true}]
+              InjectionPoints: [{PC: "0x809bb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -579,7 +579,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1469 EventRootType Probe[main.testCombinedByte]
-              InjectionPoints: [{PC: "0x809750", Frameless: true}]
+              InjectionPoints: [{PC: "0x8098f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{w}, {x}, {y}'
@@ -608,11 +608,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1536 EventRootType Probe[main.testConflictingReturn]
-              InjectionPoints: [{PC: "0x80a8e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80aa88", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1537 EventRootType Probe[main.testConflictingReturn]Return
-              InjectionPoints: [{PC: "0x80a98c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ab2c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -634,7 +634,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1483 EventRootType Probe[main.testCycle]
-              InjectionPoints: [{PC: "0x809c90", Frameless: true}]
+              InjectionPoints: [{PC: "0x809e30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{t}'
@@ -656,7 +656,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1412 EventRootType Probe[main.testDeepMap1]
-              InjectionPoints: [{PC: "0x8041b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x804290", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -678,7 +678,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1413 EventRootType Probe[main.testDeepMap7]
-              InjectionPoints: [{PC: "0x8041c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8042a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -700,7 +700,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1408 EventRootType Probe[main.testDeepPtr1]
-              InjectionPoints: [{PC: "0x803f20", Frameless: true}]
+              InjectionPoints: [{PC: "0x804000", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -722,7 +722,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1409 EventRootType Probe[main.testDeepPtr7]
-              InjectionPoints: [{PC: "0x803f30", Frameless: true}]
+              InjectionPoints: [{PC: "0x804010", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -744,7 +744,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1410 EventRootType Probe[main.testDeepSlice1]
-              InjectionPoints: [{PC: "0x804050", Frameless: true}]
+              InjectionPoints: [{PC: "0x804130", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -766,7 +766,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1411 EventRootType Probe[main.testDeepSlice7]
-              InjectionPoints: [{PC: "0x804060", Frameless: true}]
+              InjectionPoints: [{PC: "0x804140", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -788,7 +788,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1588 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0x80c370", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c510", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -815,7 +815,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1591 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0x80c3a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c540", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -843,7 +843,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1612 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0x80c7b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cc10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -865,7 +865,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1623 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0x80ca60", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cec0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -886,7 +886,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1624 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0x80ca70", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ced0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -908,7 +908,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1441 EventRootType Probe[main.testError]
-              InjectionPoints: [{PC: "0x807c70", Frameless: true}]
+              InjectionPoints: [{PC: "0x807d50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -942,7 +942,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1407 EventRootType Probe[main.testErrorAtLine]Line
-              InjectionPoints: [{PC: "0x803de0", Frameless: false}]
+              InjectionPoints: [{PC: "0x803ec0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}, err={err}
@@ -970,11 +970,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1423 EventRootType Probe[main.testEsotericHeap]
-              InjectionPoints: [{PC: "0x806628", Frameless: false}]
+              InjectionPoints: [{PC: "0x806708", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1424 EventRootType Probe[main.testEsotericHeap]Return
-              InjectionPoints: [{PC: "0x806660", Frameless: false}]
+              InjectionPoints: [{PC: "0x806740", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -996,11 +996,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1421 EventRootType Probe[main.testEsotericStack]
-              InjectionPoints: [{PC: "0x80656c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80664c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1422 EventRootType Probe[main.testEsotericStack]Return
-              InjectionPoints: [{PC: "0x8065c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8066a8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1022,11 +1022,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1433 EventRootType Probe[main.testFrameless]
-              InjectionPoints: [{PC: "0x807990", Frameless: true}]
+              InjectionPoints: [{PC: "0x807a70", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1434 EventRootType Probe[main.testFrameless]Return
-              InjectionPoints: [{PC: "0x807998", Frameless: true}]
+              InjectionPoints: [{PC: "0x807a78", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1048,11 +1048,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1435 EventRootType Probe[main.testFramelessArray]
-              InjectionPoints: [{PC: "0x8079ac", Frameless: false}]
+              InjectionPoints: [{PC: "0x807a8c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1436 EventRootType Probe[main.testFramelessArray]Return
-              InjectionPoints: [{PC: "0x8079e0", Frameless: false}]
+              InjectionPoints: [{PC: "0x807ac0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1077,7 +1077,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1437 EventRootType Probe[main.testFramelessArray]Line
-              InjectionPoints: [{PC: "0x8079ac", Frameless: false}]
+              InjectionPoints: [{PC: "0x807a8c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1099,11 +1099,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1661 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0x80e840", Frameless: true}]
+              InjectionPoints: [{PC: "0x80eca0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1662 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x80e844", Frameless: true}]
+              InjectionPoints: [{PC: "0x80eca4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1117,11 +1117,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1663 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0x80e860", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ecc0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1664 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0x80e894", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ecf4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1144,11 +1144,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1657 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0x80e7a8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ec08", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1658 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0x80e7b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ec18", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1162,11 +1162,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1659 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0x80e7f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ec58", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1660 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0x80e810", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ec70", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1189,14 +1189,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1665 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0x80e8a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ed00", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1666 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0x80e8c8"
+                - PC: "0x80ed28"
                   Frameless: true
-                - PC: "0x80e8d0"
+                - PC: "0x80ed30"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1211,14 +1211,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1667 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0x80e8f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ed58", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1668 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0x80e958"
+                - PC: "0x80edb8"
                   Frameless: false
-                - PC: "0x80e968"
+                - PC: "0x80edc8"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1245,7 +1245,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1669 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0x80e8a4", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ed04", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1257,7 +1257,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1670 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0x80e908", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ed68", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1278,11 +1278,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1645 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0x80e520", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e980", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1646 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0x80e524", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e984", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1296,11 +1296,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1647 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0x80e5a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ea00", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1648 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0x80e5a4", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ea04", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1324,11 +1324,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1633 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0x80e12c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e58c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1634 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x80e278", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e6d8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1370,11 +1370,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1637 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x80e2c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e728", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1638 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x80e2d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e738", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1397,11 +1397,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1671 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0x80e9a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ee00", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1672 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0x80e9a8", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ee08", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1415,11 +1415,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1673 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0x80ea18", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ee78", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1674 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0x80ea3c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ee9c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1442,11 +1442,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1629 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0x80e090", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e4f0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1630 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x80e094", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e4f4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1460,11 +1460,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1631 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0x80e0a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e500", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1632 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x80e0ac", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e50c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1487,11 +1487,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1649 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0x80e620", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ea80", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1650 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0x80e628", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ea88", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1505,11 +1505,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1651 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0x80e6a8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80eb08", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1652 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0x80e6d0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80eb30", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1532,11 +1532,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1639 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0x80e4f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e950", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1640 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x80e4f4", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e954", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1550,11 +1550,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1641 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0x80e500", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e960", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1642 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0x80e504", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e964", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1568,11 +1568,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1643 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0x80e510", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e970", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1644 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0x80e514", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e974", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1595,11 +1595,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1653 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0x80e760", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ebc0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1654 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0x80e768", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ebc8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1613,11 +1613,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1655 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x80e770", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ebd0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1656 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x80e780", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ebe0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1640,11 +1640,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1625 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0x80e070", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e4d0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1626 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x80e074", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e4d4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1658,11 +1658,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1627 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0x80e080", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e4e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1628 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x80e08c", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e4ec", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1685,11 +1685,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1425 EventRootType Probe[main.testInlinedBA]
-              InjectionPoints: [{PC: "0x8076d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8077b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1426 EventRootType Probe[main.testInlinedBA]Return
-              InjectionPoints: [{PC: "0x807724", Frameless: false}]
+              InjectionPoints: [{PC: "0x807804", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1716,11 +1716,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1427 EventRootType Probe[main.testInlinedBB]
-              InjectionPoints: [{PC: "0x807768", Frameless: false}]
+              InjectionPoints: [{PC: "0x807848", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1428 EventRootType Probe[main.testInlinedBB]Return
-              InjectionPoints: [{PC: "0x8077e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8078c8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}'
@@ -1747,11 +1747,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1429 EventRootType Probe[main.testInlinedBBA]
-              InjectionPoints: [{PC: "0x807828", Frameless: false}]
+              InjectionPoints: [{PC: "0x807908", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1430 EventRootType Probe[main.testInlinedBBA]Return
-              InjectionPoints: [{PC: "0x807860", Frameless: false}]
+              InjectionPoints: [{PC: "0x807940", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1773,7 +1773,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1681 EventRootType Probe[main.testInlinedBBB]
-              InjectionPoints: [{PC: "0x8077b4", Frameless: false}]
+              InjectionPoints: [{PC: "0x807894", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBBB
@@ -1791,11 +1791,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1431 EventRootType Probe[main.testInlinedBC]
-              InjectionPoints: [{PC: "0x807898", Frameless: false}]
+              InjectionPoints: [{PC: "0x807978", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1432 EventRootType Probe[main.testInlinedBC]Return
-              InjectionPoints: [{PC: "0x807974", Frameless: false}]
+              InjectionPoints: [{PC: "0x807a54", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBC
@@ -1813,7 +1813,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1682 EventRootType Probe[main.testInlinedBCA]
-              InjectionPoints: [{PC: "0x80789c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80797c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1834,7 +1834,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1683 EventRootType Probe[main.testInlinedBCA]Line
-              InjectionPoints: [{PC: "0x80789c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80797c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1852,7 +1852,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1684 EventRootType Probe[main.testInlinedBCB]
-              InjectionPoints: [{PC: "0x807940", Frameless: false}]
+              InjectionPoints: [{PC: "0x807a20", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1873,7 +1873,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1685 EventRootType Probe[main.testInlinedBCB]Line
-              InjectionPoints: [{PC: "0x807940", Frameless: false}]
+              InjectionPoints: [{PC: "0x807a20", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1894,7 +1894,7 @@ Probes:
               InjectionPoints:
                 - PC: "0x139638"
                   Frameless: true
-                - PC: "0x8081b4"
+                - PC: "0x8083c0"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1915,20 +1915,20 @@ Probes:
             - Kind: Entry
               Type: 1678 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
-                - PC: "0x807548"
+                - PC: "0x807628"
                   Frameless: false
-                - PC: "0x8075bc"
+                - PC: "0x80769c"
                   Frameless: false
-                - PC: "0x8076f0"
+                - PC: "0x8077d0"
                   Frameless: false
-                - PC: "0x807774"
+                - PC: "0x807854"
                   Frameless: false
-                - PC: "0x80782c"
+                - PC: "0x80790c"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1679 EventRootType Probe[main.testInlinedPrint]Return
-              InjectionPoints: [{PC: "0x80757c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80765c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1954,15 +1954,15 @@ Probes:
             - Kind: Line
               Type: 1680 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x807548"
+                - PC: "0x807628"
                   Frameless: false
-                - PC: "0x8075bc"
+                - PC: "0x80769c"
                   Frameless: false
-                - PC: "0x8076f0"
+                - PC: "0x8077d0"
                   Frameless: false
-                - PC: "0x807774"
+                - PC: "0x807854"
                   Frameless: false
-                - PC: "0x80782c"
+                - PC: "0x80790c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1985,7 +1985,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1686 EventRootType Probe[main.testInlinedSq]
-              InjectionPoints: [{PC: "0x807994", Frameless: true}]
+              InjectionPoints: [{PC: "0x807a74", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2010,7 +2010,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1687 EventRootType Probe[main.testInlinedSq]Line
-              InjectionPoints: [{PC: "0x807994", Frameless: true}]
+              InjectionPoints: [{PC: "0x807a74", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2034,9 +2034,9 @@ Probes:
             - Kind: Entry
               Type: 1688 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
-                - PC: "0x8079c4"
+                - PC: "0x807aa4"
                   Frameless: false
-                - PC: "0x807a4c"
+                - PC: "0x807b2c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2059,7 +2059,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1376 EventRootType Probe[main.testInt16Array]
-              InjectionPoints: [{PC: "0x803740", Frameless: true}]
+              InjectionPoints: [{PC: "0x803820", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2081,7 +2081,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1377 EventRootType Probe[main.testInt32Array]
-              InjectionPoints: [{PC: "0x803750", Frameless: true}]
+              InjectionPoints: [{PC: "0x803830", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2103,7 +2103,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1378 EventRootType Probe[main.testInt64Array]
-              InjectionPoints: [{PC: "0x803760", Frameless: true}]
+              InjectionPoints: [{PC: "0x803840", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2125,7 +2125,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1375 EventRootType Probe[main.testInt8Array]
-              InjectionPoints: [{PC: "0x803730", Frameless: true}]
+              InjectionPoints: [{PC: "0x803810", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2147,7 +2147,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1374 EventRootType Probe[main.testIntArray]
-              InjectionPoints: [{PC: "0x803720", Frameless: true}]
+              InjectionPoints: [{PC: "0x803800", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2169,7 +2169,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1438 EventRootType Probe[main.testInterface]
-              InjectionPoints: [{PC: "0x807c00", Frameless: true}]
+              InjectionPoints: [{PC: "0x807ce0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -2190,11 +2190,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1569 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0x80b460", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b600", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1570 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x80b590", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b730", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2216,7 +2216,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1477 EventRootType Probe[main.testLinkedList]
-              InjectionPoints: [{PC: "0x809ba0", Frameless: true}]
+              InjectionPoints: [{PC: "0x809d40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -2241,7 +2241,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1416 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x80420c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8042ec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2263,7 +2263,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1417 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x8042ac", Frameless: false}]
+              InjectionPoints: [{PC: "0x80438c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2285,7 +2285,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1418 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x804350", Frameless: false}]
+              InjectionPoints: [{PC: "0x804430", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2328,11 +2328,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1575 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0x80b8cc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ba6c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1576 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0x80ba20", Frameless: false}]
+              InjectionPoints: [{PC: "0x80bbc0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2395,7 +2395,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1419 EventRootType Probe[main.testManyPointers]
-              InjectionPoints: [{PC: "0x8046d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8047b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2419,7 +2419,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1420 EventRootType Probe[main.testManyStrings]
-              InjectionPoints: [{PC: "0x806280", Frameless: true}]
+              InjectionPoints: [{PC: "0x806360", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{ss}'
@@ -2441,7 +2441,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1449 EventRootType Probe[main.testMapArrayToArray]
-              InjectionPoints: [{PC: "0x8082c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x808460", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2463,7 +2463,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1456 EventRootType Probe[main.testMapEmbeddedMaps]
-              InjectionPoints: [{PC: "0x808320", Frameless: true}]
+              InjectionPoints: [{PC: "0x8084c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2485,7 +2485,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1466 EventRootType Probe[main.testMapEmptyKey]
-              InjectionPoints: [{PC: "0x8083c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x808560", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2507,7 +2507,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1468 EventRootType Probe[main.testMapEmptyKeyAndValue]
-              InjectionPoints: [{PC: "0x8083e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x808580", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2529,7 +2529,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1467 EventRootType Probe[main.testMapEmptyValue]
-              InjectionPoints: [{PC: "0x8083d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x808570", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2551,7 +2551,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1453 EventRootType Probe[main.testMapIntToInt]
-              InjectionPoints: [{PC: "0x808300", Frameless: true}]
+              InjectionPoints: [{PC: "0x8084a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2573,7 +2573,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1465 EventRootType Probe[main.testMapLargeKeyLargeValue]
-              InjectionPoints: [{PC: "0x8083b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x808550", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2595,7 +2595,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1464 EventRootType Probe[main.testMapLargeKeySmallValue]
-              InjectionPoints: [{PC: "0x8083a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x808540", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2619,7 +2619,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1454 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x808310", Frameless: true}]
+              InjectionPoints: [{PC: "0x8084b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2643,7 +2643,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1455 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x808310", Frameless: true}]
+              InjectionPoints: [{PC: "0x8084b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2665,7 +2665,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1463 EventRootType Probe[main.testMapSmallKeyLargeValue]
-              InjectionPoints: [{PC: "0x808390", Frameless: true}]
+              InjectionPoints: [{PC: "0x808530", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2687,7 +2687,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1462 EventRootType Probe[main.testMapSmallKeySmallValue]
-              InjectionPoints: [{PC: "0x808380", Frameless: true}]
+              InjectionPoints: [{PC: "0x808520", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2709,7 +2709,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1447 EventRootType Probe[main.testMapStringToInt]
-              InjectionPoints: [{PC: "0x8082a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x808440", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2731,7 +2731,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1448 EventRootType Probe[main.testMapStringToSlice]
-              InjectionPoints: [{PC: "0x8082b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x808450", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2753,7 +2753,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1446 EventRootType Probe[main.testMapStringToStruct]
-              InjectionPoints: [{PC: "0x808290", Frameless: true}]
+              InjectionPoints: [{PC: "0x808430", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2775,7 +2775,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1457 EventRootType Probe[main.testMapWithLinkedList]
-              InjectionPoints: [{PC: "0x808330", Frameless: true}]
+              InjectionPoints: [{PC: "0x8084d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2797,7 +2797,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1460 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-              InjectionPoints: [{PC: "0x808360", Frameless: true}]
+              InjectionPoints: [{PC: "0x808500", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2819,7 +2819,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1461 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-              InjectionPoints: [{PC: "0x808370", Frameless: true}]
+              InjectionPoints: [{PC: "0x808510", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2841,7 +2841,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1458 EventRootType Probe[main.testMapWithSmallValue]
-              InjectionPoints: [{PC: "0x808340", Frameless: true}]
+              InjectionPoints: [{PC: "0x8084e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2865,7 +2865,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1459 EventRootType Probe[main.testMapWithSmallValueMassive]
-              InjectionPoints: [{PC: "0x808350", Frameless: true}]
+              InjectionPoints: [{PC: "0x8084f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2887,7 +2887,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1609 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x80c790", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cbf0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2910,7 +2910,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1610 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x80c790", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cbf0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2957,11 +2957,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1577 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0x80ba80", Frameless: false}]
+              InjectionPoints: [{PC: "0x80bc20", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1578 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0x80bc0c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80bdac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -3027,11 +3027,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1581 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0x80bcfc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80be9c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1582 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0x80bd98", Frameless: false}]
+              InjectionPoints: [{PC: "0x80bf38", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3062,11 +3062,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1573 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0x80b6c0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b860", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1574 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0x80b868", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ba08", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3092,11 +3092,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1514 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80a768", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a908", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1515 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80a7ec", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a98c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3132,7 +3132,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1472 EventRootType Probe[main.testMultipleSimpleParams]
-              InjectionPoints: [{PC: "0x809830", Frameless: true}]
+              InjectionPoints: [{PC: "0x8099d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -3173,11 +3173,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1508 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x80a6c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a868", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1509 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x80a724", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a8c4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3201,11 +3201,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1510 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x80a6c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a868", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1511 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x80a724", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a8c4", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
       version: 0
@@ -3224,11 +3224,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1516 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80a768", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a908", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1517 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80a7ec", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a98c", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
       version: 0
@@ -3248,11 +3248,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1518 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80a768", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a908", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1519 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80a7ec", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a98c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r1={result} r2={result2}
@@ -3285,11 +3285,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1512 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x80a6c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a868", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1513 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x80a724", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a8c4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Parameter {i} * 2 = result {result}
@@ -3317,7 +3317,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1618 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80ca20", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ce80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3342,7 +3342,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1619 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80ca20", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ce80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3373,7 +3373,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1620 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80ca20", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ce80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3398,7 +3398,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1621 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80ca20", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ce80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3425,7 +3425,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1482 EventRootType Probe[main.testNilPointer]
-              InjectionPoints: [{PC: "0x809c70", Frameless: true}]
+              InjectionPoints: [{PC: "0x809e10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}, {a}'
@@ -3452,7 +3452,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1595 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0x80c3e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c580", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3479,7 +3479,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1592 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0x80c3b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c550", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3514,7 +3514,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1594 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0x80c3d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c570", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3546,7 +3546,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1608 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0x80c780", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cbe0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3568,7 +3568,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1478 EventRootType Probe[main.testPointerLoop]
-              InjectionPoints: [{PC: "0x809bb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x809d50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3590,7 +3590,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1452 EventRootType Probe[main.testPointerToMap]
-              InjectionPoints: [{PC: "0x8082f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x808490", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3612,7 +3612,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1476 EventRootType Probe[main.testPointerToSimpleStruct]
-              InjectionPoints: [{PC: "0x809b90", Frameless: true}]
+              InjectionPoints: [{PC: "0x809d30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3636,11 +3636,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1484 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x809fa8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a148", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1485 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x809fe8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a188", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
       version: 0
@@ -3660,11 +3660,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1528 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x80a828", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a9c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1529 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x80a8b0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80aa50", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3707,11 +3707,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1494 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x80a0c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a268", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1495 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x80a158", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a2f8", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3751,11 +3751,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1486 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x809fa8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a148", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1487 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x809fe8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a188", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3798,11 +3798,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1496 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x80a0c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a268", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1497 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x80a158", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a2f8", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3844,11 +3844,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1530 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x80a828", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a9c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1531 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x80a8b0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80aa50", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
       version: 0
@@ -3865,11 +3865,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1532 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x80a828", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a9c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1533 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x80a8b0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80aa50", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r0={@return.r0}
@@ -3891,11 +3891,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1488 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x809fa8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a148", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1489 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x809fe8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a188", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: result={@return}
@@ -3918,18 +3918,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1504 EventRootType Probe[main.testReturnsAny]
-              InjectionPoints: [{PC: "0x80a398", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a538", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1505 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
-                - PC: "0x80a420"
+                - PC: "0x80a5c0"
                   Frameless: false
-                - PC: "0x80a474"
+                - PC: "0x80a614"
                   Frameless: false
-                - PC: "0x80a52c"
+                - PC: "0x80a6cc"
                   Frameless: false
-                - PC: "0x80a540"
+                - PC: "0x80a6e0"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3957,18 +3957,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1502 EventRootType Probe[main.testReturnsAnyAndError]
-              InjectionPoints: [{PC: "0x80a218", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a3b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1503 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
-                - PC: "0x80a26c"
+                - PC: "0x80a40c"
                   Frameless: false
-                - PC: "0x80a2c8"
+                - PC: "0x80a468"
                   Frameless: false
-                - PC: "0x80a310"
+                - PC: "0x80a4b0"
                   Frameless: false
-                - PC: "0x80a354"
+                - PC: "0x80a4f4"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3995,11 +3995,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1547 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0x80ae9c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b03c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1548 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0x80aeec", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b08c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -4016,11 +4016,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1549 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0x80af28", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b0c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1550 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0x80af60", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b100", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -4037,11 +4037,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1551 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0x80af98", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b138", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1552 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0x80afcc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b16c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4058,11 +4058,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1555 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0x80b088", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b228", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1556 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0x80b0e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b288", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4079,11 +4079,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1567 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0x80b3e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b588", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1568 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0x80b424", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b5c4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4100,11 +4100,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1543 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0x80ad58", Frameless: false}]
+              InjectionPoints: [{PC: "0x80aef8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1544 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0x80ada0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80af40", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4122,14 +4122,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1500 EventRootType Probe[main.testReturnsError]
-              InjectionPoints: [{PC: "0x80a198", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a338", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1501 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
-                - PC: "0x80a1cc"
+                - PC: "0x80a36c"
                   Frameless: false
-                - PC: "0x80a1e0"
+                - PC: "0x80a380"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4151,11 +4151,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1490 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x809fa8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a148", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1491 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x809fe8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a188", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4176,11 +4176,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1498 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x80a0c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a268", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1499 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x80a158", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a2f8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4201,11 +4201,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1492 EventRootType Probe[main.testReturnsIntPointer]
-              InjectionPoints: [{PC: "0x80a028", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a1c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1493 EventRootType Probe[main.testReturnsIntPointer]Return
-              InjectionPoints: [{PC: "0x80a084", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a224", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4227,14 +4227,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1506 EventRootType Probe[main.testReturnsInterface]
-              InjectionPoints: [{PC: "0x80a578", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a718", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1507 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
-                - PC: "0x80a630"
+                - PC: "0x80a7d0"
                   Frameless: false
-                - PC: "0x80a644"
+                - PC: "0x80a7e4"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4256,11 +4256,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1545 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0x80ade0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80af80", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1546 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0x80ae60", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b000", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4277,11 +4277,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1541 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0x80aca8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ae48", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1542 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0x80ad28", Frameless: false}]
+              InjectionPoints: [{PC: "0x80aec8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4298,11 +4298,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1559 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0x80b1e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b388", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1560 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0x80b23c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b3dc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4319,11 +4319,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1553 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0x80b008", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b1a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1554 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0x80b04c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b1ec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4340,11 +4340,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1565 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0x80b378", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b518", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1566 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0x80b3b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b558", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
@@ -4364,7 +4364,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1538 EventRootType Probe[main.testReturnsNamedDeferLine]Line
-              InjectionPoints: [{PC: "0x80aa74", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ac14", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4385,11 +4385,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1563 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0x80b308", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b4a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1564 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0x80b344", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b4e4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4406,11 +4406,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1539 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0x80ac18", Frameless: false}]
+              InjectionPoints: [{PC: "0x80adb8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1540 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0x80ac6c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ae0c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4427,11 +4427,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1561 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0x80b27c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b41c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1562 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0x80b2cc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b46c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4448,11 +4448,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1557 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0x80b120", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b2c0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1558 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0x80b1b0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b350", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4470,7 +4470,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1371 EventRootType Probe[main.testRuneArray]
-              InjectionPoints: [{PC: "0x8036f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8037d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4505,11 +4505,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1520 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80a768", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a908", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1521 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80a7ec", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a98c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -4555,7 +4555,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1392 EventRootType Probe[main.testSingleBool]
-              InjectionPoints: [{PC: "0x803b80", Frameless: true}]
+              InjectionPoints: [{PC: "0x803c60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4577,7 +4577,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1390 EventRootType Probe[main.testSingleByte]
-              InjectionPoints: [{PC: "0x803b60", Frameless: true}]
+              InjectionPoints: [{PC: "0x803c40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4599,7 +4599,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1403 EventRootType Probe[main.testSingleFloat32]
-              InjectionPoints: [{PC: "0x803c30", Frameless: true}]
+              InjectionPoints: [{PC: "0x803d10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4617,7 +4617,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1404 EventRootType Probe[main.testSingleFloat64]
-              InjectionPoints: [{PC: "0x803c40", Frameless: true}]
+              InjectionPoints: [{PC: "0x803d20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4635,7 +4635,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1393 EventRootType Probe[main.testSingleInt]
-              InjectionPoints: [{PC: "0x803b90", Frameless: true}]
+              InjectionPoints: [{PC: "0x803c70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4657,7 +4657,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1395 EventRootType Probe[main.testSingleInt16]
-              InjectionPoints: [{PC: "0x803bb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x803c90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}
@@ -4680,7 +4680,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1396 EventRootType Probe[main.testSingleInt32]
-              InjectionPoints: [{PC: "0x803bc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x803ca0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4702,7 +4702,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1397 EventRootType Probe[main.testSingleInt64]
-              InjectionPoints: [{PC: "0x803bd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x803cb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4731,7 +4731,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1394 EventRootType Probe[main.testSingleInt8]
-              InjectionPoints: [{PC: "0x803ba0", Frameless: true}]
+              InjectionPoints: [{PC: "0x803c80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}{x}{x}
@@ -4762,7 +4762,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1391 EventRootType Probe[main.testSingleRune]
-              InjectionPoints: [{PC: "0x803b70", Frameless: true}]
+              InjectionPoints: [{PC: "0x803c50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4784,7 +4784,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1602 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0x80c740", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cba0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4806,7 +4806,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1398 EventRootType Probe[main.testSingleUint]
-              InjectionPoints: [{PC: "0x803be0", Frameless: true}]
+              InjectionPoints: [{PC: "0x803cc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4828,7 +4828,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1400 EventRootType Probe[main.testSingleUint16]
-              InjectionPoints: [{PC: "0x803c00", Frameless: true}]
+              InjectionPoints: [{PC: "0x803ce0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4850,7 +4850,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1401 EventRootType Probe[main.testSingleUint32]
-              InjectionPoints: [{PC: "0x803c10", Frameless: true}]
+              InjectionPoints: [{PC: "0x803cf0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4872,7 +4872,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1402 EventRootType Probe[main.testSingleUint64]
-              InjectionPoints: [{PC: "0x803c20", Frameless: true}]
+              InjectionPoints: [{PC: "0x803d00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4894,7 +4894,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1399 EventRootType Probe[main.testSingleUint8]
-              InjectionPoints: [{PC: "0x803bf0", Frameless: true}]
+              InjectionPoints: [{PC: "0x803cd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4916,7 +4916,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1598 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0x80c400", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c5a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -4938,7 +4938,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1589 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0x80c380", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c520", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -4960,7 +4960,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1450 EventRootType Probe[main.testSmallMap]
-              InjectionPoints: [{PC: "0x8082d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x808470", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -4981,11 +4981,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1534 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x80a828", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a9c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1535 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x80a8b0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80aa50", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -5006,11 +5006,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1579 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0x80bc68", Frameless: false}]
+              InjectionPoints: [{PC: "0x80be08", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1580 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0x80bcc4", Frameless: false}]
+              InjectionPoints: [{PC: "0x80be64", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5032,7 +5032,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1372 EventRootType Probe[main.testStringArray]
-              InjectionPoints: [{PC: "0x803700", Frameless: true}]
+              InjectionPoints: [{PC: "0x8037e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5054,7 +5054,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1481 EventRootType Probe[main.testStringPointer]
-              InjectionPoints: [{PC: "0x809c50", Frameless: true}]
+              InjectionPoints: [{PC: "0x809df0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}'
@@ -5076,7 +5076,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1593 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0x80c3c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c560", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5098,7 +5098,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1414 EventRootType Probe[main.testStringType1]
-              InjectionPoints: [{PC: "0x8041d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8042b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5120,7 +5120,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1415 EventRootType Probe[main.testStringType2]
-              InjectionPoints: [{PC: "0x8041e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8042c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5142,7 +5142,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1617 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x80c9c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ce20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5169,7 +5169,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1590 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0x80c390", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c530", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5196,7 +5196,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1444 EventRootType Probe[main.testStructWithAny]
-              InjectionPoints: [{PC: "0x807ce0", Frameless: true}]
+              InjectionPoints: [{PC: "0x807dc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5217,11 +5217,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1583 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0x80bdcc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80bf6c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1584 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0x80be54", Frameless: false}]
+              InjectionPoints: [{PC: "0x80bff4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5243,7 +5243,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1615 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0x80c920", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cd80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5264,7 +5264,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1614 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0x80c910", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cd70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5291,7 +5291,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1445 EventRootType Probe[main.testStructWithMap]
-              InjectionPoints: [{PC: "0x808280", Frameless: true}]
+              InjectionPoints: [{PC: "0x808420", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s} {@duration}'
@@ -5324,7 +5324,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1599 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0x80c410", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c5b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5364,7 +5364,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1613 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0x80c7c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cc20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5397,11 +5397,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1522 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80a768", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a908", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1523 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80a7ec", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a98c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{nonexistentVariable}'
@@ -5422,11 +5422,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1524 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80a768", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a908", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1525 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80a7ec", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a98c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{unsupportedExpression}'
@@ -5449,11 +5449,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1526 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80a768", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a908", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1527 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80a7ec", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a98c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -5485,7 +5485,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1603 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0x80c750", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cbb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5517,7 +5517,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1604 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x80c760", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cbc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5547,7 +5547,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1605 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x80c760", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cbc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5579,7 +5579,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1606 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x80c770", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cbd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5609,7 +5609,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1607 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x80c770", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cbd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5641,7 +5641,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1405 EventRootType Probe[main.testTypeAlias]
-              InjectionPoints: [{PC: "0x803c50", Frameless: true}]
+              InjectionPoints: [{PC: "0x803d30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5663,7 +5663,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1381 EventRootType Probe[main.testUint16Array]
-              InjectionPoints: [{PC: "0x803790", Frameless: true}]
+              InjectionPoints: [{PC: "0x803870", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5685,7 +5685,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1382 EventRootType Probe[main.testUint32Array]
-              InjectionPoints: [{PC: "0x8037a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x803880", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5707,7 +5707,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1383 EventRootType Probe[main.testUint64Array]
-              InjectionPoints: [{PC: "0x8037b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x803890", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5729,7 +5729,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1380 EventRootType Probe[main.testUint8Array]
-              InjectionPoints: [{PC: "0x803780", Frameless: true}]
+              InjectionPoints: [{PC: "0x803860", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5751,7 +5751,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1379 EventRootType Probe[main.testUintArray]
-              InjectionPoints: [{PC: "0x803770", Frameless: true}]
+              InjectionPoints: [{PC: "0x803850", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5773,7 +5773,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1480 EventRootType Probe[main.testUintPointer]
-              InjectionPoints: [{PC: "0x809be0", Frameless: true}]
+              InjectionPoints: [{PC: "0x809d80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5795,7 +5795,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1587 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0x80c360", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c500", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5817,7 +5817,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1611 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0x80c7a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cc00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5839,7 +5839,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1479 EventRootType Probe[main.testUnsafePointer]
-              InjectionPoints: [{PC: "0x809bc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x809d60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5861,7 +5861,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1389 EventRootType Probe[main.testVeryLargeArray]
-              InjectionPoints: [{PC: "0x803820", Frameless: true}]
+              InjectionPoints: [{PC: "0x803900", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5883,7 +5883,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1596 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x80c3f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c590", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5905,7 +5905,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1597 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x80c3f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c590", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5928,14 +5928,14 @@ Probes:
             - Kind: Entry
               Type: 1689 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
-                - PC: "0x807b48"
+                - PC: "0x807c28"
                   Frameless: false
-                - PC: "0x80eaf0"
+                - PC: "0x80ef50"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 1690 EventRootType Probe[main.firstBehavior.DoSomething]Return
-              InjectionPoints: [{PC: "0x807b70", Frameless: false}]
+              InjectionPoints: [{PC: "0x807c50", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testWhollyInlinedSubroutine
@@ -5957,11 +5957,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1585 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0x80be88", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c028", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1586 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x80beec", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c08c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -5978,481 +5978,481 @@ Probes:
 Subprograms:
     - ID: 1
       Name: main.testByteArray
-      OutOfLinePCRanges: [0x8036e0..0x8036f0]
+      OutOfLinePCRanges: [0x8037c0..0x8037d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 116 ArrayType [2]uint8
           Locations:
-            - Range: 0x8036e0..0x8036f0
+            - Range: 0x8037c0..0x8037d0
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 2
       Name: main.testRuneArray
-      OutOfLinePCRanges: [0x8036f0..0x803700]
+      OutOfLinePCRanges: [0x8037d0..0x8037e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 117 ArrayType [2]int32
           Locations:
-            - Range: 0x8036f0..0x803700
+            - Range: 0x8037d0..0x8037e0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 3
       Name: main.testStringArray
-      OutOfLinePCRanges: [0x803700..0x803710]
+      OutOfLinePCRanges: [0x8037e0..0x8037f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 118 ArrayType [2]string
           Locations:
-            - Range: 0x803700..0x803710
+            - Range: 0x8037e0..0x8037f0
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 4
       Name: main.testBoolArray
-      OutOfLinePCRanges: [0x803710..0x803720]
+      OutOfLinePCRanges: [0x8037f0..0x803800]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 119 ArrayType [2]bool
           Locations:
-            - Range: 0x803710..0x803720
+            - Range: 0x8037f0..0x803800
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 5
       Name: main.testIntArray
-      OutOfLinePCRanges: [0x803720..0x803730]
+      OutOfLinePCRanges: [0x803800..0x803810]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 120 ArrayType [2]int
           Locations:
-            - Range: 0x803720..0x803730
+            - Range: 0x803800..0x803810
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 6
       Name: main.testInt8Array
-      OutOfLinePCRanges: [0x803730..0x803740]
+      OutOfLinePCRanges: [0x803810..0x803820]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 121 ArrayType [2]int8
           Locations:
-            - Range: 0x803730..0x803740
+            - Range: 0x803810..0x803820
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 7
       Name: main.testInt16Array
-      OutOfLinePCRanges: [0x803740..0x803750]
+      OutOfLinePCRanges: [0x803820..0x803830]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 122 ArrayType [2]int16
           Locations:
-            - Range: 0x803740..0x803750
+            - Range: 0x803820..0x803830
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 8
       Name: main.testInt32Array
-      OutOfLinePCRanges: [0x803750..0x803760]
+      OutOfLinePCRanges: [0x803830..0x803840]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 117 ArrayType [2]int32
           Locations:
-            - Range: 0x803750..0x803760
+            - Range: 0x803830..0x803840
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 9
       Name: main.testInt64Array
-      OutOfLinePCRanges: [0x803760..0x803770]
+      OutOfLinePCRanges: [0x803840..0x803850]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 123 ArrayType [2]int64
           Locations:
-            - Range: 0x803760..0x803770
+            - Range: 0x803840..0x803850
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 10
       Name: main.testUintArray
-      OutOfLinePCRanges: [0x803770..0x803780]
+      OutOfLinePCRanges: [0x803850..0x803860]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 124 ArrayType [2]uint
           Locations:
-            - Range: 0x803770..0x803780
+            - Range: 0x803850..0x803860
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 11
       Name: main.testUint8Array
-      OutOfLinePCRanges: [0x803780..0x803790]
+      OutOfLinePCRanges: [0x803860..0x803870]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 116 ArrayType [2]uint8
           Locations:
-            - Range: 0x803780..0x803790
+            - Range: 0x803860..0x803870
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 12
       Name: main.testUint16Array
-      OutOfLinePCRanges: [0x803790..0x8037a0]
+      OutOfLinePCRanges: [0x803870..0x803880]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 125 ArrayType [2]uint16
           Locations:
-            - Range: 0x803790..0x8037a0
+            - Range: 0x803870..0x803880
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 13
       Name: main.testUint32Array
-      OutOfLinePCRanges: [0x8037a0..0x8037b0]
+      OutOfLinePCRanges: [0x803880..0x803890]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 126 ArrayType [2]uint32
           Locations:
-            - Range: 0x8037a0..0x8037b0
+            - Range: 0x803880..0x803890
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 14
       Name: main.testUint64Array
-      OutOfLinePCRanges: [0x8037b0..0x8037c0]
+      OutOfLinePCRanges: [0x803890..0x8038a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 59 ArrayType [2]uint64
           Locations:
-            - Range: 0x8037b0..0x8037c0
+            - Range: 0x803890..0x8038a0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 15
       Name: main.testArrayOfArrays
-      OutOfLinePCRanges: [0x8037c0..0x8037d0]
+      OutOfLinePCRanges: [0x8038a0..0x8038b0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 127 ArrayType [2][2]int
           Locations:
-            - Range: 0x8037c0..0x8037d0
+            - Range: 0x8038a0..0x8038b0
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 16
       Name: main.testArrayOfStrings
-      OutOfLinePCRanges: [0x8037d0..0x8037e0]
+      OutOfLinePCRanges: [0x8038b0..0x8038c0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 118 ArrayType [2]string
           Locations:
-            - Range: 0x8037d0..0x8037e0
+            - Range: 0x8038b0..0x8038c0
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 17
       Name: main.testArrayOfArraysOfArrays
-      OutOfLinePCRanges: [0x8037e0..0x8037f0]
+      OutOfLinePCRanges: [0x8038c0..0x8038d0]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 128 ArrayType [2][2][2]int
           Locations:
-            - Range: 0x8037e0..0x8037f0
+            - Range: 0x8038c0..0x8038d0
               Pieces: [{Size: 64, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 18
       Name: main.testArrayOfStructs
-      OutOfLinePCRanges: [0x8037f0..0x803800]
+      OutOfLinePCRanges: [0x8038d0..0x8038e0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 129 ArrayType [2]main.nestedStruct
           Locations:
-            - Range: 0x8037f0..0x803800
+            - Range: 0x8038d0..0x8038e0
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 19
       Name: main.testArrayEmptyStructs
-      OutOfLinePCRanges: [0x803800..0x803810]
+      OutOfLinePCRanges: [0x8038e0..0x8038f0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 131 ArrayType [2]struct {}
           Locations:
-            - Range: 0x803800..0x803810
+            - Range: 0x8038e0..0x8038f0
               Pieces: [{Size: 0, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 20
       Name: main.testVeryLargeArray
-      OutOfLinePCRanges: [0x803820..0x803830]
+      OutOfLinePCRanges: [0x803900..0x803910]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 133 ArrayType [100]uint
           Locations:
-            - Range: 0x803820..0x803830
+            - Range: 0x803900..0x803910
               Pieces: [{Size: 800, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 21
       Name: main.testSingleByte
-      OutOfLinePCRanges: [0x803b60..0x803b70]
+      OutOfLinePCRanges: [0x803c40..0x803c50]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x803b60..0x803b70
+            - Range: 0x803c40..0x803c50
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 22
       Name: main.testSingleRune
-      OutOfLinePCRanges: [0x803b70..0x803b80]
+      OutOfLinePCRanges: [0x803c50..0x803c60]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x803b70..0x803b80
+            - Range: 0x803c50..0x803c60
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 23
       Name: main.testSingleBool
-      OutOfLinePCRanges: [0x803b80..0x803b90]
+      OutOfLinePCRanges: [0x803c60..0x803c70]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x803b80..0x803b90
+            - Range: 0x803c60..0x803c70
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 24
       Name: main.testSingleInt
-      OutOfLinePCRanges: [0x803b90..0x803ba0]
+      OutOfLinePCRanges: [0x803c70..0x803c80]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0x803b90..0x803ba0
+            - Range: 0x803c70..0x803c80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 25
       Name: main.testSingleInt8
-      OutOfLinePCRanges: [0x803ba0..0x803bb0]
+      OutOfLinePCRanges: [0x803c80..0x803c90]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 20 BaseType int8
           Locations:
-            - Range: 0x803ba0..0x803bb0
+            - Range: 0x803c80..0x803c90
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 26
       Name: main.testSingleInt16
-      OutOfLinePCRanges: [0x803bb0..0x803bc0]
+      OutOfLinePCRanges: [0x803c90..0x803ca0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 103 BaseType int16
           Locations:
-            - Range: 0x803bb0..0x803bc0
+            - Range: 0x803c90..0x803ca0
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 27
       Name: main.testSingleInt32
-      OutOfLinePCRanges: [0x803bc0..0x803bd0]
+      OutOfLinePCRanges: [0x803ca0..0x803cb0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x803bc0..0x803bd0
+            - Range: 0x803ca0..0x803cb0
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 28
       Name: main.testSingleInt64
-      OutOfLinePCRanges: [0x803bd0..0x803be0]
+      OutOfLinePCRanges: [0x803cb0..0x803cc0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 BaseType int64
           Locations:
-            - Range: 0x803bd0..0x803be0
+            - Range: 0x803cb0..0x803cc0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 29
       Name: main.testSingleUint
-      OutOfLinePCRanges: [0x803be0..0x803bf0]
+      OutOfLinePCRanges: [0x803cc0..0x803cd0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x803be0..0x803bf0
+            - Range: 0x803cc0..0x803cd0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 30
       Name: main.testSingleUint8
-      OutOfLinePCRanges: [0x803bf0..0x803c00]
+      OutOfLinePCRanges: [0x803cd0..0x803ce0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x803bf0..0x803c00
+            - Range: 0x803cd0..0x803ce0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 31
       Name: main.testSingleUint16
-      OutOfLinePCRanges: [0x803c00..0x803c10]
+      OutOfLinePCRanges: [0x803ce0..0x803cf0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType uint16
           Locations:
-            - Range: 0x803c00..0x803c10
+            - Range: 0x803ce0..0x803cf0
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 32
       Name: main.testSingleUint32
-      OutOfLinePCRanges: [0x803c10..0x803c20]
+      OutOfLinePCRanges: [0x803cf0..0x803d00]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint32
           Locations:
-            - Range: 0x803c10..0x803c20
+            - Range: 0x803cf0..0x803d00
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 33
       Name: main.testSingleUint64
-      OutOfLinePCRanges: [0x803c20..0x803c30]
+      OutOfLinePCRanges: [0x803d00..0x803d10]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0x803c20..0x803c30
+            - Range: 0x803d00..0x803d10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 34
       Name: main.testSingleFloat32
-      OutOfLinePCRanges: [0x803c30..0x803c40]
+      OutOfLinePCRanges: [0x803d10..0x803d20]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 18 BaseType float32
           Locations:
-            - Range: 0x803c30..0x803c40
+            - Range: 0x803d10..0x803d20
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 35
       Name: main.testSingleFloat64
-      OutOfLinePCRanges: [0x803c40..0x803c50]
+      OutOfLinePCRanges: [0x803d20..0x803d30]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 BaseType float64
           Locations:
-            - Range: 0x803c40..0x803c50
+            - Range: 0x803d20..0x803d30
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 36
       Name: main.testTypeAlias
-      OutOfLinePCRanges: [0x803c50..0x803c60]
+      OutOfLinePCRanges: [0x803d30..0x803d40]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 134 BaseType main.typeAlias
           Locations:
-            - Range: 0x803c50..0x803c60
+            - Range: 0x803d30..0x803d40
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 37
       Name: main.testBigStruct
-      OutOfLinePCRanges: [0x803d50..0x803d60]
+      OutOfLinePCRanges: [0x803e30..0x803e40]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 135 StructureType main.bigStruct
           Locations:
-            - Range: 0x803d50..0x803d60
+            - Range: 0x803e30..0x803e40
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6471,42 +6471,42 @@ Subprograms:
       DictRegister: null
     - ID: 38
       Name: main.testErrorAtLine
-      OutOfLinePCRanges: [0x803d80..0x803e90]
+      OutOfLinePCRanges: [0x803e60..0x803f70]
       InlinePCRanges: []
       Variables:
         - Name: shouldErr
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x803d80..0x803da0
+            - Range: 0x803e60..0x803e80
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
-          Locations: [{Range: 0x803d80..0x803e90, Pieces: []}]
+          Locations: [{Range: 0x803e60..0x803f70, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 8 BaseType int
-          Locations: [{Range: 0x803d80..0x803e90, Pieces: []}]
+          Locations: [{Range: 0x803e60..0x803f70, Pieces: []}]
           Role: Local
           DictIndex: -1
         - Name: err
           Type: 16 GoInterfaceType error
           Locations:
-            - Range: 0x803d98..0x803ddc
+            - Range: 0x803e78..0x803ebc
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
-            - Range: 0x803ddc..0x803e3c
+            - Range: 0x803ebc..0x803f1c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
-            - Range: 0x803e3c..0x803e90
+            - Range: 0x803f1c..0x803f70
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -64}
@@ -6517,39 +6517,39 @@ Subprograms:
       DictRegister: null
     - ID: 39
       Name: main.testDeepPtr1
-      OutOfLinePCRanges: [0x803f20..0x803f30]
+      OutOfLinePCRanges: [0x804000..0x804010]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 139 StructureType main.deepPtr1
           Locations:
-            - Range: 0x803f20..0x803f30
+            - Range: 0x804000..0x804010
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 40
       Name: main.testDeepPtr7
-      OutOfLinePCRanges: [0x803f30..0x803f40]
+      OutOfLinePCRanges: [0x804010..0x804020]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 142 PointerType *main.deepPtr7
           Locations:
-            - Range: 0x803f30..0x803f40
+            - Range: 0x804010..0x804020
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 41
       Name: main.testDeepSlice1
-      OutOfLinePCRanges: [0x804050..0x804060]
+      OutOfLinePCRanges: [0x804130..0x804140]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 144 StructureType main.deepSlice1
           Locations:
-            - Range: 0x804050..0x804060
+            - Range: 0x804130..0x804140
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6562,134 +6562,134 @@ Subprograms:
       DictRegister: null
     - ID: 42
       Name: main.testDeepSlice7
-      OutOfLinePCRanges: [0x804060..0x804070]
+      OutOfLinePCRanges: [0x804140..0x804150]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 148 PointerType *main.deepSlice7
           Locations:
-            - Range: 0x804060..0x804070
+            - Range: 0x804140..0x804150
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 43
       Name: main.testDeepMap1
-      OutOfLinePCRanges: [0x8041b0..0x8041c0]
+      OutOfLinePCRanges: [0x804290..0x8042a0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 150 StructureType main.deepMap1
           Locations:
-            - Range: 0x8041b0..0x8041c0
+            - Range: 0x804290..0x8042a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 44
       Name: main.testDeepMap7
-      OutOfLinePCRanges: [0x8041c0..0x8041d0]
+      OutOfLinePCRanges: [0x8042a0..0x8042b0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 156 PointerType *main.deepMap7
           Locations:
-            - Range: 0x8041c0..0x8041d0
+            - Range: 0x8042a0..0x8042b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 45
       Name: main.testStringType1
-      OutOfLinePCRanges: [0x8041d0..0x8041e0]
+      OutOfLinePCRanges: [0x8042b0..0x8042c0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 158 PointerType *main.stringType1
           Locations:
-            - Range: 0x8041d0..0x8041e0
+            - Range: 0x8042b0..0x8042c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 46
       Name: main.testStringType2
-      OutOfLinePCRanges: [0x8041e0..0x8041f0]
+      OutOfLinePCRanges: [0x8042c0..0x8042d0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 160 PointerType **main.stringType2
           Locations:
-            - Range: 0x8041e0..0x8041f0
+            - Range: 0x8042c0..0x8042d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 47
       Name: main.testLongFunctionWithChangingState
-      OutOfLinePCRanges: [0x8041f0..0x8043d0]
+      OutOfLinePCRanges: [0x8042d0..0x8044b0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 8 BaseType int
           Locations:
-            - Range: 0x8042ac..0x8042c0
+            - Range: 0x80438c..0x8043a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x804350..0x804364
+            - Range: 0x804430..0x804444
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: aPerArch
           Type: 8 BaseType int
           Locations:
-            - Range: 0x804210..0x8043d0
+            - Range: 0x8042f0..0x8044b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80428c..0x804298
+            - Range: 0x80436c..0x804378
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x804298..0x804298
+            - Range: 0x804378..0x804378
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x804298..0x8042ac
+            - Range: 0x804378..0x80438c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8042ac..0x804344
+            - Range: 0x80438c..0x804424
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0x804344..0x804348
+            - Range: 0x804424..0x804428
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0x804348..0x80434c
+            - Range: 0x804428..0x80442c
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x80434c..0x804364
+            - Range: 0x80442c..0x804444
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x804364..0x8043d0
+            - Range: 0x804444..0x8044b0
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 48
       Name: main.testManyPointers
-      OutOfLinePCRanges: [0x8046d0..0x8046e0]
+      OutOfLinePCRanges: [0x8047b0..0x8047c0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 162 StructureType main.manyPointers
           Locations:
-            - Range: 0x8046d0..0x8046e0
+            - Range: 0x8047b0..0x8047c0
               Pieces: [{Size: 560, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 49
       Name: main.testManyStrings
-      OutOfLinePCRanges: [0x806280..0x806290]
+      OutOfLinePCRanges: [0x806360..0x806370]
       InlinePCRanges: []
       Variables:
         - Name: ss
           Type: 165 GoSliceHeaderType []string
           Locations:
-            - Range: 0x806280..0x806290
+            - Range: 0x806360..0x806370
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6702,13 +6702,13 @@ Subprograms:
       DictRegister: null
     - ID: 50
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0x806550..0x806610]
+      OutOfLinePCRanges: [0x806630..0x8066f0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 166 StructureType main.esotericStack
           Locations:
-            - Range: 0x806550..0x806588
+            - Range: 0x806630..0x806668
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -6728,7 +6728,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x806588..0x80658c
+            - Range: 0x806668..0x80666c
               Pieces:
                 - Size: 4
                   Op: null
@@ -6748,7 +6748,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x80658c..0x806590
+            - Range: 0x80666c..0x806670
               Pieces:
                 - Size: 4
                   Op: null
@@ -6773,251 +6773,151 @@ Subprograms:
       DictRegister: null
     - ID: 51
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0x806610..0x806680]
+      OutOfLinePCRanges: [0x8066f0..0x806760]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 170 PointerType *main.esotericHeap
           Locations:
-            - Range: 0x806610..0x806644
+            - Range: 0x8066f0..0x806724
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 52
       Name: main.testInlinedBA
-      OutOfLinePCRanges: [0x8076c0..0x807750]
+      OutOfLinePCRanges: [0x8077a0..0x807830]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0x8076c0..0x8076f0
+            - Range: 0x8077a0..0x8077d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 53
       Name: main.testInlinedBB
-      OutOfLinePCRanges: [0x807750..0x807810]
+      OutOfLinePCRanges: [0x807830..0x8078f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0x807750..0x80776c
+            - Range: 0x807830..0x80784c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: "y"
           Type: 8 BaseType int
           Locations:
-            - Range: 0x807750..0x80777c
+            - Range: 0x807830..0x80785c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: z
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80776c..0x80777c
+            - Range: 0x80784c..0x80785c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80777c..0x807810
+            - Range: 0x80785c..0x8078f0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 54
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0x807810..0x807880]
+      OutOfLinePCRanges: [0x8078f0..0x807960]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0x807810..0x807834
+            - Range: 0x8078f0..0x807914
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 55
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0x807880..0x807990]
+      OutOfLinePCRanges: [0x807960..0x807a70]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80789c..0x807908
+            - Range: 0x80797c..0x8079e8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x807908..0x807910
+            - Range: 0x8079e8..0x8079f0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80789c..0x807908
+            - Range: 0x80797c..0x8079e8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x807908..0x80790c
+            - Range: 0x8079e8..0x8079ec
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 56
       Name: main.testFrameless
-      OutOfLinePCRanges: [0x807990..0x8079a0]
+      OutOfLinePCRanges: [0x807a70..0x807a80]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0x807990..0x807998
+            - Range: 0x807a70..0x807a78
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x807990..0x807998
+            - Range: 0x807a70..0x807a78
               Pieces: []
-            - Range: 0x807998..0x807999
+            - Range: 0x807a78..0x807a79
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x807999..0x8079a0
+            - Range: 0x807a79..0x807a80
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 57
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0x8079a0..0x8079f0]
+      OutOfLinePCRanges: [0x807a80..0x807ad0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 172 ArrayType [5]int
           Locations:
-            - Range: 0x8079a0..0x8079f0
+            - Range: 0x807a80..0x807ad0
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x8079a0..0x8079e0
+            - Range: 0x807a80..0x807ac0
               Pieces: []
-            - Range: 0x8079e0..0x8079e1
+            - Range: 0x807ac0..0x807ac1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8079e1..0x8079f0
+            - Range: 0x807ac1..0x807ad0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 58
       Name: main.testInterface
-      OutOfLinePCRanges: [0x807c00..0x807c10]
+      OutOfLinePCRanges: [0x807ce0..0x807cf0]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 173 GoInterfaceType main.behavior
-          Locations:
-            - Range: 0x807c00..0x807c10
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 59
-      Name: main.testAny
-      OutOfLinePCRanges: [0x807c10..0x807c70]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 168 GoEmptyInterfaceType interface {}
-          Locations:
-            - Range: 0x807c10..0x807c3c
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x807c3c..0x807c40
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-        - Name: ~r0
-          Type: 10 GoStringHeaderType string
-          Locations:
-            - Range: 0x807c10..0x807c50
-              Pieces: []
-            - Range: 0x807c50..0x807c51
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x807c51..0x807c70
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-      DictRegister: null
-    - ID: 60
-      Name: main.testError
-      OutOfLinePCRanges: [0x807c70..0x807c80]
-      InlinePCRanges: []
-      Variables:
-        - Name: e
-          Type: 16 GoInterfaceType error
-          Locations:
-            - Range: 0x807c70..0x807c80
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 61
-      Name: main.testAnyPtr
-      OutOfLinePCRanges: [0x807c80..0x807ce0]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 174 PointerType *interface {}
-          Locations:
-            - Range: 0x807c80..0x807cac
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: ~r0
-          Type: 10 GoStringHeaderType string
-          Locations:
-            - Range: 0x807c80..0x807cc0
-              Pieces: []
-            - Range: 0x807cc0..0x807cc1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x807cc1..0x807ce0
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-      DictRegister: null
-    - ID: 62
-      Name: main.testStructWithAny
-      OutOfLinePCRanges: [0x807ce0..0x807cf0]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 175 StructureType main.structWithAny
           Locations:
             - Range: 0x807ce0..0x807cf0
               Pieces:
@@ -7028,348 +6928,448 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 59
+      Name: main.testAny
+      OutOfLinePCRanges: [0x807cf0..0x807d50]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 168 GoEmptyInterfaceType interface {}
+          Locations:
+            - Range: 0x807cf0..0x807d1c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x807d1c..0x807d20
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: ~r0
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0x807cf0..0x807d30
+              Pieces: []
+            - Range: 0x807d30..0x807d31
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x807d31..0x807d50
+              Pieces: []
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 60
+      Name: main.testError
+      OutOfLinePCRanges: [0x807d50..0x807d60]
+      InlinePCRanges: []
+      Variables:
+        - Name: e
+          Type: 16 GoInterfaceType error
+          Locations:
+            - Range: 0x807d50..0x807d60
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 61
+      Name: main.testAnyPtr
+      OutOfLinePCRanges: [0x807d60..0x807dc0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 174 PointerType *interface {}
+          Locations:
+            - Range: 0x807d60..0x807d8c
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: ~r0
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0x807d60..0x807da0
+              Pieces: []
+            - Range: 0x807da0..0x807da1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x807da1..0x807dc0
+              Pieces: []
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 62
+      Name: main.testStructWithAny
+      OutOfLinePCRanges: [0x807dc0..0x807dd0]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 175 StructureType main.structWithAny
+          Locations:
+            - Range: 0x807dc0..0x807dd0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 63
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x808280..0x808290]
+      OutOfLinePCRanges: [0x808420..0x808430]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 176 StructureType main.structWithMap
           Locations:
-            - Range: 0x808280..0x808290
+            - Range: 0x808420..0x808430
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 64
       Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x808290..0x8082a0]
+      OutOfLinePCRanges: [0x808430..0x808440]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 182 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0x808290..0x8082a0
+            - Range: 0x808430..0x808440
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 65
       Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0x8082a0..0x8082b0]
+      OutOfLinePCRanges: [0x808440..0x808450]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 187 GoMapType map[string]int
           Locations:
-            - Range: 0x8082a0..0x8082b0
+            - Range: 0x808440..0x808450
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 66
       Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0x8082b0..0x8082c0]
+      OutOfLinePCRanges: [0x808450..0x808460]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 192 GoMapType map[string][]string
           Locations:
-            - Range: 0x8082b0..0x8082c0
+            - Range: 0x808450..0x808460
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 67
       Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0x8082c0..0x8082d0]
+      OutOfLinePCRanges: [0x808460..0x808470]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 197 GoMapType map[[4]string][2]int
           Locations:
-            - Range: 0x8082c0..0x8082d0
+            - Range: 0x808460..0x808470
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 68
       Name: main.testSmallMap
-      OutOfLinePCRanges: [0x8082d0..0x8082e0]
+      OutOfLinePCRanges: [0x808470..0x808480]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 187 GoMapType map[string]int
           Locations:
-            - Range: 0x8082d0..0x8082e0
+            - Range: 0x808470..0x808480
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 69
       Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0x8082e0..0x8082f0]
+      OutOfLinePCRanges: [0x808480..0x808490]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 202 ArrayType [2]map[string]int
           Locations:
-            - Range: 0x8082e0..0x8082f0
+            - Range: 0x808480..0x808490
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 70
       Name: main.testPointerToMap
-      OutOfLinePCRanges: [0x8082f0..0x808300]
+      OutOfLinePCRanges: [0x808490..0x8084a0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 203 PointerType *map[string]int
           Locations:
-            - Range: 0x8082f0..0x808300
+            - Range: 0x808490..0x8084a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 71
       Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0x808300..0x808310]
+      OutOfLinePCRanges: [0x8084a0..0x8084b0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 177 GoMapType map[int]int
           Locations:
-            - Range: 0x808300..0x808310
+            - Range: 0x8084a0..0x8084b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 72
       Name: main.testMapMassive
-      OutOfLinePCRanges: [0x808310..0x808320]
+      OutOfLinePCRanges: [0x8084b0..0x8084c0]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 204 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x808310..0x808320
+            - Range: 0x8084b0..0x8084c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 73
       Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0x808320..0x808330]
+      OutOfLinePCRanges: [0x8084c0..0x8084d0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 204 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x808320..0x808330
+            - Range: 0x8084c0..0x8084d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 74
       Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0x808330..0x808340]
+      OutOfLinePCRanges: [0x8084d0..0x8084e0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 209 GoMapType map[bool]main.node
           Locations:
-            - Range: 0x808330..0x808340
+            - Range: 0x8084d0..0x8084e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 75
       Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0x808340..0x808350]
+      OutOfLinePCRanges: [0x8084e0..0x8084f0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 214 GoMapType map[int]uint8
           Locations:
-            - Range: 0x808340..0x808350
+            - Range: 0x8084e0..0x8084f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 76
       Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0x808350..0x808360]
+      OutOfLinePCRanges: [0x8084f0..0x808500]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 214 GoMapType map[int]uint8
           Locations:
-            - Range: 0x808350..0x808360
+            - Range: 0x8084f0..0x808500
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 77
       Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0x808360..0x808370]
+      OutOfLinePCRanges: [0x808500..0x808510]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 219 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x808360..0x808370
+            - Range: 0x808500..0x808510
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 78
       Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0x808370..0x808380]
+      OutOfLinePCRanges: [0x808510..0x808520]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 219 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x808370..0x808380
+            - Range: 0x808510..0x808520
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 79
       Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0x808380..0x808390]
+      OutOfLinePCRanges: [0x808520..0x808530]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 219 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x808380..0x808390
+            - Range: 0x808520..0x808530
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 80
       Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0x808390..0x8083a0]
+      OutOfLinePCRanges: [0x808530..0x808540]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 224 GoMapType map[uint8][4]int
           Locations:
-            - Range: 0x808390..0x8083a0
+            - Range: 0x808530..0x808540
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 81
       Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0x8083a0..0x8083b0]
+      OutOfLinePCRanges: [0x808540..0x808550]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 229 GoMapType map[[4]int]uint8
           Locations:
-            - Range: 0x8083a0..0x8083b0
+            - Range: 0x808540..0x808550
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 82
       Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0x8083b0..0x8083c0]
+      OutOfLinePCRanges: [0x808550..0x808560]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 234 GoMapType map[[4]int][4]int
           Locations:
-            - Range: 0x8083b0..0x8083c0
+            - Range: 0x808550..0x808560
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 83
       Name: main.testMapEmptyKey
-      OutOfLinePCRanges: [0x8083c0..0x8083d0]
+      OutOfLinePCRanges: [0x808560..0x808570]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 239 GoMapType map[struct {}]int
           Locations:
-            - Range: 0x8083c0..0x8083d0
+            - Range: 0x808560..0x808570
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 84
       Name: main.testMapEmptyValue
-      OutOfLinePCRanges: [0x8083d0..0x8083e0]
+      OutOfLinePCRanges: [0x808570..0x808580]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 244 GoMapType map[int]struct {}
           Locations:
-            - Range: 0x8083d0..0x8083e0
+            - Range: 0x808570..0x808580
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 85
       Name: main.testMapEmptyKeyAndValue
-      OutOfLinePCRanges: [0x8083e0..0x8083f0]
+      OutOfLinePCRanges: [0x808580..0x808590]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 249 GoMapType map[struct {}]struct {}
           Locations:
-            - Range: 0x8083e0..0x8083f0
+            - Range: 0x808580..0x808590
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 86
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x809750..0x809760]
+      OutOfLinePCRanges: [0x8098f0..0x809900]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x809750..0x809760
+            - Range: 0x8098f0..0x809900
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x809750..0x809760
+            - Range: 0x8098f0..0x809900
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: "y"
           Type: 18 BaseType float32
           Locations:
-            - Range: 0x809750..0x809760
+            - Range: 0x8098f0..0x809900
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 87
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0x809770..0x809780]
+      OutOfLinePCRanges: [0x809910..0x809920]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x809770..0x809780
+            - Range: 0x809910..0x809920
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x809770..0x809780
+            - Range: 0x809910..0x809920
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -7380,48 +7380,48 @@ Subprograms:
         - Name: "y"
           Type: 18 BaseType float32
           Locations:
-            - Range: 0x809770..0x809780
+            - Range: 0x809910..0x809920
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 88
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x809830..0x809840]
+      OutOfLinePCRanges: [0x8099d0..0x8099e0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x809830..0x809840
+            - Range: 0x8099d0..0x8099e0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x809830..0x809840
+            - Range: 0x8099d0..0x8099e0
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x809830..0x809840
+            - Range: 0x8099d0..0x8099e0
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x809830..0x809840
+            - Range: 0x8099d0..0x8099e0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x809830..0x809840
+            - Range: 0x8099d0..0x8099e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7432,63 +7432,63 @@ Subprograms:
       DictRegister: null
     - ID: 89
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0x8099d0..0x809a10]
+      OutOfLinePCRanges: [0x809b70..0x809bb0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0x8099d0..0x809a0c
+            - Range: 0x809b70..0x809bac
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0x8099d0..0x809a0c
+            - Range: 0x809b70..0x809bac
               Pieces: []
-            - Range: 0x809a0c..0x809a0d
+            - Range: 0x809bac..0x809bad
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x809a0d..0x809a10
+            - Range: 0x809bad..0x809bb0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 90
       Name: main.testChannel
-      OutOfLinePCRanges: [0x809a10..0x809a20]
+      OutOfLinePCRanges: [0x809bb0..0x809bc0]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 254 GoChannelType chan bool
           Locations:
-            - Range: 0x809a10..0x809a20
+            - Range: 0x809bb0..0x809bc0
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 91
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x809b90..0x809ba0]
+      OutOfLinePCRanges: [0x809d30..0x809d40]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 255 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x809b90..0x809ba0
+            - Range: 0x809d30..0x809d40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 92
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x809ba0..0x809bb0]
+      OutOfLinePCRanges: [0x809d40..0x809d50]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 257 StructureType main.node
           Locations:
-            - Range: 0x809ba0..0x809bb0
+            - Range: 0x809d40..0x809d50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7499,267 +7499,267 @@ Subprograms:
       DictRegister: null
     - ID: 93
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x809bb0..0x809bc0]
+      OutOfLinePCRanges: [0x809d50..0x809d60]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 258 PointerType *main.node
           Locations:
-            - Range: 0x809bb0..0x809bc0
+            - Range: 0x809d50..0x809d60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 94
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x809bc0..0x809bd0]
+      OutOfLinePCRanges: [0x809d60..0x809d70]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0x809bc0..0x809bd0
+            - Range: 0x809d60..0x809d70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 95
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x809be0..0x809bf0]
+      OutOfLinePCRanges: [0x809d80..0x809d90]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 113 PointerType *uint
           Locations:
-            - Range: 0x809be0..0x809bf0
+            - Range: 0x809d80..0x809d90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 96
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x809c50..0x809c60]
+      OutOfLinePCRanges: [0x809df0..0x809e00]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 102 PointerType *string
           Locations:
-            - Range: 0x809c50..0x809c60
+            - Range: 0x809df0..0x809e00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 97
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x809c70..0x809c80]
+      OutOfLinePCRanges: [0x809e10..0x809e20]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 11 PointerType *bool
           Locations:
-            - Range: 0x809c70..0x809c80
+            - Range: 0x809e10..0x809e20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x809c70..0x809c80
+            - Range: 0x809e10..0x809e20
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 98
       Name: main.testCycle
-      OutOfLinePCRanges: [0x809c90..0x809ca0]
+      OutOfLinePCRanges: [0x809e30..0x809e40]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 259 PointerType *main.t
           Locations:
-            - Range: 0x809c90..0x809ca0
+            - Range: 0x809e30..0x809e40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 99
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0x809f90..0x80a010]
+      OutOfLinePCRanges: [0x80a130..0x80a1b0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x809f90..0x809fac
+            - Range: 0x80a130..0x80a14c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x809f90..0x809fe8
+            - Range: 0x80a130..0x80a188
               Pieces: []
-            - Range: 0x809fe8..0x809fe9
+            - Range: 0x80a188..0x80a189
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x809fe9..0x80a010
+            - Range: 0x80a189..0x80a1b0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result
           Type: 8 BaseType int
           Locations:
-            - Range: 0x809fac..0x809fb8
+            - Range: 0x80a14c..0x80a158
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x809fb8..0x80a010
+            - Range: 0x80a158..0x80a1b0
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 100
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0x80a010..0x80a0b0]
+      OutOfLinePCRanges: [0x80a1b0..0x80a250]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80a010..0x80a034
+            - Range: 0x80a1b0..0x80a1d4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a034..0x80a0b0
+            - Range: 0x80a1d4..0x80a250
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 106 PointerType *int
           Locations:
-            - Range: 0x80a010..0x80a084
+            - Range: 0x80a1b0..0x80a224
               Pieces: []
-            - Range: 0x80a084..0x80a085
+            - Range: 0x80a224..0x80a225
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a085..0x80a0b0
+            - Range: 0x80a225..0x80a250
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: '&result'
           Type: 106 PointerType *int
           Locations:
-            - Range: 0x80a038..0x80a050
+            - Range: 0x80a1d8..0x80a1f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a050..0x80a0b0
+            - Range: 0x80a1f0..0x80a250
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 101
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0x80a0b0..0x80a180]
+      OutOfLinePCRanges: [0x80a250..0x80a320]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80a0b0..0x80a108
+            - Range: 0x80a250..0x80a2a8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80a0b0..0x80a158
+            - Range: 0x80a250..0x80a2f8
               Pieces: []
-            - Range: 0x80a158..0x80a159
+            - Range: 0x80a2f8..0x80a2f9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a159..0x80a180
+            - Range: 0x80a2f9..0x80a320
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80a0b0..0x80a180, Pieces: []}]
+          Locations: [{Range: 0x80a250..0x80a320, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: resultInt
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80a0cc..0x80a10c
+            - Range: 0x80a26c..0x80a2ac
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80a10c..0x80a180
+            - Range: 0x80a2ac..0x80a320
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: -1
         - Name: resultFloat
           Type: 15 BaseType float64
           Locations:
-            - Range: 0x80a0dc..0x80a10c
+            - Range: 0x80a27c..0x80a2ac
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-            - Range: 0x80a10c..0x80a180
+            - Range: 0x80a2ac..0x80a320
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 102
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0x80a180..0x80a200]
+      OutOfLinePCRanges: [0x80a320..0x80a3a0]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x80a180..0x80a1a0
+            - Range: 0x80a320..0x80a340
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 16 GoInterfaceType error
           Locations:
-            - Range: 0x80a180..0x80a1cc
+            - Range: 0x80a320..0x80a36c
               Pieces: []
-            - Range: 0x80a1cc..0x80a1cd
+            - Range: 0x80a36c..0x80a36d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a1cd..0x80a1e0
+            - Range: 0x80a36d..0x80a380
               Pieces: []
-            - Range: 0x80a1e0..0x80a1e1
+            - Range: 0x80a380..0x80a381
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a1e1..0x80a200
+            - Range: 0x80a381..0x80a3a0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 103
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0x80a200..0x80a380]
+      OutOfLinePCRanges: [0x80a3a0..0x80a520]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 168 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80a200..0x80a250
+            - Range: 0x80a3a0..0x80a3f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a250..0x80a254
+            - Range: 0x80a3f0..0x80a3f4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x80a2d8..0x80a2e0
+            - Range: 0x80a478..0x80a480
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a320..0x80a328
+            - Range: 0x80a4c0..0x80a4c8
               Pieces:
                 - Size: 8
                   Op: null
@@ -7770,117 +7770,117 @@ Subprograms:
         - Name: failed
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x80a200..0x80a258
+            - Range: 0x80a3a0..0x80a3f8
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 168 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80a200..0x80a26c
+            - Range: 0x80a3a0..0x80a40c
               Pieces: []
-            - Range: 0x80a26c..0x80a26d
+            - Range: 0x80a40c..0x80a40d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a26d..0x80a2c8
+            - Range: 0x80a40d..0x80a468
               Pieces: []
-            - Range: 0x80a2c8..0x80a2c9
+            - Range: 0x80a468..0x80a469
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a2c9..0x80a310
+            - Range: 0x80a469..0x80a4b0
               Pieces: []
-            - Range: 0x80a310..0x80a311
+            - Range: 0x80a4b0..0x80a4b1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a311..0x80a354
+            - Range: 0x80a4b1..0x80a4f4
               Pieces: []
-            - Range: 0x80a354..0x80a355
+            - Range: 0x80a4f4..0x80a4f5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a355..0x80a380
+            - Range: 0x80a4f5..0x80a520
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 16 GoInterfaceType error
           Locations:
-            - Range: 0x80a200..0x80a26c
+            - Range: 0x80a3a0..0x80a40c
               Pieces: []
-            - Range: 0x80a26c..0x80a26d
+            - Range: 0x80a40c..0x80a40d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80a26d..0x80a2c8
+            - Range: 0x80a40d..0x80a468
               Pieces: []
-            - Range: 0x80a2c8..0x80a2c9
+            - Range: 0x80a468..0x80a469
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80a2c9..0x80a310
+            - Range: 0x80a469..0x80a4b0
               Pieces: []
-            - Range: 0x80a310..0x80a311
+            - Range: 0x80a4b0..0x80a4b1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80a311..0x80a354
+            - Range: 0x80a4b1..0x80a4f4
               Pieces: []
-            - Range: 0x80a354..0x80a355
+            - Range: 0x80a4f4..0x80a4f5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80a355..0x80a380
+            - Range: 0x80a4f5..0x80a520
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80a250..0x80a258
+            - Range: 0x80a3f0..0x80a3f8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 104
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0x80a380..0x80a560]
+      OutOfLinePCRanges: [0x80a520..0x80a700]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 168 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80a380..0x80a3c0
+            - Range: 0x80a520..0x80a560
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a3c0..0x80a3c8
+            - Range: 0x80a560..0x80a568
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80a3c8..0x80a560
+            - Range: 0x80a568..0x80a700
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -7891,549 +7891,549 @@ Subprograms:
         - Name: ~r0
           Type: 168 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80a380..0x80a420
+            - Range: 0x80a520..0x80a5c0
               Pieces: []
-            - Range: 0x80a420..0x80a421
+            - Range: 0x80a5c0..0x80a5c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a421..0x80a474
+            - Range: 0x80a5c1..0x80a614
               Pieces: []
-            - Range: 0x80a474..0x80a475
+            - Range: 0x80a614..0x80a615
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a475..0x80a52c
+            - Range: 0x80a615..0x80a6cc
               Pieces: []
-            - Range: 0x80a52c..0x80a52d
+            - Range: 0x80a6cc..0x80a6cd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a52d..0x80a540
+            - Range: 0x80a6cd..0x80a6e0
               Pieces: []
-            - Range: 0x80a540..0x80a541
+            - Range: 0x80a6e0..0x80a6e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a541..0x80a560
+            - Range: 0x80a6e1..0x80a700
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80a40c..0x80a414
+            - Range: 0x80a5ac..0x80a5b4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: '&result'
           Type: 106 PointerType *int
           Locations:
-            - Range: 0x80a458..0x80a474
+            - Range: 0x80a5f8..0x80a614
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 105
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0x80a560..0x80a6b0]
+      OutOfLinePCRanges: [0x80a700..0x80a850]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 168 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80a560..0x80a59c
+            - Range: 0x80a700..0x80a73c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a59c..0x80a5e0
+            - Range: 0x80a73c..0x80a780
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x80a5e0..0x80a650
+            - Range: 0x80a780..0x80a7f0
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x80a650..0x80a678
+            - Range: 0x80a7f0..0x80a818
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80a678..0x80a67c
+            - Range: 0x80a818..0x80a81c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80a67c..0x80a6b0
+            - Range: 0x80a81c..0x80a850
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 173 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x80a560..0x80a630
+            - Range: 0x80a700..0x80a7d0
               Pieces: []
-            - Range: 0x80a630..0x80a631
+            - Range: 0x80a7d0..0x80a7d1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a631..0x80a644
+            - Range: 0x80a7d1..0x80a7e4
               Pieces: []
-            - Range: 0x80a644..0x80a645
+            - Range: 0x80a7e4..0x80a7e5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a645..0x80a6b0
+            - Range: 0x80a7e5..0x80a850
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 173 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x80a560..0x80a59c
+            - Range: 0x80a700..0x80a73c
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a59c..0x80a5e0
+            - Range: 0x80a73c..0x80a780
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80a5e0..0x80a5e8
+            - Range: 0x80a780..0x80a788
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80a5e8..0x80a63c
+            - Range: 0x80a788..0x80a7dc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80a63c..0x80a640
+            - Range: 0x80a7dc..0x80a7e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80a640..0x80a644
+            - Range: 0x80a7e0..0x80a7e4
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x80a644..0x80a6b0
+            - Range: 0x80a7e4..0x80a850
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 106
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0x80a6b0..0x80a750]
+      OutOfLinePCRanges: [0x80a850..0x80a8f0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80a6b0..0x80a6cc
+            - Range: 0x80a850..0x80a86c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80a6b0..0x80a724
+            - Range: 0x80a850..0x80a8c4
               Pieces: []
-            - Range: 0x80a724..0x80a725
+            - Range: 0x80a8c4..0x80a8c5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a725..0x80a750
+            - Range: 0x80a8c5..0x80a8f0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 107
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0x80a750..0x80a810]
+      OutOfLinePCRanges: [0x80a8f0..0x80a9b0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80a750..0x80a7a0
+            - Range: 0x80a8f0..0x80a940
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80a750..0x80a7ec
+            - Range: 0x80a8f0..0x80a98c
               Pieces: []
-            - Range: 0x80a7ec..0x80a7ed
+            - Range: 0x80a98c..0x80a98d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a7ed..0x80a810
+            - Range: 0x80a98d..0x80a9b0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80a750..0x80a7ec
+            - Range: 0x80a8f0..0x80a98c
               Pieces: []
-            - Range: 0x80a7ec..0x80a7ed
+            - Range: 0x80a98c..0x80a98d
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80a7ed..0x80a810
+            - Range: 0x80a98d..0x80a9b0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 108
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0x80a810..0x80a8d0]
+      OutOfLinePCRanges: [0x80a9b0..0x80aa70]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80a810..0x80a850
+            - Range: 0x80a9b0..0x80a9f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a850..0x80a8d0
+            - Range: 0x80a9f0..0x80aa70
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80a810..0x80a8b0
+            - Range: 0x80a9b0..0x80aa50
               Pieces: []
-            - Range: 0x80a8b0..0x80a8b1
+            - Range: 0x80aa50..0x80aa51
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a8b1..0x80a8d0
+            - Range: 0x80aa51..0x80aa70
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80a810..0x80a8b0
+            - Range: 0x80a9b0..0x80aa50
               Pieces: []
-            - Range: 0x80a8b0..0x80a8b1
+            - Range: 0x80aa50..0x80aa51
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80a8b1..0x80a8d0
+            - Range: 0x80aa51..0x80aa70
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80a810..0x80a8b0
+            - Range: 0x80a9b0..0x80aa50
               Pieces: []
-            - Range: 0x80a8b0..0x80a8b1
+            - Range: 0x80aa50..0x80aa51
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80a8b1..0x80a8d0
+            - Range: 0x80aa51..0x80aa70
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 109
       Name: main.testConflictingReturn
-      OutOfLinePCRanges: [0x80a8d0..0x80a9b0]
+      OutOfLinePCRanges: [0x80aa70..0x80ab50]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80a8d0..0x80a910
+            - Range: 0x80aa70..0x80aab0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a910..0x80a9b0
+            - Range: 0x80aab0..0x80ab50
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80a8d0..0x80a98c
+            - Range: 0x80aa70..0x80ab2c
               Pieces: []
-            - Range: 0x80a98c..0x80a98d
+            - Range: 0x80ab2c..0x80ab2d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a98d..0x80a9b0
+            - Range: 0x80ab2d..0x80ab50
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80a8d0..0x80a98c
+            - Range: 0x80aa70..0x80ab2c
               Pieces: []
-            - Range: 0x80a98c..0x80a98d
+            - Range: 0x80ab2c..0x80ab2d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80a98d..0x80a9b0
+            - Range: 0x80ab2d..0x80ab50
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 110
       Name: main.testReturnsNamedDeferLine
-      OutOfLinePCRanges: [0x80a9b0..0x80ab40]
+      OutOfLinePCRanges: [0x80ab50..0x80ace0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80a9b0..0x80aa10
+            - Range: 0x80ab50..0x80abb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80aa10..0x80ab40
+            - Range: 0x80abb0..0x80ace0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80a9dc..0x80ab40
+            - Range: 0x80ab7c..0x80ace0
               Pieces: [{Size: 16, Op: {CfaOffset: -120}}]
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80a9e0..0x80ab40
+            - Range: 0x80ab80..0x80ace0
               Pieces: [{Size: 16, Op: {CfaOffset: -136}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 111
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0x80ac00..0x80ac90]
+      OutOfLinePCRanges: [0x80ada0..0x80ae30]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 20 BaseType int8
           Locations:
-            - Range: 0x80ac00..0x80ac6c
+            - Range: 0x80ada0..0x80ae0c
               Pieces: []
-            - Range: 0x80ac6c..0x80ac6d
+            - Range: 0x80ae0c..0x80ae0d
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ac6d..0x80ac90
+            - Range: 0x80ae0d..0x80ae30
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 103 BaseType int16
           Locations:
-            - Range: 0x80ac00..0x80ac6c
+            - Range: 0x80ada0..0x80ae0c
               Pieces: []
-            - Range: 0x80ac6c..0x80ac6d
+            - Range: 0x80ae0c..0x80ae0d
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80ac6d..0x80ac90
+            - Range: 0x80ae0d..0x80ae30
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x80ac00..0x80ac6c
+            - Range: 0x80ada0..0x80ae0c
               Pieces: []
-            - Range: 0x80ac6c..0x80ac6d
+            - Range: 0x80ae0c..0x80ae0d
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80ac6d..0x80ac90
+            - Range: 0x80ae0d..0x80ae30
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 14 BaseType int64
           Locations:
-            - Range: 0x80ac00..0x80ac6c
+            - Range: 0x80ada0..0x80ae0c
               Pieces: []
-            - Range: 0x80ac6c..0x80ac6d
+            - Range: 0x80ae0c..0x80ae0d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80ac6d..0x80ac90
+            - Range: 0x80ae0d..0x80ae30
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x80ac00..0x80ac6c
+            - Range: 0x80ada0..0x80ae0c
               Pieces: []
-            - Range: 0x80ac6c..0x80ac6d
+            - Range: 0x80ae0c..0x80ae0d
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80ac6d..0x80ac90
+            - Range: 0x80ae0d..0x80ae30
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 7 BaseType uint16
           Locations:
-            - Range: 0x80ac00..0x80ac6c
+            - Range: 0x80ada0..0x80ae0c
               Pieces: []
-            - Range: 0x80ac6c..0x80ac6d
+            - Range: 0x80ae0c..0x80ae0d
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80ac6d..0x80ac90
+            - Range: 0x80ae0d..0x80ae30
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 3 BaseType uint32
           Locations:
-            - Range: 0x80ac00..0x80ac6c
+            - Range: 0x80ada0..0x80ae0c
               Pieces: []
-            - Range: 0x80ac6c..0x80ac6d
+            - Range: 0x80ae0c..0x80ae0d
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80ac6d..0x80ac90
+            - Range: 0x80ae0d..0x80ae30
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0x80ac00..0x80ac6c
+            - Range: 0x80ada0..0x80ae0c
               Pieces: []
-            - Range: 0x80ac6c..0x80ac6d
+            - Range: 0x80ae0c..0x80ae0d
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80ac6d..0x80ac90
+            - Range: 0x80ae0d..0x80ae30
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 112
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0x80ac90..0x80ad40]
+      OutOfLinePCRanges: [0x80ae30..0x80aee0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80ac90..0x80ad40, Pieces: []}]
+          Locations: [{Range: 0x80ae30..0x80aee0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80ac90..0x80ad40, Pieces: []}]
+          Locations: [{Range: 0x80ae30..0x80aee0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80ac90..0x80ad40, Pieces: []}]
+          Locations: [{Range: 0x80ae30..0x80aee0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80ac90..0x80ad40, Pieces: []}]
+          Locations: [{Range: 0x80ae30..0x80aee0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80ac90..0x80ad40, Pieces: []}]
+          Locations: [{Range: 0x80ae30..0x80aee0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80ac90..0x80ad40, Pieces: []}]
+          Locations: [{Range: 0x80ae30..0x80aee0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80ac90..0x80ad40, Pieces: []}]
+          Locations: [{Range: 0x80ae30..0x80aee0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80ac90..0x80ad40, Pieces: []}]
+          Locations: [{Range: 0x80ae30..0x80aee0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80ac90..0x80ad40, Pieces: []}]
+          Locations: [{Range: 0x80ae30..0x80aee0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r9
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80ac90..0x80ad40, Pieces: []}]
+          Locations: [{Range: 0x80ae30..0x80aee0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r10
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80ac90..0x80ad40, Pieces: []}]
+          Locations: [{Range: 0x80ae30..0x80aee0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r11
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80ac90..0x80ad40, Pieces: []}]
+          Locations: [{Range: 0x80ae30..0x80aee0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r12
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80ac90..0x80ad40, Pieces: []}]
+          Locations: [{Range: 0x80ae30..0x80aee0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r13
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80ac90..0x80ad40, Pieces: []}]
+          Locations: [{Range: 0x80ae30..0x80aee0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r14
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80ac90..0x80ad40, Pieces: []}]
+          Locations: [{Range: 0x80ae30..0x80aee0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: onlyOnAmd64_16
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80ac90..0x80ad40, Pieces: []}]
+          Locations: [{Range: 0x80ae30..0x80aee0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: bothArmAndAmd64
           Type: 15 BaseType float64
           Locations:
-            - Range: 0x80ac90..0x80ad28
+            - Range: 0x80ae30..0x80aec8
               Pieces: []
-            - Range: 0x80ad28..0x80ad29
+            - Range: 0x80aec8..0x80aec9
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x80ad29..0x80ad40
+            - Range: 0x80aec9..0x80aee0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 113
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0x80ad40..0x80adc0]
+      OutOfLinePCRanges: [0x80aee0..0x80af60]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 104 BaseType complex64
-          Locations: [{Range: 0x80ad40..0x80adc0, Pieces: []}]
+          Locations: [{Range: 0x80aee0..0x80af60, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 19 BaseType complex128
-          Locations: [{Range: 0x80ad40..0x80adc0, Pieces: []}]
+          Locations: [{Range: 0x80aee0..0x80af60, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 114
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0x80adc0..0x80ae80]
+      OutOfLinePCRanges: [0x80af60..0x80b020]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0x80adc0..0x80ae60
+            - Range: 0x80af60..0x80b000
               Pieces: []
-            - Range: 0x80ae60..0x80ae61
+            - Range: 0x80b000..0x80b001
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8455,193 +8455,193 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80ae61..0x80ae80
+            - Range: 0x80b001..0x80b020
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 115
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0x80ae80..0x80af10]
+      OutOfLinePCRanges: [0x80b020..0x80b0b0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 262 ArrayType [3]int
           Locations:
-            - Range: 0x80ae80..0x80aeec
+            - Range: 0x80b020..0x80b08c
               Pieces: []
-            - Range: 0x80aeec..0x80aeed
+            - Range: 0x80b08c..0x80b08d
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x80aeed..0x80af10
+            - Range: 0x80b08d..0x80b0b0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 116
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0x80af10..0x80af80]
+      OutOfLinePCRanges: [0x80b0b0..0x80b120]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 263 ArrayType [1]int
           Locations:
-            - Range: 0x80af10..0x80af60
+            - Range: 0x80b0b0..0x80b100
               Pieces: []
-            - Range: 0x80af60..0x80af61
+            - Range: 0x80b100..0x80b101
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80af61..0x80af80
+            - Range: 0x80b101..0x80b120
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 117
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0x80af80..0x80aff0]
+      OutOfLinePCRanges: [0x80b120..0x80b190]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 264 ArrayType [0]int
           Locations:
-            - Range: 0x80af80..0x80afcc
+            - Range: 0x80b120..0x80b16c
               Pieces: []
-            - Range: 0x80afcc..0x80afcd
+            - Range: 0x80b16c..0x80b16d
               Pieces: []
-            - Range: 0x80afcd..0x80aff0
+            - Range: 0x80b16d..0x80b190
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 118
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0x80aff0..0x80b070]
+      OutOfLinePCRanges: [0x80b190..0x80b210]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 265 StructureType main.mixedStruct
-          Locations: [{Range: 0x80aff0..0x80b070, Pieces: []}]
+          Locations: [{Range: 0x80b190..0x80b210, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 119
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0x80b070..0x80b100]
+      OutOfLinePCRanges: [0x80b210..0x80b2a0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80b070..0x80b0e8
+            - Range: 0x80b210..0x80b288
               Pieces: []
-            - Range: 0x80b0e8..0x80b0e9
+            - Range: 0x80b288..0x80b289
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80b0e9..0x80b100
+            - Range: 0x80b289..0x80b2a0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80b070..0x80b0e8
+            - Range: 0x80b210..0x80b288
               Pieces: []
-            - Range: 0x80b0e8..0x80b0e9
+            - Range: 0x80b288..0x80b289
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80b0e9..0x80b100
+            - Range: 0x80b289..0x80b2a0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80b070..0x80b0e8
+            - Range: 0x80b210..0x80b288
               Pieces: []
-            - Range: 0x80b0e8..0x80b0e9
+            - Range: 0x80b288..0x80b289
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80b0e9..0x80b100
+            - Range: 0x80b289..0x80b2a0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80b070..0x80b0e8
+            - Range: 0x80b210..0x80b288
               Pieces: []
-            - Range: 0x80b0e8..0x80b0e9
+            - Range: 0x80b288..0x80b289
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80b0e9..0x80b100
+            - Range: 0x80b289..0x80b2a0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80b070..0x80b0e8
+            - Range: 0x80b210..0x80b288
               Pieces: []
-            - Range: 0x80b0e8..0x80b0e9
+            - Range: 0x80b288..0x80b289
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80b0e9..0x80b100
+            - Range: 0x80b289..0x80b2a0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80b070..0x80b0e8
+            - Range: 0x80b210..0x80b288
               Pieces: []
-            - Range: 0x80b0e8..0x80b0e9
+            - Range: 0x80b288..0x80b289
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80b0e9..0x80b100
+            - Range: 0x80b289..0x80b2a0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80b070..0x80b0e8
+            - Range: 0x80b210..0x80b288
               Pieces: []
-            - Range: 0x80b0e8..0x80b0e9
+            - Range: 0x80b288..0x80b289
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80b0e9..0x80b100
+            - Range: 0x80b289..0x80b2a0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80b070..0x80b0e8
+            - Range: 0x80b210..0x80b288
               Pieces: []
-            - Range: 0x80b0e8..0x80b0e9
+            - Range: 0x80b288..0x80b289
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80b0e9..0x80b100
+            - Range: 0x80b289..0x80b2a0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80b070..0x80b0e8
+            - Range: 0x80b210..0x80b288
               Pieces: []
-            - Range: 0x80b0e8..0x80b0e9
+            - Range: 0x80b288..0x80b289
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80b0e9..0x80b100
+            - Range: 0x80b289..0x80b2a0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 120
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0x80b100..0x80b1d0]
+      OutOfLinePCRanges: [0x80b2a0..0x80b370]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 266 StructureType main.wideStruct
           Locations:
-            - Range: 0x80b100..0x80b1b0
+            - Range: 0x80b2a0..0x80b350
               Pieces: []
-            - Range: 0x80b1b0..0x80b1b1
+            - Range: 0x80b350..0x80b351
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8665,145 +8665,145 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0x80b1b1..0x80b1d0
+            - Range: 0x80b351..0x80b370
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 121
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0x80b1d0..0x80b260]
+      OutOfLinePCRanges: [0x80b370..0x80b400]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80b1d0..0x80b23c
+            - Range: 0x80b370..0x80b3dc
               Pieces: []
-            - Range: 0x80b23c..0x80b23d
+            - Range: 0x80b3dc..0x80b3dd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80b23d..0x80b260
+            - Range: 0x80b3dd..0x80b400
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80b1d0..0x80b260, Pieces: []}]
+          Locations: [{Range: 0x80b370..0x80b400, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80b1d0..0x80b23c
+            - Range: 0x80b370..0x80b3dc
               Pieces: []
-            - Range: 0x80b23c..0x80b23d
+            - Range: 0x80b3dc..0x80b3dd
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80b23d..0x80b260
+            - Range: 0x80b3dd..0x80b400
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80b1d0..0x80b260, Pieces: []}]
+          Locations: [{Range: 0x80b370..0x80b400, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80b1d0..0x80b23c
+            - Range: 0x80b370..0x80b3dc
               Pieces: []
-            - Range: 0x80b23c..0x80b23d
+            - Range: 0x80b3dc..0x80b3dd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80b23d..0x80b260
+            - Range: 0x80b3dd..0x80b400
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 122
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0x80b260..0x80b2f0]
+      OutOfLinePCRanges: [0x80b400..0x80b490]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 267 StructureType main.structWithArray
           Locations:
-            - Range: 0x80b260..0x80b2cc
+            - Range: 0x80b400..0x80b46c
               Pieces: []
-            - Range: 0x80b2cc..0x80b2cd
+            - Range: 0x80b46c..0x80b46d
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x80b2cd..0x80b2f0
+            - Range: 0x80b46d..0x80b490
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 123
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0x80b2f0..0x80b360]
+      OutOfLinePCRanges: [0x80b490..0x80b500]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80b2f0..0x80b360, Pieces: []}]
+          Locations: [{Range: 0x80b490..0x80b500, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 124
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0x80b360..0x80b3d0]
+      OutOfLinePCRanges: [0x80b500..0x80b570]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float32
-          Locations: [{Range: 0x80b360..0x80b3d0, Pieces: []}]
+          Locations: [{Range: 0x80b500..0x80b570, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80b360..0x80b3d0, Pieces: []}]
+          Locations: [{Range: 0x80b500..0x80b570, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 125
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0x80b3d0..0x80b440]
+      OutOfLinePCRanges: [0x80b570..0x80b5e0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x80b3d0..0x80b424
+            - Range: 0x80b570..0x80b5c4
               Pieces: []
-            - Range: 0x80b424..0x80b425
+            - Range: 0x80b5c4..0x80b5c5
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80b425..0x80b440
+            - Range: 0x80b5c5..0x80b5e0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 2 BaseType uintptr
           Locations:
-            - Range: 0x80b3d0..0x80b424
+            - Range: 0x80b570..0x80b5c4
               Pieces: []
-            - Range: 0x80b424..0x80b425
+            - Range: 0x80b5c4..0x80b5c5
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80b425..0x80b440
+            - Range: 0x80b5c5..0x80b5e0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 126
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0x80b440..0x80b5d0]
+      OutOfLinePCRanges: [0x80b5e0..0x80b770]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0x80b440..0x80b474
+            - Range: 0x80b5e0..0x80b614
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8825,7 +8825,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80b474..0x80b4a4
+            - Range: 0x80b614..0x80b644
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8847,7 +8847,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80b4a4..0x80b4ac
+            - Range: 0x80b644..0x80b64c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8869,7 +8869,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80b4ac..0x80b4b0
+            - Range: 0x80b64c..0x80b650
               Pieces:
                 - Size: 8
                   Op: null
@@ -8896,9 +8896,9 @@ Subprograms:
         - Name: ~r0
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0x80b440..0x80b590
+            - Range: 0x80b5e0..0x80b730
               Pieces: []
-            - Range: 0x80b590..0x80b591
+            - Range: 0x80b730..0x80b731
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8920,44 +8920,44 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80b591..0x80b5d0
+            - Range: 0x80b731..0x80b770
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 127
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0x80b5d0..0x80b6a0]
+      OutOfLinePCRanges: [0x80b770..0x80b840]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 262 ArrayType [3]int
           Locations:
-            - Range: 0x80b5d0..0x80b6a0
+            - Range: 0x80b770..0x80b840
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 262 ArrayType [3]int
           Locations:
-            - Range: 0x80b5d0..0x80b680
+            - Range: 0x80b770..0x80b820
               Pieces: []
-            - Range: 0x80b680..0x80b681
+            - Range: 0x80b820..0x80b821
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x80b681..0x80b6a0
+            - Range: 0x80b821..0x80b840
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 128
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0x80b6a0..0x80b8b0]
+      OutOfLinePCRanges: [0x80b840..0x80ba50]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0x80b6a0..0x80b6d4
+            - Range: 0x80b840..0x80b874
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8979,7 +8979,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80b6d4..0x80b708
+            - Range: 0x80b874..0x80b8a8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9001,7 +9001,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80b708..0x80b710
+            - Range: 0x80b8a8..0x80b8b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9023,7 +9023,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80b710..0x80b714
+            - Range: 0x80b8b0..0x80b8b4
               Pieces:
                 - Size: 8
                   Op: null
@@ -9050,16 +9050,16 @@ Subprograms:
         - Name: s2
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0x80b6a0..0x80b8b0
+            - Range: 0x80b840..0x80ba50
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0x80b6a0..0x80b868
+            - Range: 0x80b840..0x80ba08
               Pieces: []
-            - Range: 0x80b868..0x80b869
+            - Range: 0x80ba08..0x80ba09
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9081,196 +9081,196 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80b869..0x80b8b0
+            - Range: 0x80ba09..0x80ba50
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 129
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0x80b8b0..0x80ba60]
+      OutOfLinePCRanges: [0x80ba50..0x80bc00]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80b8b0..0x80b938
+            - Range: 0x80ba50..0x80bad8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80b938..0x80ba60
+            - Range: 0x80bad8..0x80bc00
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80b8b0..0x80b8f8
+            - Range: 0x80ba50..0x80ba98
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80b8f8..0x80ba60
+            - Range: 0x80ba98..0x80bc00
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80b8b0..0x80b930
+            - Range: 0x80ba50..0x80bad0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80b930..0x80ba60
+            - Range: 0x80bad0..0x80bc00
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80b8b0..0x80b938
+            - Range: 0x80ba50..0x80bad8
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80b938..0x80ba60
+            - Range: 0x80bad8..0x80bc00
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80b8b0..0x80b938
+            - Range: 0x80ba50..0x80bad8
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80b938..0x80ba60
+            - Range: 0x80bad8..0x80bc00
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80b8b0..0x80b938
+            - Range: 0x80ba50..0x80bad8
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80b938..0x80ba60
+            - Range: 0x80bad8..0x80bc00
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80b8b0..0x80b938
+            - Range: 0x80ba50..0x80bad8
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80b938..0x80ba60
+            - Range: 0x80bad8..0x80bc00
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80b8b0..0x80b938
+            - Range: 0x80ba50..0x80bad8
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80b938..0x80ba60
+            - Range: 0x80bad8..0x80bc00
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80b8b0..0x80b938
+            - Range: 0x80ba50..0x80bad8
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0x80b938..0x80ba60
+            - Range: 0x80bad8..0x80bc00
               Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 120 ArrayType [2]int
           Locations:
-            - Range: 0x80b8b0..0x80ba20
+            - Range: 0x80ba50..0x80bbc0
               Pieces: []
-            - Range: 0x80ba20..0x80ba21
+            - Range: 0x80bbc0..0x80bbc1
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-            - Range: 0x80ba21..0x80ba60
+            - Range: 0x80bbc1..0x80bc00
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 130
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0x80ba60..0x80bc50]
+      OutOfLinePCRanges: [0x80bc00..0x80bdf0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80ba60..0x80bae8
+            - Range: 0x80bc00..0x80bc88
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80bae8..0x80bc50
+            - Range: 0x80bc88..0x80bdf0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80ba60..0x80baac
+            - Range: 0x80bc00..0x80bc4c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80baac..0x80bc50
+            - Range: 0x80bc4c..0x80bdf0
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80ba60..0x80bae0
+            - Range: 0x80bc00..0x80bc80
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80bae0..0x80bc50
+            - Range: 0x80bc80..0x80bdf0
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80ba60..0x80bae8
+            - Range: 0x80bc00..0x80bc88
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80bae8..0x80bc50
+            - Range: 0x80bc88..0x80bdf0
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80ba60..0x80bae8
+            - Range: 0x80bc00..0x80bc88
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80bae8..0x80bc50
+            - Range: 0x80bc88..0x80bdf0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80ba60..0x80bae8
+            - Range: 0x80bc00..0x80bc88
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80bae8..0x80bc50
+            - Range: 0x80bc88..0x80bdf0
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80ba60..0x80bae8
+            - Range: 0x80bc00..0x80bc88
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80bae8..0x80bc50
+            - Range: 0x80bc88..0x80bdf0
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80ba60..0x80bae8
+            - Range: 0x80bc00..0x80bc88
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80bae8..0x80bc50
+            - Range: 0x80bc88..0x80bdf0
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80ba60..0x80bae8
+            - Range: 0x80bc00..0x80bc88
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80bae8..0x80bc50
+            - Range: 0x80bc88..0x80bdf0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 72}
@@ -9281,9 +9281,9 @@ Subprograms:
         - Name: ~r0
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0x80ba60..0x80bc0c
+            - Range: 0x80bc00..0x80bdac
               Pieces: []
-            - Range: 0x80bc0c..0x80bc0d
+            - Range: 0x80bdac..0x80bdad
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9305,196 +9305,196 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80bc0d..0x80bc50
+            - Range: 0x80bdad..0x80bdf0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 131
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0x80bc50..0x80bce0]
+      OutOfLinePCRanges: [0x80bdf0..0x80be80]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 172 ArrayType [5]int
           Locations:
-            - Range: 0x80bc50..0x80bce0
+            - Range: 0x80bdf0..0x80be80
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80bc50..0x80bcc4
+            - Range: 0x80bdf0..0x80be64
               Pieces: []
-            - Range: 0x80bcc4..0x80bcc5
+            - Range: 0x80be64..0x80be65
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80bcc5..0x80bce0
+            - Range: 0x80be65..0x80be80
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80bc50..0x80bcc4
+            - Range: 0x80bdf0..0x80be64
               Pieces: []
-            - Range: 0x80bcc4..0x80bcc5
+            - Range: 0x80be64..0x80be65
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80bcc5..0x80bce0
+            - Range: 0x80be65..0x80be80
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80bc50..0x80bcc4
+            - Range: 0x80bdf0..0x80be64
               Pieces: []
-            - Range: 0x80bcc4..0x80bcc5
+            - Range: 0x80be64..0x80be65
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80bcc5..0x80bce0
+            - Range: 0x80be65..0x80be80
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 132
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0x80bce0..0x80bdb0]
+      OutOfLinePCRanges: [0x80be80..0x80bf50]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 120 ArrayType [2]int
           Locations:
-            - Range: 0x80bce0..0x80bdb0
+            - Range: 0x80be80..0x80bf50
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 262 ArrayType [3]int
           Locations:
-            - Range: 0x80bce0..0x80bdb0
+            - Range: 0x80be80..0x80bf50
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80bce0..0x80bd98
+            - Range: 0x80be80..0x80bf38
               Pieces: []
-            - Range: 0x80bd98..0x80bd99
+            - Range: 0x80bf38..0x80bf39
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80bd99..0x80bdb0
+            - Range: 0x80bf39..0x80bf50
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 120 ArrayType [2]int
           Locations:
-            - Range: 0x80bce0..0x80bd98
+            - Range: 0x80be80..0x80bf38
               Pieces: []
-            - Range: 0x80bd98..0x80bd99
+            - Range: 0x80bf38..0x80bf39
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
-            - Range: 0x80bd99..0x80bdb0
+            - Range: 0x80bf39..0x80bf50
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 133
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0x80bdb0..0x80be70]
+      OutOfLinePCRanges: [0x80bf50..0x80c010]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 267 StructureType main.structWithArray
           Locations:
-            - Range: 0x80bdb0..0x80be70
+            - Range: 0x80bf50..0x80c010
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80bdb0..0x80be54
+            - Range: 0x80bf50..0x80bff4
               Pieces: []
-            - Range: 0x80be54..0x80be55
+            - Range: 0x80bff4..0x80bff5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80be55..0x80be70
+            - Range: 0x80bff5..0x80c010
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 267 StructureType main.structWithArray
           Locations:
-            - Range: 0x80bdb0..0x80be54
+            - Range: 0x80bf50..0x80bff4
               Pieces: []
-            - Range: 0x80be54..0x80be55
+            - Range: 0x80bff4..0x80bff5
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x80be55..0x80be70
+            - Range: 0x80bff5..0x80c010
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80be30..0x80be70
+            - Range: 0x80bfd0..0x80c010
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 134
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0x80be70..0x80bf10]
+      OutOfLinePCRanges: [0x80c010..0x80c0b0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 264 ArrayType [0]int
-          Locations: [{Range: 0x80be70..0x80bf10, Pieces: []}]
+          Locations: [{Range: 0x80c010..0x80c0b0, Pieces: []}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80be70..0x80beb0
+            - Range: 0x80c010..0x80c050
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80beb0..0x80bec8
+            - Range: 0x80c050..0x80c068
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x80bec8..0x80bed0
+            - Range: 0x80c068..0x80c070
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x80bed0..0x80bf10
+            - Range: 0x80c070..0x80c0b0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80be70..0x80beec
+            - Range: 0x80c010..0x80c08c
               Pieces: []
-            - Range: 0x80beec..0x80beed
+            - Range: 0x80c08c..0x80c08d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80beed..0x80bf10
+            - Range: 0x80c08d..0x80c0b0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 264 ArrayType [0]int
           Locations:
-            - Range: 0x80be70..0x80beec
+            - Range: 0x80c010..0x80c08c
               Pieces: []
-            - Range: 0x80beec..0x80beed
+            - Range: 0x80c08c..0x80c08d
               Pieces: []
-            - Range: 0x80beed..0x80bf10
+            - Range: 0x80c08d..0x80c0b0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 135
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0x80c360..0x80c370]
+      OutOfLinePCRanges: [0x80c500..0x80c510]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 268 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80c360..0x80c370
+            - Range: 0x80c500..0x80c510
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9507,13 +9507,13 @@ Subprograms:
       DictRegister: null
     - ID: 136
       Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x80c370..0x80c380]
+      OutOfLinePCRanges: [0x80c510..0x80c520]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 268 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80c370..0x80c380
+            - Range: 0x80c510..0x80c520
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9526,13 +9526,13 @@ Subprograms:
       DictRegister: null
     - ID: 137
       Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x80c380..0x80c390]
+      OutOfLinePCRanges: [0x80c520..0x80c530]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 269 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0x80c380..0x80c390
+            - Range: 0x80c520..0x80c530
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9545,13 +9545,13 @@ Subprograms:
       DictRegister: null
     - ID: 138
       Name: main.testStructSlice
-      OutOfLinePCRanges: [0x80c390..0x80c3a0]
+      OutOfLinePCRanges: [0x80c530..0x80c540]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 271 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x80c390..0x80c3a0
+            - Range: 0x80c530..0x80c540
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9564,20 +9564,20 @@ Subprograms:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80c390..0x80c3a0
+            - Range: 0x80c530..0x80c540
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 139
       Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x80c3a0..0x80c3b0]
+      OutOfLinePCRanges: [0x80c540..0x80c550]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 271 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x80c3a0..0x80c3b0
+            - Range: 0x80c540..0x80c550
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9590,20 +9590,20 @@ Subprograms:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80c3a0..0x80c3b0
+            - Range: 0x80c540..0x80c550
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 140
       Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x80c3b0..0x80c3c0]
+      OutOfLinePCRanges: [0x80c550..0x80c560]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 271 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x80c3b0..0x80c3c0
+            - Range: 0x80c550..0x80c560
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9616,20 +9616,20 @@ Subprograms:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80c3b0..0x80c3c0
+            - Range: 0x80c550..0x80c560
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 141
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0x80c3c0..0x80c3d0]
+      OutOfLinePCRanges: [0x80c560..0x80c570]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 165 GoSliceHeaderType []string
           Locations:
-            - Range: 0x80c3c0..0x80c3d0
+            - Range: 0x80c560..0x80c570
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9642,20 +9642,20 @@ Subprograms:
       DictRegister: null
     - ID: 142
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x80c3d0..0x80c3e0]
+      OutOfLinePCRanges: [0x80c570..0x80c580]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 20 BaseType int8
           Locations:
-            - Range: 0x80c3d0..0x80c3e0
+            - Range: 0x80c570..0x80c580
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 274 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x80c3d0..0x80c3e0
+            - Range: 0x80c570..0x80c580
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -9668,20 +9668,20 @@ Subprograms:
         - Name: x
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x80c3d0..0x80c3e0
+            - Range: 0x80c570..0x80c580
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 143
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x80c3e0..0x80c3f0]
+      OutOfLinePCRanges: [0x80c580..0x80c590]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 275 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x80c3e0..0x80c3f0
+            - Range: 0x80c580..0x80c590
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9694,13 +9694,13 @@ Subprograms:
       DictRegister: null
     - ID: 144
       Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x80c3f0..0x80c400]
+      OutOfLinePCRanges: [0x80c590..0x80c5a0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 268 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80c3f0..0x80c400
+            - Range: 0x80c590..0x80c5a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9713,13 +9713,13 @@ Subprograms:
       DictRegister: null
     - ID: 145
       Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0x80c400..0x80c410]
+      OutOfLinePCRanges: [0x80c5a0..0x80c5b0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 276 GoSliceHeaderType []struct {}
           Locations:
-            - Range: 0x80c400..0x80c410
+            - Range: 0x80c5a0..0x80c5b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9732,13 +9732,13 @@ Subprograms:
       DictRegister: null
     - ID: 146
       Name: main.testSubslices
-      OutOfLinePCRanges: [0x80c410..0x80c420]
+      OutOfLinePCRanges: [0x80c5b0..0x80c5c0]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 268 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80c410..0x80c420
+            - Range: 0x80c5b0..0x80c5c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9751,7 +9751,7 @@ Subprograms:
         - Name: bs
           Type: 268 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80c410..0x80c420
+            - Range: 0x80c5b0..0x80c5c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9764,7 +9764,7 @@ Subprograms:
         - Name: cs
           Type: 268 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80c410..0x80c420
+            - Range: 0x80c5b0..0x80c5c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -9777,34 +9777,34 @@ Subprograms:
       DictRegister: null
     - ID: 147
       Name: main.stackC
-      OutOfLinePCRanges: [0x80c6e0..0x80c740]
+      OutOfLinePCRanges: [0x80cb40..0x80cba0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80c6e0..0x80c728
+            - Range: 0x80cb40..0x80cb88
               Pieces: []
-            - Range: 0x80c728..0x80c729
+            - Range: 0x80cb88..0x80cb89
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80c729..0x80c740
+            - Range: 0x80cb89..0x80cba0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 148
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x80c740..0x80c750]
+      OutOfLinePCRanges: [0x80cba0..0x80cbb0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80c740..0x80c750
+            - Range: 0x80cba0..0x80cbb0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9815,13 +9815,13 @@ Subprograms:
       DictRegister: null
     - ID: 149
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x80c750..0x80c760]
+      OutOfLinePCRanges: [0x80cbb0..0x80cbc0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80c750..0x80c760
+            - Range: 0x80cbb0..0x80cbc0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9832,7 +9832,7 @@ Subprograms:
         - Name: "y"
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80c750..0x80c760
+            - Range: 0x80cbb0..0x80cbc0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9843,7 +9843,7 @@ Subprograms:
         - Name: z
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80c750..0x80c760
+            - Range: 0x80cbb0..0x80cbc0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9854,13 +9854,13 @@ Subprograms:
       DictRegister: null
     - ID: 150
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x80c760..0x80c770]
+      OutOfLinePCRanges: [0x80cbc0..0x80cbd0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 278 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x80c760..0x80c770
+            - Range: 0x80cbc0..0x80cbd0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9879,39 +9879,39 @@ Subprograms:
       DictRegister: null
     - ID: 151
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x80c770..0x80c780]
+      OutOfLinePCRanges: [0x80cbd0..0x80cbe0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 279 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x80c770..0x80c780
+            - Range: 0x80cbd0..0x80cbe0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 152
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x80c780..0x80c790]
+      OutOfLinePCRanges: [0x80cbe0..0x80cbf0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 280 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x80c780..0x80c790
+            - Range: 0x80cbe0..0x80cbf0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 153
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0x80c790..0x80c7a0]
+      OutOfLinePCRanges: [0x80cbf0..0x80cc00]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80c790..0x80c7a0
+            - Range: 0x80cbf0..0x80cc00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9922,13 +9922,13 @@ Subprograms:
       DictRegister: null
     - ID: 154
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x80c7a0..0x80c7b0]
+      OutOfLinePCRanges: [0x80cc00..0x80cc10]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80c7a0..0x80c7b0
+            - Range: 0x80cc00..0x80cc10
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9939,13 +9939,13 @@ Subprograms:
       DictRegister: null
     - ID: 155
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0x80c7b0..0x80c7c0]
+      OutOfLinePCRanges: [0x80cc10..0x80cc20]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80c7b0..0x80c7c0
+            - Range: 0x80cc10..0x80cc20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9956,13 +9956,13 @@ Subprograms:
       DictRegister: null
     - ID: 156
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0x80c7c0..0x80c7d0]
+      OutOfLinePCRanges: [0x80cc20..0x80cc30]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80c7c0..0x80c7d0
+            - Range: 0x80cc20..0x80cc30
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9973,7 +9973,7 @@ Subprograms:
         - Name: b
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80c7c0..0x80c7d0
+            - Range: 0x80cc20..0x80cc30
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9984,7 +9984,7 @@ Subprograms:
         - Name: c
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80c7c0..0x80c7d0
+            - Range: 0x80cc20..0x80cc30
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9995,26 +9995,26 @@ Subprograms:
       DictRegister: null
     - ID: 157
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x80c910..0x80c920]
+      OutOfLinePCRanges: [0x80cd70..0x80cd80]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 282 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x80c910..0x80c920
+            - Range: 0x80cd70..0x80cd80
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 158
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x80c920..0x80c930]
+      OutOfLinePCRanges: [0x80cd80..0x80cd90]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 295 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x80c920..0x80c930
+            - Range: 0x80cd80..0x80cd90
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10033,13 +10033,13 @@ Subprograms:
       DictRegister: null
     - ID: 159
       Name: main.testStruct
-      OutOfLinePCRanges: [0x80c9c0..0x80c9d0]
+      OutOfLinePCRanges: [0x80ce20..0x80ce30]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 326 StructureType main.aStruct
           Locations:
-            - Range: 0x80c9c0..0x80c9d0
+            - Range: 0x80ce20..0x80ce30
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -10060,93 +10060,93 @@ Subprograms:
       DictRegister: null
     - ID: 160
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0x80ca20..0x80ca30]
+      OutOfLinePCRanges: [0x80ce80..0x80ce90]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 327 PointerType *main.anotherStruct
           Locations:
-            - Range: 0x80ca20..0x80ca30
+            - Range: 0x80ce80..0x80ce90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 161
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0x80ca30..0x80ca40]
+      OutOfLinePCRanges: [0x80ce90..0x80cea0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 329 StructureType main.tenStrings
           Locations:
-            - Range: 0x80ca30..0x80ca40
+            - Range: 0x80ce90..0x80cea0
               Pieces: [{Size: 160, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 162
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x80ca60..0x80ca70]
+      OutOfLinePCRanges: [0x80cec0..0x80ced0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 330 StructureType main.emptyStruct
-          Locations: [{Range: 0x80ca60..0x80ca70, Pieces: []}]
+          Locations: [{Range: 0x80cec0..0x80ced0, Pieces: []}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 163
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x80ca70..0x80ca80]
+      OutOfLinePCRanges: [0x80ced0..0x80cee0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 331 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x80ca70..0x80ca80
+            - Range: 0x80ced0..0x80cee0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 164
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0x80e070..0x80e080]
+      OutOfLinePCRanges: [0x80e4d0..0x80e4e0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0x80e070..0x80e080
+            - Range: 0x80e4d0..0x80e4e0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x80e070..0x80e074
+            - Range: 0x80e4d0..0x80e4d4
               Pieces: []
-            - Range: 0x80e074..0x80e075
+            - Range: 0x80e4d4..0x80e4d5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e075..0x80e080
+            - Range: 0x80e4d5..0x80e4e0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 165
       Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0x80e080..0x80e090]
+      OutOfLinePCRanges: [0x80e4e0..0x80e4f0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80e080..0x80e08c
+            - Range: 0x80e4e0..0x80e4ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80e08c..0x80e090
+            - Range: 0x80e4ec..0x80e4f0
               Pieces:
                 - Size: 8
                   Op: null
@@ -10157,58 +10157,58 @@ Subprograms:
         - Name: ~r0
           Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x80e080..0x80e08c
+            - Range: 0x80e4e0..0x80e4ec
               Pieces: []
-            - Range: 0x80e08c..0x80e08d
+            - Range: 0x80e4ec..0x80e4ed
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80e08d..0x80e090
+            - Range: 0x80e4ed..0x80e4f0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 166
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0x80e090..0x80e0a0]
+      OutOfLinePCRanges: [0x80e4f0..0x80e500]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x80e090..0x80e0a0
+            - Range: 0x80e4f0..0x80e500
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0x80e090..0x80e094
+            - Range: 0x80e4f0..0x80e4f4
               Pieces: []
-            - Range: 0x80e094..0x80e095
+            - Range: 0x80e4f4..0x80e4f5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e095..0x80e0a0
+            - Range: 0x80e4f5..0x80e500
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 167
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0x80e0a0..0x80e0b0]
+      OutOfLinePCRanges: [0x80e500..0x80e510]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x80e0a0..0x80e0ac
+            - Range: 0x80e500..0x80e50c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80e0ac..0x80e0b0
+            - Range: 0x80e50c..0x80e510
               Pieces:
                 - Size: 8
                   Op: null
@@ -10219,28 +10219,28 @@ Subprograms:
         - Name: ~r0
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80e0a0..0x80e0ac
+            - Range: 0x80e500..0x80e50c
               Pieces: []
-            - Range: 0x80e0ac..0x80e0ad
+            - Range: 0x80e50c..0x80e50d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80e0ad..0x80e0b0
+            - Range: 0x80e50d..0x80e510
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 168
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0x80e110..0x80e2b0]
+      OutOfLinePCRanges: [0x80e570..0x80e710]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 336 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x80e110..0x80e140
+            - Range: 0x80e570..0x80e5a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10248,7 +10248,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80e140..0x80e154
+            - Range: 0x80e5a0..0x80e5b4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10256,7 +10256,7 @@ Subprograms:
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: null
-            - Range: 0x80e154..0x80e2b0
+            - Range: 0x80e5b4..0x80e710
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10269,18 +10269,18 @@ Subprograms:
         - Name: pred
           Type: 338 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0x80e110..0x80e154
+            - Range: 0x80e570..0x80e5b4
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80e154..0x80e2b0
+            - Range: 0x80e5b4..0x80e710
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 336 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x80e110..0x80e278
+            - Range: 0x80e570..0x80e6d8
               Pieces: []
-            - Range: 0x80e278..0x80e279
+            - Range: 0x80e6d8..0x80e6d9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10288,14 +10288,14 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80e279..0x80e2b0
+            - Range: 0x80e6d9..0x80e710
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
           Type: 336 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x80e140..0x80e154
+            - Range: 0x80e5a0..0x80e5b4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10303,7 +10303,7 @@ Subprograms:
                   Op: null
                 - Size: 8
                   Op: null
-            - Range: 0x80e154..0x80e174
+            - Range: 0x80e5b4..0x80e5d4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10311,7 +10311,7 @@ Subprograms:
                   Op: {CfaOffset: -80}
                 - Size: 8
                   Op: {CfaOffset: -72}
-            - Range: 0x80e174..0x80e178
+            - Range: 0x80e5d4..0x80e5d8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10319,7 +10319,7 @@ Subprograms:
                   Op: {CfaOffset: -80}
                 - Size: 8
                   Op: {CfaOffset: -72}
-            - Range: 0x80e178..0x80e178
+            - Range: 0x80e5d8..0x80e5d8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10327,7 +10327,7 @@ Subprograms:
                   Op: {CfaOffset: -80}
                 - Size: 8
                   Op: {CfaOffset: -72}
-            - Range: 0x80e178..0x80e1a8
+            - Range: 0x80e5d8..0x80e608
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10335,7 +10335,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 7, Shift: 0}
-            - Range: 0x80e1a8..0x80e238
+            - Range: 0x80e608..0x80e698
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10343,7 +10343,7 @@ Subprograms:
                   Op: {CfaOffset: -80}
                 - Size: 8
                   Op: {CfaOffset: -72}
-            - Range: 0x80e238..0x80e24c
+            - Range: 0x80e698..0x80e6ac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10351,7 +10351,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 7, Shift: 0}
-            - Range: 0x80e24c..0x80e260
+            - Range: 0x80e6ac..0x80e6c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10359,7 +10359,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 7, Shift: 0}
-            - Range: 0x80e260..0x80e26c
+            - Range: 0x80e6c0..0x80e6cc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10367,7 +10367,7 @@ Subprograms:
                   Op: null
                 - Size: 8
                   Op: null
-            - Range: 0x80e26c..0x80e2b0
+            - Range: 0x80e6cc..0x80e710
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10380,215 +10380,215 @@ Subprograms:
         - Name: item
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0x80e198..0x80e1a8
+            - Range: 0x80e5f8..0x80e608
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e1a8..0x80e238
+            - Range: 0x80e608..0x80e698
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
     - ID: 169
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x80e2b0..0x80e300]
+      OutOfLinePCRanges: [0x80e710..0x80e760]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x80e2b0..0x80e2d8
+            - Range: 0x80e710..0x80e738
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
           Type: 339 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0x80e2b0..0x80e2d8
+            - Range: 0x80e710..0x80e738
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x80e2b0..0x80e2d8
+            - Range: 0x80e710..0x80e738
               Pieces: []
-            - Range: 0x80e2d8..0x80e2d9
+            - Range: 0x80e738..0x80e739
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80e2d9..0x80e300
+            - Range: 0x80e739..0x80e760
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
     - ID: 170
       Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0x80e4f0..0x80e500]
+      OutOfLinePCRanges: [0x80e950..0x80e960]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 337 PointerType *go.shape.int
           Locations:
-            - Range: 0x80e4f0..0x80e500
+            - Range: 0x80e950..0x80e960
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 337 PointerType *go.shape.int
           Locations:
-            - Range: 0x80e4f0..0x80e4f4
+            - Range: 0x80e950..0x80e954
               Pieces: []
-            - Range: 0x80e4f4..0x80e4f5
+            - Range: 0x80e954..0x80e955
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e4f5..0x80e500
+            - Range: 0x80e955..0x80e960
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 171
       Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0x80e500..0x80e510]
+      OutOfLinePCRanges: [0x80e960..0x80e970]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 340 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0x80e500..0x80e510
+            - Range: 0x80e960..0x80e970
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 340 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0x80e500..0x80e504
+            - Range: 0x80e960..0x80e964
               Pieces: []
-            - Range: 0x80e504..0x80e505
+            - Range: 0x80e964..0x80e965
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e505..0x80e510
+            - Range: 0x80e965..0x80e970
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 172
       Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0x80e510..0x80e520]
+      OutOfLinePCRanges: [0x80e970..0x80e980]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 342 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0x80e510..0x80e520
+            - Range: 0x80e970..0x80e980
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 342 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0x80e510..0x80e514
+            - Range: 0x80e970..0x80e974
               Pieces: []
-            - Range: 0x80e514..0x80e515
+            - Range: 0x80e974..0x80e975
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e515..0x80e520
+            - Range: 0x80e975..0x80e980
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 173
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0x80e520..0x80e530]
+      OutOfLinePCRanges: [0x80e980..0x80e990]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 344 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0x80e520..0x80e530
+            - Range: 0x80e980..0x80e990
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80e520..0x80e524
+            - Range: 0x80e980..0x80e984
               Pieces: []
-            - Range: 0x80e524..0x80e525
+            - Range: 0x80e984..0x80e985
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80e525..0x80e530
+            - Range: 0x80e985..0x80e990
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 174
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0x80e5a0..0x80e5b0]
+      OutOfLinePCRanges: [0x80ea00..0x80ea10]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 346 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0x80e5a0..0x80e5b0
+            - Range: 0x80ea00..0x80ea10
               Pieces: [{Size: 136, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0x80e5a0..0x80e5a4
+            - Range: 0x80ea00..0x80ea04
               Pieces: []
-            - Range: 0x80e5a4..0x80e5a5
+            - Range: 0x80ea04..0x80ea05
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e5a5..0x80e5b0
+            - Range: 0x80ea05..0x80ea10
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 175
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0x80e620..0x80e630]
+      OutOfLinePCRanges: [0x80ea80..0x80ea90]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 347 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0x80e620..0x80e630
+            - Range: 0x80ea80..0x80ea90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0x80e620..0x80e630
+            - Range: 0x80ea80..0x80ea90
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
           Type: 349 BaseType go.shape.bool
           Locations:
-            - Range: 0x80e620..0x80e630
+            - Range: 0x80ea80..0x80ea90
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
     - ID: 176
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0x80e690..0x80e700]
+      OutOfLinePCRanges: [0x80eaf0..0x80eb60]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 350 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0x80e690..0x80e700
+            - Range: 0x80eaf0..0x80eb60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80e690..0x80e700
+            - Range: 0x80eaf0..0x80eb60
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10599,20 +10599,20 @@ Subprograms:
         - Name: v
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0x80e690..0x80e700
+            - Range: 0x80eaf0..0x80eb60
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
     - ID: 177
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0x80e760..0x80e770]
+      OutOfLinePCRanges: [0x80ebc0..0x80ebd0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80e760..0x80e770
+            - Range: 0x80ebc0..0x80ebd0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10623,59 +10623,59 @@ Subprograms:
         - Name: b
           Type: 349 BaseType go.shape.bool
           Locations:
-            - Range: 0x80e760..0x80e770
+            - Range: 0x80ebc0..0x80ebd0
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 349 BaseType go.shape.bool
           Locations:
-            - Range: 0x80e760..0x80e768
+            - Range: 0x80ebc0..0x80ebc8
               Pieces: []
-            - Range: 0x80e768..0x80e769
+            - Range: 0x80ebc8..0x80ebc9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e769..0x80e770
+            - Range: 0x80ebc9..0x80ebd0
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80e760..0x80e768
+            - Range: 0x80ebc0..0x80ebc8
               Pieces: []
-            - Range: 0x80e768..0x80e769
+            - Range: 0x80ebc8..0x80ebc9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80e769..0x80e770
+            - Range: 0x80ebc9..0x80ebd0
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 178
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x80e770..0x80e790]
+      OutOfLinePCRanges: [0x80ebd0..0x80ebf0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0x80e770..0x80e780
+            - Range: 0x80ebd0..0x80ebe0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80e770..0x80e77c
+            - Range: 0x80ebd0..0x80ebdc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80e77c..0x80e790
+            - Range: 0x80ebdc..0x80ebf0
               Pieces:
                 - Size: 8
                   Op: null
@@ -10686,73 +10686,73 @@ Subprograms:
         - Name: ~r0
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80e770..0x80e780
+            - Range: 0x80ebd0..0x80ebe0
               Pieces: []
-            - Range: 0x80e780..0x80e781
+            - Range: 0x80ebe0..0x80ebe1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80e781..0x80e790
+            - Range: 0x80ebe1..0x80ebf0
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0x80e770..0x80e780
+            - Range: 0x80ebd0..0x80ebe0
               Pieces: []
-            - Range: 0x80e780..0x80e781
+            - Range: 0x80ebe0..0x80ebe1
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80e781..0x80e790
+            - Range: 0x80ebe1..0x80ebf0
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 179
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0x80e790..0x80e7e0]
+      OutOfLinePCRanges: [0x80ebf0..0x80ec40]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 352 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0x80e790..0x80e7b8
+            - Range: 0x80ebf0..0x80ec18
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80e790..0x80e7b8
+            - Range: 0x80ebf0..0x80ec18
               Pieces: []
-            - Range: 0x80e7b8..0x80e7b9
+            - Range: 0x80ec18..0x80ec19
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80e7b9..0x80e7e0
+            - Range: 0x80ec19..0x80ec40
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 180
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0x80e7e0..0x80e840]
+      OutOfLinePCRanges: [0x80ec40..0x80eca0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 353 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0x80e7e0..0x80e80c
+            - Range: 0x80ec40..0x80ec6c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80e80c..0x80e810
+            - Range: 0x80ec6c..0x80ec70
               Pieces:
                 - Size: 8
                   Op: null
@@ -10763,65 +10763,65 @@ Subprograms:
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80e7e0..0x80e810
+            - Range: 0x80ec40..0x80ec70
               Pieces: []
-            - Range: 0x80e810..0x80e811
+            - Range: 0x80ec70..0x80ec71
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80e811..0x80e840
+            - Range: 0x80ec71..0x80eca0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 181
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0x80e840..0x80e850]
+      OutOfLinePCRanges: [0x80eca0..0x80ecb0]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 354 PointerType *go.shape.string
           Locations:
-            - Range: 0x80e840..0x80e844
+            - Range: 0x80eca0..0x80eca4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80e840..0x80e844
+            - Range: 0x80eca0..0x80eca4
               Pieces: []
-            - Range: 0x80e844..0x80e845
+            - Range: 0x80eca4..0x80eca5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80e845..0x80e850
+            - Range: 0x80eca5..0x80ecb0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 182
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0x80e850..0x80e8a0]
+      OutOfLinePCRanges: [0x80ecb0..0x80ed00]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 355 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x80e850..0x80e890
+            - Range: 0x80ecb0..0x80ecf0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 356 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x80e850..0x80e894
+            - Range: 0x80ecb0..0x80ecf4
               Pieces: []
-            - Range: 0x80e894..0x80e895
+            - Range: 0x80ecf4..0x80ecf5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10835,20 +10835,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x80e895..0x80e8a0
+            - Range: 0x80ecf5..0x80ed00
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 183
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0x80e8a0..0x80e8e0]
+      OutOfLinePCRanges: [0x80ed00..0x80ed40]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 336 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x80e8a0..0x80e8ac
+            - Range: 0x80ed00..0x80ed0c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10856,7 +10856,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80e8ac..0x80e8e0
+            - Range: 0x80ed0c..0x80ed40
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10869,42 +10869,42 @@ Subprograms:
         - Name: needle
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0x80e8a0..0x80e8e0
+            - Range: 0x80ed00..0x80ed40
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x80e8a0..0x80e8c8
+            - Range: 0x80ed00..0x80ed28
               Pieces: []
-            - Range: 0x80e8c8..0x80e8c9
+            - Range: 0x80ed28..0x80ed29
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e8c9..0x80e8d0
+            - Range: 0x80ed29..0x80ed30
               Pieces: []
-            - Range: 0x80e8d0..0x80e8d1
+            - Range: 0x80ed30..0x80ed31
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e8d1..0x80e8e0
+            - Range: 0x80ed31..0x80ed40
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0x80e8bc..0x80e8cc
+            - Range: 0x80ed1c..0x80ed2c
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Local
           DictIndex: 1
       DictRegister: 0
     - ID: 184
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0x80e8e0..0x80e9a0]
+      OutOfLinePCRanges: [0x80ed40..0x80ee00]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 357 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0x80e8e0..0x80e904
+            - Range: 0x80ed40..0x80ed64
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10912,7 +10912,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80e904..0x80e908
+            - Range: 0x80ed64..0x80ed68
               Pieces:
                 - Size: 8
                   Op: null
@@ -10925,13 +10925,13 @@ Subprograms:
         - Name: needle
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80e8e0..0x80e93c
+            - Range: 0x80ed40..0x80ed9c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x80e93c..0x80e9a0
+            - Range: 0x80ed9c..0x80ee00
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 40}
@@ -10942,22 +10942,22 @@ Subprograms:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x80e8e0..0x80e958
+            - Range: 0x80ed40..0x80edb8
               Pieces: []
-            - Range: 0x80e958..0x80e959
+            - Range: 0x80edb8..0x80edb9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e959..0x80e968
+            - Range: 0x80edb9..0x80edc8
               Pieces: []
-            - Range: 0x80e968..0x80e969
+            - Range: 0x80edc8..0x80edc9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e969..0x80e9a0
+            - Range: 0x80edc9..0x80ee00
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80e924..0x80e93c
+            - Range: 0x80ed84..0x80ed9c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10968,56 +10968,56 @@ Subprograms:
       DictRegister: 0
     - ID: 185
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0x80e9a0..0x80e9b0]
+      OutOfLinePCRanges: [0x80ee00..0x80ee10]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 358 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0x80e9a0..0x80e9a8
+            - Range: 0x80ee00..0x80ee08
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0x80e9a0..0x80e9b0
+            - Range: 0x80ee00..0x80ee10
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x80e9a0..0x80e9a8
+            - Range: 0x80ee00..0x80ee08
               Pieces: []
-            - Range: 0x80e9a8..0x80e9a9
+            - Range: 0x80ee08..0x80ee09
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e9a9..0x80e9b0
+            - Range: 0x80ee09..0x80ee10
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 1
     - ID: 186
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0x80ea00..0x80ea70]
+      OutOfLinePCRanges: [0x80ee60..0x80eed0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 359 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0x80ea00..0x80ea2c
+            - Range: 0x80ee60..0x80ee8c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80ea2c..0x80ea38
+            - Range: 0x80ee8c..0x80ee98
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80ea38..0x80ea3c
+            - Range: 0x80ee98..0x80ee9c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11028,7 +11028,7 @@ Subprograms:
         - Name: value
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80ea00..0x80ea3c
+            - Range: 0x80ee60..0x80ee9c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -11039,11 +11039,11 @@ Subprograms:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x80ea00..0x80ea3c
+            - Range: 0x80ee60..0x80ee9c
               Pieces: []
-            - Range: 0x80ea3c..0x80ea3d
+            - Range: 0x80ee9c..0x80ee9d
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ea3d..0x80ea70
+            - Range: 0x80ee9d..0x80eed0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11205,31 +11205,31 @@ Subprograms:
       DictRegister: 0
     - ID: 188
       Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0x807530..0x8075a0]
+      OutOfLinePCRanges: [0x807610..0x807680]
       InlinePCRanges:
-        - Ranges: [0x8075bc..0x8075f0]
-          RootRanges: [0x8075a0..0x807610]
-        - Ranges: [0x8076f0..0x807724]
-          RootRanges: [0x8076c0..0x807750]
-        - Ranges: [0x807774..0x8077a8]
-          RootRanges: [0x807750..0x807810]
-        - Ranges: [0x80782c..0x807860]
-          RootRanges: [0x807810..0x807880]
+        - Ranges: [0x80769c..0x8076d0]
+          RootRanges: [0x807680..0x8076f0]
+        - Ranges: [0x8077d0..0x807804]
+          RootRanges: [0x8077a0..0x807830]
+        - Ranges: [0x807854..0x807888]
+          RootRanges: [0x807830..0x8078f0]
+        - Ranges: [0x80790c..0x807940]
+          RootRanges: [0x8078f0..0x807960]
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0x807530..0x807550
+            - Range: 0x807610..0x807630
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8075bc..0x8075c4
+            - Range: 0x80769c..0x8076a4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8076f0..0x8076f8
+            - Range: 0x8077d0..0x8077d8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80776c..0x80777c
+            - Range: 0x80784c..0x80785c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80777c..0x807810
+            - Range: 0x80785c..0x8078f0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x807810..0x807834
+            - Range: 0x8078f0..0x807914
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -11238,37 +11238,37 @@ Subprograms:
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x8077b4..0x8077e8]
-          RootRanges: [0x807750..0x807810]
+        - Ranges: [0x807894..0x8078c8]
+          RootRanges: [0x807830..0x8078f0]
       Variables: []
       DictRegister: null
     - ID: 190
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x80789c..0x8078d0, 0x8078d8..0x8078dc]
-          RootRanges: [0x807880..0x807990]
+        - Ranges: [0x80797c..0x8079b0, 0x8079b8..0x8079bc]
+          RootRanges: [0x807960..0x807a70]
       Variables: []
       DictRegister: null
     - ID: 191
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x807940..0x807974]
-          RootRanges: [0x807880..0x807990]
+        - Ranges: [0x807a20..0x807a54]
+          RootRanges: [0x807960..0x807a70]
       Variables: []
       DictRegister: null
     - ID: 192
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x807994..0x807998]
-          RootRanges: [0x807990..0x8079a0]
+        - Ranges: [0x807a74..0x807a78]
+          RootRanges: [0x807a70..0x807a80]
       Variables:
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0x807990..0x807998
+            - Range: 0x807a70..0x807a78
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -11277,32 +11277,32 @@ Subprograms:
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x8079c4..0x8079e0]
-          RootRanges: [0x8079a0..0x8079f0]
-        - Ranges: [0x807a4c..0x807a6c]
-          RootRanges: [0x8079f0..0x807b30]
+        - Ranges: [0x807aa4..0x807ac0]
+          RootRanges: [0x807a80..0x807ad0]
+        - Ranges: [0x807b2c..0x807b4c]
+          RootRanges: [0x807ad0..0x807c10]
       Variables:
         - Name: a
           Type: 172 ArrayType [5]int
           Locations:
-            - Range: 0x8079b0..0x8079f0
+            - Range: 0x807a90..0x807ad0
               Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
-            - Range: 0x807a38..0x807b30
+            - Range: 0x807b18..0x807c10
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 194
       Name: main.firstBehavior.DoSomething
-      OutOfLinePCRanges: [0x807b30..0x807b90]
+      OutOfLinePCRanges: [0x807c10..0x807c70]
       InlinePCRanges:
-        - Ranges: [0x80eaf0..0x80eb14]
-          RootRanges: [0x80ead0..0x80eb40]
+        - Ranges: [0x80ef50..0x80ef74]
+          RootRanges: [0x80ef30..0x80efa0]
       Variables:
         - Name: b
           Type: 364 StructureType main.firstBehavior
           Locations:
-            - Range: 0x807b30..0x807b54
+            - Range: 0x807c10..0x807c34
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11313,15 +11313,15 @@ Subprograms:
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x807b30..0x807b70
+            - Range: 0x807c10..0x807c50
               Pieces: []
-            - Range: 0x807b70..0x807b71
+            - Range: 0x807c50..0x807c51
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x807b71..0x807b90
+            - Range: 0x807c51..0x807c70
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11330,8 +11330,8 @@ Subprograms:
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x8081b4..0x8081c0, 0x8081c4..0x8081cc]
-          RootRanges: [0x808090..0x808210]
+        - Ranges: [0x8083c0..0x8083cc, 0x8083d0..0x8083d8]
+          RootRanges: [0x808330..0x808420]
         - Ranges: [0x139638..0x13963c, 0x139640..0x139648]
           RootRanges: [0x139630..0x139650]
       Variables: []
@@ -11650,7 +11650,7 @@ Types:
       ID: 41
       Name: '*[]runtime.ancestorInfo'
       ByteSize: 8
-      GoRuntimeType: 496768
+      GoRuntimeType: 497024
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
@@ -11753,7 +11753,7 @@ Types:
       ID: 11
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 400448
+      GoRuntimeType: 400576
       GoKind: 22
       Pointee: 5 BaseType bool
     - __kind: PointerType
@@ -11781,7 +11781,7 @@ Types:
       ID: 115
       Name: '*complex128'
       ByteSize: 8
-      GoRuntimeType: 400256
+      GoRuntimeType: 400384
       GoKind: 22
       Pointee: 19 BaseType complex128
     - __kind: PointerType
@@ -12171,7 +12171,7 @@ Types:
       ID: 112
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 399360
+      GoRuntimeType: 399488
       GoKind: 22
       Pointee: 16 GoInterfaceType error
     - __kind: PointerType
@@ -12192,14 +12192,14 @@ Types:
       ID: 114
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 400320
+      GoRuntimeType: 400448
       GoKind: 22
       Pointee: 18 BaseType float32
     - __kind: PointerType
       ID: 105
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 400384
+      GoRuntimeType: 400512
       GoKind: 22
       Pointee: 15 BaseType float64
     - __kind: PointerType
@@ -13058,42 +13058,42 @@ Types:
       ID: 106
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 400000
+      GoRuntimeType: 400128
       GoKind: 22
       Pointee: 8 BaseType int
     - __kind: PointerType
       ID: 110
       Name: '*int16'
       ByteSize: 8
-      GoRuntimeType: 399616
+      GoRuntimeType: 399744
       GoKind: 22
       Pointee: 103 BaseType int16
     - __kind: PointerType
       ID: 22
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 399744
+      GoRuntimeType: 399872
       GoKind: 22
       Pointee: 13 BaseType int32
     - __kind: PointerType
       ID: 108
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 399872
+      GoRuntimeType: 400000
       GoKind: 22
       Pointee: 14 BaseType int64
     - __kind: PointerType
       ID: 111
       Name: '*int8'
       ByteSize: 8
-      GoRuntimeType: 399488
+      GoRuntimeType: 399616
       GoKind: 22
       Pointee: 20 BaseType int8
     - __kind: PointerType
       ID: 174
       Name: '*interface {}'
       ByteSize: 8
-      GoRuntimeType: 400576
+      GoRuntimeType: 400704
       GoKind: 22
       Pointee: 168 GoEmptyInterfaceType interface {}
     - __kind: PointerType
@@ -13121,7 +13121,7 @@ Types:
       ID: 1068
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
-      GoRuntimeType: 913920
+      GoRuntimeType: 914400
       GoKind: 22
       Pointee: 1069 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
@@ -13146,12 +13146,12 @@ Types:
       GoKind: 22
       Pointee: 953 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 674
+      ID: 679
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
-      GoRuntimeType: 912768
+      GoRuntimeType: 913248
       GoKind: 22
-      Pointee: 675 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 680 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
       ID: 100
       Name: '*internal/runtime/atomic.Pointer[runtime.m]'
@@ -13179,12 +13179,12 @@ Types:
       GoKind: 22
       Pointee: 910 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
-      ID: 678
+      ID: 683
       Name: '*internal/strconv.Error'
       ByteSize: 8
-      GoRuntimeType: 913536
+      GoRuntimeType: 914016
       GoKind: 22
-      Pointee: 597 BaseType internal/strconv.Error
+      Pointee: 600 BaseType internal/strconv.Error
     - __kind: PointerType
       ID: 1114
       Name: '*io.PipeWriter'
@@ -14270,12 +14270,12 @@ Types:
       GoKind: 22
       Pointee: 649 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 676
+      ID: 681
       Name: '*reflect.ValueError'
       ByteSize: 8
-      GoRuntimeType: 913440
+      GoRuntimeType: 913920
       GoKind: 22
-      Pointee: 677 UnresolvedPointeeType reflect.ValueError
+      Pointee: 682 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
       ID: 777
       Name: '*regexp/syntax.Error'
@@ -14287,21 +14287,21 @@ Types:
       ID: 884
       Name: '*runtime.PanicNilError'
       ByteSize: 8
-      GoRuntimeType: 1042720
+      GoRuntimeType: 1042976
       GoKind: 22
       Pointee: 885 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
       ID: 888
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
-      GoRuntimeType: 1043360
+      GoRuntimeType: 1043616
       GoKind: 22
       Pointee: 889 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 28
       Name: '*runtime._defer'
       ByteSize: 8
-      GoRuntimeType: 400640
+      GoRuntimeType: 400768
       GoKind: 22
       Pointee: 29 UnresolvedPointeeType runtime._defer
     - __kind: PointerType
@@ -14315,21 +14315,21 @@ Types:
       ID: 886
       Name: '*runtime.boundsError'
       ByteSize: 8
-      GoRuntimeType: 1042848
+      GoRuntimeType: 1043104
       GoKind: 22
       Pointee: 887 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 70
       Name: '*runtime.cgoCallers'
       ByteSize: 8
-      GoRuntimeType: 402816
+      GoRuntimeType: 402944
       GoKind: 22
       Pointee: 71 UnresolvedPointeeType runtime.cgoCallers
     - __kind: PointerType
       ID: 49
       Name: '*runtime.coro'
       ByteSize: 8
-      GoRuntimeType: 401536
+      GoRuntimeType: 401664
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
@@ -14343,7 +14343,7 @@ Types:
       ID: 882
       Name: '*runtime.errorString'
       ByteSize: 8
-      GoRuntimeType: 1041056
+      GoRuntimeType: 1041312
       GoKind: 22
       Pointee: 863 GoStringHeaderType runtime.errorString
     - __kind: PointerType
@@ -14369,14 +14369,14 @@ Types:
       ID: 69
       Name: '*runtime.p'
       ByteSize: 8
-      GoRuntimeType: 1042464
+      GoRuntimeType: 1042720
       GoKind: 22
       Pointee: 371 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 883
       Name: '*runtime.plainError'
       ByteSize: 8
-      GoRuntimeType: 1041184
+      GoRuntimeType: 1041440
       GoKind: 22
       Pointee: 866 GoStringHeaderType runtime.plainError
     - __kind: PointerType
@@ -14388,7 +14388,7 @@ Types:
       ID: 43
       Name: '*runtime.sudog'
       ByteSize: 8
-      GoRuntimeType: 401408
+      GoRuntimeType: 401536
       GoKind: 22
       Pointee: 44 UnresolvedPointeeType runtime.sudog
     - __kind: PointerType
@@ -14399,12 +14399,12 @@ Types:
       GoKind: 22
       Pointee: 52 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 672
+      ID: 677
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
-      GoRuntimeType: 912480
+      GoRuntimeType: 912960
       GoKind: 22
-      Pointee: 673 StructureType runtime.synctestDeadlockError
+      Pointee: 678 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 46
       Name: '*runtime.timer'
@@ -14416,14 +14416,14 @@ Types:
       ID: 84
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 1644896
+      GoRuntimeType: 1645280
       GoKind: 22
       Pointee: 85 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 54
       Name: '*runtime.xRegState'
       ByteSize: 8
-      GoRuntimeType: 401728
+      GoRuntimeType: 401856
       GoKind: 22
       Pointee: 55 UnresolvedPointeeType runtime.xRegState
     - __kind: PointerType
@@ -14437,7 +14437,7 @@ Types:
       ID: 102
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 399424
+      GoRuntimeType: 399552
       GoKind: 22
       Pointee: 10 GoStringHeaderType string
     - __kind: PointerType
@@ -14633,75 +14633,75 @@ Types:
       ID: 1016
       Name: '*time.Location'
       ByteSize: 8
-      GoRuntimeType: 1649504
+      GoRuntimeType: 1640480
       GoKind: 22
       Pointee: 1017 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 682
+      ID: 675
       Name: '*time.ParseError'
       ByteSize: 8
-      GoRuntimeType: 914784
+      GoRuntimeType: 910176
       GoKind: 22
-      Pointee: 683 UnresolvedPointeeType time.ParseError
+      Pointee: 676 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 679
+      ID: 672
       Name: '*time.fileSizeError'
       ByteSize: 8
-      GoRuntimeType: 914592
+      GoRuntimeType: 909984
       GoKind: 22
-      Pointee: 598 GoStringHeaderType time.fileSizeError
+      Pointee: 597 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 600
+      ID: 599
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 599 GoStringDataType time.fileSizeError.str
+      Pointee: 598 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 680
+      ID: 673
       Name: '*time.parseDurationError'
       ByteSize: 8
-      GoRuntimeType: 914688
+      GoRuntimeType: 910080
       GoKind: 22
-      Pointee: 681 UnresolvedPointeeType time.parseDurationError
+      Pointee: 674 UnresolvedPointeeType time.parseDurationError
     - __kind: PointerType
       ID: 113
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 400064
+      GoRuntimeType: 400192
       GoKind: 22
       Pointee: 12 BaseType uint
     - __kind: PointerType
       ID: 109
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 399680
+      GoRuntimeType: 399808
       GoKind: 22
       Pointee: 7 BaseType uint16
     - __kind: PointerType
       ID: 23
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 399808
+      GoRuntimeType: 399936
       GoKind: 22
       Pointee: 3 BaseType uint32
     - __kind: PointerType
       ID: 107
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 399936
+      GoRuntimeType: 400064
       GoKind: 22
       Pointee: 9 BaseType uint64
     - __kind: PointerType
       ID: 6
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 399552
+      GoRuntimeType: 399680
       GoKind: 22
       Pointee: 4 BaseType uint8
     - __kind: PointerType
       ID: 21
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 400128
+      GoRuntimeType: 400256
       GoKind: 22
       Pointee: 2 BaseType uintptr
     - __kind: PointerType
@@ -23862,7 +23862,7 @@ Types:
       ID: 83
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 712128
+      GoRuntimeType: 713472
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23871,7 +23871,7 @@ Types:
       ID: 82
       Name: '[2][2]*runtime.traceBuf'
       ByteSize: 32
-      GoRuntimeType: 712224
+      GoRuntimeType: 713568
       GoKind: 17
       Count: 2
       HasCount: true
@@ -23896,7 +23896,7 @@ Types:
       ID: 88
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 712416
+      GoRuntimeType: 713760
       GoKind: 17
       Count: 2
       HasCount: true
@@ -24056,7 +24056,7 @@ Types:
       ID: 58
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 710496
+      GoRuntimeType: 711840
       GoKind: 17
       Count: 3
       HasCount: true
@@ -24126,7 +24126,7 @@ Types:
       ID: 89
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 712320
+      GoRuntimeType: 713664
       GoKind: 17
       Count: 8
       HasCount: true
@@ -24567,7 +24567,7 @@ Types:
       ID: 274
       Name: '[]bool'
       ByteSize: 24
-      GoRuntimeType: 495808
+      GoRuntimeType: 496064
       GoKind: 23
       RawFields:
         - Name: array
@@ -24590,7 +24590,7 @@ Types:
       ID: 1041
       Name: '[]float64'
       ByteSize: 24
-      GoRuntimeType: 495680
+      GoRuntimeType: 495936
       GoKind: 23
       RawFields:
         - Name: array
@@ -24680,7 +24680,7 @@ Types:
       ID: 1321
       Name: '[]interface {}'
       ByteSize: 24
-      GoRuntimeType: 496128
+      GoRuntimeType: 496384
       GoKind: 23
       RawFields:
         - Name: array
@@ -24936,7 +24936,7 @@ Types:
       ID: 165
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 495936
+      GoRuntimeType: 496192
       GoKind: 23
       RawFields:
         - Name: array
@@ -24980,7 +24980,7 @@ Types:
       ID: 268
       Name: '[]uint'
       ByteSize: 24
-      GoRuntimeType: 495424
+      GoRuntimeType: 495680
       GoKind: 23
       RawFields:
         - Name: array
@@ -25003,7 +25003,7 @@ Types:
       ID: 275
       Name: '[]uint16'
       ByteSize: 24
-      GoRuntimeType: 494784
+      GoRuntimeType: 495040
       GoKind: 23
       RawFields:
         - Name: array
@@ -25026,7 +25026,7 @@ Types:
       ID: 40
       Name: '[]uint8'
       ByteSize: 24
-      GoRuntimeType: 494656
+      GoRuntimeType: 494912
       GoKind: 23
       RawFields:
         - Name: array
@@ -25049,7 +25049,7 @@ Types:
       ID: 45
       Name: '[]uintptr'
       ByteSize: 24
-      GoRuntimeType: 495488
+      GoRuntimeType: 495744
       GoKind: 23
       RawFields:
         - Name: array
@@ -25505,7 +25505,7 @@ Types:
       ID: 16
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1040928
+      GoRuntimeType: 1041184
       GoKind: 20
       RawFields:
         - Name: tab
@@ -27146,7 +27146,7 @@ Types:
       ID: 168
       Name: interface {}
       ByteSize: 16
-      GoRuntimeType: 859712
+      GoRuntimeType: 860000
       GoKind: 20
       RawFields:
         - Name: _type
@@ -27210,11 +27210,11 @@ Types:
     - __kind: StructureType
       ID: 953
       Name: internal/poll.errNetClosing
-      GoRuntimeType: 1496736
+      GoRuntimeType: 1497216
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 675
+      ID: 680
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -27315,16 +27315,16 @@ Types:
           Offset: 0
           Type: 1022 PointerType *internal/abi.Type
     - __kind: BaseType
-      ID: 597
+      ID: 600
       Name: internal/strconv.Error
       ByteSize: 8
-      GoRuntimeType: 841568
+      GoRuntimeType: 841856
       GoKind: 2
     - __kind: StructureType
       ID: 1270
       Name: internal/sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1494176
+      GoRuntimeType: 1494656
       GoKind: 25
       RawFields:
         - Name: state
@@ -31127,7 +31127,7 @@ Types:
       GoRuntimeType: 848768
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 677
+      ID: 682
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -31187,7 +31187,7 @@ Types:
       ID: 949
       Name: runtime.errorAddressString
       ByteSize: 24
-      GoRuntimeType: 1780512
+      GoRuntimeType: 1780704
       GoKind: 25
       RawFields:
         - Name: msg
@@ -31431,7 +31431,7 @@ Types:
       ID: 32
       Name: runtime.gobuf
       ByteSize: 48
-      GoRuntimeType: 1942208
+      GoRuntimeType: 1942464
       GoKind: 25
       RawFields:
         - Name: sp
@@ -31456,7 +31456,7 @@ Types:
       ID: 48
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 1488736
+      GoRuntimeType: 1489216
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -31469,7 +31469,7 @@ Types:
       ID: 61
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 1779360
+      GoRuntimeType: 1779552
       GoKind: 25
       RawFields:
         - Name: stack
@@ -31488,13 +31488,13 @@ Types:
       ID: 33
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 840896
+      GoRuntimeType: 841184
       GoKind: 12
     - __kind: StructureType
       ID: 97
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 1491136
+      GoRuntimeType: 1491616
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -31507,7 +31507,7 @@ Types:
       ID: 73
       Name: runtime.listNodeManual
       ByteSize: 16
-      GoRuntimeType: 1490336
+      GoRuntimeType: 1490816
       GoKind: 25
       RawFields:
         - Name: prev
@@ -31520,7 +31520,7 @@ Types:
       ID: 98
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 841280
+      GoRuntimeType: 841568
       GoKind: 2
     - __kind: StructureType
       ID: 31
@@ -31755,7 +31755,7 @@ Types:
       ID: 76
       Name: runtime.mLockProfile
       ByteSize: 56
-      GoRuntimeType: 1942720
+      GoRuntimeType: 1942976
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -31780,7 +31780,7 @@ Types:
       ID: 92
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 1867968
+      GoRuntimeType: 1868192
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -31802,7 +31802,7 @@ Types:
       ID: 81
       Name: runtime.mTraceState
       ByteSize: 72
-      GoRuntimeType: 1942976
+      GoRuntimeType: 1943232
       GoKind: 25
       RawFields:
         - Name: writing
@@ -31827,7 +31827,7 @@ Types:
       ID: 75
       Name: runtime.mWaitList
       ByteSize: 16
-      GoRuntimeType: 1490816
+      GoRuntimeType: 1491296
       GoKind: 25
       RawFields:
         - Name: next
@@ -31850,7 +31850,7 @@ Types:
       ID: 39
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 840992
+      GoRuntimeType: 841280
       GoKind: 12
     - __kind: StructureType
       ID: 72
@@ -31867,7 +31867,7 @@ Types:
       ID: 87
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 1490976
+      GoRuntimeType: 1491456
       GoKind: 25
       RawFields:
         - Name: entries
@@ -31880,7 +31880,7 @@ Types:
       ID: 90
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 1780320
+      GoRuntimeType: 1780512
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -31918,13 +31918,13 @@ Types:
       ID: 65
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 841184
+      GoRuntimeType: 841472
       GoKind: 12
     - __kind: ArrayType
       ID: 62
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 911040
+      GoRuntimeType: 911520
       GoKind: 17
       Count: 2
       HasCount: true
@@ -31933,7 +31933,7 @@ Types:
       ID: 25
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 1487456
+      GoRuntimeType: 1487936
       GoKind: 25
       RawFields:
         - Name: lo
@@ -31951,7 +31951,7 @@ Types:
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 673
+      ID: 678
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1618688
@@ -31987,7 +31987,7 @@ Types:
       ID: 57
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 1489056
+      GoRuntimeType: 1489536
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -32849,14 +32849,14 @@ Types:
       ID: 1152
       Name: time.Duration
       ByteSize: 8
-      GoRuntimeType: 1943744
+      GoRuntimeType: 1940672
       GoKind: 6
     - __kind: UnresolvedPointeeType
       ID: 1017
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 683
+      ID: 676
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
@@ -32876,26 +32876,26 @@ Types:
           Offset: 16
           Type: 1016 PointerType *time.Location
     - __kind: GoStringHeaderType
-      ID: 598
+      ID: 597
       Name: time.fileSizeError
       ByteSize: 16
-      GoRuntimeType: 841760
+      GoRuntimeType: 840416
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 600 PointerType *time.fileSizeError.str
+          Type: 599 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 8 BaseType int
-      Data: 599 GoStringDataType time.fileSizeError.str
+      Data: 598 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 599
+      ID: 598
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 681
+      ID: 674
       Name: time.parseDurationError
       ByteSize: 8
     - __kind: BaseType

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -260,10 +260,12 @@ Package: main
 	Function: iterExample.rangeOverIterator.Values[...].func1 (main.iterExample.rangeOverIterator.Values[go.shape.[]int,go.shape.int].func1) in slices/iter.go [38:40] injectible: [39-40]
 		Var: v: go.shape.int (declared at line 39, available: [40-40])
 		Arg: yield: func(go.shape.int) bool (declared at line 0, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [20:58] injectible: [20-21], [24-25], [27-39], [41-42], [44-46], [48-49], [52-58]
-		Var: scanner: *bufio.Scanner (declared at line 24, available: )
-		Var: it: main.iterExample (declared at line 43, available: [20-58])
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 40, available: [20-58])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [21:39] injectible: [21-22], [24-24], [26-29], [33-37], [39-39]
+		Var: ticker: *time.Ticker (declared at line 33, available: [34-34])
+		Scope: 26-34
+			Var: scanner: *bufio.Scanner (declared at line 26, available: )
+		Scope: 34-37
+			Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 35, available: [34-37])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
@@ -288,6 +290,9 @@ Package: main
 		Arg: ~r0: uint64 (declared at line 40, available: )
 		Var: n: uint64 (declared at line 45, available: [44-46])
 		Var: b: []uint8 (declared at line 41, available: [44-45])
+	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [41:73] injectible: [41-54], [56-57], [59-61], [63-64], [67-73]
+		Var: it: main.iterExample (declared at line 58, available: [41-73])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 55, available: [41-73])
 	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
 		Arg: x: []int (declared at line 16, available: [16-17])
 		Arg: ~r0: string (declared at line 16, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -152,12 +152,12 @@ Package: main
 		Var: &v: *main.firstBehavior (declared at line 400, available: [391-449])
 		Var: &fortyTwo: *int (declared at line 403, available: [404-404])
 		Var: .autotmp_8: [0]int (declared at line 448, available: [391-449])
-	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [76:105] injectible: [76-79], [81-88], [90-94], [96-96], [98-100], [103-105]
-		Var: originalSlice: []int (declared at line 77, available: )
-		Var: s: []uint (declared at line 86, available: )
-		Var: s2: []uint (declared at line 103, available: )
-		Scope: 87-90
-			Var: i: int (declared at line 87, available: [90-90])
+	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [132:181] injectible: [132-135], [137-144], [146-150], [152-152], [154-156], [159-160], [162-173], [175-175], [177-177], [179-181]
+		Var: originalSlice: []int (declared at line 133, available: )
+		Var: s: []uint (declared at line 142, available: )
+		Var: s2: []uint (declared at line 159, available: )
+		Scope: 143-146
+			Var: i: int (declared at line 143, available: [146-146])
 	Function: executeStack (main.executeStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [29:30] injectible: [30-30]
 	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [57:74] injectible: [57-57], [59-64], [67-69], [73-74]
 		Var: abc: string (declared at line 58, available: )
@@ -330,8 +330,30 @@ Package: main
 		Arg: b: main.bigStruct (declared at line 82, available: [82-82])
 	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [26:26] injectible: [26-26]
 		Arg: x: [2]bool (declared at line 26, available: [26-26])
+	Function: testByteAndUint8Slices (main.testByteAndUint8Slices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [117:117] injectible: [117-117]
+		Arg: a: []uint8 (declared at line 117, available: [117-117])
+		Arg: b: []uint8 (declared at line 117, available: [117-117])
 	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14] injectible: [14-14]
 		Arg: x: [2]uint8 (declared at line 14, available: [14-14])
+	Function: testByteSliceAndIntSlice (main.testByteSliceAndIntSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [129:129] injectible: [129-129]
+		Arg: a: []uint8 (declared at line 129, available: [129-129])
+		Arg: b: []int (declared at line 129, available: [129-129])
+	Function: testByteSliceAscii (main.testByteSliceAscii) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [77:77] injectible: [77-77]
+		Arg: x: []uint8 (declared at line 77, available: [77-77])
+	Function: testByteSliceBinary (main.testByteSliceBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [81:81] injectible: [81-81]
+		Arg: x: []uint8 (declared at line 81, available: [81-81])
+	Function: testByteSliceEmbeddedNul (main.testByteSliceEmbeddedNul) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [85:85] injectible: [85-85]
+		Arg: x: []uint8 (declared at line 85, available: [85-85])
+	Function: testByteSliceInvalidUtf8 (main.testByteSliceInvalidUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [89:89] injectible: [89-89]
+		Arg: x: []uint8 (declared at line 89, available: [89-89])
+	Function: testByteSliceMultibyteUtf8 (main.testByteSliceMultibyteUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [93:93] injectible: [93-93]
+		Arg: x: []uint8 (declared at line 93, available: [93-93])
+	Function: testByteSliceOfSlices (main.testByteSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [121:121] injectible: [121-121]
+		Arg: x: [][]uint8 (declared at line 121, available: [121-121])
+	Function: testByteSliceWithOtherParams (main.testByteSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [125:125] injectible: [125-125]
+		Arg: a: int (declared at line 125, available: [125-125])
+		Arg: x: []uint8 (declared at line 125, available: [125-125])
+		Arg: b: string (declared at line 125, available: [125-125])
 	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [30:30] injectible: [30-30]
 		Arg: c: chan bool (declared at line 30, available: [30-30])
 	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [90:90] injectible: [90-90]
@@ -414,6 +436,8 @@ Package: main
 		Arg: a: *main.deepSlice7 (declared at line 165, available: [165-165])
 	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120] injectible: [120-120]
 		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
+	Function: testEmptyByteSlice (main.testEmptyByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [97:97] injectible: [97-97]
+		Arg: x: []uint8 (declared at line 97, available: [97-97])
 	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [33:33] injectible: [33-33]
 		Arg: u: []uint (declared at line 33, available: [33-33])
 	Function: testEmptySliceOfStructs (main.testEmptySliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [45:45] injectible: [45-45]
@@ -594,6 +618,8 @@ Package: main
 		Arg: result: int (declared at line 88, available: )
 	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
 		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
+	Function: testNilByteSlice (main.testNilByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [101:101] injectible: [101-101]
+		Arg: x: []uint8 (declared at line 101, available: [101-101])
 	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
 		Arg: z: *bool (declared at line 99, available: [99-99])
 		Arg: a: uint (declared at line 99, available: [99-99])
@@ -915,6 +941,9 @@ Package: main
 		Arg: a: *main.threeStringStruct (declared at line 34, available: [34-34])
 	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [34:34] injectible: [34-34]
 		Arg: t: main.triggerVerifierErrorForTesting (declared at line 34, available: [34-34])
+	Function: testTwoByteSlicesAsciiAndBinary (main.testTwoByteSlicesAsciiAndBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [113:113] injectible: [113-113]
+		Arg: a: []uint8 (declared at line 113, available: [113-113])
+		Arg: b: []uint8 (declared at line 113, available: [113-113])
 	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73] injectible: [73-73]
 		Arg: x: main.typeAlias (declared at line 73, available: [73-73])
 	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [58:58] injectible: [58-58]
@@ -925,6 +954,10 @@ Package: main
 		Arg: x: [2]uint64 (declared at line 66, available: [66-66])
 	Function: testUint8Array (main.testUint8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [54:54] injectible: [54-54]
 		Arg: x: [2]uint8 (declared at line 54, available: [54-54])
+	Function: testUint8SliceFromString (main.testUint8SliceFromString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [105:105] injectible: [105-105]
+		Arg: x: []uint8 (declared at line 105, available: [105-105])
+	Function: testUint8SliceHighBytes (main.testUint8SliceHighBytes) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [109:109] injectible: [109-109]
+		Arg: x: []uint8 (declared at line 109, available: [109-109])
 	Function: testUintArray (main.testUintArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [50:50] injectible: [50-50]
 		Arg: x: [2]uint (declared at line 50, available: [50-50])
 	Function: testUintPointer (main.testUintPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [63:63] injectible: [63-63]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -250,9 +250,10 @@ Package: main
 	Function: iterExample.rangeOverIterator.Values[...].func1 (main.iterExample.rangeOverIterator.Values[go.shape.[]int,go.shape.int].func1) in slices/iter.go [38:40] injectible: [39-40]
 		Var: v: go.shape.int (declared at line 39, available: [40-40])
 		Arg: yield: func(go.shape.int) bool (declared at line 0, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [20:58] injectible: [20-21], [24-25], [27-39], [41-42], [44-46], [48-49], [52-58]
-		Var: it: main.iterExample (declared at line 43, available: [20-58])
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 40, available: [20-58])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [21:39] injectible: [21-22], [24-24], [26-29], [33-37], [39-39]
+		Var: ticker: *time.Ticker (declared at line 33, available: [34-34])
+		Scope: 34-37
+			Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 35, available: [34-37])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
@@ -277,6 +278,9 @@ Package: main
 		Arg: ~r0: uint64 (declared at line 40, available: )
 		Var: n: uint64 (declared at line 45, available: [44-46])
 		Var: b: []uint8 (declared at line 41, available: [44-45])
+	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [41:73] injectible: [41-54], [56-57], [59-61], [63-64], [67-73]
+		Var: it: main.iterExample (declared at line 58, available: [41-73])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 55, available: [41-73])
 	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
 		Arg: x: []int (declared at line 16, available: [16-17])
 		Arg: ~r0: string (declared at line 16, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -141,12 +141,12 @@ Package: main
 		Var: &v: *main.firstBehavior (declared at line 400, available: [391-449])
 		Var: &fortyTwo: *int (declared at line 403, available: [404-404])
 		Var: .autotmp_8: [0]int (declared at line 448, available: [391-449])
-	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [76:105] injectible: [76-79], [81-88], [90-94], [96-96], [98-100], [103-105]
-		Var: originalSlice: []int (declared at line 77, available: )
-		Var: s: []uint (declared at line 86, available: )
-		Var: s2: []uint (declared at line 103, available: )
-		Scope: 87-90
-			Var: i: int (declared at line 87, available: [90-90])
+	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [132:181] injectible: [132-135], [137-144], [146-150], [152-152], [154-156], [159-160], [162-173], [175-175], [177-177], [179-181]
+		Var: originalSlice: []int (declared at line 133, available: )
+		Var: s: []uint (declared at line 142, available: )
+		Var: s2: []uint (declared at line 159, available: )
+		Scope: 143-146
+			Var: i: int (declared at line 143, available: [146-146])
 	Function: executeStack (main.executeStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [29:30] injectible: [30-30]
 	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [57:74] injectible: [57-57], [59-64], [67-69], [73-74]
 		Var: abc: string (declared at line 58, available: )
@@ -318,8 +318,30 @@ Package: main
 		Arg: b: main.bigStruct (declared at line 82, available: [82-82])
 	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [26:26] injectible: [26-26]
 		Arg: x: [2]bool (declared at line 26, available: [26-26])
+	Function: testByteAndUint8Slices (main.testByteAndUint8Slices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [117:117] injectible: [117-117]
+		Arg: a: []uint8 (declared at line 117, available: [117-117])
+		Arg: b: []uint8 (declared at line 117, available: [117-117])
 	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14] injectible: [14-14]
 		Arg: x: [2]uint8 (declared at line 14, available: [14-14])
+	Function: testByteSliceAndIntSlice (main.testByteSliceAndIntSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [129:129] injectible: [129-129]
+		Arg: a: []uint8 (declared at line 129, available: [129-129])
+		Arg: b: []int (declared at line 129, available: [129-129])
+	Function: testByteSliceAscii (main.testByteSliceAscii) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [77:77] injectible: [77-77]
+		Arg: x: []uint8 (declared at line 77, available: [77-77])
+	Function: testByteSliceBinary (main.testByteSliceBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [81:81] injectible: [81-81]
+		Arg: x: []uint8 (declared at line 81, available: [81-81])
+	Function: testByteSliceEmbeddedNul (main.testByteSliceEmbeddedNul) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [85:85] injectible: [85-85]
+		Arg: x: []uint8 (declared at line 85, available: [85-85])
+	Function: testByteSliceInvalidUtf8 (main.testByteSliceInvalidUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [89:89] injectible: [89-89]
+		Arg: x: []uint8 (declared at line 89, available: [89-89])
+	Function: testByteSliceMultibyteUtf8 (main.testByteSliceMultibyteUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [93:93] injectible: [93-93]
+		Arg: x: []uint8 (declared at line 93, available: [93-93])
+	Function: testByteSliceOfSlices (main.testByteSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [121:121] injectible: [121-121]
+		Arg: x: [][]uint8 (declared at line 121, available: [121-121])
+	Function: testByteSliceWithOtherParams (main.testByteSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [125:125] injectible: [125-125]
+		Arg: a: int (declared at line 125, available: [125-125])
+		Arg: x: []uint8 (declared at line 125, available: [125-125])
+		Arg: b: string (declared at line 125, available: [125-125])
 	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [30:30] injectible: [30-30]
 		Arg: c: chan bool (declared at line 30, available: [30-30])
 	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [90:90] injectible: [90-90]
@@ -402,6 +424,8 @@ Package: main
 		Arg: a: *main.deepSlice7 (declared at line 165, available: [165-165])
 	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120] injectible: [120-120]
 		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
+	Function: testEmptyByteSlice (main.testEmptyByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [97:97] injectible: [97-97]
+		Arg: x: []uint8 (declared at line 97, available: [97-97])
 	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [33:33] injectible: [33-33]
 		Arg: u: []uint (declared at line 33, available: [33-33])
 	Function: testEmptySliceOfStructs (main.testEmptySliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [45:45] injectible: [45-45]
@@ -582,6 +606,8 @@ Package: main
 		Arg: result: int (declared at line 88, available: )
 	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
 		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
+	Function: testNilByteSlice (main.testNilByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [101:101] injectible: [101-101]
+		Arg: x: []uint8 (declared at line 101, available: [101-101])
 	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
 		Arg: z: *bool (declared at line 99, available: [99-99])
 		Arg: a: uint (declared at line 99, available: [99-99])
@@ -903,6 +929,9 @@ Package: main
 		Arg: a: *main.threeStringStruct (declared at line 34, available: [34-34])
 	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [34:34] injectible: [34-34]
 		Arg: t: main.triggerVerifierErrorForTesting (declared at line 34, available: [34-34])
+	Function: testTwoByteSlicesAsciiAndBinary (main.testTwoByteSlicesAsciiAndBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [113:113] injectible: [113-113]
+		Arg: a: []uint8 (declared at line 113, available: [113-113])
+		Arg: b: []uint8 (declared at line 113, available: [113-113])
 	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73] injectible: [73-73]
 		Arg: x: main.typeAlias (declared at line 73, available: [73-73])
 	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [58:58] injectible: [58-58]
@@ -913,6 +942,10 @@ Package: main
 		Arg: x: [2]uint64 (declared at line 66, available: [66-66])
 	Function: testUint8Array (main.testUint8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [54:54] injectible: [54-54]
 		Arg: x: [2]uint8 (declared at line 54, available: [54-54])
+	Function: testUint8SliceFromString (main.testUint8SliceFromString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [105:105] injectible: [105-105]
+		Arg: x: []uint8 (declared at line 105, available: [105-105])
+	Function: testUint8SliceHighBytes (main.testUint8SliceHighBytes) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [109:109] injectible: [109-109]
+		Arg: x: []uint8 (declared at line 109, available: [109-109])
 	Function: testUintArray (main.testUintArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [50:50] injectible: [50-50]
 		Arg: x: [2]uint (declared at line 50, available: [50-50])
 	Function: testUintPointer (main.testUintPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [63:63] injectible: [63-63]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -138,12 +138,12 @@ Package: main
 		Var: &v: *main.firstBehavior (declared at line 400, available: [391-449])
 		Var: &fortyTwo: *int (declared at line 403, available: [404-404])
 		Var: .autotmp_8: [0]int (declared at line 448, available: [391-449])
-	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [76:105] injectible: [76-79], [81-88], [90-94], [96-96], [98-100], [103-105]
-		Var: originalSlice: []int (declared at line 77, available: )
-		Var: s: []uint (declared at line 86, available: )
-		Var: s2: []uint (declared at line 103, available: )
-		Scope: 87-90
-			Var: i: int (declared at line 87, available: [90-90])
+	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [132:181] injectible: [132-135], [137-144], [146-150], [152-152], [154-156], [159-160], [162-173], [175-175], [177-177], [179-181]
+		Var: originalSlice: []int (declared at line 133, available: )
+		Var: s: []uint (declared at line 142, available: )
+		Var: s2: []uint (declared at line 159, available: )
+		Scope: 143-146
+			Var: i: int (declared at line 143, available: [146-146])
 	Function: executeStack (main.executeStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [29:30] injectible: [30-30]
 	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [57:74] injectible: [57-57], [59-64], [67-69], [73-74]
 		Var: abc: string (declared at line 58, available: )
@@ -315,8 +315,30 @@ Package: main
 		Arg: b: main.bigStruct (declared at line 82, available: [82-82])
 	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [26:26] injectible: [26-26]
 		Arg: x: [2]bool (declared at line 26, available: [26-26])
+	Function: testByteAndUint8Slices (main.testByteAndUint8Slices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [117:117] injectible: [117-117]
+		Arg: a: []uint8 (declared at line 117, available: [117-117])
+		Arg: b: []uint8 (declared at line 117, available: [117-117])
 	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14] injectible: [14-14]
 		Arg: x: [2]uint8 (declared at line 14, available: [14-14])
+	Function: testByteSliceAndIntSlice (main.testByteSliceAndIntSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [129:129] injectible: [129-129]
+		Arg: a: []uint8 (declared at line 129, available: [129-129])
+		Arg: b: []int (declared at line 129, available: [129-129])
+	Function: testByteSliceAscii (main.testByteSliceAscii) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [77:77] injectible: [77-77]
+		Arg: x: []uint8 (declared at line 77, available: [77-77])
+	Function: testByteSliceBinary (main.testByteSliceBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [81:81] injectible: [81-81]
+		Arg: x: []uint8 (declared at line 81, available: [81-81])
+	Function: testByteSliceEmbeddedNul (main.testByteSliceEmbeddedNul) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [85:85] injectible: [85-85]
+		Arg: x: []uint8 (declared at line 85, available: [85-85])
+	Function: testByteSliceInvalidUtf8 (main.testByteSliceInvalidUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [89:89] injectible: [89-89]
+		Arg: x: []uint8 (declared at line 89, available: [89-89])
+	Function: testByteSliceMultibyteUtf8 (main.testByteSliceMultibyteUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [93:93] injectible: [93-93]
+		Arg: x: []uint8 (declared at line 93, available: [93-93])
+	Function: testByteSliceOfSlices (main.testByteSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [121:121] injectible: [121-121]
+		Arg: x: [][]uint8 (declared at line 121, available: [121-121])
+	Function: testByteSliceWithOtherParams (main.testByteSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [125:125] injectible: [125-125]
+		Arg: a: int (declared at line 125, available: [125-125])
+		Arg: x: []uint8 (declared at line 125, available: [125-125])
+		Arg: b: string (declared at line 125, available: [125-125])
 	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [30:30] injectible: [30-30]
 		Arg: c: chan bool (declared at line 30, available: [30-30])
 	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [90:90] injectible: [90-90]
@@ -399,6 +421,8 @@ Package: main
 		Arg: a: *main.deepSlice7 (declared at line 165, available: [165-165])
 	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120] injectible: [120-120]
 		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
+	Function: testEmptyByteSlice (main.testEmptyByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [97:97] injectible: [97-97]
+		Arg: x: []uint8 (declared at line 97, available: [97-97])
 	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [33:33] injectible: [33-33]
 		Arg: u: []uint (declared at line 33, available: [33-33])
 	Function: testEmptySliceOfStructs (main.testEmptySliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [45:45] injectible: [45-45]
@@ -579,6 +603,8 @@ Package: main
 		Arg: result: int (declared at line 88, available: )
 	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
 		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
+	Function: testNilByteSlice (main.testNilByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [101:101] injectible: [101-101]
+		Arg: x: []uint8 (declared at line 101, available: [101-101])
 	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
 		Arg: z: *bool (declared at line 99, available: [99-99])
 		Arg: a: uint (declared at line 99, available: [99-99])
@@ -900,6 +926,9 @@ Package: main
 		Arg: a: *main.threeStringStruct (declared at line 34, available: [34-34])
 	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [34:34] injectible: [34-34]
 		Arg: t: main.triggerVerifierErrorForTesting (declared at line 34, available: [34-34])
+	Function: testTwoByteSlicesAsciiAndBinary (main.testTwoByteSlicesAsciiAndBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [113:113] injectible: [113-113]
+		Arg: a: []uint8 (declared at line 113, available: [113-113])
+		Arg: b: []uint8 (declared at line 113, available: [113-113])
 	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73] injectible: [73-73]
 		Arg: x: main.typeAlias (declared at line 73, available: [73-73])
 	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [58:58] injectible: [58-58]
@@ -910,6 +939,10 @@ Package: main
 		Arg: x: [2]uint64 (declared at line 66, available: [66-66])
 	Function: testUint8Array (main.testUint8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [54:54] injectible: [54-54]
 		Arg: x: [2]uint8 (declared at line 54, available: [54-54])
+	Function: testUint8SliceFromString (main.testUint8SliceFromString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [105:105] injectible: [105-105]
+		Arg: x: []uint8 (declared at line 105, available: [105-105])
+	Function: testUint8SliceHighBytes (main.testUint8SliceHighBytes) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [109:109] injectible: [109-109]
+		Arg: x: []uint8 (declared at line 109, available: [109-109])
 	Function: testUintArray (main.testUintArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [50:50] injectible: [50-50]
 		Arg: x: [2]uint (declared at line 50, available: [50-50])
 	Function: testUintPointer (main.testUintPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [63:63] injectible: [63-63]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -247,9 +247,10 @@ Package: main
 	Function: iterExample.rangeOverIterator.Values[...].func1 (main.iterExample.rangeOverIterator.Values[go.shape.[]int,go.shape.int].func1) in slices/iter.go [38:40] injectible: [39-40]
 		Var: v: go.shape.int (declared at line 39, available: [40-40])
 		Arg: yield: func(go.shape.int) bool (declared at line 0, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [20:58] injectible: [20-21], [24-25], [27-39], [41-42], [44-46], [48-49], [52-58]
-		Var: it: main.iterExample (declared at line 43, available: [20-58])
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 40, available: [20-58])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [21:39] injectible: [21-22], [24-24], [26-29], [33-37], [39-39]
+		Var: ticker: *time.Ticker (declared at line 33, available: [34-34])
+		Scope: 34-37
+			Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 35, available: [34-37])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
@@ -274,6 +275,9 @@ Package: main
 		Arg: ~r0: uint64 (declared at line 40, available: )
 		Var: n: uint64 (declared at line 45, available: [44-46])
 		Var: b: []uint8 (declared at line 41, available: [42-45])
+	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [41:73] injectible: [41-54], [56-57], [59-61], [63-64], [67-73]
+		Var: it: main.iterExample (declared at line 58, available: [41-73])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 55, available: [41-73])
 	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
 		Arg: x: []int (declared at line 16, available: [16-17])
 		Arg: ~r0: string (declared at line 16, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.26rc1.out
@@ -138,12 +138,12 @@ Package: main
 		Var: &v: *main.firstBehavior (declared at line 400, available: [391-449])
 		Var: &fortyTwo: *int (declared at line 403, available: [404-404])
 		Var: .autotmp_8: [0]int (declared at line 448, available: [391-449])
-	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [76:105] injectible: [76-79], [81-88], [90-94], [96-96], [98-100], [103-105]
-		Var: originalSlice: []int (declared at line 77, available: )
-		Var: s: []uint (declared at line 86, available: )
-		Var: s2: []uint (declared at line 103, available: )
-		Scope: 87-90
-			Var: i: int (declared at line 87, available: [90-90])
+	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [132:181] injectible: [132-135], [137-144], [146-150], [152-152], [154-156], [159-160], [162-173], [175-175], [177-177], [179-181]
+		Var: originalSlice: []int (declared at line 133, available: )
+		Var: s: []uint (declared at line 142, available: )
+		Var: s2: []uint (declared at line 159, available: )
+		Scope: 143-146
+			Var: i: int (declared at line 143, available: [146-146])
 	Function: executeStack (main.executeStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [29:30] injectible: [30-30]
 	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [57:74] injectible: [57-57], [59-64], [67-69], [73-74]
 		Var: abc: string (declared at line 58, available: )
@@ -315,8 +315,30 @@ Package: main
 		Arg: b: main.bigStruct (declared at line 82, available: [82-82])
 	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [26:26] injectible: [26-26]
 		Arg: x: [2]bool (declared at line 26, available: [26-26])
+	Function: testByteAndUint8Slices (main.testByteAndUint8Slices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [117:117] injectible: [117-117]
+		Arg: a: []uint8 (declared at line 117, available: [117-117])
+		Arg: b: []uint8 (declared at line 117, available: [117-117])
 	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14] injectible: [14-14]
 		Arg: x: [2]uint8 (declared at line 14, available: [14-14])
+	Function: testByteSliceAndIntSlice (main.testByteSliceAndIntSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [129:129] injectible: [129-129]
+		Arg: a: []uint8 (declared at line 129, available: [129-129])
+		Arg: b: []int (declared at line 129, available: [129-129])
+	Function: testByteSliceAscii (main.testByteSliceAscii) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [77:77] injectible: [77-77]
+		Arg: x: []uint8 (declared at line 77, available: [77-77])
+	Function: testByteSliceBinary (main.testByteSliceBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [81:81] injectible: [81-81]
+		Arg: x: []uint8 (declared at line 81, available: [81-81])
+	Function: testByteSliceEmbeddedNul (main.testByteSliceEmbeddedNul) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [85:85] injectible: [85-85]
+		Arg: x: []uint8 (declared at line 85, available: [85-85])
+	Function: testByteSliceInvalidUtf8 (main.testByteSliceInvalidUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [89:89] injectible: [89-89]
+		Arg: x: []uint8 (declared at line 89, available: [89-89])
+	Function: testByteSliceMultibyteUtf8 (main.testByteSliceMultibyteUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [93:93] injectible: [93-93]
+		Arg: x: []uint8 (declared at line 93, available: [93-93])
+	Function: testByteSliceOfSlices (main.testByteSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [121:121] injectible: [121-121]
+		Arg: x: [][]uint8 (declared at line 121, available: [121-121])
+	Function: testByteSliceWithOtherParams (main.testByteSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [125:125] injectible: [125-125]
+		Arg: a: int (declared at line 125, available: [125-125])
+		Arg: x: []uint8 (declared at line 125, available: [125-125])
+		Arg: b: string (declared at line 125, available: [125-125])
 	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [30:30] injectible: [30-30]
 		Arg: c: chan bool (declared at line 30, available: [30-30])
 	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [90:90] injectible: [90-90]
@@ -399,6 +421,8 @@ Package: main
 		Arg: a: *main.deepSlice7 (declared at line 165, available: [165-165])
 	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120] injectible: [120-120]
 		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
+	Function: testEmptyByteSlice (main.testEmptyByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [97:97] injectible: [97-97]
+		Arg: x: []uint8 (declared at line 97, available: [97-97])
 	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [33:33] injectible: [33-33]
 		Arg: u: []uint (declared at line 33, available: [33-33])
 	Function: testEmptySliceOfStructs (main.testEmptySliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [45:45] injectible: [45-45]
@@ -579,6 +603,8 @@ Package: main
 		Arg: result: int (declared at line 88, available: )
 	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
 		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
+	Function: testNilByteSlice (main.testNilByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [101:101] injectible: [101-101]
+		Arg: x: []uint8 (declared at line 101, available: [101-101])
 	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
 		Arg: z: *bool (declared at line 99, available: [99-99])
 		Arg: a: uint (declared at line 99, available: [99-99])
@@ -900,6 +926,9 @@ Package: main
 		Arg: a: *main.threeStringStruct (declared at line 34, available: [34-34])
 	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [34:34] injectible: [34-34]
 		Arg: t: main.triggerVerifierErrorForTesting (declared at line 34, available: [34-34])
+	Function: testTwoByteSlicesAsciiAndBinary (main.testTwoByteSlicesAsciiAndBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [113:113] injectible: [113-113]
+		Arg: a: []uint8 (declared at line 113, available: [113-113])
+		Arg: b: []uint8 (declared at line 113, available: [113-113])
 	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73] injectible: [73-73]
 		Arg: x: main.typeAlias (declared at line 73, available: [73-73])
 	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [58:58] injectible: [58-58]
@@ -910,6 +939,10 @@ Package: main
 		Arg: x: [2]uint64 (declared at line 66, available: [66-66])
 	Function: testUint8Array (main.testUint8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [54:54] injectible: [54-54]
 		Arg: x: [2]uint8 (declared at line 54, available: [54-54])
+	Function: testUint8SliceFromString (main.testUint8SliceFromString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [105:105] injectible: [105-105]
+		Arg: x: []uint8 (declared at line 105, available: [105-105])
+	Function: testUint8SliceHighBytes (main.testUint8SliceHighBytes) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [109:109] injectible: [109-109]
+		Arg: x: []uint8 (declared at line 109, available: [109-109])
 	Function: testUintArray (main.testUintArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [50:50] injectible: [50-50]
 		Arg: x: [2]uint (declared at line 50, available: [50-50])
 	Function: testUintPointer (main.testUintPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [63:63] injectible: [63-63]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.26rc1.out
@@ -247,9 +247,10 @@ Package: main
 	Function: iterExample.rangeOverIterator.Values[...].func1 (main.iterExample.rangeOverIterator.Values[go.shape.[]int,go.shape.int].func1) in slices/iter.go [38:40] injectible: [39-40]
 		Var: v: go.shape.int (declared at line 39, available: [40-40])
 		Arg: yield: func(go.shape.int) bool (declared at line 0, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [20:58] injectible: [20-21], [24-25], [27-39], [41-42], [44-46], [48-49], [52-58]
-		Var: it: main.iterExample (declared at line 43, available: [20-58])
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 40, available: [20-58])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [21:39] injectible: [21-22], [24-24], [26-29], [33-37], [39-39]
+		Var: ticker: *time.Ticker (declared at line 33, available: [34-34])
+		Scope: 34-37
+			Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 35, available: [34-37])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
@@ -274,6 +275,9 @@ Package: main
 		Arg: ~r0: uint64 (declared at line 40, available: )
 		Var: n: uint64 (declared at line 45, available: [44-46])
 		Var: b: []uint8 (declared at line 41, available: [42-45])
+	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [41:73] injectible: [41-54], [56-57], [59-61], [63-64], [67-73]
+		Var: it: main.iterExample (declared at line 58, available: [41-73])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 55, available: [41-73])
 	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
 		Arg: x: []int (declared at line 16, available: [16-17])
 		Arg: ~r0: string (declared at line 16, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -152,12 +152,12 @@ Package: main
 		Var: &v: *main.firstBehavior (declared at line 400, available: [391-449])
 		Var: &fortyTwo: *int (declared at line 403, available: [404-404])
 		Var: .autotmp_8: [0]int (declared at line 448, available: [391-449])
-	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [76:105] injectible: [76-79], [81-88], [90-94], [96-96], [98-100], [103-105]
-		Var: originalSlice: []int (declared at line 77, available: )
-		Var: s: []uint (declared at line 86, available: )
-		Var: s2: []uint (declared at line 103, available: )
-		Scope: 87-90
-			Var: i: int (declared at line 87, available: [90-90])
+	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [132:181] injectible: [132-135], [137-144], [146-150], [152-152], [154-156], [159-160], [162-173], [175-175], [177-177], [179-181]
+		Var: originalSlice: []int (declared at line 133, available: )
+		Var: s: []uint (declared at line 142, available: )
+		Var: s2: []uint (declared at line 159, available: )
+		Scope: 143-146
+			Var: i: int (declared at line 143, available: [146-146])
 	Function: executeStack (main.executeStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [29:30] injectible: [30-30]
 	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [57:74] injectible: [57-57], [59-64], [67-69], [73-74]
 		Var: abc: string (declared at line 58, available: )
@@ -332,8 +332,30 @@ Package: main
 		Arg: b: main.bigStruct (declared at line 82, available: [82-82])
 	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [26:26] injectible: [26-26]
 		Arg: x: [2]bool (declared at line 26, available: [26-26])
+	Function: testByteAndUint8Slices (main.testByteAndUint8Slices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [117:117] injectible: [117-117]
+		Arg: a: []uint8 (declared at line 117, available: [117-117])
+		Arg: b: []uint8 (declared at line 117, available: [117-117])
 	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14] injectible: [14-14]
 		Arg: x: [2]uint8 (declared at line 14, available: [14-14])
+	Function: testByteSliceAndIntSlice (main.testByteSliceAndIntSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [129:129] injectible: [129-129]
+		Arg: a: []uint8 (declared at line 129, available: [129-129])
+		Arg: b: []int (declared at line 129, available: [129-129])
+	Function: testByteSliceAscii (main.testByteSliceAscii) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [77:77] injectible: [77-77]
+		Arg: x: []uint8 (declared at line 77, available: [77-77])
+	Function: testByteSliceBinary (main.testByteSliceBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [81:81] injectible: [81-81]
+		Arg: x: []uint8 (declared at line 81, available: [81-81])
+	Function: testByteSliceEmbeddedNul (main.testByteSliceEmbeddedNul) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [85:85] injectible: [85-85]
+		Arg: x: []uint8 (declared at line 85, available: [85-85])
+	Function: testByteSliceInvalidUtf8 (main.testByteSliceInvalidUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [89:89] injectible: [89-89]
+		Arg: x: []uint8 (declared at line 89, available: [89-89])
+	Function: testByteSliceMultibyteUtf8 (main.testByteSliceMultibyteUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [93:93] injectible: [93-93]
+		Arg: x: []uint8 (declared at line 93, available: [93-93])
+	Function: testByteSliceOfSlices (main.testByteSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [121:121] injectible: [121-121]
+		Arg: x: [][]uint8 (declared at line 121, available: [121-121])
+	Function: testByteSliceWithOtherParams (main.testByteSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [125:125] injectible: [125-125]
+		Arg: a: int (declared at line 125, available: [125-125])
+		Arg: x: []uint8 (declared at line 125, available: [125-125])
+		Arg: b: string (declared at line 125, available: [125-125])
 	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [30:30] injectible: [30-30]
 		Arg: c: chan bool (declared at line 30, available: [30-30])
 	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [90:90] injectible: [90-90]
@@ -416,6 +438,8 @@ Package: main
 		Arg: a: *main.deepSlice7 (declared at line 165, available: [165-165])
 	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120] injectible: [120-120]
 		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
+	Function: testEmptyByteSlice (main.testEmptyByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [97:97] injectible: [97-97]
+		Arg: x: []uint8 (declared at line 97, available: [97-97])
 	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [33:33] injectible: [33-33]
 		Arg: u: []uint (declared at line 33, available: [33-33])
 	Function: testEmptySliceOfStructs (main.testEmptySliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [45:45] injectible: [45-45]
@@ -599,6 +623,8 @@ Package: main
 		Arg: result: int (declared at line 88, available: )
 	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
 		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
+	Function: testNilByteSlice (main.testNilByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [101:101] injectible: [101-101]
+		Arg: x: []uint8 (declared at line 101, available: [101-101])
 	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
 		Arg: z: *bool (declared at line 99, available: [99-99])
 		Arg: a: uint (declared at line 99, available: [99-99])
@@ -922,6 +948,9 @@ Package: main
 		Arg: a: *main.threeStringStruct (declared at line 34, available: [34-34])
 	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [34:34] injectible: [34-34]
 		Arg: t: main.triggerVerifierErrorForTesting (declared at line 34, available: [34-34])
+	Function: testTwoByteSlicesAsciiAndBinary (main.testTwoByteSlicesAsciiAndBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [113:113] injectible: [113-113]
+		Arg: a: []uint8 (declared at line 113, available: [113-113])
+		Arg: b: []uint8 (declared at line 113, available: [113-113])
 	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73] injectible: [73-73]
 		Arg: x: main.typeAlias (declared at line 73, available: [73-73])
 	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [58:58] injectible: [58-58]
@@ -932,6 +961,10 @@ Package: main
 		Arg: x: [2]uint64 (declared at line 66, available: [66-66])
 	Function: testUint8Array (main.testUint8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [54:54] injectible: [54-54]
 		Arg: x: [2]uint8 (declared at line 54, available: [54-54])
+	Function: testUint8SliceFromString (main.testUint8SliceFromString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [105:105] injectible: [105-105]
+		Arg: x: []uint8 (declared at line 105, available: [105-105])
+	Function: testUint8SliceHighBytes (main.testUint8SliceHighBytes) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [109:109] injectible: [109-109]
+		Arg: x: []uint8 (declared at line 109, available: [109-109])
 	Function: testUintArray (main.testUintArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [50:50] injectible: [50-50]
 		Arg: x: [2]uint (declared at line 50, available: [50-50])
 	Function: testUintPointer (main.testUintPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [63:63] injectible: [63-63]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -262,10 +262,12 @@ Package: main
 	Function: iterExample.rangeOverIterator.Values[...].func1 (main.iterExample.rangeOverIterator.Values[go.shape.[]int,go.shape.int].func1) in slices/iter.go [38:40] injectible: [39-40]
 		Var: v: go.shape.int (declared at line 39, available: [40-40])
 		Arg: yield: func(go.shape.int) bool (declared at line 0, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [20:58] injectible: [20-21], [24-25], [27-39], [41-42], [44-46], [48-49], [52-58]
-		Var: scanner: *bufio.Scanner (declared at line 24, available: )
-		Var: it: main.iterExample (declared at line 43, available: [20-58])
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 40, available: [20-58])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [21:39] injectible: [21-22], [24-24], [26-29], [33-37], [39-39]
+		Var: ticker: *time.Ticker (declared at line 33, available: [34-34])
+		Scope: 26-34
+			Var: scanner: *bufio.Scanner (declared at line 26, available: )
+		Scope: 34-37
+			Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 35, available: [34-37])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
@@ -290,6 +292,9 @@ Package: main
 		Arg: ~r0: uint64 (declared at line 40, available: )
 		Var: n: uint64 (declared at line 45, available: [44-46])
 		Var: b: []uint8 (declared at line 41, available: [44-45])
+	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [41:73] injectible: [41-54], [56-57], [59-61], [63-64], [67-73]
+		Var: it: main.iterExample (declared at line 58, available: [41-73])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 55, available: [41-73])
 	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
 		Arg: x: []int (declared at line 16, available: [16-17])
 		Arg: ~r0: string (declared at line 16, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -252,9 +252,10 @@ Package: main
 	Function: iterExample.rangeOverIterator.Values[...].func1 (main.iterExample.rangeOverIterator.Values[go.shape.[]int,go.shape.int].func1) in slices/iter.go [38:40] injectible: [39-40]
 		Var: v: go.shape.int (declared at line 39, available: [40-40])
 		Arg: yield: func(go.shape.int) bool (declared at line 0, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [20:58] injectible: [20-21], [24-25], [27-39], [41-42], [44-46], [48-49], [52-58]
-		Var: it: main.iterExample (declared at line 43, available: [20-58])
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 40, available: [20-58])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [21:39] injectible: [21-22], [24-24], [26-29], [33-37], [39-39]
+		Var: ticker: *time.Ticker (declared at line 33, available: [34-34])
+		Scope: 34-37
+			Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 35, available: [34-37])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
@@ -279,6 +280,9 @@ Package: main
 		Arg: ~r0: uint64 (declared at line 40, available: )
 		Var: n: uint64 (declared at line 45, available: [44-46])
 		Var: b: []uint8 (declared at line 41, available: [44-45])
+	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [41:73] injectible: [41-54], [56-57], [59-61], [63-64], [67-73]
+		Var: it: main.iterExample (declared at line 58, available: [41-73])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 55, available: [41-73])
 	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
 		Arg: x: []int (declared at line 16, available: [16-17])
 		Arg: ~r0: string (declared at line 16, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -141,12 +141,12 @@ Package: main
 		Var: &v: *main.firstBehavior (declared at line 400, available: [391-449])
 		Var: &fortyTwo: *int (declared at line 403, available: [404-404])
 		Var: .autotmp_8: [0]int (declared at line 448, available: [391-449])
-	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [76:105] injectible: [76-79], [81-88], [90-94], [96-96], [98-100], [103-105]
-		Var: originalSlice: []int (declared at line 77, available: )
-		Var: s: []uint (declared at line 86, available: )
-		Var: s2: []uint (declared at line 103, available: )
-		Scope: 87-90
-			Var: i: int (declared at line 87, available: [90-90])
+	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [132:181] injectible: [132-135], [137-144], [146-150], [152-152], [154-156], [159-160], [162-173], [175-175], [177-177], [179-181]
+		Var: originalSlice: []int (declared at line 133, available: )
+		Var: s: []uint (declared at line 142, available: )
+		Var: s2: []uint (declared at line 159, available: )
+		Scope: 143-146
+			Var: i: int (declared at line 143, available: [146-146])
 	Function: executeStack (main.executeStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [29:30] injectible: [30-30]
 	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [57:74] injectible: [57-57], [59-64], [67-69], [73-74]
 		Var: abc: string (declared at line 58, available: )
@@ -320,8 +320,30 @@ Package: main
 		Arg: b: main.bigStruct (declared at line 82, available: [82-82])
 	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [26:26] injectible: [26-26]
 		Arg: x: [2]bool (declared at line 26, available: [26-26])
+	Function: testByteAndUint8Slices (main.testByteAndUint8Slices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [117:117] injectible: [117-117]
+		Arg: a: []uint8 (declared at line 117, available: [117-117])
+		Arg: b: []uint8 (declared at line 117, available: [117-117])
 	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14] injectible: [14-14]
 		Arg: x: [2]uint8 (declared at line 14, available: [14-14])
+	Function: testByteSliceAndIntSlice (main.testByteSliceAndIntSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [129:129] injectible: [129-129]
+		Arg: a: []uint8 (declared at line 129, available: [129-129])
+		Arg: b: []int (declared at line 129, available: [129-129])
+	Function: testByteSliceAscii (main.testByteSliceAscii) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [77:77] injectible: [77-77]
+		Arg: x: []uint8 (declared at line 77, available: [77-77])
+	Function: testByteSliceBinary (main.testByteSliceBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [81:81] injectible: [81-81]
+		Arg: x: []uint8 (declared at line 81, available: [81-81])
+	Function: testByteSliceEmbeddedNul (main.testByteSliceEmbeddedNul) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [85:85] injectible: [85-85]
+		Arg: x: []uint8 (declared at line 85, available: [85-85])
+	Function: testByteSliceInvalidUtf8 (main.testByteSliceInvalidUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [89:89] injectible: [89-89]
+		Arg: x: []uint8 (declared at line 89, available: [89-89])
+	Function: testByteSliceMultibyteUtf8 (main.testByteSliceMultibyteUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [93:93] injectible: [93-93]
+		Arg: x: []uint8 (declared at line 93, available: [93-93])
+	Function: testByteSliceOfSlices (main.testByteSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [121:121] injectible: [121-121]
+		Arg: x: [][]uint8 (declared at line 121, available: [121-121])
+	Function: testByteSliceWithOtherParams (main.testByteSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [125:125] injectible: [125-125]
+		Arg: a: int (declared at line 125, available: [125-125])
+		Arg: x: []uint8 (declared at line 125, available: [125-125])
+		Arg: b: string (declared at line 125, available: [125-125])
 	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [30:30] injectible: [30-30]
 		Arg: c: chan bool (declared at line 30, available: [30-30])
 	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [90:90] injectible: [90-90]
@@ -404,6 +426,8 @@ Package: main
 		Arg: a: *main.deepSlice7 (declared at line 165, available: [165-165])
 	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120] injectible: [120-120]
 		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
+	Function: testEmptyByteSlice (main.testEmptyByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [97:97] injectible: [97-97]
+		Arg: x: []uint8 (declared at line 97, available: [97-97])
 	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [33:33] injectible: [33-33]
 		Arg: u: []uint (declared at line 33, available: [33-33])
 	Function: testEmptySliceOfStructs (main.testEmptySliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [45:45] injectible: [45-45]
@@ -587,6 +611,8 @@ Package: main
 		Arg: result: int (declared at line 88, available: )
 	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
 		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
+	Function: testNilByteSlice (main.testNilByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [101:101] injectible: [101-101]
+		Arg: x: []uint8 (declared at line 101, available: [101-101])
 	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
 		Arg: z: *bool (declared at line 99, available: [99-99])
 		Arg: a: uint (declared at line 99, available: [99-99])
@@ -910,6 +936,9 @@ Package: main
 		Arg: a: *main.threeStringStruct (declared at line 34, available: [34-34])
 	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [34:34] injectible: [34-34]
 		Arg: t: main.triggerVerifierErrorForTesting (declared at line 34, available: [34-34])
+	Function: testTwoByteSlicesAsciiAndBinary (main.testTwoByteSlicesAsciiAndBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [113:113] injectible: [113-113]
+		Arg: a: []uint8 (declared at line 113, available: [113-113])
+		Arg: b: []uint8 (declared at line 113, available: [113-113])
 	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73] injectible: [73-73]
 		Arg: x: main.typeAlias (declared at line 73, available: [73-73])
 	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [58:58] injectible: [58-58]
@@ -920,6 +949,10 @@ Package: main
 		Arg: x: [2]uint64 (declared at line 66, available: [66-66])
 	Function: testUint8Array (main.testUint8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [54:54] injectible: [54-54]
 		Arg: x: [2]uint8 (declared at line 54, available: [54-54])
+	Function: testUint8SliceFromString (main.testUint8SliceFromString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [105:105] injectible: [105-105]
+		Arg: x: []uint8 (declared at line 105, available: [105-105])
+	Function: testUint8SliceHighBytes (main.testUint8SliceHighBytes) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [109:109] injectible: [109-109]
+		Arg: x: []uint8 (declared at line 109, available: [109-109])
 	Function: testUintArray (main.testUintArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [50:50] injectible: [50-50]
 		Arg: x: [2]uint (declared at line 50, available: [50-50])
 	Function: testUintPointer (main.testUintPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [63:63] injectible: [63-63]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -249,9 +249,10 @@ Package: main
 	Function: iterExample.rangeOverIterator.Values[...].func1 (main.iterExample.rangeOverIterator.Values[go.shape.[]int,go.shape.int].func1) in slices/iter.go [38:40] injectible: [39-40]
 		Var: v: go.shape.int (declared at line 39, available: [40-40])
 		Arg: yield: func(go.shape.int) bool (declared at line 0, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [20:58] injectible: [20-21], [24-25], [27-39], [41-42], [44-46], [48-49], [52-58]
-		Var: it: main.iterExample (declared at line 43, available: [20-58])
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 40, available: [20-58])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [21:39] injectible: [21-22], [24-24], [26-29], [33-37], [39-39]
+		Var: ticker: *time.Ticker (declared at line 33, available: [34-34])
+		Scope: 34-37
+			Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 35, available: [34-37])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [988-989])
@@ -276,6 +277,9 @@ Package: main
 		Arg: ~r0: uint64 (declared at line 40, available: )
 		Var: n: uint64 (declared at line 45, available: [44-46])
 		Var: b: []uint8 (declared at line 41, available: [42-45])
+	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [41:73] injectible: [41-54], [56-57], [59-61], [63-64], [67-73]
+		Var: it: main.iterExample (declared at line 58, available: [41-73])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 55, available: [41-73])
 	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
 		Arg: x: []int (declared at line 16, available: [16-17])
 		Arg: ~r0: string (declared at line 16, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -138,12 +138,12 @@ Package: main
 		Var: &v: *main.firstBehavior (declared at line 400, available: [391-449])
 		Var: &fortyTwo: *int (declared at line 403, available: [404-404])
 		Var: .autotmp_8: [0]int (declared at line 448, available: [391-449])
-	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [76:105] injectible: [76-79], [81-88], [90-94], [96-96], [98-100], [103-105]
-		Var: originalSlice: []int (declared at line 77, available: )
-		Var: s: []uint (declared at line 86, available: )
-		Var: s2: []uint (declared at line 103, available: )
-		Scope: 87-90
-			Var: i: int (declared at line 87, available: [90-90])
+	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [132:181] injectible: [132-135], [137-144], [146-150], [152-152], [154-156], [159-160], [162-173], [175-175], [177-177], [179-181]
+		Var: originalSlice: []int (declared at line 133, available: )
+		Var: s: []uint (declared at line 142, available: )
+		Var: s2: []uint (declared at line 159, available: )
+		Scope: 143-146
+			Var: i: int (declared at line 143, available: [146-146])
 	Function: executeStack (main.executeStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [29:30] injectible: [30-30]
 	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [57:74] injectible: [57-57], [59-64], [67-69], [73-74]
 		Var: abc: string (declared at line 58, available: )
@@ -317,8 +317,30 @@ Package: main
 		Arg: b: main.bigStruct (declared at line 82, available: [82-82])
 	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [26:26] injectible: [26-26]
 		Arg: x: [2]bool (declared at line 26, available: [26-26])
+	Function: testByteAndUint8Slices (main.testByteAndUint8Slices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [117:117] injectible: [117-117]
+		Arg: a: []uint8 (declared at line 117, available: [117-117])
+		Arg: b: []uint8 (declared at line 117, available: [117-117])
 	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14] injectible: [14-14]
 		Arg: x: [2]uint8 (declared at line 14, available: [14-14])
+	Function: testByteSliceAndIntSlice (main.testByteSliceAndIntSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [129:129] injectible: [129-129]
+		Arg: a: []uint8 (declared at line 129, available: [129-129])
+		Arg: b: []int (declared at line 129, available: [129-129])
+	Function: testByteSliceAscii (main.testByteSliceAscii) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [77:77] injectible: [77-77]
+		Arg: x: []uint8 (declared at line 77, available: [77-77])
+	Function: testByteSliceBinary (main.testByteSliceBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [81:81] injectible: [81-81]
+		Arg: x: []uint8 (declared at line 81, available: [81-81])
+	Function: testByteSliceEmbeddedNul (main.testByteSliceEmbeddedNul) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [85:85] injectible: [85-85]
+		Arg: x: []uint8 (declared at line 85, available: [85-85])
+	Function: testByteSliceInvalidUtf8 (main.testByteSliceInvalidUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [89:89] injectible: [89-89]
+		Arg: x: []uint8 (declared at line 89, available: [89-89])
+	Function: testByteSliceMultibyteUtf8 (main.testByteSliceMultibyteUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [93:93] injectible: [93-93]
+		Arg: x: []uint8 (declared at line 93, available: [93-93])
+	Function: testByteSliceOfSlices (main.testByteSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [121:121] injectible: [121-121]
+		Arg: x: [][]uint8 (declared at line 121, available: [121-121])
+	Function: testByteSliceWithOtherParams (main.testByteSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [125:125] injectible: [125-125]
+		Arg: a: int (declared at line 125, available: [125-125])
+		Arg: x: []uint8 (declared at line 125, available: [125-125])
+		Arg: b: string (declared at line 125, available: [125-125])
 	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [30:30] injectible: [30-30]
 		Arg: c: chan bool (declared at line 30, available: [30-30])
 	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [90:90] injectible: [90-90]
@@ -401,6 +423,8 @@ Package: main
 		Arg: a: *main.deepSlice7 (declared at line 165, available: [165-165])
 	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120] injectible: [120-120]
 		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
+	Function: testEmptyByteSlice (main.testEmptyByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [97:97] injectible: [97-97]
+		Arg: x: []uint8 (declared at line 97, available: [97-97])
 	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [33:33] injectible: [33-33]
 		Arg: u: []uint (declared at line 33, available: [33-33])
 	Function: testEmptySliceOfStructs (main.testEmptySliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [45:45] injectible: [45-45]
@@ -584,6 +608,8 @@ Package: main
 		Arg: result: int (declared at line 88, available: )
 	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
 		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
+	Function: testNilByteSlice (main.testNilByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [101:101] injectible: [101-101]
+		Arg: x: []uint8 (declared at line 101, available: [101-101])
 	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
 		Arg: z: *bool (declared at line 99, available: [99-99])
 		Arg: a: uint (declared at line 99, available: [99-99])
@@ -907,6 +933,9 @@ Package: main
 		Arg: a: *main.threeStringStruct (declared at line 34, available: [34-34])
 	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [34:34] injectible: [34-34]
 		Arg: t: main.triggerVerifierErrorForTesting (declared at line 34, available: [34-34])
+	Function: testTwoByteSlicesAsciiAndBinary (main.testTwoByteSlicesAsciiAndBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [113:113] injectible: [113-113]
+		Arg: a: []uint8 (declared at line 113, available: [113-113])
+		Arg: b: []uint8 (declared at line 113, available: [113-113])
 	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73] injectible: [73-73]
 		Arg: x: main.typeAlias (declared at line 73, available: [73-73])
 	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [58:58] injectible: [58-58]
@@ -917,6 +946,10 @@ Package: main
 		Arg: x: [2]uint64 (declared at line 66, available: [66-66])
 	Function: testUint8Array (main.testUint8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [54:54] injectible: [54-54]
 		Arg: x: [2]uint8 (declared at line 54, available: [54-54])
+	Function: testUint8SliceFromString (main.testUint8SliceFromString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [105:105] injectible: [105-105]
+		Arg: x: []uint8 (declared at line 105, available: [105-105])
+	Function: testUint8SliceHighBytes (main.testUint8SliceHighBytes) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [109:109] injectible: [109-109]
+		Arg: x: []uint8 (declared at line 109, available: [109-109])
 	Function: testUintArray (main.testUintArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [50:50] injectible: [50-50]
 		Arg: x: [2]uint (declared at line 50, available: [50-50])
 	Function: testUintPointer (main.testUintPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [63:63] injectible: [63-63]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.26rc1.out
@@ -249,9 +249,10 @@ Package: main
 	Function: iterExample.rangeOverIterator.Values[...].func1 (main.iterExample.rangeOverIterator.Values[go.shape.[]int,go.shape.int].func1) in slices/iter.go [38:40] injectible: [39-40]
 		Var: v: go.shape.int (declared at line 39, available: [40-40])
 		Arg: yield: func(go.shape.int) bool (declared at line 0, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [20:58] injectible: [20-21], [24-25], [27-39], [41-42], [44-46], [48-49], [52-58]
-		Var: it: main.iterExample (declared at line 43, available: [20-58])
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 40, available: [20-58])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [21:39] injectible: [21-22], [24-24], [26-29], [33-37], [39-39]
+		Var: ticker: *time.Ticker (declared at line 33, available: [34-34])
+		Scope: 34-37
+			Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 35, available: [34-37])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [988-989])
@@ -276,6 +277,9 @@ Package: main
 		Arg: ~r0: uint64 (declared at line 40, available: )
 		Var: n: uint64 (declared at line 45, available: [44-46])
 		Var: b: []uint8 (declared at line 41, available: [42-45])
+	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [41:73] injectible: [41-54], [56-57], [59-61], [63-64], [67-73]
+		Var: it: main.iterExample (declared at line 58, available: [41-73])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 55, available: [41-73])
 	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
 		Arg: x: []int (declared at line 16, available: [16-17])
 		Arg: ~r0: string (declared at line 16, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.26rc1.out
@@ -138,12 +138,12 @@ Package: main
 		Var: &v: *main.firstBehavior (declared at line 400, available: [391-449])
 		Var: &fortyTwo: *int (declared at line 403, available: [404-404])
 		Var: .autotmp_8: [0]int (declared at line 448, available: [391-449])
-	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [76:105] injectible: [76-79], [81-88], [90-94], [96-96], [98-100], [103-105]
-		Var: originalSlice: []int (declared at line 77, available: )
-		Var: s: []uint (declared at line 86, available: )
-		Var: s2: []uint (declared at line 103, available: )
-		Scope: 87-90
-			Var: i: int (declared at line 87, available: [90-90])
+	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [132:181] injectible: [132-135], [137-144], [146-150], [152-152], [154-156], [159-160], [162-173], [175-175], [177-177], [179-181]
+		Var: originalSlice: []int (declared at line 133, available: )
+		Var: s: []uint (declared at line 142, available: )
+		Var: s2: []uint (declared at line 159, available: )
+		Scope: 143-146
+			Var: i: int (declared at line 143, available: [146-146])
 	Function: executeStack (main.executeStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [29:30] injectible: [30-30]
 	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [57:74] injectible: [57-57], [59-64], [67-69], [73-74]
 		Var: abc: string (declared at line 58, available: )
@@ -317,8 +317,30 @@ Package: main
 		Arg: b: main.bigStruct (declared at line 82, available: [82-82])
 	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [26:26] injectible: [26-26]
 		Arg: x: [2]bool (declared at line 26, available: [26-26])
+	Function: testByteAndUint8Slices (main.testByteAndUint8Slices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [117:117] injectible: [117-117]
+		Arg: a: []uint8 (declared at line 117, available: [117-117])
+		Arg: b: []uint8 (declared at line 117, available: [117-117])
 	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14] injectible: [14-14]
 		Arg: x: [2]uint8 (declared at line 14, available: [14-14])
+	Function: testByteSliceAndIntSlice (main.testByteSliceAndIntSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [129:129] injectible: [129-129]
+		Arg: a: []uint8 (declared at line 129, available: [129-129])
+		Arg: b: []int (declared at line 129, available: [129-129])
+	Function: testByteSliceAscii (main.testByteSliceAscii) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [77:77] injectible: [77-77]
+		Arg: x: []uint8 (declared at line 77, available: [77-77])
+	Function: testByteSliceBinary (main.testByteSliceBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [81:81] injectible: [81-81]
+		Arg: x: []uint8 (declared at line 81, available: [81-81])
+	Function: testByteSliceEmbeddedNul (main.testByteSliceEmbeddedNul) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [85:85] injectible: [85-85]
+		Arg: x: []uint8 (declared at line 85, available: [85-85])
+	Function: testByteSliceInvalidUtf8 (main.testByteSliceInvalidUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [89:89] injectible: [89-89]
+		Arg: x: []uint8 (declared at line 89, available: [89-89])
+	Function: testByteSliceMultibyteUtf8 (main.testByteSliceMultibyteUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [93:93] injectible: [93-93]
+		Arg: x: []uint8 (declared at line 93, available: [93-93])
+	Function: testByteSliceOfSlices (main.testByteSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [121:121] injectible: [121-121]
+		Arg: x: [][]uint8 (declared at line 121, available: [121-121])
+	Function: testByteSliceWithOtherParams (main.testByteSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [125:125] injectible: [125-125]
+		Arg: a: int (declared at line 125, available: [125-125])
+		Arg: x: []uint8 (declared at line 125, available: [125-125])
+		Arg: b: string (declared at line 125, available: [125-125])
 	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [30:30] injectible: [30-30]
 		Arg: c: chan bool (declared at line 30, available: [30-30])
 	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [90:90] injectible: [90-90]
@@ -401,6 +423,8 @@ Package: main
 		Arg: a: *main.deepSlice7 (declared at line 165, available: [165-165])
 	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120] injectible: [120-120]
 		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
+	Function: testEmptyByteSlice (main.testEmptyByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [97:97] injectible: [97-97]
+		Arg: x: []uint8 (declared at line 97, available: [97-97])
 	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [33:33] injectible: [33-33]
 		Arg: u: []uint (declared at line 33, available: [33-33])
 	Function: testEmptySliceOfStructs (main.testEmptySliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [45:45] injectible: [45-45]
@@ -584,6 +608,8 @@ Package: main
 		Arg: result: int (declared at line 88, available: )
 	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
 		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
+	Function: testNilByteSlice (main.testNilByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [101:101] injectible: [101-101]
+		Arg: x: []uint8 (declared at line 101, available: [101-101])
 	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
 		Arg: z: *bool (declared at line 99, available: [99-99])
 		Arg: a: uint (declared at line 99, available: [99-99])
@@ -907,6 +933,9 @@ Package: main
 		Arg: a: *main.threeStringStruct (declared at line 34, available: [34-34])
 	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [34:34] injectible: [34-34]
 		Arg: t: main.triggerVerifierErrorForTesting (declared at line 34, available: [34-34])
+	Function: testTwoByteSlicesAsciiAndBinary (main.testTwoByteSlicesAsciiAndBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [113:113] injectible: [113-113]
+		Arg: a: []uint8 (declared at line 113, available: [113-113])
+		Arg: b: []uint8 (declared at line 113, available: [113-113])
 	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73] injectible: [73-73]
 		Arg: x: main.typeAlias (declared at line 73, available: [73-73])
 	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [58:58] injectible: [58-58]
@@ -917,6 +946,10 @@ Package: main
 		Arg: x: [2]uint64 (declared at line 66, available: [66-66])
 	Function: testUint8Array (main.testUint8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [54:54] injectible: [54-54]
 		Arg: x: [2]uint8 (declared at line 54, available: [54-54])
+	Function: testUint8SliceFromString (main.testUint8SliceFromString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [105:105] injectible: [105-105]
+		Arg: x: []uint8 (declared at line 105, available: [105-105])
+	Function: testUint8SliceHighBytes (main.testUint8SliceHighBytes) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [109:109] injectible: [109-109]
+		Arg: x: []uint8 (declared at line 109, available: [109-109])
 	Function: testUintArray (main.testUintArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [50:50] injectible: [50-50]
 		Arg: x: [2]uint (declared at line 50, available: [50-50])
 	Function: testUintPointer (main.testUintPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [63:63] injectible: [63-63]

--- a/pkg/dyninst/testdata/decoded/sample/stackC.json
+++ b/pkg/dyninst/testdata/decoded/sample/stackC.json
@@ -36,9 +36,14 @@
             "lineNumber": 30
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 49
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 34
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testAny.json
@@ -26,9 +26,14 @@
             "lineNumber": 88
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 70
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 55
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -105,9 +110,14 @@
             "lineNumber": 89
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 70
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 55
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -184,9 +194,14 @@
             "lineNumber": 90
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 70
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 55
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -263,9 +278,14 @@
             "lineNumber": 91
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 70
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 55
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -342,9 +362,14 @@
             "lineNumber": 92
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 70
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 55
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -421,9 +446,14 @@
             "lineNumber": 93
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 70
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 55
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -500,9 +530,14 @@
             "lineNumber": 94
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 70
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 55
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -574,9 +609,14 @@
             "lineNumber": 96
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 70
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 55
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -653,9 +693,14 @@
             "lineNumber": 97
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 70
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 55
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -733,9 +778,14 @@
             "lineNumber": 99
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 70
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 55
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testAnyPtr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testAnyPtr.json
@@ -26,9 +26,14 @@
             "lineNumber": 107
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 70
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 55
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -100,9 +105,14 @@
             "lineNumber": 108
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 70
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 55
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -175,9 +185,14 @@
             "lineNumber": 109
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 70
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 55
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -255,9 +270,14 @@
             "lineNumber": 110
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 70
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 55
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -335,9 +355,14 @@
             "lineNumber": 111
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 70
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 55
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -421,9 +446,14 @@
             "lineNumber": 112
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 70
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 55
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayArgAndReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayArgAndReturn.json
@@ -26,9 +26,14 @@
             "lineNumber": 438
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayEmptyStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayEmptyStructs.json
@@ -26,9 +26,14 @@
             "lineNumber": 128
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 31
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfArrays.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfArrays.json
@@ -26,9 +26,14 @@
             "lineNumber": 119
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 31
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfArraysOfArrays.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfArraysOfArrays.json
@@ -26,9 +26,14 @@
             "lineNumber": 122
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 31
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfMaps.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfMaps.json
@@ -26,9 +26,14 @@
             "lineNumber": 147
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 69
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 54
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfStrings.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfStrings.json
@@ -26,9 +26,14 @@
             "lineNumber": 120
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 31
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfStructs.json
@@ -26,9 +26,14 @@
             "lineNumber": 121
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 31
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testAtomicAdd.json
+++ b/pkg/dyninst/testdata/decoded/sample/testAtomicAdd.json
@@ -26,9 +26,14 @@
             "lineNumber": 54
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 42
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 27
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testBigStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testBigStruct.json
@@ -26,9 +26,14 @@
             "lineNumber": 260
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 52
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 37
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testBigStruct_geq_go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testBigStruct_geq_go1.26rc1.json
@@ -26,9 +26,14 @@
             "lineNumber": 260
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 52
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 37
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testBoolArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testBoolArray.json
@@ -26,9 +26,14 @@
             "lineNumber": 107
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 31
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testByteArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testByteArray.json
@@ -26,9 +26,14 @@
             "lineNumber": 104
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 31
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testCaptureExprGetmember.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCaptureExprGetmember.json
@@ -26,9 +26,14 @@
             "lineNumber": 143
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 48
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 33
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testCaptureExprGetmember_geq_go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCaptureExprGetmember_geq_go1.26rc1.json
@@ -26,9 +26,14 @@
             "lineNumber": 143
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 48
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 33
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testCaptureExprLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCaptureExprLine.json
@@ -31,9 +31,14 @@
             "lineNumber": 101
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 35
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -108,9 +113,14 @@
             "lineNumber": 102
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 35
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -185,9 +195,14 @@
             "lineNumber": 102
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 35
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -267,9 +282,14 @@
             "lineNumber": 102
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 35
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -339,9 +359,14 @@
             "lineNumber": 103
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 35
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testCaptureExprLineCond.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCaptureExprLineCond.json
@@ -36,9 +36,14 @@
             "lineNumber": 102
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 35
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testCaptureExprLineWithTemplate.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCaptureExprLineWithTemplate.json
@@ -31,9 +31,14 @@
             "lineNumber": 101
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 35
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -109,9 +114,14 @@
             "lineNumber": 102
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 35
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -187,9 +197,14 @@
             "lineNumber": 102
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 35
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -270,9 +285,14 @@
             "lineNumber": 102
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 35
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -343,9 +363,14 @@
             "lineNumber": 103
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 35
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testCaptureExprSimple.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCaptureExprSimple.json
@@ -26,9 +26,14 @@
             "lineNumber": 102
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 44
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 29
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testCaptureExprWithTemplate.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCaptureExprWithTemplate.json
@@ -26,9 +26,14 @@
             "lineNumber": 102
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 44
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 29
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testChannel.json
+++ b/pkg/dyninst/testdata/decoded/sample/testChannel.json
@@ -26,9 +26,14 @@
             "lineNumber": 53
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 42
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 27
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testCombinedByte.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCombinedByte.json
@@ -26,9 +26,14 @@
             "lineNumber": 100
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 44
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 29
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testConflictingReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testConflictingReturn.json
@@ -26,9 +26,14 @@
             "lineNumber": 413
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testCycle.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCycle.json
@@ -26,9 +26,14 @@
             "lineNumber": 177
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 51
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 36
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepMap1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepMap1.json
@@ -26,9 +26,14 @@
             "lineNumber": 304
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 52
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 37
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepMap7.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepMap7.json
@@ -26,9 +26,14 @@
             "lineNumber": 305
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 52
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 37
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepPtr1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepPtr1.json
@@ -26,9 +26,14 @@
             "lineNumber": 298
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 52
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 37
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepPtr7.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepPtr7.json
@@ -26,9 +26,14 @@
             "lineNumber": 299
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 52
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 37
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepSlice1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepSlice1.json
@@ -26,9 +26,14 @@
             "lineNumber": 301
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 52
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 37
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepSlice7.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepSlice7.json
@@ -26,9 +26,14 @@
             "lineNumber": 302
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 52
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 37
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testEmptySlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptySlice.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeSliceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 96
+            "lineNumber": 152
           },
           {
             "function": "main.runAll",

--- a/pkg/dyninst/testdata/decoded/sample/testEmptySlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptySlice.json
@@ -26,9 +26,14 @@
             "lineNumber": 96
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 47
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 32
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testEmptySliceOfStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptySliceOfStructs.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeSliceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 84
+            "lineNumber": 140
           },
           {
             "function": "main.runAll",

--- a/pkg/dyninst/testdata/decoded/sample/testEmptySliceOfStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptySliceOfStructs.json
@@ -26,9 +26,14 @@
             "lineNumber": 84
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 47
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 32
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testEmptyString.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptyString.json
@@ -26,9 +26,14 @@
             "lineNumber": 68
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 45
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 30
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -90,9 +95,14 @@
             "lineNumber": 69
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 45
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 30
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testEmptyStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptyStruct.json
@@ -26,9 +26,14 @@
             "lineNumber": 190
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 48
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 33
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testEmptyStructPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptyStructPointer.json
@@ -26,9 +26,14 @@
             "lineNumber": 191
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 48
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 33
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testError.json
@@ -26,9 +26,14 @@
             "lineNumber": 101
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 70
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 55
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testErrorAtLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testErrorAtLine.json
@@ -26,9 +26,14 @@
             "lineNumber": 296
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 52
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 37
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testErrorAtLine_config_arch=amd64,toolchain=go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testErrorAtLine_config_arch=amd64,toolchain=go1.26rc1.json
@@ -26,9 +26,14 @@
             "lineNumber": 296
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 52
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 37
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testEsotericHeap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEsotericHeap.json
@@ -26,9 +26,14 @@
             "lineNumber": 68
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 67
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testEsotericStack.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEsotericStack.json
@@ -26,9 +26,14 @@
             "lineNumber": 60
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 67
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testFrameless.json
+++ b/pkg/dyninst/testdata/decoded/sample/testFrameless.json
@@ -26,9 +26,14 @@
             "lineNumber": 104
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 35
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testFramelessArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testFramelessArray.json
@@ -26,9 +26,14 @@
             "lineNumber": 105
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 35
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testFramelessArrayLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testFramelessArrayLine.json
@@ -26,9 +26,14 @@
             "lineNumber": 105
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 35
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericDeref.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericDeref.json
@@ -26,9 +26,14 @@
             "lineNumber": 228
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 68
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 53
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -127,9 +132,14 @@
             "lineNumber": 230
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 68
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 53
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericDo.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericDo.json
@@ -26,9 +26,14 @@
             "lineNumber": 234
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 68
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 53
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -105,9 +110,14 @@
             "lineNumber": 235
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 68
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 53
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericFuncContains.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericFuncContains.json
@@ -26,9 +26,14 @@
             "lineNumber": 217
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 68
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 53
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -118,9 +123,14 @@
             "lineNumber": 218
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 68
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 53
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -210,9 +220,14 @@
             "lineNumber": 222
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 68
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 53
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -302,9 +317,14 @@
             "lineNumber": 263
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 68
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 53
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -394,9 +414,14 @@
             "lineNumber": 264
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 68
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 53
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericFuncContainsLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericFuncContainsLine.json
@@ -26,9 +26,14 @@
             "lineNumber": 217
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 68
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 53
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -95,9 +100,14 @@
             "lineNumber": 218
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 68
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 53
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -182,9 +192,14 @@
             "lineNumber": 222
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 68
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 53
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -269,9 +284,14 @@
             "lineNumber": 263
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 68
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 53
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -356,9 +376,14 @@
             "lineNumber": 264
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 68
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 53
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericLargeGet.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericLargeGet.json
@@ -26,9 +26,14 @@
             "lineNumber": 250
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 68
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 53
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -665,9 +670,14 @@
             "lineNumber": 252
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 68
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 53
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericLibFilter.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericLibFilter.json
@@ -26,9 +26,14 @@
             "lineNumber": 99
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 61
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -133,9 +138,14 @@
             "lineNumber": 282
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 68
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 53
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericLibMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericLibMap.json
@@ -26,9 +26,14 @@
             "lineNumber": 278
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 68
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 53
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericMethodGuess.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericMethodGuess.json
@@ -26,9 +26,14 @@
             "lineNumber": 212
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 68
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 53
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -109,9 +114,14 @@
             "lineNumber": 214
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 68
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 53
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericNested.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericNested.json
@@ -26,9 +26,14 @@
             "lineNumber": 285
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 68
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 53
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -105,9 +110,14 @@
             "lineNumber": 286
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 68
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 53
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericPairSetValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericPairSetValue.json
@@ -26,9 +26,14 @@
             "lineNumber": 243
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 68
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 53
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -110,9 +115,14 @@
             "lineNumber": 245
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 68
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 53
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericPtrIdentity.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericPtrIdentity.json
@@ -26,9 +26,14 @@
             "lineNumber": 270
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 68
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 53
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -120,9 +125,14 @@
             "lineNumber": 272
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 68
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 53
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -206,9 +216,14 @@
             "lineNumber": 274
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 68
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 53
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericSwap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericSwap.json
@@ -26,9 +26,14 @@
             "lineNumber": 238
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 68
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 53
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -112,9 +117,14 @@
             "lineNumber": 239
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 68
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 53
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericWrapBox.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericWrapBox.json
@@ -26,9 +26,14 @@
             "lineNumber": 289
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 68
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 53
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -105,9 +110,14 @@
             "lineNumber": 290
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 68
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 53
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBA.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBA.json
@@ -31,9 +31,14 @@
             "lineNumber": 102
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 35
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBB.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBB.json
@@ -31,9 +31,14 @@
             "lineNumber": 102
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 35
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBBA.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBBA.json
@@ -36,9 +36,14 @@
             "lineNumber": 102
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 35
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBBB.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBBB.json
@@ -36,9 +36,14 @@
             "lineNumber": 102
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 35
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBC.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBC.json
@@ -31,9 +31,14 @@
             "lineNumber": 102
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 35
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBCA.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBCA.json
@@ -36,9 +36,14 @@
             "lineNumber": 102
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 35
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBCALine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBCALine.json
@@ -36,9 +36,14 @@
             "lineNumber": 102
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 35
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBCB.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBCB.json
@@ -36,9 +36,14 @@
             "lineNumber": 102
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 35
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBCBLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBCBLine.json
@@ -36,9 +36,14 @@
             "lineNumber": 102
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 35
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedFuncFromOtherPackage.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedFuncFromOtherPackage.json
@@ -26,9 +26,14 @@
             "lineNumber": 13
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 53
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 38
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedPrint.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedPrint.json
@@ -31,9 +31,14 @@
             "lineNumber": 101
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 35
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -106,9 +111,14 @@
             "lineNumber": 102
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 35
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -181,9 +191,14 @@
             "lineNumber": 102
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 35
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -261,9 +276,14 @@
             "lineNumber": 102
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 35
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -331,9 +351,14 @@
             "lineNumber": 103
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 35
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedPrintLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedPrintLine.json
@@ -31,9 +31,14 @@
             "lineNumber": 101
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 35
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -110,9 +115,14 @@
             "lineNumber": 102
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 35
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -189,9 +199,14 @@
             "lineNumber": 102
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 35
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -273,9 +288,14 @@
             "lineNumber": 102
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 35
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -347,9 +367,14 @@
             "lineNumber": 103
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 35
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedSq.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedSq.json
@@ -31,9 +31,14 @@
             "lineNumber": 104
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 35
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedSqLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedSqLine.json
@@ -31,9 +31,14 @@
             "lineNumber": 104
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 35
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedSumArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedSumArray.json
@@ -26,9 +26,14 @@
             "lineNumber": 100
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 35
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -118,9 +123,14 @@
             "lineNumber": 105
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 35
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInt16Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt16Array.json
@@ -26,9 +26,14 @@
             "lineNumber": 110
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 31
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInt32Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt32Array.json
@@ -26,9 +26,14 @@
             "lineNumber": 111
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 31
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInt64Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt64Array.json
@@ -26,9 +26,14 @@
             "lineNumber": 112
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 31
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInt8Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt8Array.json
@@ -26,9 +26,14 @@
             "lineNumber": 109
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 31
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testIntArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testIntArray.json
@@ -26,9 +26,14 @@
             "lineNumber": 108
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 31
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInterface.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInterface.json
@@ -26,9 +26,14 @@
             "lineNumber": 77
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 70
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 55
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -101,9 +106,14 @@
             "lineNumber": 78
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 70
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 55
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -177,9 +187,14 @@
             "lineNumber": 79
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 70
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 55
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -252,9 +267,14 @@
             "lineNumber": 80
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 70
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 55
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -328,9 +348,14 @@
             "lineNumber": 81
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 70
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 55
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -398,9 +423,14 @@
             "lineNumber": 82
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 70
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 55
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testLargeArgAndReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLargeArgAndReturn.json
@@ -26,9 +26,14 @@
             "lineNumber": 437
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testLinkedList.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLinkedList.json
@@ -26,9 +26,14 @@
             "lineNumber": 155
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 51
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 36
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineA.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineA.json
@@ -26,9 +26,14 @@
             "lineNumber": 313
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 52
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 37
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineB.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineB.json
@@ -26,9 +26,14 @@
             "lineNumber": 313
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 52
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 37
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -99,9 +104,14 @@
             "lineNumber": 313
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 52
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 37
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -172,9 +182,14 @@
             "lineNumber": 313
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 52
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 37
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -245,9 +260,14 @@
             "lineNumber": 313
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 52
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 37
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -318,9 +338,14 @@
             "lineNumber": 313
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 52
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 37
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -391,9 +416,14 @@
             "lineNumber": 313
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 52
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 37
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -464,9 +494,14 @@
             "lineNumber": 313
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 52
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 37
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -537,9 +572,14 @@
             "lineNumber": 313
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 52
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 37
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -610,9 +650,14 @@
             "lineNumber": 313
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 52
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 37
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -683,9 +728,14 @@
             "lineNumber": 313
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 52
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 37
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineB_geq_go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineB_geq_go1.26rc1.json
@@ -26,9 +26,14 @@
             "lineNumber": 313
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 52
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 37
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineC.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineC.json
@@ -26,9 +26,14 @@
             "lineNumber": 313
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 52
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 37
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -99,9 +104,14 @@
             "lineNumber": 313
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 52
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 37
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -172,9 +182,14 @@
             "lineNumber": 313
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 52
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 37
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -245,9 +260,14 @@
             "lineNumber": 313
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 52
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 37
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -318,9 +338,14 @@
             "lineNumber": 313
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 52
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 37
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -391,9 +416,14 @@
             "lineNumber": 313
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 52
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 37
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -464,9 +494,14 @@
             "lineNumber": 313
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 52
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 37
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -537,9 +572,14 @@
             "lineNumber": 313
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 52
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 37
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -610,9 +650,14 @@
             "lineNumber": 313
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 52
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 37
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -683,9 +728,14 @@
             "lineNumber": 313
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 52
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 37
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineC_geq_go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineC_geq_go1.26rc1.json
@@ -26,9 +26,14 @@
             "lineNumber": 313
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 52
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 37
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testManyArgsArrayReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testManyArgsArrayReturn.json
@@ -26,9 +26,14 @@
             "lineNumber": 443
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testManyPointers.json
+++ b/pkg/dyninst/testdata/decoded/sample/testManyPointers.json
@@ -26,9 +26,14 @@
             "lineNumber": 186
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 63
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 48
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testManyStrings.json
+++ b/pkg/dyninst/testdata/decoded/sample/testManyStrings.json
@@ -26,9 +26,14 @@
             "lineNumber": 49
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 64
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 49
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapArrayToArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapArrayToArray.json
@@ -26,9 +26,14 @@
             "lineNumber": 163
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 69
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 54
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmbeddedMaps.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmbeddedMaps.json
@@ -26,9 +26,14 @@
             "lineNumber": 169
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 69
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 54
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmptyKey.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmptyKey.json
@@ -26,9 +26,14 @@
             "lineNumber": 216
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 69
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 54
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmptyKeyAndValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmptyKeyAndValue.json
@@ -26,9 +26,14 @@
             "lineNumber": 218
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 69
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 54
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmptyValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmptyValue.json
@@ -26,9 +26,14 @@
             "lineNumber": 217
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 69
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 54
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapIntToInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapIntToInt.json
@@ -26,9 +26,14 @@
             "lineNumber": 145
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 69
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 54
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapLargeKeyLargeValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapLargeKeyLargeValue.json
@@ -26,9 +26,14 @@
             "lineNumber": 207
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 69
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 54
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapLargeKeySmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapLargeKeySmallValue.json
@@ -26,9 +26,14 @@
             "lineNumber": 214
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 69
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 54
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapMassive.json
@@ -26,9 +26,14 @@
             "lineNumber": 170
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 69
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 54
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapMassiveWithSizeLimit.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapMassiveWithSizeLimit.json
@@ -26,9 +26,14 @@
             "lineNumber": 170
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 69
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 54
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapSmallKeyLargeValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapSmallKeyLargeValue.json
@@ -26,9 +26,14 @@
             "lineNumber": 199
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 69
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 54
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapSmallKeySmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapSmallKeySmallValue.json
@@ -26,9 +26,14 @@
             "lineNumber": 193
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 69
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 54
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapStringToInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapStringToInt.json
@@ -26,9 +26,14 @@
             "lineNumber": 142
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 69
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 54
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapStringToSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapStringToSlice.json
@@ -26,9 +26,14 @@
             "lineNumber": 150
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 69
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 54
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapStringToStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapStringToStruct.json
@@ -26,9 +26,14 @@
             "lineNumber": 143
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 69
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 54
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithLinkedList.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithLinkedList.json
@@ -26,9 +26,14 @@
             "lineNumber": 158
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 69
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 54
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValue.json
@@ -26,9 +26,14 @@
             "lineNumber": 191
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 69
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 54
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValueMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValueMassive.json
@@ -26,9 +26,14 @@
             "lineNumber": 192
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 69
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 54
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValue.json
@@ -26,9 +26,14 @@
             "lineNumber": 180
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 69
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 54
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValueMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValueMassive.json
@@ -26,9 +26,14 @@
             "lineNumber": 181
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 69
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 54
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMassiveString.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMassiveString.json
@@ -26,9 +26,14 @@
             "lineNumber": 64
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 45
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 30
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMassiveStringWithSizeLimit.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMassiveStringWithSizeLimit.json
@@ -26,9 +26,14 @@
             "lineNumber": 64
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 45
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 30
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMixedArgsStackReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMixedArgsStackReturn.json
@@ -26,9 +26,14 @@
             "lineNumber": 444
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleArrayArgs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleArrayArgs.json
@@ -26,9 +26,14 @@
             "lineNumber": 446
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleLargeArgs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleLargeArgs.json
@@ -26,9 +26,14 @@
             "lineNumber": 439
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleNamedReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleNamedReturn.json
@@ -26,9 +26,14 @@
             "lineNumber": 411
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleSimpleParams.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleSimpleParams.json
@@ -26,9 +26,14 @@
             "lineNumber": 87
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 44
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 29
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturn.json
@@ -26,9 +26,14 @@
             "lineNumber": 410
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturnByNameCaptureExpr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturnByNameCaptureExpr.json
@@ -26,9 +26,14 @@
             "lineNumber": 410
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturnByNameMultiCaptureExpr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturnByNameMultiCaptureExpr.json
@@ -26,9 +26,14 @@
             "lineNumber": 411
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturnByNameTemplate.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturnByNameTemplate.json
@@ -26,9 +26,14 @@
             "lineNumber": 411
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturnWithTemplate.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturnWithTemplate.json
@@ -26,9 +26,14 @@
             "lineNumber": 410
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNestedPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNestedPointer.json
@@ -26,9 +26,14 @@
             "lineNumber": 152
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 48
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 33
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNilPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNilPointer.json
@@ -26,9 +26,14 @@
             "lineNumber": 165
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 51
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 36
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNilSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNilSlice.json
@@ -26,9 +26,14 @@
             "lineNumber": 99
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 47
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 32
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNilSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNilSlice.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeSliceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 99
+            "lineNumber": 155
           },
           {
             "function": "main.runAll",

--- a/pkg/dyninst/testdata/decoded/sample/testNilSliceOfStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNilSliceOfStructs.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeSliceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 85
+            "lineNumber": 141
           },
           {
             "function": "main.runAll",

--- a/pkg/dyninst/testdata/decoded/sample/testNilSliceOfStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNilSliceOfStructs.json
@@ -26,9 +26,14 @@
             "lineNumber": 85
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 47
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 32
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNilSliceWithOtherParams.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNilSliceWithOtherParams.json
@@ -26,9 +26,14 @@
             "lineNumber": 98
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 47
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 32
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNilSliceWithOtherParams.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNilSliceWithOtherParams.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeSliceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 98
+            "lineNumber": 154
           },
           {
             "function": "main.runAll",

--- a/pkg/dyninst/testdata/decoded/sample/testOneStringInStructPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testOneStringInStructPointer.json
@@ -26,9 +26,14 @@
             "lineNumber": 63
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 45
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 30
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testPointerLoop.json
+++ b/pkg/dyninst/testdata/decoded/sample/testPointerLoop.json
@@ -26,9 +26,14 @@
             "lineNumber": 176
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 51
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 36
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testPointerToMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testPointerToMap.json
@@ -26,9 +26,14 @@
             "lineNumber": 149
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 69
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 54
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testPointerToSimpleStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testPointerToSimpleStruct.json
@@ -26,9 +26,14 @@
             "lineNumber": 135
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 51
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 36
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnCaptureExpr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnCaptureExpr.json
@@ -26,9 +26,14 @@
             "lineNumber": 392
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnCondMulti.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnCondMulti.json
@@ -26,9 +26,14 @@
             "lineNumber": 412
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnCondMultiFloat.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnCondMultiFloat.json
@@ -26,9 +26,14 @@
             "lineNumber": 394
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnCondSingle.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnCondSingle.json
@@ -26,9 +26,14 @@
             "lineNumber": 392
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnCondUnavailableFloat.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnCondUnavailableFloat.json
@@ -26,9 +26,14 @@
             "lineNumber": 394
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnMultiCaptureExpr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnMultiCaptureExpr.json
@@ -26,9 +26,14 @@
             "lineNumber": 412
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnMultiTemplate.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnMultiTemplate.json
@@ -26,9 +26,14 @@
             "lineNumber": 412
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnTemplate.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnTemplate.json
@@ -26,9 +26,14 @@
             "lineNumber": 392
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsAny.json
@@ -26,9 +26,14 @@
             "lineNumber": 401
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -100,9 +105,14 @@
             "lineNumber": 402
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -184,9 +194,14 @@
             "lineNumber": 404
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsAnyAndError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsAnyAndError.json
@@ -26,9 +26,14 @@
             "lineNumber": 397
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -128,9 +133,14 @@
             "lineNumber": 398
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsArray.json
@@ -26,9 +26,14 @@
             "lineNumber": 421
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsArrayOne.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsArrayOne.json
@@ -26,9 +26,14 @@
             "lineNumber": 422
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsArrayZero.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsArrayZero.json
@@ -26,9 +26,14 @@
             "lineNumber": 423
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsBacktrackInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsBacktrackInt.json
@@ -26,9 +26,14 @@
             "lineNumber": 425
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsBoolAndUintptr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsBoolAndUintptr.json
@@ -26,9 +26,14 @@
             "lineNumber": 431
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsComplex.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsComplex.json
@@ -26,9 +26,14 @@
             "lineNumber": 419
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsError.json
@@ -26,9 +26,14 @@
             "lineNumber": 395
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -111,9 +116,14 @@
             "lineNumber": 396
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsInt.json
@@ -26,9 +26,14 @@
             "lineNumber": 392
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsIntAndFloat.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsIntAndFloat.json
@@ -26,9 +26,14 @@
             "lineNumber": 394
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsIntPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsIntPointer.json
@@ -26,9 +26,14 @@
             "lineNumber": 393
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsInterface.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsInterface.json
@@ -26,9 +26,14 @@
             "lineNumber": 406
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -105,9 +110,14 @@
             "lineNumber": 407
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -199,9 +209,14 @@
             "lineNumber": 408
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsLargeStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsLargeStruct.json
@@ -26,9 +26,14 @@
             "lineNumber": 420
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsManyFloats.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsManyFloats.json
@@ -26,9 +26,14 @@
             "lineNumber": 418
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsMixed.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsMixed.json
@@ -26,9 +26,14 @@
             "lineNumber": 427
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsMixedStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsMixedStruct.json
@@ -26,9 +26,14 @@
             "lineNumber": 424
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsMultipleFloats.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsMultipleFloats.json
@@ -26,9 +26,14 @@
             "lineNumber": 430
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsNamedDeferLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsNamedDeferLine.json
@@ -26,9 +26,14 @@
             "lineNumber": 414
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsOnlyFloat.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsOnlyFloat.json
@@ -26,9 +26,14 @@
             "lineNumber": 429
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsPrimitives.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsPrimitives.json
@@ -26,9 +26,14 @@
             "lineNumber": 417
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsStructWithArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsStructWithArray.json
@@ -26,9 +26,14 @@
             "lineNumber": 428
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsWideStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsWideStruct.json
@@ -26,9 +26,14 @@
             "lineNumber": 426
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testRuneArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testRuneArray.json
@@ -26,9 +26,14 @@
             "lineNumber": 105
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 31
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSegmentsForParamsAndReturnsOutOfOrder.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSegmentsForParamsAndReturnsOutOfOrder.json
@@ -26,9 +26,14 @@
             "lineNumber": 411
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleBool.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleBool.json
@@ -26,6 +26,11 @@
             "lineNumber": 89
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 43
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
             "lineNumber": 28

--- a/pkg/dyninst/testdata/decoded/sample/testSingleByte.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleByte.json
@@ -26,6 +26,11 @@
             "lineNumber": 90
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 43
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
             "lineNumber": 28

--- a/pkg/dyninst/testdata/decoded/sample/testSingleFloat32.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleFloat32.json
@@ -26,6 +26,11 @@
             "lineNumber": 86
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 43
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
             "lineNumber": 28

--- a/pkg/dyninst/testdata/decoded/sample/testSingleFloat64.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleFloat64.json
@@ -26,6 +26,11 @@
             "lineNumber": 87
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 43
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
             "lineNumber": 28

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt.json
@@ -26,6 +26,11 @@
             "lineNumber": 92
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 43
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
             "lineNumber": 28

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt16.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt16.json
@@ -26,6 +26,11 @@
             "lineNumber": 78
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 43
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
             "lineNumber": 28

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt32.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt32.json
@@ -26,6 +26,11 @@
             "lineNumber": 79
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 43
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
             "lineNumber": 28

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt64.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt64.json
@@ -26,6 +26,11 @@
             "lineNumber": 80
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 43
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
             "lineNumber": 28

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt8.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt8.json
@@ -26,6 +26,11 @@
             "lineNumber": 77
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 43
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
             "lineNumber": 28

--- a/pkg/dyninst/testdata/decoded/sample/testSingleRune.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleRune.json
@@ -26,6 +26,11 @@
             "lineNumber": 91
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 43
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
             "lineNumber": 28

--- a/pkg/dyninst/testdata/decoded/sample/testSingleString.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleString.json
@@ -26,9 +26,14 @@
             "lineNumber": 59
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 45
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 30
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint.json
@@ -26,6 +26,11 @@
             "lineNumber": 93
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 43
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
             "lineNumber": 28

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint16.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint16.json
@@ -26,6 +26,11 @@
             "lineNumber": 83
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 43
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
             "lineNumber": 28

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint32.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint32.json
@@ -26,6 +26,11 @@
             "lineNumber": 84
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 43
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
             "lineNumber": 28

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint64.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint64.json
@@ -26,6 +26,11 @@
             "lineNumber": 85
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 43
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
             "lineNumber": 28

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint8.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint8.json
@@ -26,6 +26,11 @@
             "lineNumber": 82
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 43
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
             "lineNumber": 28

--- a/pkg/dyninst/testdata/decoded/sample/testSliceEmptyStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSliceEmptyStructs.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeSliceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 100
+            "lineNumber": 156
           },
           {
             "function": "main.runAll",

--- a/pkg/dyninst/testdata/decoded/sample/testSliceEmptyStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSliceEmptyStructs.json
@@ -26,9 +26,14 @@
             "lineNumber": 100
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 47
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 32
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSliceOfSlices.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSliceOfSlices.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeSliceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 91
+            "lineNumber": 147
           },
           {
             "function": "main.runAll",

--- a/pkg/dyninst/testdata/decoded/sample/testSliceOfSlices.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSliceOfSlices.json
@@ -26,9 +26,14 @@
             "lineNumber": 91
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 47
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 32
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSmallMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSmallMap.json
@@ -26,9 +26,14 @@
             "lineNumber": 124
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 69
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 54
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSomeNamedReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSomeNamedReturn.json
@@ -26,9 +26,14 @@
             "lineNumber": 412
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStackArgRegReturns.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStackArgRegReturns.json
@@ -26,9 +26,14 @@
             "lineNumber": 445
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStringArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringArray.json
@@ -26,9 +26,14 @@
             "lineNumber": 106
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 31
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStringPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringPointer.json
@@ -26,9 +26,14 @@
             "lineNumber": 132
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 51
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 36
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStringSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringSlice.json
@@ -26,9 +26,14 @@
             "lineNumber": 81
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 47
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 32
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStringSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringSlice.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeSliceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 81
+            "lineNumber": 137
           },
           {
             "function": "main.runAll",

--- a/pkg/dyninst/testdata/decoded/sample/testStringType1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringType1.json
@@ -26,9 +26,14 @@
             "lineNumber": 310
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 52
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 37
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStringType2.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringType2.json
@@ -26,9 +26,14 @@
             "lineNumber": 311
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 52
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 37
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStruct.json
@@ -26,9 +26,14 @@
             "lineNumber": 143
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 48
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 33
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStructSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructSlice.json
@@ -26,9 +26,14 @@
             "lineNumber": 83
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 47
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 32
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStructSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructSlice.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeSliceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 83
+            "lineNumber": 139
           },
           {
             "function": "main.runAll",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithAny.json
@@ -26,9 +26,14 @@
             "lineNumber": 122
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 70
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 55
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithArrayArg.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithArrayArg.json
@@ -26,9 +26,14 @@
             "lineNumber": 447
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicMaps.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicMaps.json
@@ -26,9 +26,14 @@
             "lineNumber": 235
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 48
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 33
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicMaps_geq_go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicMaps_geq_go1.26rc1.json
@@ -26,9 +26,14 @@
             "lineNumber": 235
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 48
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 33
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicSlices.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicSlices.json
@@ -26,9 +26,14 @@
             "lineNumber": 215
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 48
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 33
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithMap.json
@@ -26,9 +26,14 @@
             "lineNumber": 148
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 69
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 54
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStruct_geq_go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStruct_geq_go1.26rc1.json
@@ -26,9 +26,14 @@
             "lineNumber": 143
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 48
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 33
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSubslices.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSubslices.json
@@ -26,9 +26,14 @@
             "lineNumber": 104
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 47
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 32
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSubslices.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSubslices.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeSliceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 104
+            "lineNumber": 160
           },
           {
             "function": "main.runAll",

--- a/pkg/dyninst/testdata/decoded/sample/testSubstrings.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSubstrings.json
@@ -26,9 +26,14 @@
             "lineNumber": 73
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 45
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 30
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testTemplateWithNonexistantVariableName.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTemplateWithNonexistantVariableName.json
@@ -26,9 +26,14 @@
             "lineNumber": 411
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testTemplateWithUnsupportedExpression.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTemplateWithUnsupportedExpression.json
@@ -26,9 +26,14 @@
             "lineNumber": 411
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testTemplateWithUnsupportedVariable.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTemplateWithUnsupportedVariable.json
@@ -26,9 +26,14 @@
             "lineNumber": 411
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testThreeStrings.json
+++ b/pkg/dyninst/testdata/decoded/sample/testThreeStrings.json
@@ -26,9 +26,14 @@
             "lineNumber": 60
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 45
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 30
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStruct.json
@@ -26,9 +26,14 @@
             "lineNumber": 61
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 45
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 30
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStructPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStructPointer.json
@@ -26,9 +26,14 @@
             "lineNumber": 62
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 45
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 30
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStruct_geq_go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStruct_geq_go1.26rc1.json
@@ -26,9 +26,14 @@
             "lineNumber": 61
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 45
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 30
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testTypeAlias.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTypeAlias.json
@@ -26,6 +26,11 @@
             "lineNumber": 94
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 43
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
             "lineNumber": 28

--- a/pkg/dyninst/testdata/decoded/sample/testUint16Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint16Array.json
@@ -26,9 +26,14 @@
             "lineNumber": 115
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 31
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testUint32Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint32Array.json
@@ -26,9 +26,14 @@
             "lineNumber": 116
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 31
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testUint64Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint64Array.json
@@ -26,9 +26,14 @@
             "lineNumber": 117
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 31
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testUint8Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint8Array.json
@@ -26,9 +26,14 @@
             "lineNumber": 114
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 31
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testUintArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUintArray.json
@@ -26,9 +26,14 @@
             "lineNumber": 113
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 31
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testUintPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUintPointer.json
@@ -26,9 +26,14 @@
             "lineNumber": 121
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 51
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 36
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testUintSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUintSlice.json
@@ -26,9 +26,14 @@
             "lineNumber": 82
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 47
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 32
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testUintSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUintSlice.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeSliceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 82
+            "lineNumber": 138
           },
           {
             "function": "main.runAll",

--- a/pkg/dyninst/testdata/decoded/sample/testUnitializedString.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUnitializedString.json
@@ -26,9 +26,14 @@
             "lineNumber": 67
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 45
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 30
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testUnsafePointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUnsafePointer.json
@@ -26,9 +26,14 @@
             "lineNumber": 157
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 51
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 36
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testVeryLargeArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testVeryLargeArray.json
@@ -26,9 +26,14 @@
             "lineNumber": 103
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 31
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testVeryLargeSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testVeryLargeSlice.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeSliceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 90
+            "lineNumber": 146
           },
           {
             "function": "main.runAll",

--- a/pkg/dyninst/testdata/decoded/sample/testVeryLargeSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testVeryLargeSlice.json
@@ -26,9 +26,14 @@
             "lineNumber": 90
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 47
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 32
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testVeryLargeSliceWithSizeLimit.json
+++ b/pkg/dyninst/testdata/decoded/sample/testVeryLargeSliceWithSizeLimit.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeSliceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 90
+            "lineNumber": 146
           },
           {
             "function": "main.runAll",

--- a/pkg/dyninst/testdata/decoded/sample/testVeryLargeSliceWithSizeLimit.json
+++ b/pkg/dyninst/testdata/decoded/sample/testVeryLargeSliceWithSizeLimit.json
@@ -26,9 +26,14 @@
             "lineNumber": 90
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 47
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 32
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testWhollyInlinedSubroutine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testWhollyInlinedSubroutine.json
@@ -31,9 +31,14 @@
             "lineNumber": 234
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 68
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 53
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -115,9 +120,14 @@
             "lineNumber": 407
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",
@@ -185,9 +195,14 @@
             "lineNumber": 408
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testZeroSizeArgAndReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testZeroSizeArgAndReturn.json
@@ -26,9 +26,14 @@
             "lineNumber": 448
           },
           {
+            "function": "main.runAll",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 71
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 56
+            "lineNumber": 28
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testprogs/progs/sample/main.go
+++ b/pkg/dyninst/testprogs/progs/sample/main.go
@@ -9,6 +9,7 @@ package main
 import (
 	"bufio"
 	"os"
+	"time"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 
@@ -20,10 +21,24 @@ import (
 func main() {
 	tracer.Start(tracer.WithService("sample-service"))
 
-	// Wait for input before executing functions to allow time for uprobe attachment
-	scanner := bufio.NewScanner(os.Stdin)
-	scanner.Scan()
+	if os.Getenv("DD_SAMPLE_LOOP") == "" {
+		// Wait for input before executing functions to allow time for uprobe attachment
+		scanner := bufio.NewScanner(os.Stdin)
+		scanner.Scan()
+		runAll()
+		return
+	}
 
+	// Long-running mode used by the debugger demo deployment.
+	ticker := time.NewTicker(500 * time.Millisecond)
+	for range ticker.C {
+		span := tracer.StartSpan("demo-round")
+		runAll()
+		span.Finish()
+	}
+}
+
+func runAll() {
 	executeOther()
 	executeBasicFuncs()
 	executeMultiParamFuncs()

--- a/pkg/dyninst/testprogs/progs/sample/slices.go
+++ b/pkg/dyninst/testprogs/progs/sample/slices.go
@@ -73,6 +73,62 @@ func testSliceEmptyStructs(xs []struct{}) {}
 func testSubslices(as []uint, bs []uint, cs []uint) {}
 
 //nolint:all
+//go:noinline
+func testByteSliceAscii(x []byte) {}
+
+//nolint:all
+//go:noinline
+func testByteSliceBinary(x []byte) {}
+
+//nolint:all
+//go:noinline
+func testByteSliceEmbeddedNul(x []byte) {}
+
+//nolint:all
+//go:noinline
+func testByteSliceInvalidUtf8(x []byte) {}
+
+//nolint:all
+//go:noinline
+func testByteSliceMultibyteUtf8(x []byte) {}
+
+//nolint:all
+//go:noinline
+func testEmptyByteSlice(x []byte) {}
+
+//nolint:all
+//go:noinline
+func testNilByteSlice(x []byte) {}
+
+//nolint:all
+//go:noinline
+func testUint8SliceFromString(x []uint8) {}
+
+//nolint:all
+//go:noinline
+func testUint8SliceHighBytes(x []uint8) {}
+
+//nolint:all
+//go:noinline
+func testTwoByteSlicesAsciiAndBinary(a, b []byte) {}
+
+//nolint:all
+//go:noinline
+func testByteAndUint8Slices(a []byte, b []uint8) {}
+
+//nolint:all
+//go:noinline
+func testByteSliceOfSlices(x [][]byte) {}
+
+//nolint:all
+//go:noinline
+func testByteSliceWithOtherParams(a int, x []byte, b string) {}
+
+//nolint:all
+//go:noinline
+func testByteSliceAndIntSlice(a []byte, b []int) {}
+
+//nolint:all
 func executeSliceFuncs() {
 	originalSlice := []int{1, 2, 3}
 	expandSlice(originalSlice)
@@ -102,4 +158,24 @@ func executeSliceFuncs() {
 	// Check captures when multiple variables are aliasing the same underlying buffer.
 	s2 := []uint{1, 2, 3}
 	testSubslices(s2[:2], s2[:1], s2)
+
+	testByteSliceAscii([]byte("Hello!"))
+	testByteSliceBinary([]byte{0xDE, 0xAD, 0xBE, 0xEF})
+	testByteSliceEmbeddedNul([]byte("hello\x00world"))
+	testByteSliceInvalidUtf8([]byte{0xFF, 0xFE, 0xC0, 0x80})
+	testByteSliceMultibyteUtf8([]byte("héllo, 世界"))
+	testEmptyByteSlice([]byte{})
+	testNilByteSlice(nil)
+	testUint8SliceFromString([]uint8("ascii via uint8"))
+	testUint8SliceHighBytes([]uint8{0x80, 0xFE, 0xFF})
+	testTwoByteSlicesAsciiAndBinary([]byte("Hello!"), []byte{0xDE, 0xAD, 0xBE, 0xEF})
+	testByteAndUint8Slices([]byte("Hello!"), []uint8{0x80, 0x81, 0x82})
+	testByteSliceOfSlices([][]byte{
+		[]byte("Hello!"),
+		{0xDE, 0xAD, 0xBE, 0xEF},
+		[]byte("héllo, 世界"),
+		{},
+	})
+	testByteSliceWithOtherParams(1, []byte("Hello!"), "world")
+	testByteSliceAndIntSlice([]byte("Hello!"), []int{1, 2, 3})
 }


### PR DESCRIPTION
### What does this PR do?

Adds a long-running mode to the dyninst sample test program. When `DD_SAMPLE_LOOP` is set, `main` runs the function suite in a 500ms ticker wrapped in a `demo-round` span. When the env var is unset, behavior is unchanged. The body of `main` is extracted into a `runAll` helper to support both paths.

### Motivation

The [Go debugger demo service in DataDog/debugger-demos](https://github.com/DataDog/debugger-demos/tree/main/go) has been a hand-maintained fork of this sample. It drifted from upstream over time (snake_case names, missing newer test cases like atomics, continuations, returns) and adds maintenance overhead with no upside.

The demo deployment will instead build this program directly so there is one source of truth and the demo automatically picks up new dyninst test coverage. The demo runtime needs continuous execution with a span per iteration, which is what `DD_SAMPLE_LOOP` enables.

### Describe how you validated your changes

Built standalone with `GOWORK=off go build -o /tmp/sample-service ./sample` from `pkg/dyninst/testprogs/progs`. Ran the binary in both modes:

  - Default: runs the suite once and exits 0.
  - Loop: `DD_SAMPLE_LOOP=1  sample-service` runs continuously until killed.

Existing dyninst tests that exec this binary are unaffected. The default code path is identical.

### Additional Notes

Companion PR ([link](#)) in DataDog/debugger-demos switches the Go demo image to build this program at the agent's current main SHA and sets `DD_SAMPLE_LOOP=1` in the deployment manifest.