### PR TITLE
[ABLD-387] `bazel`ify proto generation: `dogstatsdhttp`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -534,7 +534,6 @@ exports_files(glob(
 # gazelle:exclude pkg/procmgr
 # gazelle:exclude pkg/proto/datadog/api
 # gazelle:exclude pkg/proto/datadog/autodiscovery
-# gazelle:exclude pkg/proto/datadog/dogstatsdhttp
 # gazelle:exclude pkg/proto/datadog/kubemetadata
 # gazelle:exclude pkg/proto/datadog/model
 # gazelle:exclude pkg/proto/datadog/privateactionrunner

--- a/bazel/rules/go_proto_compiler/BUILD.bazel
+++ b/bazel/rules/go_proto_compiler/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@rules_go//proto:compiler.bzl", "go_proto_compiler")
+
+[
+    go_proto_compiler(
+        name = name,
+        options = options,
+        plugin = "@com_github_planetscale_vtprotobuf//cmd/protoc-gen-go-vtproto",
+        suffix = "_vtproto.pb.go",
+        visibility = ["//visibility:public"],
+        deps = ["@com_github_planetscale_vtprotobuf//protohelpers"],
+    )
+    for name, options in {
+        # https://github.com/planetscale/vtprotobuf#usage
+        "go_vtproto_full": [],  # default: "If no features are given, all the codegen steps will be performed"
+        "go_vtproto_serde": ["features=marshal+unmarshal+size"],  # SERialize/DEserialize: "Example from Vitess"
+    }.items()
+]

--- a/bazel/rules/write_pb_go/BUILD.bazel
+++ b/bazel/rules/write_pb_go/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
     importpath = "github.com/DataDog/datadog-agent/bazel/rules/write_pb_go",
     visibility = ["//visibility:public"],
     deps = [
+        "@gazelle//label",
         "@gazelle//language",
         "@gazelle//language/proto",
         "@gazelle//rule",

--- a/bazel/rules/write_pb_go/_gazelle_extension.go
+++ b/bazel/rules/write_pb_go/_gazelle_extension.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/bazelbuild/bazel-gazelle/label"
 	"github.com/bazelbuild/bazel-gazelle/language"
 	"github.com/bazelbuild/bazel-gazelle/language/proto"
 	"github.com/bazelbuild/bazel-gazelle/rule"
@@ -21,8 +22,7 @@ const name = "write_pb_go"
 var compilerRe = regexp.MustCompile(`:go_([^_]+)`)
 
 type goProtoLibrary struct {
-	relDir        string
-	relTarget     string
+	label         label.Label
 	generatedSrcs []string
 }
 
@@ -70,10 +70,68 @@ func (l *lang) GenerateRules(args language.GenerateArgs) language.GenerateResult
 	}
 	// GenerateRules is called once per directory; accumulate across visits so that proto dirs
 	// (visited first) are available when Go dirs are processed.
-	for i, libs := range goProtoLibraries(args, protoLibrarySrcs(args)) {
+	// TODO(regis): find an approach that doesn't rely on directory traversal order
+	for i, libs := range goProtoLibraries(args) {
 		l.goProtoLibraries[i] = append(l.goProtoLibraries[i], libs...)
 	}
 	return generateResult(args, l.goProtoLibraries)
+}
+
+// goProtoLibraries indexes go_proto_library entries by fully-qualified importpath; relative
+// importpaths are prefixed with GoPrefix to normalize them.
+func goProtoLibraries(args language.GenerateArgs) map[string][]goProtoLibrary {
+	protoLibrarySrcs := protoLibrarySrcs(args)
+	result := map[string][]goProtoLibrary{}
+	for _, r := range args.OtherGen {
+		if r.Kind() != "go_proto_library" {
+			continue
+		}
+		importPath := r.AttrString("importpath")
+		if importPath == "" {
+			continue
+		}
+		if pc := proto.GetProtoConfig(args.Config); pc != nil && !strings.HasPrefix(importPath, pc.GoPrefix) {
+			importPath = fmt.Sprintf("%s/%s", pc.GoPrefix, importPath)
+		}
+		protoLabel, err := label.Parse(r.AttrString("proto"))
+		if err != nil {
+			continue
+		}
+		if protos, ok := protoLibrarySrcs[protoLabel.Name]; ok {
+			result[importPath] = append(result[importPath], goProtoLibrary{
+				label:         label.New("", args.Rel, r.Name()),
+				generatedSrcs: generatedSrcs(r, protos),
+			})
+		}
+	}
+	return result
+}
+
+// generateResult emits a write_pb_go rule when the current directory holds a go_library whose
+// importpath matches an accumulated go_proto_library, or deletes a stale one otherwise.
+func generateResult(args language.GenerateArgs, goProtoLibraries map[string][]goProtoLibrary) language.GenerateResult {
+	if importPath := goLibraryImportPath(args.File); importPath != "" {
+		srcs := map[string][]string{}
+		for _, lib := range goProtoLibraries[importPath] {
+			srcs[lib.label.Rel("", args.Rel).String()] = lib.generatedSrcs
+		}
+		if len(srcs) > 0 {
+			r := rule.NewRule(name, name)
+			r.SetAttr("srcs", srcs)
+			return language.GenerateResult{
+				Gen:     []*rule.Rule{r},
+				Imports: []interface{}{nil},
+			}
+		}
+	}
+	if args.File != nil {
+		for _, r := range args.File.Rules {
+			if r.Kind() == name {
+				return language.GenerateResult{Empty: []*rule.Rule{rule.NewRule(name, name)}}
+			}
+		}
+	}
+	return language.GenerateResult{}
 }
 
 // protoLibrarySrcs indexes proto_library srcs by rule name; OtherGen takes precedence over
@@ -95,65 +153,6 @@ func protoLibrarySrcs(args language.GenerateArgs) map[string][]string {
 		}
 	}
 	return result
-}
-
-// goProtoLibraries indexes go_proto_library entries by fully-qualified importpath; relative
-// importpaths are prefixed with GoPrefix to normalize them.
-func goProtoLibraries(args language.GenerateArgs, protoLibrarySrcs map[string][]string) map[string][]goProtoLibrary {
-	result := map[string][]goProtoLibrary{}
-	for _, r := range args.OtherGen {
-		if r.Kind() != "go_proto_library" {
-			continue
-		}
-		importPath := r.AttrString("importpath")
-		if importPath == "" {
-			continue
-		}
-		if pc := proto.GetProtoConfig(args.Config); pc != nil && !strings.HasPrefix(importPath, pc.GoPrefix) {
-			importPath = fmt.Sprintf("%s/%s", pc.GoPrefix, importPath)
-		}
-		if protos, ok := protoLibrarySrcs[r.AttrString("proto")[strings.LastIndex(r.AttrString("proto"), ":")+1:]]; ok {
-			result[importPath] = append(result[importPath], goProtoLibrary{
-				relDir:        args.Rel,
-				relTarget:     fmt.Sprintf(":%s", r.Name()),
-				generatedSrcs: generatedSrcs(r, protos),
-			})
-		}
-	}
-	return result
-}
-
-// generateResult emits a write_pb_go rule when the current directory holds a go_library whose
-// importpath matches an accumulated go_proto_library, or deletes a stale one otherwise.
-func generateResult(args language.GenerateArgs, goProtoLibraries map[string][]goProtoLibrary) language.GenerateResult {
-	if importPath := goLibraryImportPath(args.File); importPath != "" {
-		srcs := map[string][]string{}
-		for _, lib := range goProtoLibraries[importPath] {
-			var target string
-			if lib.relDir == args.Rel {
-				target = lib.relTarget // canonical case: .proto and .go coexist
-			} else {
-				target = fmt.Sprintf("//%s%s", lib.relDir, lib.relTarget) // foreign case
-			}
-			srcs[target] = lib.generatedSrcs
-		}
-		if len(srcs) > 0 {
-			r := rule.NewRule(name, name)
-			r.SetAttr("srcs", srcs)
-			return language.GenerateResult{
-				Gen:     []*rule.Rule{r},
-				Imports: []interface{}{nil},
-			}
-		}
-	}
-	if args.File != nil {
-		for _, r := range args.File.Rules {
-			if r.Kind() == name {
-				return language.GenerateResult{Empty: []*rule.Rule{rule.NewRule(name, name)}}
-			}
-		}
-	}
-	return language.GenerateResult{}
 }
 
 // generatedSrcs infers .pb.go filenames from the compiler labels: :go_proto -> .pb.go,

