### PR TITLE
diagnose: surface check name in output and extend --include/--exclude filtering

### DIFF
--- a/comp/collector/collector/diagnose.go
+++ b/comp/collector/collector/diagnose.go
@@ -47,11 +47,14 @@ func GetInstanceDiagnoses(instance check.Check) []diagnose.Diagnosis {
 		}
 	}
 
-	// Set category as check name if it was not set
+	// Set category and check name if not provided by the check
 	if len(diagnoses) > 0 {
 		for i, d := range diagnoses {
 			if len(d.Category) == 0 {
 				diagnoses[i].Category = instance.String()
+			}
+			if len(d.CheckName) == 0 {
+				diagnoses[i].CheckName = instance.String()
 			}
 		}
 	}

--- a/comp/collector/collector/diagnose_test.go
+++ b/comp/collector/collector/diagnose_test.go
@@ -1,0 +1,65 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package collector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	diagnose "github.com/DataDog/datadog-agent/comp/core/diagnose/def"
+	"github.com/DataDog/datadog-agent/pkg/collector/check/stub"
+)
+
+type stubCheckWithDiagnoses struct {
+	stub.StubCheck
+	name      string
+	diagnoses []diagnose.Diagnosis
+	err       error
+}
+
+func (c *stubCheckWithDiagnoses) String() string { return c.name }
+func (c *stubCheckWithDiagnoses) GetDiagnoses() ([]diagnose.Diagnosis, error) {
+	return c.diagnoses, c.err
+}
+
+func TestGetInstanceDiagnosesStampsCheckName(t *testing.T) {
+	t.Run("stamps CheckName when not set", func(t *testing.T) {
+		ch := &stubCheckWithDiagnoses{
+			name: "postgres",
+			diagnoses: []diagnose.Diagnosis{
+				{Status: diagnose.DiagnosisSuccess, Name: "conn", Diagnosis: "ok", Category: "dbm"},
+			},
+		}
+		got := GetInstanceDiagnoses(ch)
+		assert.Len(t, got, 1)
+		assert.Equal(t, "postgres", got[0].CheckName)
+		assert.Equal(t, "dbm", got[0].Category) // category unchanged
+	})
+
+	t.Run("does not overwrite existing CheckName", func(t *testing.T) {
+		ch := &stubCheckWithDiagnoses{
+			name: "postgres",
+			diagnoses: []diagnose.Diagnosis{
+				{Status: diagnose.DiagnosisSuccess, Name: "conn", Diagnosis: "ok", CheckName: "custom-name"},
+			},
+		}
+		got := GetInstanceDiagnoses(ch)
+		assert.Equal(t, "custom-name", got[0].CheckName)
+	})
+
+	t.Run("falls back category to check name when category empty", func(t *testing.T) {
+		ch := &stubCheckWithDiagnoses{
+			name: "mysql",
+			diagnoses: []diagnose.Diagnosis{
+				{Status: diagnose.DiagnosisSuccess, Name: "conn", Diagnosis: "ok"},
+			},
+		}
+		got := GetInstanceDiagnoses(ch)
+		assert.Equal(t, "mysql", got[0].Category)
+		assert.Equal(t, "mysql", got[0].CheckName)
+	})
+}

