### PR TITLE
dyninst: include service and runtime ID in SymDB log lines

### DIFF
--- a/pkg/dyninst/module/debug_info.go
+++ b/pkg/dyninst/module/debug_info.go
@@ -134,12 +134,14 @@ func (m *symdbManager) debugInfo() SymDBDebugInfo {
 
 	tracked := make([]string, 0, len(m.mu.trackedProcesses))
 	for k := range m.mu.trackedProcesses {
-		tracked = append(tracked, k.String())
+		tracked = append(tracked, fmt.Sprintf("%s (service: %s, version: %s)", k.pid, k.service, k.version))
 	}
 
 	var currentUpload string
 	if m.mu.currentUpload != nil {
-		currentUpload = m.mu.currentUpload.procID.String()
+		k := m.mu.currentUpload.procID
+		currentUpload = fmt.Sprintf("%s (service: %s, version: %s, runtime ID: %s)",
+			k.pid, k.service, k.version, m.mu.currentUpload.runtimeID)
 	}
 
 	return SymDBDebugInfo{

--- a/pkg/dyninst/module/symdb.go
+++ b/pkg/dyninst/module/symdb.go
@@ -90,10 +90,6 @@ type processKey struct {
 	version string
 }
 
-func (k processKey) String() string {
-	return fmt.Sprintf("%s (service: %s)", k.pid, k.service)
-}
-
 type uploadRequest struct {
 	procID         processKey
 	runtimeID      string
@@ -279,7 +275,8 @@ func (m *symdbManager) queueUpload(runtimeID procRuntimeID, executablePath strin
 	if m.persistentCache != nil {
 		entry, err := m.persistentCache.GetEntry(runtimeID.ID.PID)
 		if err != nil {
-			log.Warnf("failed to check upload cache for process %s", runtimeID.String())
+			log.Warnf("failed to check upload cache for process %s (service: %s, version: %s, runtime ID: %s): %v",
+				runtimeID.ID, runtimeID.service, runtimeID.version, runtimeID.runtimeID, err)
 		}
 		if entry != nil && entry.ServiceName == runtimeID.service && entry.ServiceVersion == runtimeID.version {
 			switch entry.Type {
@@ -290,7 +287,8 @@ func (m *symdbManager) queueUpload(runtimeID procRuntimeID, executablePath strin
 				if m.cfg.testingKnobs.onUploadRejectedByPersistentCache != nil {
 					m.cfg.testingKnobs.onUploadRejectedByPersistentCache()
 				}
-				log.Debugf("skipping SymDB upload for %s (%s) because it was previously uploaded", runtimeID.service, runtimeID.ID)
+				log.Debugf("skipping SymDB upload for process %s (service: %s, version: %s, runtime ID: %s) because it was previously uploaded",
+					runtimeID.ID, runtimeID.service, runtimeID.version, runtimeID.runtimeID)
 				return nil
 			case entryTypeAttempt:
 				// We already attempted to upload symbols for this process
@@ -314,8 +312,8 @@ func (m *symdbManager) queueUpload(runtimeID procRuntimeID, executablePath strin
 					// The backoff duration has expired. Allow the upload to proceed.
 					break
 				}
-				log.Infof("SymDB: scheduling retry upload for process %s after backoff of %v (error number %d, elapsed since last attempt: %s)",
-					runtimeID.ID, remainingWait, entry.ErrorNumber, elapsed)
+				log.Infof("SymDB: scheduling retry upload for process %s (service: %s, version: %s, runtime ID: %s) after backoff of %v (error number %d, elapsed since last attempt: %s)",
+					runtimeID.ID, runtimeID.service, runtimeID.version, runtimeID.runtimeID, remainingWait, entry.ErrorNumber, elapsed)
 
 				if m.cfg.testingKnobs.onDeferUpload != nil {
 					m.cfg.testingKnobs.onDeferUpload()
@@ -330,7 +328,8 @@ func (m *symdbManager) queueUpload(runtimeID procRuntimeID, executablePath strin
 
 				return nil
 			default:
-				log.Warnf("invalid entry type in cache for process %s: %d", runtimeID, entry.Type)
+				log.Warnf("invalid entry type in cache for process %s (service: %s, version: %s, runtime ID: %s): %d",
+					runtimeID.ID, runtimeID.service, runtimeID.version, runtimeID.runtimeID, entry.Type)
 			}
 		}
 	}
@@ -396,7 +395,8 @@ func (m *symdbManager) removeUploadInner(key processKey) {
 	delete(m.mu.trackedProcesses, key)
 	if m.persistentCache != nil {
 		if err := m.persistentCache.RemoveEntry(key.pid.PID); err != nil {
-			log.Warnf("failed to remove cache entry for process %s", key.pid)
+			log.Warnf("failed to remove cache entry for process %s (service: %s, version: %s): %v",
+				key.pid, key.service, key.version, err)
 		}
 	}
 
@@ -413,7 +413,8 @@ func (m *symdbManager) removeUploadInner(key processKey) {
 	// wait for it to terminate.
 	var doneCh chan struct{}
 	if m.mu.currentUpload != nil && m.mu.currentUpload.procID == key {
-		log.Infof("Cancelling symbols upload for process %s", key)
+		log.Infof("Cancelling symbols upload for process %s (service: %s, version: %s, runtime ID: %s)",
+			key.pid, key.service, key.version, m.mu.currentUpload.runtimeID)
 		// Cancel the upload first.
 		if m.mu.currentCancel != nil {
 			m.mu.currentCancel(errors.New("symbols upload no longer required"))
@@ -528,8 +529,8 @@ func (m *symdbManager) worker(ctx context.Context) {
 		err := m.performUpload(uploadCtx, req.procID, req.runtimeID, req.executablePath)
 		if err != nil {
 			if uploadCtx.Err() != nil {
-				log.Infof("SymDB: upload cancelled for process %v (executable: %s): %v",
-					req.runtimeID, req.executablePath, context.Cause(uploadCtx))
+				log.Infof("SymDB: upload cancelled for process %s (service: %s, version: %s, runtime ID: %s, executable: %s): %v",
+					req.procID.pid, req.procID.service, req.procID.version, req.runtimeID, req.executablePath, context.Cause(uploadCtx))
 			} else {
 				// We'll retry the upload on network errors, but not on other errors.
 				var ue uploadError
@@ -540,12 +541,12 @@ func (m *symdbManager) worker(ctx context.Context) {
 						retryDelay = m.cfg.testingKnobs.networkErrorRetryDelay
 					}
 					nextAttempt := time.Now().Add(retryDelay)
-					log.Errorf("SymDB: failed to upload symbols for process %v (executable: %s): %v. Will be attempted again at: %s.",
-						req.procID.pid, req.executablePath, err, nextAttempt)
+					log.Errorf("SymDB: failed to upload symbols for process %s (service: %s, version: %s, runtime ID: %s, executable: %s): %v. Will be attempted again at: %s.",
+						req.procID.pid, req.procID.service, req.procID.version, req.runtimeID, req.executablePath, err, nextAttempt)
 					m.addToQueue(req, nextAttempt)
 				} else {
-					log.Errorf("SymDB: failed to upload symbols for process %v (executable: %s): %v. It will not be attempted again.",
-						req.procID.pid, req.executablePath, err)
+					log.Errorf("SymDB: failed to upload symbols for process %s (service: %s, version: %s, runtime ID: %s, executable: %s): %v. It will not be attempted again.",
+						req.procID.pid, req.procID.service, req.procID.version, req.runtimeID, req.executablePath, err)
 				}
 			}
 		}
@@ -569,7 +570,8 @@ func (m *symdbManager) performUpload(
 		// error number.
 		entry, err := m.persistentCache.GetEntry(procID.pid.PID)
 		if err != nil {
-			return fmt.Errorf("failed to read cache entry for process %v: %w", procID.pid, err)
+			return fmt.Errorf("failed to read cache entry for process %s (service: %s, version: %s, runtime ID: %s): %w",
+				procID.pid, procID.service, procID.version, runtimeID, err)
 		}
 		if entry != nil && entry.Type == entryTypeAttempt {
 			errorNumber = entry.ErrorNumber + 1
@@ -577,7 +579,8 @@ func (m *symdbManager) performUpload(
 
 		// Record this attempt in the cache.
 		if err := m.persistentCache.AddAttempt(procID.pid.PID, procID.service, procID.version, errorNumber, "" /* errMsg */); err != nil {
-			return fmt.Errorf("failed to create cache entry for process %v: %w", procID.pid, err)
+			return fmt.Errorf("failed to create cache entry for process %s (service: %s, version: %s, runtime ID: %s): %w",
+				procID.pid, procID.service, procID.version, runtimeID, err)
 		}
 
 		// Update the cache entry when the upload is complete.
@@ -589,7 +592,8 @@ func (m *symdbManager) performUpload(
 				if err := m.persistentCache.AddCompleted(
 					procID.pid.PID, procID.service, procID.version,
 				); err != nil {
-					retErr = fmt.Errorf("failed to update cache entry for process %v: %w", procID.pid, err)
+					retErr = fmt.Errorf("failed to update cache entry for process %s (service: %s, version: %s, runtime ID: %s): %w",
+						procID.pid, procID.service, procID.version, runtimeID, err)
 				}
 			} else {
 				// Upload failed, update the cache entry we created above with
@@ -597,14 +601,15 @@ func (m *symdbManager) performUpload(
 				if err := m.persistentCache.AddAttempt(
 					procID.pid.PID, procID.service, procID.version, errorNumber, retErr.Error(),
 				); err != nil {
-					log.Errorf("Failed to update cache entry with error for process %v: %v", procID.pid, err)
+					log.Errorf("Failed to update cache entry with error for process %s (service: %s, version: %s, runtime ID: %s): %v",
+						procID.pid, procID.service, procID.version, runtimeID, err)
 				}
 			}
 		}()
 	}
 
-	log.Infof("SymDB: uploading symbols for process %v (service: %s, version: %s, executable: %s)",
-		procID.pid, procID.service, procID.version, executablePath)
+	log.Infof("SymDB: uploading symbols for process %s (service: %s, version: %s, runtime ID: %s, executable: %s)",
+		procID.pid, procID.service, procID.version, runtimeID, executablePath)
 	startTime := time.Now()
 	extractOpts := symdb.ExtractOptions{Scope: symdb.ExtractScopeModulesFromSameOrg}
 	if dc, ok := m.objectLoader.(*object.DiskCache); ok {
@@ -615,8 +620,8 @@ func (m *symdbManager) performUpload(
 		m.objectLoader,
 		extractOpts)
 	if err != nil {
-		return fmt.Errorf("failed to read symbols for process %v (executable: %s): %w",
-			procID.pid, executablePath, err)
+		return fmt.Errorf("failed to read symbols for process %s (service: %s, version: %s, runtime ID: %s, executable: %s): %w",
+			procID.pid, procID.service, procID.version, runtimeID, executablePath, err)
 	}
 
 	enc := uploader.NewBatchEncoder(
@@ -634,7 +639,8 @@ func (m *symdbManager) performUpload(
 		if !final && enc.Size() < m.cfg.flushThresholdBytes {
 			return nil
 		}
-		log.Tracef("SymDB: uploading symbols chunk. Final chunk: %t", final)
+		log.Tracef("SymDB: uploading symbols chunk for process %s (service: %s, version: %s, runtime ID: %s). Final chunk: %t",
+			procID.pid, procID.service, procID.version, runtimeID, final)
 		if err := enc.Flush(ctx, final); err != nil {
 			if errors.Is(err, uploader.ErrUpload) {
 				return uploadError{cause: err}
@@ -645,8 +651,8 @@ func (m *symdbManager) performUpload(
 	}
 	for pkg, err := range it {
 		if err != nil {
-			return fmt.Errorf("failed to iterate packages for process %v (executable: %s): %w",
-				procID.pid, executablePath, err)
+			return fmt.Errorf("failed to iterate packages for process %s (service: %s, version: %s, runtime ID: %s, executable: %s): %w",
+				procID.pid, procID.service, procID.version, runtimeID, executablePath, err)
 		}
 
 		if ctx.Err() != nil {
@@ -664,10 +670,10 @@ func (m *symdbManager) performUpload(
 		}
 	}
 
-	log.Infof("SymDB: Successfully uploaded symbols for process %v "+
-		"(service: %s, version: %s, executable: %s):"+
+	log.Infof("SymDB: Successfully uploaded symbols for process %s "+
+		"(service: %s, version: %s, runtime ID: %s, executable: %s):"+
 		" %d packages, %d functions, %d chunks in %v",
-		procID.pid, procID.service, procID.version, executablePath,
+		procID.pid, procID.service, procID.version, runtimeID, executablePath,
 		totalPackages, totalFuncs, enc.BatchCount(), time.Since(startTime))
 	return nil
 }


### PR DESCRIPTION
### What does this PR do?

Previously SymDB log lines identified the process only by PID, which makes it hard to correlate them with the corresponding tracer when multiple services run on the host or when a process is restarted. Include service, version, and runtime ID consistently in every SymDB-related log line.

Example before:

  `SymDB: scheduling retry upload for process {PID:4126611} after backoff of 1h55m40.073449527s (error number 39, elapsed since last attempt: 4m19.926550473s)`

Example after:

  `SymDB: scheduling retry upload for process {PID:4126611} (service: my-svc, version: 1.2.3, runtime ID: abc-123) after backoff of 1h55m40.073449527s (error number 39, elapsed since last attempt: 4m19.926550473s)`

  `SymDB: failed to upload symbols for process {PID:4126611} (service: my-svc, version: 1.2.3, runtime ID: abc-123, executable: /usr/bin/foo): upload failed: connection refused. Will be attempted again at: 2026-05-06 14:32:00.`

### Motivation

I wanna know the service.

### Describe how you validated your changes

Logging only

### Additional Notes

Loosely relates to https://datadoghq.atlassian.net/browse/DEBUG-5553