--- a/bazel/rules/write_pb_go/_gazelle_extension.go
+++ b/bazel/rules/write_pb_go/_gazelle_extension.go
@@ -7,7 +7,7 @@ package write_pb_go
 
 import (
 	"fmt"
-	"path"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -18,19 +18,22 @@ import (
 
 const name = "write_pb_go"
 
-type protoEntry struct {
-	relDir     string
-	protoFiles []string
+var compilerRe = regexp.MustCompile(`:go_([^_]+)`)
+
+type goProtoLibrary struct {
+	relDir        string
+	relTarget     string
+	generatedSrcs []string
 }
 
 type lang struct {
 	language.BaseLang
-	importToProto map[string]protoEntry
+	goProtoLibraries map[string][]goProtoLibrary
 }
 
 //goland:noinspection GoUnusedExportedFunction
 func NewLanguage() language.Language {
-	return &lang{importToProto: make(map[string]protoEntry)}
+	return &lang{goProtoLibraries: make(map[string][]goProtoLibrary)}
 }
 
 func (*lang) Name() string {
@@ -40,8 +43,8 @@ func (*lang) Name() string {
 func (*lang) Kinds() map[string]rule.KindInfo {
 	return map[string]rule.KindInfo{
 		name: {
-			NonEmptyAttrs:  map[string]bool{"srcs": true},
 			MergeableAttrs: map[string]bool{"srcs": true},
+			NonEmptyAttrs:  map[string]bool{"srcs": true},
 		},
 	}
 }
@@ -65,80 +68,125 @@ func (l *lang) GenerateRules(args language.GenerateArgs) language.GenerateResult
 			}
 		}
 	}
-
-	// Accumulate go_package -> proto entry from proto_library rules in this
-	// directory. The proto extension sets PackageKey on every proto_library
-	// it generates; directories are visited alphabetically, so this map is
-	// always populated before the corresponding Go package is visited.
-	for _, r := range args.OtherGen {
-		if r.Kind() != "proto_library" {
-			continue
-		}
-		pkg, ok := r.PrivateAttr(proto.PackageKey).(proto.Package)
-		if !ok {
-			continue
-		}
-		goPackage, ok := pkg.Options["go_package"]
-		if !ok {
-			continue
-		}
-		goPackage, _, _ = strings.Cut(goPackage, ";")
-		var protoFiles []string
-		for f := range pkg.Files {
-			protoFiles = append(protoFiles, f)
-		}
-		sort.Strings(protoFiles)
-		l.importToProto[goPackage] = protoEntry{relDir: args.Rel, protoFiles: protoFiles}
+	// GenerateRules is called once per directory; accumulate across visits so that proto dirs
+	// (visited first) are available when Go dirs are processed.
+	for i, libs := range goProtoLibraries(args, protoLibrarySrcs(args)) {
+		l.goProtoLibraries[i] = append(l.goProtoLibraries[i], libs...)
 	}
-
-	srcs := map[string][]string{}
-	hasGo := false
-	for _, f := range args.RegularFiles {
-		if strings.HasSuffix(f, ".go") {
-			hasGo = true
-		} else if stem, ok := strings.CutSuffix(f, ".proto"); ok {
-			// Canonical: proto and Go files coexist in the current directory.
-			label := fmt.Sprintf(":%s_go_proto", path.Base(args.Rel))
-			srcs[label] = append(srcs[label], fmt.Sprintf("%s.pb.go", stem))
-		}
-	}
-	if !hasGo {
-		return language.GenerateResult{}
-	}
-
-	// Foreign: proto files live in a different directory; discover via go_package.
-	// go_package may be a relative path (e.g. "pkg/proto/pbgo/foo") or a fully
-	// qualified importpath; match either against the go_library importpath.
-	if importPath := goLibraryImportPath(args.File); importPath != "" {
-		for goPackage, entry := range l.importToProto {
-			if entry.relDir == args.Rel {
-				continue
-			}
-			if importPath != goPackage && !strings.HasSuffix(importPath, fmt.Sprintf("/%s", goPackage)) {
-				continue
-			}
-			label := fmt.Sprintf("//%s:%s_go_proto", entry.relDir, path.Base(entry.relDir))
-			for _, f := range entry.protoFiles {
-				if stem, ok := strings.CutSuffix(f, ".proto"); ok {
-					srcs[label] = append(srcs[label], fmt.Sprintf("%s.pb.go", stem))
-				}
-			}
-			break
-		}
-	}
-
-	if len(srcs) == 0 {
-		return language.GenerateResult{}
-	}
-
-	r := rule.NewRule(name, name)
-	r.SetAttr("srcs", srcs)
-	return language.GenerateResult{
-		Gen:     []*rule.Rule{r},
-		Imports: []interface{}{nil},
-	}
+	return generateResult(args, l.goProtoLibraries)
 }
 
+// protoLibrarySrcs indexes proto_library srcs by rule name; OtherGen takes precedence over
+// File.Rules so Gazelle-generated rules are preferred over potentially stale committed ones.
+func protoLibrarySrcs(args language.GenerateArgs) map[string][]string {
+	result := map[string][]string{}
+	for _, r := range args.OtherGen {
+		if r.Kind() == "proto_library" {
+			result[r.Name()] = r.AttrStrings("srcs")
+		}
+	}
+	if args.File != nil {
+		for _, r := range args.File.Rules {
+			if r.Kind() == "proto_library" {
+				if _, ok := result[r.Name()]; !ok {
+					result[r.Name()] = r.AttrStrings("srcs")
+				}
+			}
+		}
+	}
+	return result
+}
+
+// goProtoLibraries indexes go_proto_library entries by fully-qualified importpath; relative
+// importpaths are prefixed with GoPrefix to normalize them.
+func goProtoLibraries(args language.GenerateArgs, protoLibrarySrcs map[string][]string) map[string][]goProtoLibrary {
+	result := map[string][]goProtoLibrary{}
+	for _, r := range args.OtherGen {
+		if r.Kind() != "go_proto_library" {
+			continue
+		}
+		importPath := r.AttrString("importpath")
+		if importPath == "" {
+			continue
+		}
+		if pc := proto.GetProtoConfig(args.Config); pc != nil && !strings.HasPrefix(importPath, pc.GoPrefix) {
+			importPath = fmt.Sprintf("%s/%s", pc.GoPrefix, importPath)
+		}
+		if protos, ok := protoLibrarySrcs[r.AttrString("proto")[strings.LastIndex(r.AttrString("proto"), ":")+1:]]; ok {
+			result[importPath] = append(result[importPath], goProtoLibrary{
+				relDir:        args.Rel,
+				relTarget:     fmt.Sprintf(":%s", r.Name()),
+				generatedSrcs: generatedSrcs(r, protos),
+			})
+		}
+	}
+	return result
+}
+
+// generateResult emits a write_pb_go rule when the current directory holds a go_library whose
+// importpath matches an accumulated go_proto_library, or deletes a stale one otherwise.
+func generateResult(args language.GenerateArgs, goProtoLibraries map[string][]goProtoLibrary) language.GenerateResult {
+	if importPath := goLibraryImportPath(args.File); importPath != "" {
+		srcs := map[string][]string{}
+		for _, lib := range goProtoLibraries[importPath] {
+			var target string
+			if lib.relDir == args.Rel {
+				target = lib.relTarget // canonical case: .proto and .go coexist
+			} else {
+				target = fmt.Sprintf("//%s%s", lib.relDir, lib.relTarget) // foreign case
+			}
+			srcs[target] = lib.generatedSrcs
+		}
+		if len(srcs) > 0 {
+			r := rule.NewRule(name, name)
+			r.SetAttr("srcs", srcs)
+			return language.GenerateResult{
+				Gen:     []*rule.Rule{r},
+				Imports: []interface{}{nil},
+			}
+		}
+	}
+	if args.File != nil {
+		for _, r := range args.File.Rules {
+			if r.Kind() == name {
+				return language.GenerateResult{Empty: []*rule.Rule{rule.NewRule(name, name)}}
+			}
+		}
+	}
+	return language.GenerateResult{}
+}
+
+// generatedSrcs infers .pb.go filenames from the compiler labels: :go_proto -> .pb.go,
+// :go_{name}_* -> _{name}.pb.go; defaults to [.pb.go].
+func generatedSrcs(r *rule.Rule, protos []string) []string {
+	var suffixes []string
+	for _, compiler := range r.AttrStrings("compilers") {
+		m := compilerRe.FindStringSubmatch(compiler)
+		if m == nil {
+			continue
+		}
+		if m[1] == "proto" {
+			suffixes = append(suffixes, ".pb.go")
+		} else {
+			suffixes = append(suffixes, fmt.Sprintf("_%s.pb.go", m[1]))
+		}
+	}
+	if len(suffixes) == 0 {
+		suffixes = []string{".pb.go"}
+	}
+	var result []string
+	for _, proto := range protos {
+		if stem, ok := strings.CutSuffix(proto, ".proto"); ok {
+			for _, suffix := range suffixes {
+				result = append(result, stem+suffix)
+			}
+		}
+	}
+	sort.Strings(result)
+	return result
+}
+
+// goLibraryImportPath returns the importpath of the go_library in f, or "".
 func goLibraryImportPath(f *rule.File) string {
 	if f == nil {
 		return ""

--- a/pkg/proto/datadog/dogstatsdhttp/BUILD.bazel
+++ b/pkg/proto/datadog/dogstatsdhttp/BUILD.bazel
@@ -1,0 +1,22 @@
+# gazelle:go_proto_compilers @rules_go//proto:go_proto,//bazel/rules/go_proto_compiler:go_vtproto_full
+
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
+load("@rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "pb_proto",
+    srcs = ["payload.proto"],
+    strip_import_prefix = "/pkg/proto",
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "pb_go_proto",
+    compilers = [
+        "//bazel/rules/go_proto_compiler:go_vtproto_full",
+        "@rules_go//proto:go_proto",
+    ],
+    importpath = "pkg/proto/pbgo/dogstatsdhttp",
+    proto = ":pb_proto",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/proto/pbgo/dogstatsdhttp/BUILD.bazel
+++ b/pkg/proto/pbgo/dogstatsdhttp/BUILD.bazel
@@ -1,4 +1,15 @@
 load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/write_pb_go:defs.bzl", "write_pb_go")
+
+write_pb_go(
+    name = "write_pb_go",
+    srcs = {
+        "//pkg/proto/datadog/dogstatsdhttp:pb_go_proto": [
+            "payload.pb.go",
+            "payload_vtproto.pb.go",
+        ],
+    },
+)
 
 go_library(
     name = "dogstatsdhttp",

--- a/tasks/protobuf.py
+++ b/tasks/protobuf.py
@@ -21,7 +21,6 @@ PROTO_PKGS = {
     'remoteagent': False,
     'autodiscovery': False,
     'workloadfilter': False,
-    'dogstatsdhttp': False,
     'sbom': False,
 }
 
@@ -36,7 +35,6 @@ CLI_EXTRAS_GRPC = {
 # maybe put this in a separate function
 PKG_PLUGINS = {
     'trace': '--go-vtproto_out=',
-    'dogstatsdhttp': '--go-vtproto_out=',
 }
 
 PKG_CLI_EXTRAS = {
@@ -76,6 +74,7 @@ def generate(ctx, pre_commit=False):
     with ctx.cd(repo_root):
         # protobuf defs
         print(f"generating protobuf code from: {proto_root}")
+        bazel(ctx, "run", "//pkg/proto/pbgo/dogstatsdhttp:write_pb_go")
         bazel(ctx, "run", "//pkg/proto/pbgo/languagedetection:write_pb_go")
         bazel(ctx, "run", "//pkg/proto/pbgo/trace/idx:write_pb_go")
         for pkg, inject_tags in PROTO_PKGS.items():


### PR DESCRIPTION
### What does this PR do?
- bring `pkg/proto/datadog/dogstatsdhttp` under full `gazelle` control:
  - `proto_library` + `go_proto_library` with `vtproto` compilers,
  - `write_pb_go` in `pkg/proto/pbgo/dogstatsdhttp` keeps `payload.pb.go` and `payload_vtproto.pb.go` in sync,
- introduce `go_proto_compiler` targets for the 2 `vtproto` presets used in the repo (`bazel/rules/go_proto_compiler/BUILD.bazel`),
- generalize the `write_pb_go` extension to handle all `.proto`/`.go` topologies present in the repo:
  - multiple compilers per `go_proto_library` (`vtproto`),
  - multiple proto dirs targeting one Go package (e.g, `core`),
  - one proto dir fanning out to multiple Go packages (e.g., `privateactionrunner`),
- delegate the generation of `.pb.go` files for `dogstatsdhttp` to the topmost `bazel` command in `tasks/protobuf.py` (kept for didactic purposes, at least).

### Motivation
Next step migrating proto generation from the `dda inv protobuf.generate` task to pure `bazel`, enabling CI to verify that committed `.pb.go` files stay in sync with their proto source, where `dogstatsdhttp` is the first addressed `vtproto` package.

### Describe how you validated your changes
- `bazel run //:gazelle` is stable,
- `bazel test //pkg/proto/pbgo/dogstatsdhttp:write_pb_go_tests` passes,
- `dda inv protobuf.generate` succeeds.