--- a/comp/core/diagnose/def/component.go
+++ b/comp/core/diagnose/def/component.go
@@ -180,6 +180,8 @@ type Diagnosis struct {
 
 	// static-time (meta typically)
 	Category string `json:"category,omitempty"`
+	// static-time (owning check identity, set by aggregator)
+	CheckName string `json:"check_name,omitempty"`
 	// static-time (meta typically, description of what being tested)
 	Description string `json:"description,omitempty"`
 	// run-time (what can be done or what docs need to be consulted to address the issue)

--- a/comp/core/diagnose/format/BUILD.bazel
+++ b/comp/core/diagnose/format/BUILD.bazel
@@ -17,7 +17,7 @@ go_test(
     embed = [":format"],
     gotags = ["test"],
     deps = [
-        "@//comp/core/diagnose/def",
+        "//comp/core/diagnose/def",
         "@com_github_stretchr_testify//assert",
     ],
 )

--- a/comp/core/diagnose/format/BUILD.bazel
+++ b/comp/core/diagnose/format/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "format",
@@ -8,5 +8,16 @@ go_library(
     deps = [
         "//comp/core/diagnose/def",
         "@com_github_fatih_color//:color",
+    ],
+)
+
+go_test(
+    name = "format_test",
+    srcs = ["format_test.go"],
+    embed = [":format"],
+    gotags = ["test"],
+    deps = [
+        "@//comp/core/diagnose/def",
+        "@com_github_stretchr_testify//assert",
     ],
 )

--- a/comp/core/diagnose/format/format.go
+++ b/comp/core/diagnose/format/format.go
@@ -84,10 +84,15 @@ func outputDiagnosis(w io.Writer, cfg diagnose.Config, result string, diagnosisI
 	// Running index (1, 2, 3, etc)
 	fmt.Fprintf(w, "%d. --------------\n", diagnosisIdx)
 
-	// [Required] Diagnosis name (and category if it us not empty)
-	if len(d.Category) > 0 {
+	// [Required] Diagnosis name with optional [checkname] [category] prefix
+	switch {
+	case len(d.CheckName) > 0 && len(d.Category) > 0:
+		fmt.Fprintf(w, "  %s [%s] [%s] %s\n", result, d.CheckName, d.Category, d.Name)
+	case len(d.CheckName) > 0:
+		fmt.Fprintf(w, "  %s [%s] %s\n", result, d.CheckName, d.Name)
+	case len(d.Category) > 0:
 		fmt.Fprintf(w, "  %s [%s] %s\n", result, d.Category, d.Name)
-	} else {
+	default:
 		fmt.Fprintf(w, "  %s %s\n", result, d.Name)
 	}
 

--- a/comp/core/diagnose/format/format_test.go
+++ b/comp/core/diagnose/format/format_test.go
@@ -1,0 +1,48 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package format
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	diagnose "github.com/DataDog/datadog-agent/comp/core/diagnose/def"
+)
+
+func TestOutputDiagnosisNameLine(t *testing.T) {
+	cfg := diagnose.Config{Verbose: false}
+
+	cases := []struct {
+		name      string
+		checkName string
+		category  string
+		want      string
+	}{
+		{"both set", "postgres", "dbm", "  PASS [postgres] [dbm] my-diag\n"},
+		{"checkname only", "postgres", "", "  PASS [postgres] my-diag\n"},
+		{"category only", "", "dbm", "  PASS [dbm] my-diag\n"},
+		{"neither set", "", "", "  PASS my-diag\n"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			d := diagnose.Diagnosis{
+				Status:    diagnose.DiagnosisSuccess,
+				Name:      "my-diag",
+				Diagnosis: "all good",
+				CheckName: tc.checkName,
+				Category:  tc.category,
+			}
+			outputDiagnosis(&buf, cfg, "PASS", 1, d)
+			line := strings.Split(buf.String(), "\n")[1] + "\n"
+			assert.Equal(t, tc.want, line)
+		})
+	}
+}

--- a/comp/core/diagnose/impl/diagnose.go
+++ b/comp/core/diagnose/impl/diagnose.go
@@ -15,6 +15,7 @@ import (
 	"io"
 	"net/http"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -190,23 +191,9 @@ func formatResult(diagnoseResult *diagnose.Result, diagCfg diagnose.Config, form
 // Enumerate registered Diagnose suites and get their diagnoses
 // for structural output
 func getDiagnoses(diagCfg diagnose.Config, suites []suite) (*diagnose.Result, error) {
-	var filter diagSuiteFilter
-	var err error
-
-	if len(diagCfg.Include) > 0 {
-		filter.include, err = strToRegexList(diagCfg.Include)
-		if err != nil {
-			includes := strings.Join(diagCfg.Include, " ")
-			return nil, fmt.Errorf("invalid --include option value(s) provided (%s) compiled with error: %w", includes, err)
-		}
-	}
-
-	if len(diagCfg.Exclude) > 0 {
-		filter.exclude, err = strToRegexList(diagCfg.Exclude)
-		if err != nil {
-			excludes := strings.Join(diagCfg.Exclude, " ")
-			return nil, fmt.Errorf("invalid --exclude option value(s) provided (%s) compiled with error: %w", excludes, err)
-		}
+	filter, err := buildDiagSuiteFilter(diagCfg)
+	if err != nil {
+		return nil, err
 	}
 
 	sortedSuites := getSortedDiagnoseSuites(suites)
@@ -238,6 +225,29 @@ func getDiagnoses(diagCfg diagnose.Config, suites []suite) (*diagnose.Result, er
 type diagSuiteFilter struct {
 	include []*regexp.Regexp
 	exclude []*regexp.Regexp
+}
+
+func buildDiagSuiteFilter(diagCfg diagnose.Config) (diagSuiteFilter, error) {
+	var filter diagSuiteFilter
+	var err error
+
+	if len(diagCfg.Include) > 0 {
+		filter.include, err = strToRegexList(diagCfg.Include)
+		if err != nil {
+			includes := strings.Join(diagCfg.Include, " ")
+			return filter, fmt.Errorf("invalid --include option value(s) provided (%s) compiled with error: %w", includes, err)
+		}
+	}
+
+	if len(diagCfg.Exclude) > 0 {
+		filter.exclude, err = strToRegexList(diagCfg.Exclude)
+		if err != nil {
+			excludes := strings.Join(diagCfg.Exclude, " ")
+			return filter, fmt.Errorf("invalid --exclude option value(s) provided (%s) compiled with error: %w", excludes, err)
+		}
+	}
+
+	return filter, nil
 }
 
 func getSortedDiagnoseSuites(suites []suite) []suite {
@@ -276,25 +286,16 @@ func diagnosisPassesFilter(filter diagSuiteFilter, suiteName string, d diagnose.
 		candidates = append(candidates, d.Category)
 	}
 
-	if len(filter.include) > 0 {
-		matched := false
-		for _, c := range candidates {
-			if matchRegExList(filter.include, c) {
-				matched = true
-				break
-			}
-		}
-		if !matched {
-			return false
-		}
+	if len(filter.include) > 0 && !slices.ContainsFunc(candidates, func(c string) bool {
+		return matchRegExList(filter.include, c)
+	}) {
+		return false
 	}
 
-	if len(filter.exclude) > 0 {
-		for _, c := range candidates {
-			if matchRegExList(filter.exclude, c) {
-				return false
-			}
-		}
+	if len(filter.exclude) > 0 && slices.ContainsFunc(candidates, func(c string) bool {
+		return matchRegExList(filter.exclude, c)
+	}) {
+		return false
 	}
 
 	return true

--- a/comp/core/diagnose/impl/diagnose.go
+++ b/comp/core/diagnose/impl/diagnose.go
@@ -351,16 +351,3 @@ func strToRegexList(patterns []string) ([]*regexp.Regexp, error) {
 	}
 	return nil, nil
 }
-
-// matchConfigFilters reports whether s passes the include/exclude filter.
-// Used for suite names, CheckName, and Category matching.
-func matchConfigFilters(filter diagSuiteFilter, s string) bool {
-	if len(filter.include) > 0 && len(filter.exclude) > 0 {
-		return matchRegExList(filter.include, s) && !matchRegExList(filter.exclude, s)
-	} else if len(filter.include) > 0 {
-		return matchRegExList(filter.include, s)
-	} else if len(filter.exclude) > 0 {
-		return !matchRegExList(filter.exclude, s)
-	}
-	return true
-}

--- a/comp/core/diagnose/impl/diagnose.go
+++ b/comp/core/diagnose/impl/diagnose.go
@@ -190,16 +190,32 @@ func formatResult(diagnoseResult *diagnose.Result, diagCfg diagnose.Config, form
 // Enumerate registered Diagnose suites and get their diagnoses
 // for structural output
 func getDiagnoses(diagCfg diagnose.Config, suites []suite) (*diagnose.Result, error) {
-	suites, err := getSortedAndFilteredDiagnoseSuites(diagCfg, suites)
-	if err != nil {
-		return nil, err
+	var filter diagSuiteFilter
+	var err error
+
+	if len(diagCfg.Include) > 0 {
+		filter.include, err = strToRegexList(diagCfg.Include)
+		if err != nil {
+			includes := strings.Join(diagCfg.Include, " ")
+			return nil, fmt.Errorf("invalid --include option value(s) provided (%s) compiled with error: %w", includes, err)
+		}
 	}
+
+	if len(diagCfg.Exclude) > 0 {
+		filter.exclude, err = strToRegexList(diagCfg.Exclude)
+		if err != nil {
+			excludes := strings.Join(diagCfg.Exclude, " ")
+			return nil, fmt.Errorf("invalid --exclude option value(s) provided (%s) compiled with error: %w", excludes, err)
+		}
+	}
+
+	sortedSuites := getSortedDiagnoseSuites(suites)
 
 	var suitesDiagnoses []diagnose.Diagnoses
 	var count diagnose.Counters
-	for _, ds := range suites {
-		// Run particular diagnose
-		diagnoses := getSuiteDiagnoses(ds, diagCfg)
+	for _, ds := range sortedSuites {
+		// Run particular diagnose then post-filter by suite name, CheckName, or Category
+		diagnoses := filterSuiteDiagnoses(filter, ds.name, getSuiteDiagnoses(ds, diagCfg))
 		if len(diagnoses) > 0 {
 			for _, d := range diagnoses {
 				count.Increment(d.Status)
@@ -224,40 +240,64 @@ type diagSuiteFilter struct {
 	exclude []*regexp.Regexp
 }
 
-func getSortedAndFilteredDiagnoseSuites(diagCfg diagnose.Config, suites []suite) ([]suite, error) {
-	var filter diagSuiteFilter
-	var err error
-
-	if len(diagCfg.Include) > 0 {
-		filter.include, err = strToRegexList(diagCfg.Include)
-		if err != nil {
-			includes := strings.Join(diagCfg.Include, " ")
-			return nil, fmt.Errorf("invalid --include option value(s) provided (%s) compiled with error: %w", includes, err)
-		}
-	}
-
-	if len(diagCfg.Exclude) > 0 {
-		filter.exclude, err = strToRegexList(diagCfg.Exclude)
-		if err != nil {
-			excludes := strings.Join(diagCfg.Exclude, " ")
-			return nil, fmt.Errorf("invalid --exclude option value(s) provided (%s) compiled with error: %w", excludes, err)
-		}
-	}
-
+func getSortedDiagnoseSuites(suites []suite) []suite {
 	sortedValues := make([]suite, len(suites))
 	copy(sortedValues, suites)
 	sort.Slice(sortedValues, func(i, j int) bool {
 		return sortedValues[i].name < sortedValues[j].name
 	})
+	return sortedValues
+}
 
-	var sortedFilteredValues []suite
-	for _, ds := range sortedValues {
-		if matchConfigFilters(filter, ds.name) {
-			sortedFilteredValues = append(sortedFilteredValues, ds)
+// filterSuiteDiagnoses returns the subset of diagnoses that pass the filter.
+// Candidates for matching are: suite name, CheckName, and Category.
+// Include: a diagnosis passes if ANY candidate matches any include pattern.
+// Exclude: a diagnosis is dropped if ANY candidate matches any exclude pattern.
+// When no filters are set all diagnoses are returned unchanged.
+func filterSuiteDiagnoses(filter diagSuiteFilter, suiteName string, diagnoses []diagnose.Diagnosis) []diagnose.Diagnosis {
+	if len(filter.include) == 0 && len(filter.exclude) == 0 {
+		return diagnoses
+	}
+	var out []diagnose.Diagnosis
+	for _, d := range diagnoses {
+		if diagnosisPassesFilter(filter, suiteName, d) {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+func diagnosisPassesFilter(filter diagSuiteFilter, suiteName string, d diagnose.Diagnosis) bool {
+	candidates := []string{suiteName}
+	if len(d.CheckName) > 0 {
+		candidates = append(candidates, d.CheckName)
+	}
+	if len(d.Category) > 0 {
+		candidates = append(candidates, d.Category)
+	}
+
+	if len(filter.include) > 0 {
+		matched := false
+		for _, c := range candidates {
+			if matchRegExList(filter.include, c) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
 		}
 	}
 
-	return sortedFilteredValues, nil
+	if len(filter.exclude) > 0 {
+		for _, c := range candidates {
+			if matchRegExList(filter.exclude, c) {
+				return false
+			}
+		}
+	}
+
+	return true
 }
 
 func getSuiteDiagnoses(ds suite, diagConfig diagnose.Config) []diagnose.Diagnosis {
@@ -312,8 +352,8 @@ func strToRegexList(patterns []string) ([]*regexp.Regexp, error) {
 	return nil, nil
 }
 
-// Currently used only to match Diagnose Suite name. In future will be
-// extended to diagnose name or category
+// matchConfigFilters reports whether s passes the include/exclude filter.
+// Used for suite names, CheckName, and Category matching.
 func matchConfigFilters(filter diagSuiteFilter, s string) bool {
 	if len(filter.include) > 0 && len(filter.exclude) > 0 {
 		return matchRegExList(filter.include, s) && !matchRegExList(filter.exclude, s)

--- a/comp/core/diagnose/impl/diagnose_test.go
+++ b/comp/core/diagnose/impl/diagnose_test.go
@@ -194,6 +194,71 @@ func TestFlareProvider(t *testing.T) {
 	mock.AssertFileContent(strings.TrimSuffix(expectedResult, "\n"), "diagnose.log")
 }
 
+func TestFilterSuiteDiagnoses(t *testing.T) {
+	makeDiagnoses := func(checkName, category string) []diagnose.Diagnosis {
+		return []diagnose.Diagnosis{
+			{Status: diagnose.DiagnosisSuccess, Name: "d1", Diagnosis: "ok", CheckName: checkName, Category: category},
+			{Status: diagnose.DiagnosisSuccess, Name: "d2", Diagnosis: "ok", CheckName: "mysql", Category: "other"},
+		}
+	}
+
+	noFilter := diagSuiteFilter{}
+	includePostgres := mustBuildFilter(t, []string{"postgres"}, nil)
+	excludePostgres := mustBuildFilter(t, nil, []string{"postgres"})
+	includeCheckDatadog := mustBuildFilter(t, []string{"check-datadog"}, nil)
+
+	t.Run("no filter passes all", func(t *testing.T) {
+		got := filterSuiteDiagnoses(noFilter, "check-datadog", makeDiagnoses("postgres", "dbm"))
+		assert.Len(t, got, 2)
+	})
+
+	t.Run("include matches CheckName", func(t *testing.T) {
+		got := filterSuiteDiagnoses(includePostgres, "check-datadog", makeDiagnoses("postgres", "dbm"))
+		assert.Len(t, got, 1)
+		assert.Equal(t, "d1", got[0].Name)
+	})
+
+	t.Run("include matches Category", func(t *testing.T) {
+		got := filterSuiteDiagnoses(includePostgres, "check-datadog", makeDiagnoses("", "postgres"))
+		assert.Len(t, got, 1)
+		assert.Equal(t, "d1", got[0].Name)
+	})
+
+	t.Run("include suite name passes all diagnoses in suite", func(t *testing.T) {
+		got := filterSuiteDiagnoses(includeCheckDatadog, "check-datadog", makeDiagnoses("postgres", "dbm"))
+		assert.Len(t, got, 2)
+	})
+
+	t.Run("exclude drops matching diagnoses", func(t *testing.T) {
+		got := filterSuiteDiagnoses(excludePostgres, "check-datadog", makeDiagnoses("postgres", "dbm"))
+		assert.Len(t, got, 1)
+		assert.Equal(t, "mysql", got[0].CheckName)
+	})
+
+	t.Run("no CheckName or Category falls back to suite name match", func(t *testing.T) {
+		got := filterSuiteDiagnoses(includePostgres, "check-datadog", makeDiagnoses("", ""))
+		assert.Len(t, got, 0)
+
+		got = filterSuiteDiagnoses(includeCheckDatadog, "check-datadog", makeDiagnoses("", ""))
+		assert.Len(t, got, 2)
+	})
+}
+
+func mustBuildFilter(t *testing.T, include, exclude []string) diagSuiteFilter {
+	t.Helper()
+	var f diagSuiteFilter
+	var err error
+	if len(include) > 0 {
+		f.include, err = strToRegexList(include)
+		assert.NoError(t, err)
+	}
+	if len(exclude) > 0 {
+		f.exclude, err = strToRegexList(exclude)
+		assert.NoError(t, err)
+	}
+	return f
+}
+
 func setupDiagonseSuites(t *testing.T) {
 	t.Helper()
 

--- a/releasenotes/notes/diagnose-surface-check-name-faa65c113fcac2fb.yaml
+++ b/releasenotes/notes/diagnose-surface-check-name-faa65c113fcac2fb.yaml
@@ -8,13 +8,11 @@
 ---
 enhancements:
   - |
-    The ``agent diagnose`` command now surfaces the owning check name for each
-    diagnosis. Output is rendered as ``[checkname] [category] name``, making it
-    possible to tell which check instance produced each result when multiple
-    checks (for example multiple postgres or DBM instances) are configured.
-    The JSON output gains a ``check_name`` field for the same purpose.
+    ``agent diagnose`` now renders the check name as a prefix for all checks
+    under the ``check-datadog`` suite. The JSON output gains a ``check_name``
+    field for the same purpose.
   - |
-    The ``--include`` and ``--exclude`` flags of the ``agent diagnose`` command
-    now match against the suite name, the owning check name, and the diagnosis
-    category. For example, ``agent diagnose --include postgres`` now filters
-    individual diagnoses across all suites instead of only matching suite names.
+    The ``--include`` and ``--exclude`` flags of ``agent diagnose`` now match
+    against the suite name, the owning check name, and the diagnosis category.
+    For example, ``agent diagnose --include postgres`` now filters individual
+    diagnoses across all suites instead of only matching suite names.

--- a/releasenotes/notes/diagnose-surface-check-name-faa65c113fcac2fb.yaml
+++ b/releasenotes/notes/diagnose-surface-check-name-faa65c113fcac2fb.yaml
@@ -1,0 +1,20 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The ``agent diagnose`` command now surfaces the owning check name for each
+    diagnosis. Output is rendered as ``[checkname] [category] name``, making it
+    possible to tell which check instance produced each result when multiple
+    checks (for example multiple postgres or DBM instances) are configured.
+    The JSON output gains a ``check_name`` field for the same purpose.
+  - |
+    The ``--include`` and ``--exclude`` flags of the ``agent diagnose`` command
+    now match against the suite name, the owning check name, and the diagnosis
+    category. For example, ``agent diagnose --include postgres`` now filters
+    individual diagnoses across all suites instead of only matching suite names.


### PR DESCRIPTION
## Summary

- Add `CheckName` field to `Diagnosis` struct (JSON: `check_name`, `omitempty` — backwards compatible)
- Stamp `CheckName` in `GetInstanceDiagnoses` using `instance.String()` so the owning check is always identified without requiring any Python or rtloader changes
- Renderer now shows `[checkname] [category] name` when both fields are set, falling back gracefully when either is absent
- `--include`/`--exclude` now match against suite name, `CheckName`, and `Category`; switched from pre-collection suite name filtering to post-collection per-diagnosis filtering so `--include postgres` works without needing to know which suite contains which checks

### Before
```
Suite: check-datadog
1. --------------
  PASS [dbm] connection-ok
  Diagnosis: Connected to ...
2. --------------
  FAIL [dbm] missing-datadog-schema
```

### After
```
Suite: check-datadog
1. --------------
  PASS [postgres] [dbm] connection-ok
  Diagnosis: Connected to ...
2. --------------
  FAIL [postgres] [dbm] missing-datadog-schema
```

And `agent diagnose --include postgres` now actually filters to postgres diagnoses.

## Local QA:

```
$ docker exec -it datadog-agent-joel.marcotte agent diagnose --include postgres -v
=== Starting diagnose ===
==============
Suite: check-datadog
1. --------------
  PASS [postgres] [connection] connection-failure
  Diagnosis: Connected to postgres-primary:5432 (dbname=postgres) as datadog

2. --------------
  PASS [postgres] [connection] postgres-version-unsupported
  Diagnosis: Postgres version 14.22 is supported.
...
```

## Test plan

- [x] `go test -tags test ./comp/core/diagnose/...` — all passing
- [x] `go test -tags test ./comp/collector/collector/...` — all passing  
- [x] `dda inv agent.build --build-exclude=systemd` — build succeeded
- [ ] Manual: run `agent diagnose --include <checkname>` against a live agent with Python integrations configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)