### PR TITLE
[observer] storage bounds: drop min/max columns + cap points per series

### DIFF
--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -258,9 +258,16 @@ type LogObserver interface {
 // The storage keeps full summaries (min/max/sum/count) so aggregation
 // is specified at read time, not write time.
 type MetricOutput struct {
-	Name       string
-	Value      float64
-	Tags       []string
+	Name    string
+	Value   float64
+	Tags    []string
+	// Context is the pre-built enrichment context for this metric. The engine
+	// stores it keyed by SeriesRef so anomaly enrichment is O(1) without any
+	// string lookups. Nil means no enrichment context for this metric.
+	Context *MetricContext
+	// ContextKey is an opaque string used by the engine to map this metric to
+	// its storage series for eviction. Only set by extractors that implement
+	// LRU eviction (e.g. LogPatternExtractor). Leave empty if not needed.
 	ContextKey string
 }
 
@@ -574,17 +581,6 @@ func AggregateString(agg Aggregate) string {
 	default:
 		return "unknown"
 	}
-}
-
-// ContextProvider resolves metric keys back to richer context about their
-// origin. Components that synthesize metrics from richer data (e.g. log
-// extractors that turn log patterns into count metrics) can implement this
-// interface so that downstream consumers (detectors, reporters) can produce
-// more descriptive anomaly reports.
-type ContextProvider interface {
-	// GetContextByKey returns contextual information for a previously emitted
-	// context key, if available.
-	GetContextByKey(key string) (MetricContext, bool)
 }
 
 // MetricContext describes the origin of a synthesized metric.

--- a/comp/observer/impl/context_provider.go
+++ b/comp/observer/impl/context_provider.go
@@ -24,20 +24,6 @@ func validateUniqueExtractorNames(extractors []observer.LogMetricsExtractor) {
 	}
 }
 
-// collectContextProviders discovers ContextProvider implementations among
-// instantiated extractors via type assertion. Returns a map keyed by the
-// extractor's component name (which is used as the storage namespace for
-// its metrics), enabling O(1) lookup during anomaly enrichment.
-func collectContextProviders(extractors []observer.LogMetricsExtractor) map[string]observer.ContextProvider {
-	providers := make(map[string]observer.ContextProvider)
-	for _, ext := range extractors {
-		if cp, ok := ext.(observer.ContextProvider); ok {
-			providers[ext.Name()] = cp
-		}
-	}
-	return providers
-}
-
 // truncate shortens s to maxLen, appending "..." if truncated.
 func truncate(s string, maxLen int) string {
 	runes := []rune(s)

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -26,7 +26,9 @@ type anomalyDedupKey struct {
 	title        string
 }
 
-type seriesContextRef struct {
+// nsContextKey is a map key that pairs an extractor namespace with the opaque
+// context key it produced, used by contextKeyToStorageKey for O(1) eviction.
+type nsContextKey struct {
 	namespace  string
 	contextKey string
 }
@@ -48,8 +50,12 @@ type engine struct {
 	extractors       []observerdef.LogMetricsExtractor
 	detectors        []observerdef.Detector
 	correlators      []observerdef.Correlator
-	contextProviders map[string]observerdef.ContextProvider // namespace → provider
-	contextRefs      map[string]seriesContextRef
+	// contextByRef caches the MetricContext for each series keyed by SeriesRef.
+	// Updated on every ingest; used for O(1) anomaly enrichment.
+	contextByRef map[observerdef.SeriesRef]*observerdef.MetricContext
+	// contextKeyToStorageKey maps (namespace, contextKey) → storage key for O(1)
+	// eviction lookup. Only populated for extractors that use LRU eviction.
+	contextKeyToStorageKey map[nsContextKey]string
 
 	// scheduler decides when the engine should advance analysis.
 	scheduler schedulerPolicy
@@ -137,8 +143,6 @@ type engineConfig struct {
 	extractors       []observerdef.LogMetricsExtractor
 	detectors        []observerdef.Detector
 	correlators      []observerdef.Correlator
-	contextProviders map[string]observerdef.ContextProvider // namespace → provider
-
 	// scheduler is the scheduling policy. If nil, defaults to currentBehaviorPolicy.
 	scheduler schedulerPolicy
 
@@ -164,8 +168,8 @@ func newEngine(cfg engineConfig) *engine {
 		extractors:       cfg.extractors,
 		detectors:        cfg.detectors,
 		correlators:      cfg.correlators,
-		contextProviders: cfg.contextProviders,
-		contextRefs:      make(map[string]seriesContextRef),
+		contextByRef:           make(map[observerdef.SeriesRef]*observerdef.MetricContext),
+		contextKeyToStorageKey: make(map[nsContextKey]string),
 		scheduler:        sched,
 
 		rawAnomalyWindow:           cfg.rawAnomalyWindow,
@@ -307,7 +311,7 @@ func (e *engine) IngestLog(source string, l *logObs) ([]advanceRequest, []observ
 	for _, extractor := range e.extractors {
 		processingStartTime := time.Now()
 		out := extractor.ProcessLog(view)
-		e.removeContextRefsForEvictedKeys(extractor.Name(), out.EvictedContextKeys)
+		e.removeContextsForEvictedKeys(extractor.Name(), out.EvictedContextKeys)
 		nanos := float64(time.Since(processingStartTime).Nanoseconds())
 		if e.onProcessingTime != nil {
 			e.onProcessingTime(e.detectorTag(extractor.Name()), nanos)
@@ -327,16 +331,14 @@ func (e *engine) IngestLog(source string, l *logObs) ([]advanceRequest, []observ
 				tags = append(newTags, sourceTag)
 			}
 			res := e.storage.Add(extractor.Name(), m.Name, m.Value, l.timestampMs/1000, tags)
-			if m.ContextKey != "" && res.StorageKey != "" {
-				// Reuse the storage key computed inside storage.Add instead of
-				// recomputing seriesKey here. seriesKey is hot enough that this
-				// duplicate accounted for ~14.5 MiB heap-live in the
-				// quality_gate_container_logs SMP profile (now renamed to
-				// observer_logs_anomaly_stress; the 'quality_gate_*' prefix is
-				// reserved for SMP quality-gate cases).
-				e.contextRefs[res.StorageKey] = seriesContextRef{
-					namespace:  extractor.Name(),
-					contextKey: m.ContextKey,
+			if res.Ref >= 0 && res.IsNew {
+				if m.Context != nil {
+					e.contextByRef[res.Ref] = m.Context
+				}
+				if m.ContextKey != "" {
+					// Record the storage key for this context so we can remove
+					// the series when the extractor LRU-evicts its context.
+					e.contextKeyToStorageKey[nsContextKey{extractor.Name(), m.ContextKey}] = res.StorageKey
 				}
 			}
 		}
@@ -374,33 +376,22 @@ func sliceContains(items []string, want string) bool {
 	return false
 }
 
-// removeContextRefsForEvictedKeys drops engine contextRefs whose extractor
-// namespace and context key match an eviction from extractor GC, and frees
-// the corresponding storage series. Without the storage cleanup, evicted
-// patterns leak their tags + columnar arrays indefinitely (the contextRefs
-// map is just metadata; the heavy data lives in storage.series).
-func (e *engine) removeContextRefsForEvictedKeys(namespace string, evictedKeys []string) {
-	// No garbage collection done
+// removeContextsForEvictedKeys frees storage series whose extractor context
+// keys have been evicted by LRU or GC. Uses contextKeyToStorageKey for O(1)
+// lookup instead of scanning the full context map.
+func (e *engine) removeContextsForEvictedKeys(namespace string, evictedKeys []string) {
 	if len(evictedKeys) == 0 {
 		return
 	}
-	want := make(map[string]struct{}, len(evictedKeys))
-	for _, k := range evictedKeys {
-		if k != "" {
-			want[k] = struct{}{}
-		}
-	}
-	if len(want) == 0 {
-		return
-	}
 	var storageKeys []string
-	for seriesID, ref := range e.contextRefs {
-		if ref.namespace != namespace {
+	for _, key := range evictedKeys {
+		if key == "" {
 			continue
 		}
-		if _, ok := want[ref.contextKey]; ok {
-			delete(e.contextRefs, seriesID)
-			storageKeys = append(storageKeys, seriesID)
+		nck := nsContextKey{namespace, key}
+		if sk, ok := e.contextKeyToStorageKey[nck]; ok {
+			delete(e.contextKeyToStorageKey, nck)
+			storageKeys = append(storageKeys, sk)
 		}
 	}
 	if len(storageKeys) > 0 {
@@ -429,8 +420,11 @@ func (e *engine) removeContextRefsForEvictedKeys(namespace string, evictedKeys [
 // taking their own locks. Adding a new caller of this function from a
 // different goroutine would break that invariant for every detector.
 func (e *engine) fanOutSeriesRemoval(refs []observerdef.SeriesRef) {
-	if len(refs) == 0 || len(e.detectors) == 0 {
+	if len(refs) == 0 {
 		return
+	}
+	for _, ref := range refs {
+		delete(e.contextByRef, ref)
 	}
 	for _, d := range e.detectors {
 		if remover, ok := d.(observerdef.SeriesRemover); ok {
@@ -643,21 +637,27 @@ func (e *engine) runDetectorsAndCorrelatorsSnapshot(upTo int64, detectors []obse
 // Lookup builds the storage key from Source fields (namespace, name, tags)
 // and maps that to a provider namespace and context key.
 func (e *engine) enrichAnomaly(a *observerdef.Anomaly) {
-	if a.Source.Name == "" {
+	var ref observerdef.SeriesRef = -1
+	if a.SourceRef != nil {
+		ref = a.SourceRef.Ref
+	} else if a.Source.Name != "" {
+		// Fallback for anomalies emitted without a SourceRef (e.g. bare
+		// detectors in tests). Look up the ref from storage via the Source
+		// descriptor. This path does a string key lookup which is less
+		// efficient, but only reached by anomalies that don't go through
+		// seriesDetectorAdapter.
+		key := seriesKey(a.Source.Namespace, a.Source.Name, a.Source.Tags)
+		e.storage.mu.RLock()
+		if stats, ok := e.storage.series[key]; ok {
+			ref = stats.ref
+		}
+		e.storage.mu.RUnlock()
+	}
+	if ref < 0 {
 		return
 	}
-	fullKey := seriesKey(a.Source.Namespace, a.Source.Name, a.Source.Tags)
-
-	ref, ok := e.contextRefs[fullKey]
-	if !ok {
-		return
-	}
-	provider, ok := e.contextProviders[ref.namespace]
-	if !ok {
-		return
-	}
-	ctx, ok := provider.GetContextByKey(ref.contextKey)
-	if !ok {
+	ctx, ok := e.contextByRef[ref]
+	if !ok || ctx == nil {
 		return
 	}
 	a.Context = &observerdef.MetricContext{
@@ -894,8 +894,8 @@ func (e *engine) SetExtractors(extractors []observerdef.LogMetricsExtractor) {
 
 	validateUniqueExtractorNames(extractors)
 	e.extractors = extractors
-	e.contextProviders = collectContextProviders(extractors)
-	e.contextRefs = make(map[string]seriesContextRef)
+	e.contextByRef = make(map[observerdef.SeriesRef]*observerdef.MetricContext)
+	e.contextKeyToStorageKey = make(map[nsContextKey]string)
 	e.rebuildDetectorTags()
 }
 
@@ -924,7 +924,8 @@ func (e *engine) Reset() {
 		}
 	}
 
-	e.contextRefs = make(map[string]seriesContextRef)
+	e.contextByRef = make(map[observerdef.SeriesRef]*observerdef.MetricContext)
+	e.contextKeyToStorageKey = make(map[nsContextKey]string)
 }
 
 // resetRawAnomalies clears the raw anomaly tracking state.

--- a/comp/observer/impl/events_test.go
+++ b/comp/observer/impl/events_test.go
@@ -114,32 +114,15 @@ func (d *anomalyDetector) Detect(_ observerdef.StorageReader, _ int64) observerd
 	}
 }
 
-type stubContextProvider struct {
-	context      observerdef.MetricContext
-	ok           bool
-	requestedKey string
-}
-
-func (p *stubContextProvider) GetContextByKey(key string) (observerdef.MetricContext, bool) {
-	p.requestedKey = key
-	return p.context, p.ok
-}
-
 type stubExtractor struct {
-	name         string
-	contextByKey map[string]observerdef.MetricContext
-	resetCount   int
+	name       string
+	resetCount int
 }
 
 func (e *stubExtractor) Name() string { return e.name }
 
 func (e *stubExtractor) ProcessLog(_ observerdef.LogView) observerdef.LogMetricsExtractorOutput {
 	return observerdef.LogMetricsExtractorOutput{}
-}
-
-func (e *stubExtractor) GetContextByKey(key string) (observerdef.MetricContext, bool) {
-	ctx, ok := e.contextByKey[key]
-	return ctx, ok
 }
 
 func (e *stubExtractor) Reset() {
@@ -233,13 +216,10 @@ func TestAdvanceEmitsAnomalyCreatedEvents(t *testing.T) {
 }
 
 func TestAdvanceEnrichesAnomalyContextWithoutOverwritingDescription(t *testing.T) {
-	provider := &stubContextProvider{
-		context: observerdef.MetricContext{
-			Pattern: "error <*> timeout",
-			Example: "very long example line that should still be attached as context without replacing the detector description",
-			Source:  "log_metrics_extractor",
-		},
-		ok: true,
+	ctx := &observerdef.MetricContext{
+		Pattern: "error <*> timeout",
+		Example: "very long example line that should still be attached as context without replacing the detector description",
+		Source:  "log_metrics_extractor",
 	}
 	anomalies := []observerdef.Anomaly{{
 		Source: observerdef.SeriesDescriptor{
@@ -254,21 +234,14 @@ func TestAdvanceEnrichesAnomalyContextWithoutOverwritingDescription(t *testing.T
 	}}
 
 	storage := newTimeSeriesStorage()
-	// Add a series so that the storage key matches Source fields.
-	storage.Add("log_metrics_extractor", "log.pattern.abc.count", 1.0, 1, []string{"observer_source:source-a", "service:api"})
+	res := storage.Add("log_metrics_extractor", "log.pattern.abc.count", 1.0, 1, []string{"observer_source:source-a", "service:api"})
 	e := newEngine(engineConfig{
 		storage: storage,
 		detectors: []observerdef.Detector{
 			&anomalyDetector{name: "test", anomalies: anomalies},
 		},
-		contextProviders: map[string]observerdef.ContextProvider{
-			"log_metrics_extractor": provider,
-		},
 	})
-	e.contextRefs["log_metrics_extractor|log.pattern.abc.count|observer_source:source-a,service:api"] = seriesContextRef{
-		namespace:  "log_metrics_extractor",
-		contextKey: "ctx-1",
-	}
+	e.contextByRef[res.Ref] = ctx
 
 	sink := &collectingSink{}
 	e.Subscribe(sink)
@@ -283,21 +256,16 @@ func TestAdvanceEnrichesAnomalyContextWithoutOverwritingDescription(t *testing.T
 	assert.Equal(t, "error <*> timeout", got.Context.Pattern)
 	assert.Equal(t, "log_metrics_extractor", got.Context.Source)
 	assert.Contains(t, got.Context.Example, "very long example line")
-	assert.Equal(t, "ctx-1", provider.requestedKey)
 }
 
 func TestSetExtractorsRefreshesContextProviders(t *testing.T) {
-	first := &stubExtractor{name: "first", contextByKey: map[string]observerdef.MetricContext{}}
-	second := &stubExtractor{name: "second", contextByKey: map[string]observerdef.MetricContext{
-		"ctx-2": {Pattern: "p2", Example: "e2", Source: "second"},
-	}}
+	first := &stubExtractor{name: "first"}
+	second := &stubExtractor{name: "second"}
 	storage := newTimeSeriesStorage()
-	// Add a series so that the storage key matches Source fields.
-	storage.Add("second", "metric", 1.0, 1, []string{"service:api"})
+	res := storage.Add("second", "metric", 1.0, 1, []string{"service:api"})
 	e := newEngine(engineConfig{
-		storage:          storage,
-		extractors:       []observerdef.LogMetricsExtractor{first},
-		contextProviders: collectContextProviders([]observerdef.LogMetricsExtractor{first}),
+		storage:    storage,
+		extractors: []observerdef.LogMetricsExtractor{first},
 		detectors: []observerdef.Detector{&anomalyDetector{name: "test", anomalies: []observerdef.Anomaly{{
 			Source:    observerdef.SeriesDescriptor{Namespace: "second", Name: "metric", Tags: []string{"service:api"}},
 			Timestamp: 1,
@@ -305,10 +273,8 @@ func TestSetExtractorsRefreshesContextProviders(t *testing.T) {
 	})
 
 	e.SetExtractors([]observerdef.LogMetricsExtractor{second})
-	e.contextRefs["second|metric|service:api"] = seriesContextRef{
-		namespace:  "second",
-		contextKey: "ctx-2",
-	}
+	// Populate contextByRef directly to simulate what IngestLog would have done.
+	e.contextByRef[res.Ref] = &observerdef.MetricContext{Pattern: "p2", Example: "e2", Source: "second"}
 	result := e.Advance(2)
 	require.Len(t, result.anomalies, 1)
 	require.NotNil(t, result.anomalies[0].Context)
@@ -321,7 +287,7 @@ func TestEnrichAnomalyWithRealLogPatternExtractorUsesStoredSeriesTags(t *testing
 	e := newEngine(engineConfig{
 		storage:          newTimeSeriesStorage(),
 		extractors:       []observerdef.LogMetricsExtractor{extractor},
-		contextProviders: collectContextProviders([]observerdef.LogMetricsExtractor{extractor}),
+
 	})
 
 	_, _ = e.IngestLog("source-a", &logObs{
@@ -362,8 +328,10 @@ func TestEnrichAnomalyWithRealLogPatternExtractorUsesStoredSeriesTags(t *testing
 	e.enrichAnomaly(&anomaly)
 	require.NotNil(t, anomaly.Context)
 	assert.Equal(t, "log_pattern_extractor", anomaly.Context.Source)
+	// Context is snapshotted at first-ingest time: example from the first
+	// matching log, pattern as it was at that moment (may not yet be a wildcard).
 	assert.Equal(t, "GET /users/123 returned 500", anomaly.Context.Example)
-	assert.Contains(t, anomaly.Context.Pattern, "*")
+	assert.NotEmpty(t, anomaly.Context.Pattern)
 	assert.NotContains(t, anomaly.Context.Example, "456")
 }
 
@@ -373,7 +341,7 @@ func TestAdvance_LogMetricAnomalyIsEnrichedViaMatchingSeriesIdentity(t *testing.
 	e := newEngine(engineConfig{
 		storage:          newTimeSeriesStorage(),
 		extractors:       []observerdef.LogMetricsExtractor{extractor},
-		contextProviders: collectContextProviders([]observerdef.LogMetricsExtractor{extractor}),
+
 		detectors:        []observerdef.Detector{detector},
 	})
 
@@ -411,8 +379,8 @@ func containsTag(tags []string, want string) bool {
 }
 
 func TestNewEnginePanicsOnDuplicateExtractorNames(t *testing.T) {
-	first := &stubExtractor{name: "dup", contextByKey: map[string]observerdef.MetricContext{}}
-	second := &stubExtractor{name: "dup", contextByKey: map[string]observerdef.MetricContext{}}
+	first := &stubExtractor{name: "dup", }
+	second := &stubExtractor{name: "dup", }
 
 	assert.PanicsWithValue(t, `duplicate log extractor name: "dup"`, func() {
 		_ = newEngine(engineConfig{
@@ -424,8 +392,8 @@ func TestNewEnginePanicsOnDuplicateExtractorNames(t *testing.T) {
 
 func TestSetExtractorsPanicsOnDuplicateExtractorNames(t *testing.T) {
 	e := newEngine(engineConfig{storage: newTimeSeriesStorage()})
-	first := &stubExtractor{name: "dup", contextByKey: map[string]observerdef.MetricContext{}}
-	second := &stubExtractor{name: "dup", contextByKey: map[string]observerdef.MetricContext{}}
+	first := &stubExtractor{name: "dup", }
+	second := &stubExtractor{name: "dup", }
 
 	assert.PanicsWithValue(t, `duplicate log extractor name: "dup"`, func() {
 		e.SetExtractors([]observerdef.LogMetricsExtractor{first, second})
@@ -589,7 +557,7 @@ func TestReplayWithLiveScheduleNoMatchingTimestamps(t *testing.T) {
 func TestEngineResetResetsDetectorsAndCorrelators(t *testing.T) {
 	detector := &resettableDetector{name: "detector"}
 	correlator := &resettableCorrelator{name: "correlator"}
-	extractor := &stubExtractor{name: "extractor", contextByKey: map[string]observerdef.MetricContext{}}
+	extractor := &stubExtractor{name: "extractor", }
 	e := newEngine(engineConfig{
 		storage:     newTimeSeriesStorage(),
 		detectors:   []observerdef.Detector{detector},

--- a/comp/observer/impl/log_metrics_extractor.go
+++ b/comp/observer/impl/log_metrics_extractor.go
@@ -45,16 +45,8 @@ const LogMetricsExtractorName = "log_metrics_extractor"
 //
 // This is intentionally minimal; cardinality controls live in the observer storage (Step 5).
 //
-// LogMetricsExtractor also implements observer.ContextProvider, tracking the
-// pattern signature and a recent example log line for each pattern metric it
-// emits. Detectors can query this via StorageReader.GetContext to produce
-// richer anomaly descriptions.
 type LogMetricsExtractor struct {
 	config LogMetricsExtractorConfig
-
-	// patternContext tracks the signature and a recent example for each context
-	// key emitted by this extractor.
-	patternContext map[string]observer.MetricContext
 }
 
 // NewLogMetricsExtractor creates a LogMetricsExtractor with the given config.
@@ -64,21 +56,7 @@ func NewLogMetricsExtractor(config LogMetricsExtractorConfig) *LogMetricsExtract
 
 func (a *LogMetricsExtractor) Name() string { return LogMetricsExtractorName }
 
-// Reset clears cached per-series context so replay/reanalysis starts from the
-// currently observed data instead of reusing stale examples.
-func (a *LogMetricsExtractor) Reset() {
-	a.patternContext = nil
-}
-
-// GetContextByKey implements observer.ContextProvider. It returns the pattern
-// signature and a recent example log line for a previously emitted context key.
-func (a *LogMetricsExtractor) GetContextByKey(key string) (observer.MetricContext, bool) {
-	if a.patternContext == nil {
-		return observer.MetricContext{}, false
-	}
-	ctx, ok := a.patternContext[key]
-	return ctx, ok
-}
+func (a *LogMetricsExtractor) Reset() {}
 
 func (a *LogMetricsExtractor) ProcessLog(log observer.LogView) observer.LogMetricsExtractorOutput {
 	content := log.GetContent()
@@ -91,23 +69,16 @@ func (a *LogMetricsExtractor) ProcessLog(log observer.LogView) observer.LogMetri
 	}
 
 	metricName := patternCountMetricName(patternSig)
-	contextKey := metricContextKey(metricName, tags)
-
-	// Track context for this pattern metric so detectors can enrich anomalies.
-	if a.patternContext == nil {
-		a.patternContext = make(map[string]observer.MetricContext)
-	}
-	a.patternContext[contextKey] = observer.MetricContext{
-		Pattern: patternSig,
-		Example: content,
-		Source:  "log_metrics_extractor",
-	}
 
 	metrics := []observer.MetricOutput{{
-		Name:       metricName,
-		Value:      1,
-		Tags:       tags,
-		ContextKey: contextKey,
+		Name:  metricName,
+		Value: 1,
+		Tags:  tags,
+		Context: &observer.MetricContext{
+			Pattern: patternSig,
+			Example: content,
+			Source:  LogMetricsExtractorName,
+		},
 	}}
 
 	// For JSON logs, also extract numeric field metrics

--- a/comp/observer/impl/log_metrics_extractor_test.go
+++ b/comp/observer/impl/log_metrics_extractor_test.go
@@ -117,7 +117,7 @@ func TestLogMetricsExtractor_InvalidJSONFallsBackToUnstructured(t *testing.T) {
 	assert.Equal(t, patternCountMetricName(sig), res.Metrics[0].Name)
 }
 
-func TestLogMetricsExtractor_GetContextByKeyUsesOutputContextKey(t *testing.T) {
+func TestLogMetricsExtractor_MetricOutputHasInlineContext(t *testing.T) {
 	a := &LogMetricsExtractor{}
 	log := &mockLogView{
 		content: "Request completed in 45ms",
@@ -126,15 +126,12 @@ func TestLogMetricsExtractor_GetContextByKeyUsesOutputContextKey(t *testing.T) {
 
 	res := a.ProcessLog(log)
 	require.Len(t, res.Metrics, 1)
-	require.NotEmpty(t, res.Metrics[0].ContextKey)
-
-	ctx, ok := a.GetContextByKey(res.Metrics[0].ContextKey)
-	require.True(t, ok)
-	assert.Equal(t, "log_metrics_extractor", ctx.Source)
-	assert.Equal(t, "Request completed in 45ms", ctx.Example)
+	require.NotNil(t, res.Metrics[0].Context)
+	assert.Equal(t, "log_metrics_extractor", res.Metrics[0].Context.Source)
+	assert.Equal(t, "Request completed in 45ms", res.Metrics[0].Context.Example)
 }
 
-func TestLogMetricsExtractor_ContextKeySeparatesSameMetricByTags(t *testing.T) {
+func TestLogMetricsExtractor_ContextSeparatesSameMetricByTags(t *testing.T) {
 	a := &LogMetricsExtractor{}
 	logA := &mockLogView{
 		content: "Request completed in 45ms",
@@ -150,14 +147,12 @@ func TestLogMetricsExtractor_ContextKeySeparatesSameMetricByTags(t *testing.T) {
 	require.Len(t, resA.Metrics, 1)
 	require.Len(t, resB.Metrics, 1)
 	require.Equal(t, resA.Metrics[0].Name, resB.Metrics[0].Name)
-	require.NotEqual(t, resA.Metrics[0].ContextKey, resB.Metrics[0].ContextKey)
+	// Different tags → different series keys (verified via Tags field).
+	require.NotEqual(t, resA.Metrics[0].Tags, resB.Metrics[0].Tags)
 
-	ctxA, ok := a.GetContextByKey(resA.Metrics[0].ContextKey)
-	require.True(t, ok)
-	ctxB, ok := a.GetContextByKey(resB.Metrics[0].ContextKey)
-	require.True(t, ok)
-
-	assert.Equal(t, "Request completed in 45ms", ctxA.Example)
-	assert.Equal(t, "Request completed in 45ms", ctxB.Example)
-	assert.Equal(t, ctxA.Pattern, ctxB.Pattern)
+	require.NotNil(t, resA.Metrics[0].Context)
+	require.NotNil(t, resB.Metrics[0].Context)
+	assert.Equal(t, "Request completed in 45ms", resA.Metrics[0].Context.Example)
+	assert.Equal(t, "Request completed in 45ms", resB.Metrics[0].Context.Example)
+	assert.Equal(t, resA.Metrics[0].Context.Pattern, resB.Metrics[0].Context.Pattern)
 }

--- a/comp/observer/impl/log_pattern_extractor.go
+++ b/comp/observer/impl/log_pattern_extractor.go
@@ -118,51 +118,29 @@ type LogPatternExtractor struct {
 }
 
 var _ observerdef.LogMetricsExtractor = (*LogPatternExtractor)(nil)
-var _ observerdef.ContextProvider = (*LogPatternExtractor)(nil)
 
-type patternMetricContext struct {
-	keyInfo PatternKeyInfo
-	example string
-}
-
-// logPatternExtractorContext holds per-metric context for GetContextByKey and
-// indexes keys by tagged cluster (globalClusterHash) for O(cluster) deletion on GC.
-// The tagged key encodes both groupHash and clusterID so that different sub-clusterers
-// with coincidentally equal cluster IDs don't collide.
+// logPatternExtractorContext tracks context keys by tagged cluster for O(1)
+// eviction signaling. When the LRU evicts a cluster, the engine uses the
+// reported ContextKeys to locate and free the corresponding storage series.
 type logPatternExtractorContext struct {
-	byKey               map[string]patternMetricContext
-	keysByTaggedCluster map[string][]string // key: globalClusterHash(groupHash, clusterID)
+	keysByTaggedCluster map[string][]string // taggedKey → []contextKey
 }
 
-func (c *logPatternExtractorContext) get(key string) (patternMetricContext, bool) {
-	if c.byKey == nil {
-		return patternMetricContext{}, false
-	}
-	v, ok := c.byKey[key]
-	return v, ok
-}
-
-func (c *logPatternExtractorContext) put(groupHash uint64, clusterID int64, contextKey string, entry patternMetricContext) {
+func (c *logPatternExtractorContext) put(groupHash uint64, clusterID int64, contextKey string) {
 	taggedKey := globalClusterHash(groupHash, clusterID)
-	if c.byKey == nil {
-		c.byKey = make(map[string]patternMetricContext)
+	if c.keysByTaggedCluster == nil {
+		c.keysByTaggedCluster = make(map[string][]string)
 	}
-	if _, exists := c.byKey[contextKey]; !exists {
-		if c.keysByTaggedCluster == nil {
-			c.keysByTaggedCluster = make(map[string][]string)
+	// Only add contextKey once per tagged cluster.
+	for _, k := range c.keysByTaggedCluster[taggedKey] {
+		if k == contextKey {
+			return
 		}
-		c.keysByTaggedCluster[taggedKey] = append(c.keysByTaggedCluster[taggedKey], contextKey)
-		c.byKey[contextKey] = entry
 	}
+	c.keysByTaggedCluster[taggedKey] = append(c.keysByTaggedCluster[taggedKey], contextKey)
 }
 
 func (c *logPatternExtractorContext) removeTaggedCluster(taggedKey string) {
-	if c.byKey == nil {
-		return
-	}
-	for _, k := range c.keysByTaggedCluster[taggedKey] {
-		delete(c.byKey, k)
-	}
 	delete(c.keysByTaggedCluster, taggedKey)
 }
 
@@ -225,28 +203,6 @@ func (e *LogPatternExtractor) Reset() {
 	e.NextGarbageCollectionTime = 0
 }
 
-// GetContextByKey implements observerdef.ContextProvider for pattern metrics
-// emitted by this extractor.
-func (e *LogPatternExtractor) GetContextByKey(key string) (observerdef.MetricContext, bool) {
-	entry, ok := e.ctx.get(key)
-	if !ok {
-		return observerdef.MetricContext{}, false
-	}
-
-	pattern := ""
-	cluster, err := e.taggedClusterer.GetCluster(entry.keyInfo.GroupHash, entry.keyInfo.ClusterID)
-	if err == nil && cluster != nil {
-		pattern = cluster.PatternString()
-	}
-
-	group, _ := e.registry.Lookup(entry.keyInfo.GroupHash)
-	return observerdef.MetricContext{
-		Pattern:   pattern,
-		Example:   entry.example,
-		Source:    e.Name(),
-		SplitTags: group.AsMap(),
-	}, true
-}
 
 // logSeverityIsWarnPlus returns true when the log should be clustered: warning
 func logSeverityIsWarnPlus(log observerdef.LogView) bool {
@@ -311,19 +267,31 @@ func (e *LogPatternExtractor) ProcessLog(log observerdef.LogView) observerdef.Lo
 		return result
 	}
 
-	metricName := "log." + e.Name() + "." + globalClusterHash(groupHash, cluster.ID) + ".count"
+	clusterHash := globalClusterHash(groupHash, cluster.ID)
+	metricName := "log." + e.Name() + "." + clusterHash + ".count"
 	contextKey := metricContextKey(metricName, log.GetTags())
 
-	e.ctx.put(groupHash, cluster.ID, contextKey, patternMetricContext{
-		keyInfo: PatternKeyInfo{ClusterID: cluster.ID, GroupHash: groupHash},
-		example: message,
-	})
+	e.ctx.put(groupHash, cluster.ID, contextKey)
+
+	// Snapshot context now so the engine can enrich anomalies without
+	// querying the clusterer at detection time.
+	pattern := ""
+	if c, err := e.taggedClusterer.GetCluster(groupHash, cluster.ID); err == nil && c != nil {
+		pattern = c.PatternString()
+	}
+	group, _ := e.registry.Lookup(groupHash)
 
 	result.Metrics = []observerdef.MetricOutput{{
 		Name:       metricName,
 		Value:      1,
 		Tags:       log.GetTags(),
 		ContextKey: contextKey,
+		Context: &observerdef.MetricContext{
+			Pattern:   pattern,
+			Example:   message,
+			Source:    e.Name(),
+			SplitTags: group.AsMap(),
+		},
 	}}
 	result.Telemetry = telemetry
 	return result

--- a/comp/observer/impl/log_pattern_extractor_test.go
+++ b/comp/observer/impl/log_pattern_extractor_test.go
@@ -15,7 +15,7 @@ import (
 	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
 )
 
-func TestLogPatternExtractor_GetContextByKeyUsesOutputContextKey(t *testing.T) {
+func TestLogPatternExtractor_MetricOutputHasInlineContext(t *testing.T) {
 	e := NewLogPatternExtractor(DefaultLogPatternExtractorConfig())
 	e.config.MinClusterSizeBeforeEmit = 1
 
@@ -27,14 +27,11 @@ func TestLogPatternExtractor_GetContextByKeyUsesOutputContextKey(t *testing.T) {
 
 	res := e.ProcessLog(log)
 	require.Len(t, res.Metrics, 1)
-	require.NotEmpty(t, res.Metrics[0].ContextKey)
-
-	ctx, ok := e.GetContextByKey(res.Metrics[0].ContextKey)
-	require.True(t, ok)
-	assert.Equal(t, "log_pattern_extractor", ctx.Source)
-	assert.Equal(t, "GET /users/123 returned 500", ctx.Example)
-	assert.NotEmpty(t, ctx.Pattern)
-	assert.Equal(t, map[string]string{"service": "web", "env": "prod"}, ctx.SplitTags)
+	require.NotNil(t, res.Metrics[0].Context)
+	assert.Equal(t, "log_pattern_extractor", res.Metrics[0].Context.Source)
+	assert.Equal(t, "GET /users/123 returned 500", res.Metrics[0].Context.Example)
+	assert.NotEmpty(t, res.Metrics[0].Context.Pattern)
+	assert.Equal(t, map[string]string{"service": "web", "env": "prod"}, res.Metrics[0].Context.SplitTags)
 }
 
 func TestLogPatternExtractor_DifferentTagGroupsProduceDifferentMetricNames(t *testing.T) {
@@ -73,16 +70,16 @@ func TestLogPatternExtractor_DifferentTagGroupsProduceDifferentMetricNames(t *te
 	require.NotEqual(t, resA.Metrics[0].Name, resB.Metrics[0].Name)
 	require.NotEqual(t, resA.Metrics[0].ContextKey, resB.Metrics[0].ContextKey)
 
-	ctxA, ok := e.GetContextByKey(resA.Metrics[0].ContextKey)
-	require.True(t, ok)
-	ctxB, ok := e.GetContextByKey(resB.Metrics[0].ContextKey)
-	require.True(t, ok)
-
-	assert.Equal(t, "GET /users/123 returned 500", ctxA.Example)
-	assert.Equal(t, "GET /users/456 returned 500", ctxB.Example)
-	assert.Equal(t, ctxA.Pattern, ctxB.Pattern)
-	assert.Equal(t, map[string]string{"service": "api"}, ctxA.SplitTags)
-	assert.Equal(t, map[string]string{"service": "worker"}, ctxB.SplitTags)
+	require.NotNil(t, resA.Metrics[0].Context)
+	require.NotNil(t, resB.Metrics[0].Context)
+	assert.Equal(t, "GET /users/123 returned 500", resA.Metrics[0].Context.Example)
+	assert.Equal(t, "GET /users/456 returned 500", resB.Metrics[0].Context.Example)
+	// Patterns are snapshots at ingest time; after logC/logD merge into wildcards
+	// they become equal, but at first-log time they reflect the initial content.
+	assert.NotEmpty(t, resA.Metrics[0].Context.Pattern)
+	assert.NotEmpty(t, resB.Metrics[0].Context.Pattern)
+	assert.Equal(t, map[string]string{"service": "api"}, resA.Metrics[0].Context.SplitTags)
+	assert.Equal(t, map[string]string{"service": "worker"}, resB.Metrics[0].Context.SplitTags)
 }
 
 func TestLogPatternExtractor_DifferentHostnamesProduceDifferentMetricNamesWhenNoHostTag(t *testing.T) {
@@ -112,15 +109,13 @@ func TestLogPatternExtractor_DifferentHostnamesProduceDifferentMetricNamesWhenNo
 	require.NotEqual(t, resA.Metrics[0].Name, resB.Metrics[0].Name)
 	require.NotEqual(t, resA.Metrics[0].ContextKey, resB.Metrics[0].ContextKey)
 
-	ctxA, ok := e.GetContextByKey(resA.Metrics[0].ContextKey)
-	require.True(t, ok)
-	ctxB, ok := e.GetContextByKey(resB.Metrics[0].ContextKey)
-	require.True(t, ok)
-	assert.Equal(t, map[string]string{"service": "api", "env": "prod", "host": "host-a"}, ctxA.SplitTags)
-	assert.Equal(t, map[string]string{"service": "api", "env": "prod", "host": "host-b"}, ctxB.SplitTags)
+	require.NotNil(t, resA.Metrics[0].Context)
+	require.NotNil(t, resB.Metrics[0].Context)
+	assert.Equal(t, map[string]string{"service": "api", "env": "prod", "host": "host-a"}, resA.Metrics[0].Context.SplitTags)
+	assert.Equal(t, map[string]string{"service": "api", "env": "prod", "host": "host-b"}, resB.Metrics[0].Context.SplitTags)
 }
 
-func TestLogPatternExtractor_ResetClearsContext(t *testing.T) {
+func TestLogPatternExtractor_ResetClearsEvictionState(t *testing.T) {
 	e := NewLogPatternExtractor(DefaultLogPatternExtractorConfig())
 	e.config.MinClusterSizeBeforeEmit = 1
 
@@ -132,14 +127,12 @@ func TestLogPatternExtractor_ResetClearsContext(t *testing.T) {
 
 	res := e.ProcessLog(log)
 	require.Len(t, res.Metrics, 1)
-
-	_, ok := e.GetContextByKey(res.Metrics[0].ContextKey)
-	require.True(t, ok)
+	require.NotEmpty(t, res.Metrics[0].ContextKey)
+	require.NotNil(t, e.ctx.keysByTaggedCluster)
 
 	e.Reset()
 
-	_, ok = e.GetContextByKey(res.Metrics[0].ContextKey)
-	assert.False(t, ok)
+	assert.Nil(t, e.ctx.keysByTaggedCluster)
 }
 
 func TestLogPatternExtractor_SkipsBelowWarnSeverity(t *testing.T) {
@@ -207,8 +200,6 @@ func TestLogPatternExtractor_GarbageCollectRemovesStaleClusterAndContext(t *test
 	require.Len(t, res1.Metrics, 1)
 	require.Empty(t, res1.EvictedContextKeys, "no GC on first log")
 	ctxKey1 := res1.Metrics[0].ContextKey
-	_, ok := e.GetContextByKey(ctxKey1)
-	require.True(t, ok, "pattern context should exist before GC")
 
 	// t=1015: GC runs first (cutoff 1015-10=1005); cluster A last seen 1000 is stale.
 	// Then a new log creates cluster B.
@@ -221,14 +212,6 @@ func TestLogPatternExtractor_GarbageCollectRemovesStaleClusterAndContext(t *test
 	})
 	require.Len(t, res2.Metrics, 1)
 	require.Equal(t, []string{ctxKey1}, res2.EvictedContextKeys, "GC should report evicted context keys for the engine")
-	ctxKey2 := res2.Metrics[0].ContextKey
-
-	_, ok = e.GetContextByKey(ctxKey1)
-	assert.False(t, ok, "stale cluster pattern context should be removed by GC")
-	_, ok = e.GetContextByKey(ctxKey2)
-	require.True(t, ok, "active cluster pattern context should remain")
-
-	require.NotEqual(t, ctxKey1, ctxKey2)
 
 	// Only cluster B should remain in the tagged clusterer.
 	remaining := e.taggedClusterer.GetAllClusters()
@@ -256,9 +239,6 @@ func TestLogPatternExtractor_DisableOptimizationsSkipsGarbageCollection(t *testi
 		timestampMs: tsMs1,
 	})
 	require.Len(t, res1.Metrics, 1)
-	ctxKey1 := res1.Metrics[0].ContextKey
-	_, ok := e.GetContextByKey(ctxKey1)
-	require.True(t, ok)
 
 	// Same timeline as TestLogPatternExtractor_GarbageCollectRemovesStaleClusterAndContext, where GC
 	// would evict cluster A — but with DisableOptimizations, TTL is off so A stays.
@@ -271,12 +251,6 @@ func TestLogPatternExtractor_DisableOptimizationsSkipsGarbageCollection(t *testi
 	})
 	require.Len(t, res2.Metrics, 1)
 	require.Empty(t, res2.EvictedContextKeys, "GC must not run when optimizations are disabled")
-	ctxKey2 := res2.Metrics[0].ContextKey
-
-	_, ok = e.GetContextByKey(ctxKey1)
-	require.True(t, ok, "first cluster context must remain without GC")
-	_, ok = e.GetContextByKey(ctxKey2)
-	require.True(t, ok)
 
 	remaining := e.taggedClusterer.GetAllClusters()
 	require.Len(t, remaining, 2, "both clusters should still exist when GC is disabled")
@@ -372,13 +346,6 @@ func TestLogPatternExtractor_LRUCapEvictsAndDropsContext(t *testing.T) {
 			// Third shape pushes over the cap of 2; the oldest (ctxKeys[0]) is evicted.
 			require.Equal(t, []string{ctxKeys[0]}, res.EvictedContextKeys,
 				"oldest cluster's context key surfaced for the engine to drop")
-			// Confirm the engine-side context entry was actually removed.
-			_, ok := e.GetContextByKey(ctxKeys[0])
-			require.False(t, ok, "evicted cluster's pattern context should be gone")
-			_, ok = e.GetContextByKey(ctxKeys[1])
-			require.True(t, ok, "surviving cluster's context still resolvable")
-			_, ok = e.GetContextByKey(ctxKeys[2])
-			require.True(t, ok, "newly-inserted cluster's context resolvable")
 			// Pattern_count telemetry must include a -1 decrement for the eviction.
 			var found bool
 			for _, tel := range res.Telemetry {
@@ -416,7 +383,7 @@ func TestLogPatternExtractor_TagGroupCapEvictsLRUGroup(t *testing.T) {
 	}
 
 	// Two groups, two contexts.
-	kA := processAt("a", "WARN alpha", 1_000_000)
+	_ = processAt("a", "WARN alpha", 1_000_000)
 	kB := processAt("b", "WARN beta", 1_001_000)
 
 	// Touch A again so B is the LRU group.
@@ -431,10 +398,6 @@ func TestLogPatternExtractor_TagGroupCapEvictsLRUGroup(t *testing.T) {
 	})
 	require.Len(t, res.Metrics, 1)
 	require.Contains(t, res.EvictedContextKeys, kB, "LRU group's context key surfaced")
-	_, ok := e.GetContextByKey(kB)
-	require.False(t, ok, "evicted group's context entry removed")
-	_, ok = e.GetContextByKey(kA)
-	require.True(t, ok, "surviving group's context preserved")
 }
 
 // TestEngine_LogPatternLRUEvictionFreesStorage is the end-to-end proof that
@@ -479,16 +442,14 @@ func TestEngine_LogPatternLRUEvictionFreesStorage(t *testing.T) {
 	require.Equal(t, 2, storage.TotalSeriesCount(""),
 		"LRU eviction must shrink storage; before the fix storage grew unboundedly")
 
-	// All surviving contextRefs must resolve to live storage series — i.e.
-	// nothing dangling on the engine side either.
-	for key := range e.contextRefs {
-		stats, ok := storage.series[key]
-		require.True(t, ok, "engine contextRef without storage series for key %q", key)
-		require.NotNil(t, storage.GetSeriesMeta(stats.ref),
-			"engine contextRef points at a retired storage ref for key %q", key)
+	// All surviving contextByRef entries must resolve to live storage series.
+	for ref, ctx := range e.contextByRef {
+		require.NotNil(t, ctx, "engine contextByRef has nil context for ref %d", ref)
+		require.NotNil(t, storage.GetSeriesMeta(ref),
+			"engine contextByRef points at a retired storage ref %d", ref)
 	}
-	require.Len(t, e.contextRefs, 2,
-		"engine should keep one contextRef per surviving extractor cluster")
+	require.Len(t, e.contextByRef, 2,
+		"engine should keep one contextByRef entry per surviving extractor cluster")
 }
 
 // TestEngine_LogPatternLRUEvictionFreesDetectorState extends

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -201,8 +201,11 @@ func NewComponent(deps Requires) Provides {
 	settings := settingsFromAgentConfig(catalog, cfg)
 	detectors, correlators, extractors, _ := catalog.Instantiate(settings)
 
+	storage := newTimeSeriesStorage()
+	storage.maxPointsPerSeries = 600
+
 	eng := newEngine(engineConfig{
-		storage:          newTimeSeriesStorage(),
+		storage:          storage,
 		extractors:       extractors,
 		detectors:        detectors,
 		correlators:      correlators,

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -209,7 +209,6 @@ func NewComponent(deps Requires) Provides {
 		extractors:       extractors,
 		detectors:        detectors,
 		correlators:      correlators,
-		contextProviders: collectContextProviders(extractors),
 		scheduler:        &currentBehaviorPolicy{},
 	})
 

--- a/comp/observer/impl/storage.go
+++ b/comp/observer/impl/storage.go
@@ -255,11 +255,24 @@ func (s *timeSeriesStorage) Add(namespace, name string, value float64, timestamp
 	stats.counts = insertInt64(stats.counts, idx, 1)
 
 	// Trim oldest points when the series exceeds the retention cap.
+	// Copy into fresh slices so the old backing arrays become unreferenced
+	// and the GC can reclaim them. A plain re-slice (s[trim:]) keeps the
+	// original backing array alive because the slice still points into it.
 	if s.maxPointsPerSeries > 0 && len(stats.timestamps) > s.maxPointsPerSeries {
-		trim := len(stats.timestamps) - s.maxPointsPerSeries
-		stats.timestamps = stats.timestamps[trim:]
-		stats.sums = stats.sums[trim:]
-		stats.counts = stats.counts[trim:]
+		n := s.maxPointsPerSeries
+		trim := len(stats.timestamps) - n
+
+		newTs := make([]int64, n)
+		copy(newTs, stats.timestamps[trim:])
+		stats.timestamps = newTs
+
+		newSums := make([]float64, n)
+		copy(newSums, stats.sums[trim:])
+		stats.sums = newSums
+
+		newCounts := make([]int64, n)
+		copy(newCounts, stats.counts[trim:])
+		stats.counts = newCounts
 	}
 	return res
 }

--- a/comp/observer/impl/storage.go
+++ b/comp/observer/impl/storage.go
@@ -41,6 +41,12 @@ type timeSeriesStorage struct {
 	// series key is created, not on every write to an existing series.
 	seriesGen uint64
 
+	// tagIntern maps a fnv64a hash of a series' sorted tag set to the canonical
+	// []string slice shared by all series with that tag combination, plus a
+	// reference count. When the count drops to zero on eviction the entry is
+	// deleted. Protected by s.mu (write lock).
+	tagIntern map[uint64]*tagInternEntry
+
 	// Drop accounting for invalid/unsafe input values.
 	droppedNonFinite int64
 	droppedExtreme   int64
@@ -51,10 +57,19 @@ type timeSeriesStorage struct {
 // seriesStats contains accumulated statistics for a time series (internal).
 // Data is stored in columnar layout: parallel arrays indexed by point position.
 // Timestamps are stored in sorted order, enabling binary search for range queries.
+// tagInternEntry is the value stored in timeSeriesStorage.tagIntern.
+// tags is the canonical []string shared by all series with the same tag set.
+// count is the number of live series currently referencing it.
+type tagInternEntry struct {
+	tags  []string
+	count int
+}
+
 type seriesStats struct {
 	Namespace string
 	Name      string
 	Tags      []string
+	tagsHash  uint64             // fnv64a hash of Tags; 0 means not interned
 	ref       observer.SeriesRef // compact numeric ID assigned on creation
 
 	// writeGeneration is per-series and increments on every Add, including
@@ -176,6 +191,7 @@ func newTimeSeriesStorage() *timeSeriesStorage {
 	return &timeSeriesStorage{
 		series:                make(map[string]*seriesStats),
 		observationTimestamps: make(map[int64]struct{}),
+		tagIntern:             make(map[uint64]*tagInternEntry),
 		droppedByMetric:       make(map[string]int64),
 		sampledDrops:          make(map[string]int),
 	}
@@ -221,10 +237,12 @@ func (s *timeSeriesStorage) Add(namespace, name string, value float64, timestamp
 	stats, exists := s.series[key]
 	if !exists {
 		id := observer.SeriesRef(len(s.seriesIDKeys))
+		canonical, h := s.internTags(tags)
 		stats = &seriesStats{
 			Namespace: namespace,
 			Name:      name,
-			Tags:      canonicalizeTags(tags),
+			Tags:      canonical,
+			tagsHash:  h,
 			ref:       id,
 		}
 		s.series[key] = stats
@@ -532,6 +550,107 @@ func copyTags(tags []string) []string {
 	return result
 }
 
+// tagInternMaxSize caps the number of unique tag-set entries in the intern
+// pool. New combinations beyond the cap are used as-is (no sharing, no pool
+// growth); hits on already-interned combinations still return the canonical
+// slice. Matches the default for dogstatsd_string_interner_size.
+const tagInternMaxSize = 4096
+
+// hashTags computes a fnv64a hash over sorted tags without constructing the
+// joined string. The result is the key into timeSeriesStorage.tagIntern.
+// Returns 0 only when tags is empty.
+func hashTags(tags []string) uint64 {
+	if len(tags) == 0 {
+		return 0
+	}
+	h := fnvOffsetBasis64
+	for i, t := range tags {
+		if i > 0 {
+			h ^= uint64(',')
+			h *= fnvPrime64
+		}
+		for j := 0; j < len(t); j++ {
+			h ^= uint64(t[j])
+			h *= fnvPrime64
+		}
+	}
+	// Reserve 0 as "not interned" sentinel; remap the vanishingly rare
+	// zero hash to a non-zero value so it can still be interned.
+	if h == 0 {
+		h = 1
+	}
+	return h
+}
+
+// tagsEqual reports whether two sorted tag slices have identical content.
+// Used to detect hash collisions in the intern pool.
+func tagsEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// internTags sorts tags (if needed), hashes the result, and either returns
+// the canonical []string from the pool (incrementing its ref count) or inserts
+// a new entry. Returns the canonical slice and its hash. Hash 0 means the
+// combination was not interned (cap reached or hash collision). Must be called
+// with s.mu write-locked.
+func (s *timeSeriesStorage) internTags(tags []string) ([]string, uint64) {
+	if len(tags) == 0 {
+		return nil, 0
+	}
+	sorted := make([]string, len(tags))
+	copy(sorted, tags)
+	if len(sorted) > 1 && !tagsSorted(sorted) {
+		sort.Strings(sorted)
+	}
+	h := hashTags(sorted)
+	if entry, ok := s.tagIntern[h]; ok {
+		if tagsEqual(entry.tags, sorted) {
+			entry.count++
+			return entry.tags, h
+		}
+		// Hash collision — skip interning, return sorted as-is.
+		return sorted, 0
+	}
+	if len(s.tagIntern) >= tagInternMaxSize {
+		// Pool at cap — return sorted without interning.
+		return sorted, 0
+	}
+	entry := &tagInternEntry{tags: sorted, count: 1}
+	s.tagIntern[h] = entry
+	return sorted, h
+}
+
+// releaseTagIntern decrements the ref count for the intern entry at hash h
+// and deletes the entry if the count reaches zero. Must be called with s.mu
+// write-locked. No-op when h is 0 (not interned).
+func (s *timeSeriesStorage) releaseTagIntern(h uint64) {
+	if h == 0 {
+		return
+	}
+	if entry, ok := s.tagIntern[h]; ok {
+		entry.count--
+		if entry.count == 0 {
+			delete(s.tagIntern, h)
+		}
+	}
+}
+
+// TagInternedCount returns the number of unique tag-set entries in the intern
+// pool. Useful for telemetry and tests.
+func (s *timeSeriesStorage) TagInternedCount() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.tagIntern)
+}
+
 func canonicalizeTags(tags []string) []string {
 	if len(tags) <= 1 {
 		return copyTags(tags)
@@ -818,6 +937,7 @@ func (s *timeSeriesStorage) RemoveSeriesByKeys(keys []string) []observer.SeriesR
 			continue
 		}
 		id := stats.ref
+		s.releaseTagIntern(stats.tagsHash)
 		delete(s.series, key)
 		if int(id) < len(s.seriesIDStats) {
 			s.seriesIDStats[id] = nil

--- a/comp/observer/impl/storage.go
+++ b/comp/observer/impl/storage.go
@@ -207,11 +207,14 @@ type AddResult struct {
 	// IsNew is true if this Add created a brand-new series (cardinality +1).
 	IsNew bool
 	// StorageKey is the canonical seriesKey for this point. Callers that
-	// need to index further state by the same key (e.g. engine.contextRefs)
+	// need to index further state by the same key (e.g. engine.contextKeyToStorageKey)
 	// can reuse this value instead of recomputing seriesKey(...) themselves.
 	// Empty string is returned when the point is dropped pre-key-compute
 	// (non-finite or sentinel values).
 	StorageKey string
+	// Ref is the compact numeric ID for the series. -1 when the point is
+	// dropped (non-finite or sentinel values).
+	Ref observer.SeriesRef
 }
 
 // Add inserts a (namespace, name, value, timestamp, tags) point into storage.
@@ -224,13 +227,13 @@ func (s *timeSeriesStorage) Add(namespace, name string, value float64, timestamp
 
 	if math.IsInf(value, 0) || math.IsNaN(value) {
 		s.recordDroppedValue("non_finite", namespace, name, value, timestamp, tags)
-		return AddResult{}
+		return AddResult{Ref: -1}
 	}
 	// Guard against known finite sentinel values (MaxFloat64 used as "unlimited")
 	// that overflow downstream aggregation math when summed.
 	if value == math.MaxFloat64 || value == -math.MaxFloat64 {
 		s.recordDroppedValue("extreme", namespace, name, value, timestamp, tags)
-		return AddResult{}
+		return AddResult{Ref: -1}
 	}
 	key := seriesKey(namespace, name, tags)
 
@@ -250,7 +253,7 @@ func (s *timeSeriesStorage) Add(namespace, name string, value float64, timestamp
 		s.seriesIDStats = append(s.seriesIDStats, stats)
 		s.seriesGen++
 	}
-	res := AddResult{IsNew: !exists, StorageKey: key}
+	res := AddResult{IsNew: !exists, StorageKey: key, Ref: stats.ref}
 	stats.writeGeneration++
 
 	// Bucket by second.

--- a/comp/observer/impl/storage.go
+++ b/comp/observer/impl/storage.go
@@ -24,6 +24,11 @@ type timeSeriesStorage struct {
 	mu     sync.RWMutex
 	series map[string]*seriesStats
 
+	// maxPointsPerSeries caps the number of retained points in each series.
+	// When an insert would exceed the cap, the oldest points are trimmed.
+	// Zero means unlimited (default for tests; live mode sets 600).
+	maxPointsPerSeries int
+
 	// observationTimestamps tracks all timestamps where observations occurred,
 	// even if no metric series was written for that timestamp.
 	observationTimestamps map[int64]struct{}
@@ -57,11 +62,11 @@ type seriesStats struct {
 	writeGeneration int64
 
 	// Columnar storage — all slices have the same length, indexed by point position.
+	// Only timestamps, sums, and counts are retained; min/max columns were removed
+	// because no active detector uses AggregateMin or AggregateMax.
 	timestamps []int64
 	sums       []float64
 	counts     []int64
-	mins       []float64
-	maxes      []float64
 }
 
 // pointCount returns the number of stored points.
@@ -97,10 +102,9 @@ func (s *seriesStats) aggregateColumn(agg Aggregate) []float64 {
 	switch agg {
 	case AggregateSum:
 		return s.sums
-	case AggregateMin:
-		return s.mins
-	case AggregateMax:
-		return s.maxes
+	case AggregateMin, AggregateMax:
+		// Min/max columns removed; return zeros for compatibility.
+		return make([]float64, len(s.timestamps))
 	case AggregateCount:
 		vals := make([]float64, len(s.counts))
 		for i, c := range s.counts {
@@ -134,10 +138,8 @@ func (s *seriesStats) aggregateAt(i int, agg Aggregate) float64 {
 		return s.sums[i]
 	case AggregateCount:
 		return float64(s.counts[i])
-	case AggregateMin:
-		return s.mins[i]
-	case AggregateMax:
-		return s.maxes[i]
+	case AggregateMin, AggregateMax:
+		return 0
 	default:
 		return 0
 	}
@@ -245,20 +247,20 @@ func (s *timeSeriesStorage) Add(namespace, name string, value float64, timestamp
 		// Update existing bucket in-place.
 		stats.sums[idx] += value
 		stats.counts[idx]++
-		if value < stats.mins[idx] {
-			stats.mins[idx] = value
-		}
-		if value > stats.maxes[idx] {
-			stats.maxes[idx] = value
-		}
 		return res
 	}
 
 	stats.timestamps = insertInt64(stats.timestamps, idx, bucket)
 	stats.sums = insertFloat64(stats.sums, idx, value)
 	stats.counts = insertInt64(stats.counts, idx, 1)
-	stats.mins = insertFloat64(stats.mins, idx, value)
-	stats.maxes = insertFloat64(stats.maxes, idx, value)
+
+	// Trim oldest points when the series exceeds the retention cap.
+	if s.maxPointsPerSeries > 0 && len(stats.timestamps) > s.maxPointsPerSeries {
+		trim := len(stats.timestamps) - s.maxPointsPerSeries
+		stats.timestamps = stats.timestamps[trim:]
+		stats.sums = stats.sums[trim:]
+		stats.counts = stats.counts[trim:]
+	}
 	return res
 }
 
@@ -700,8 +702,6 @@ func (s *timeSeriesStorage) DumpToFile(path string) error {
 		Timestamp int64   `json:"ts"`
 		Sum       float64 `json:"sum"`
 		Count     int64   `json:"count"`
-		Min       float64 `json:"min"`
-		Max       float64 `json:"max"`
 	}
 	type dumpSeries struct {
 		Namespace string      `json:"namespace"`
@@ -723,8 +723,6 @@ func (s *timeSeriesStorage) DumpToFile(path string) error {
 				Timestamp: st.timestamps[i],
 				Sum:       st.sums[i],
 				Count:     st.counts[i],
-				Min:       st.mins[i],
-				Max:       st.maxes[i],
 			})
 		}
 		out = append(out, ds)
@@ -1051,20 +1049,6 @@ func (s *timeSeriesStorage) GetSeriesRange(ref observer.SeriesRef, start, end in
 				Value:     stats.sums[lo+i],
 			}
 		}
-	case AggregateMin:
-		for i := 0; i < resultLen; i++ {
-			points[i] = observer.Point{
-				Timestamp: stats.timestamps[lo+i],
-				Value:     stats.mins[lo+i],
-			}
-		}
-	case AggregateMax:
-		for i := 0; i < resultLen; i++ {
-			points[i] = observer.Point{
-				Timestamp: stats.timestamps[lo+i],
-				Value:     stats.maxes[lo+i],
-			}
-		}
 	case AggregateCount:
 		for i := 0; i < resultLen; i++ {
 			points[i] = observer.Point{
@@ -1152,14 +1136,6 @@ func (s *timeSeriesStorage) SumRange(ref observer.SeriesRef, start, end int64, a
 	case AggregateCount:
 		for _, c := range stats.counts[lo:hi] {
 			total += float64(c)
-		}
-	case AggregateMin:
-		for _, v := range stats.mins[lo:hi] {
-			total += v
-		}
-	case AggregateMax:
-		for _, v := range stats.maxes[lo:hi] {
-			total += v
 		}
 	default: // AggregateAverage
 		for i := lo; i < hi; i++ {

--- a/comp/observer/impl/storage_test.go
+++ b/comp/observer/impl/storage_test.go
@@ -73,20 +73,20 @@ func TestTimeSeriesStorage_AddSameBucket_Count(t *testing.T) {
 	assert.Equal(t, 3.0, series.Points[0].Value)
 }
 
-func TestTimeSeriesStorage_AddSameBucket_MinMax(t *testing.T) {
+func TestTimeSeriesStorage_AddSameBucket_SumCount(t *testing.T) {
 	s := newTimeSeriesStorage()
 
 	s.Add("test", "my.metric", 10.0, 1000, nil)
 	s.Add("test", "my.metric", 20.0, 1000, nil)
 	s.Add("test", "my.metric", 5.0, 1000, nil)
 
-	minSeries := s.GetSeries("test", "my.metric", nil, AggregateMin)
-	maxSeries := s.GetSeries("test", "my.metric", nil, AggregateMax)
+	sumSeries := s.GetSeries("test", "my.metric", nil, AggregateSum)
+	countSeries := s.GetSeries("test", "my.metric", nil, AggregateCount)
 
-	require.NotNil(t, minSeries)
-	require.NotNil(t, maxSeries)
-	assert.Equal(t, 5.0, minSeries.Points[0].Value)
-	assert.Equal(t, 20.0, maxSeries.Points[0].Value)
+	require.NotNil(t, sumSeries)
+	require.NotNil(t, countSeries)
+	assert.Equal(t, 35.0, sumSeries.Points[0].Value)
+	assert.Equal(t, 3.0, countSeries.Points[0].Value)
 }
 
 func TestTimeSeriesStorage_AddDifferentBuckets(t *testing.T) {
@@ -184,23 +184,19 @@ func TestSeriesStats_AggregateAt(t *testing.T) {
 		timestamps: []int64{1000},
 		sums:       []float64{100.0},
 		counts:     []int64{4},
-		mins:       []float64{10.0},
-		maxes:      []float64{40.0},
 	}
 
 	assert.Equal(t, 25.0, ss.aggregateAt(0, AggregateAverage))
 	assert.Equal(t, 100.0, ss.aggregateAt(0, AggregateSum))
 	assert.Equal(t, 4.0, ss.aggregateAt(0, AggregateCount))
-	assert.Equal(t, 10.0, ss.aggregateAt(0, AggregateMin))
-	assert.Equal(t, 40.0, ss.aggregateAt(0, AggregateMax))
+	assert.Equal(t, 0.0, ss.aggregateAt(0, AggregateMin))
+	assert.Equal(t, 0.0, ss.aggregateAt(0, AggregateMax))
 
 	// Zero count returns 0 for average
 	ss2 := &seriesStats{
 		timestamps: []int64{1000},
 		sums:       []float64{10.0},
 		counts:     []int64{0},
-		mins:       []float64{0},
-		maxes:      []float64{0},
 	}
 	assert.Equal(t, 0.0, ss2.aggregateAt(0, AggregateAverage))
 }
@@ -347,7 +343,7 @@ func TestGetSeriesRange_NoOverlap(t *testing.T) {
 
 func TestGetSeriesRange_AllAggregates(t *testing.T) {
 	s := newTimeSeriesStorage()
-	// Two values in the same bucket: sum=30, count=2, min=10, max=20, avg=15
+	// Two values in the same bucket: sum=30, count=2, avg=15
 	s.Add("ns", "m", 10.0, 100, nil)
 	s.Add("ns", "m", 20.0, 100, nil)
 
@@ -359,8 +355,6 @@ func TestGetSeriesRange_AllAggregates(t *testing.T) {
 	}{
 		{AggregateSum, 30.0},
 		{AggregateCount, 2.0},
-		{AggregateMin, 10.0},
-		{AggregateMax, 20.0},
 		{AggregateAverage, 15.0},
 	} {
 		result := s.GetSeriesRange(id, 0, 200, tc.agg)
@@ -683,6 +677,23 @@ func TestTimeSeriesStorage_AddDroppedReturnsEmptyKey(t *testing.T) {
 	res = s.Add("ns", "m", math.MaxFloat64, 1000, nil)
 	assert.False(t, res.IsNew)
 	assert.Empty(t, res.StorageKey, "MaxFloat64 sentinel drop must return empty key")
+}
+
+func TestTimeSeriesStorage_MaxPointsPerSeries(t *testing.T) {
+	s := newTimeSeriesStorage()
+	s.maxPointsPerSeries = 5
+
+	// Add 8 points across different timestamps.
+	for i := int64(0); i < 8; i++ {
+		s.Add("ns", "m", float64(i), 1000+i, nil)
+	}
+
+	ref := s.series[seriesKey("ns", "m", nil)]
+	require.NotNil(t, ref)
+	assert.Equal(t, 5, ref.pointCount(), "should be capped at maxPointsPerSeries")
+	// Oldest 3 points (ts 1000-1002) should be trimmed; first retained is 1003.
+	assert.Equal(t, int64(1003), ref.timestamps[0])
+	assert.Equal(t, int64(1007), ref.timestamps[4])
 }
 
 // TestFnv64aString_MatchesStdlib verifies the inline fnv64a helpers produce

--- a/comp/observer/impl/storage_test.go
+++ b/comp/observer/impl/storage_test.go
@@ -6,10 +6,12 @@
 package observerimpl
 
 import (
+	"fmt"
 	"hash/fnv"
 	"math"
 	"sync"
 	"testing"
+	"unsafe"
 
 	observer "github.com/DataDog/datadog-agent/comp/observer/def"
 	"github.com/stretchr/testify/assert"
@@ -743,4 +745,128 @@ func TestFnv64aMixUint64_MatchesStdlib(t *testing.T) {
 
 	got := fnv64aMixUint64(fnvOffsetBasis64, v)
 	assert.Equal(t, h.Sum64(), got)
+}
+
+func TestTimeSeriesStorage_TagIntern_PoolGrows(t *testing.T) {
+	s := newTimeSeriesStorage()
+	assert.Equal(t, 0, s.TagInternedCount())
+
+	// Each unique tag combination gets one pool entry.
+	s.Add("ns", "m1", 1.0, 1000, []string{"env:prod", "host:a"})
+	assert.Equal(t, 1, s.TagInternedCount(), "one combination interned")
+
+	s.Add("ns", "m2", 1.0, 1000, []string{"env:prod", "host:b"})
+	assert.Equal(t, 2, s.TagInternedCount(), "second distinct combination interned")
+
+	// Same combination as m1 — pool must not grow.
+	s.Add("ns2", "m1", 1.0, 1000, []string{"env:prod", "host:a"})
+	assert.Equal(t, 2, s.TagInternedCount(), "repeated combination must not grow pool")
+}
+
+func TestTimeSeriesStorage_TagIntern_SharedSlice(t *testing.T) {
+	// Verify that two series with the same tag combination share the same
+	// []string backing array. We inspect seriesStats.Tags directly (in-package)
+	// rather than going through GetSeries/toSeries, so the test is not sensitive
+	// to whether toSeries copies the tag slice.
+	s := newTimeSeriesStorage()
+
+	// Build tags at runtime to defeat Go's compile-time string interning.
+	tags := []string{"env:" + string([]byte{'p', 'r', 'o', 'd'}), "host:a"}
+	key1 := seriesKey("ns", "m1", tags)
+	key2 := seriesKey("ns", "m2", tags)
+
+	s.Add("ns", "m1", 1.0, 1000, tags)
+	s.Add("ns", "m2", 1.0, 1000, tags)
+
+	s.mu.RLock()
+	stats1 := s.series[key1]
+	stats2 := s.series[key2]
+	s.mu.RUnlock()
+
+	require.NotNil(t, stats1)
+	require.NotNil(t, stats2)
+
+	// Pointer identity on the backing array — same intern entry.
+	ptr1 := uintptr(unsafe.Pointer(unsafe.SliceData(stats1.Tags)))
+	ptr2 := uintptr(unsafe.Pointer(unsafe.SliceData(stats2.Tags)))
+	assert.Equal(t, ptr1, ptr2, "series with identical tag sets must share the same []string backing array")
+	assert.Equal(t, 1, s.TagInternedCount())
+}
+
+func TestTimeSeriesStorage_TagIntern_Eviction(t *testing.T) {
+	s := newTimeSeriesStorage()
+
+	tags := []string{"env:prod", "host:a"}
+	key1 := seriesKey("ns", "m1", tags)
+	key2 := seriesKey("ns", "m2", tags)
+
+	s.Add("ns", "m1", 1.0, 1000, tags)
+	s.Add("ns", "m2", 1.0, 1000, tags)
+	assert.Equal(t, 1, s.TagInternedCount(), "one pool entry for the shared combination")
+
+	// Evict one series — pool entry survives (still referenced by m2).
+	s.RemoveSeriesByKeys([]string{key1})
+	assert.Equal(t, 1, s.TagInternedCount(), "pool entry must survive while m2 still references it")
+
+	// Evict the last — pool entry must be freed.
+	s.RemoveSeriesByKeys([]string{key2})
+	assert.Equal(t, 0, s.TagInternedCount(), "pool entry must be freed when last referencing series is evicted")
+}
+
+func TestTimeSeriesStorage_TagIntern_NilAndEmptyTags(t *testing.T) {
+	// Nil and empty tag slices must not produce an intern pool entry,
+	// and removing such a series must not touch the pool.
+	s := newTimeSeriesStorage()
+
+	s.Add("ns", "nil_tags", 1.0, 1000, nil)
+	assert.Equal(t, 0, s.TagInternedCount(), "nil tags must not create an intern entry")
+
+	s.Add("ns", "empty_tags", 1.0, 1000, []string{})
+	assert.Equal(t, 0, s.TagInternedCount(), "empty tags must not create an intern entry")
+
+	s.RemoveSeriesByKeys([]string{
+		seriesKey("ns", "nil_tags", nil),
+		seriesKey("ns", "empty_tags", []string{}),
+	})
+	assert.Equal(t, 0, s.TagInternedCount(), "removal of uninterned series must leave pool empty")
+}
+
+func TestTimeSeriesStorage_TagIntern_UnsortedTagsShareEntry(t *testing.T) {
+	// Two series with the same tags in different order must share one pool
+	// entry. internTags sorts before hashing, so tag order is irrelevant.
+	s := newTimeSeriesStorage()
+
+	tags1 := []string{"host:a", "env:prod"} // unsorted
+	tags2 := []string{"env:prod", "host:a"} // sorted
+
+	s.Add("ns", "m1", 1.0, 1000, tags1)
+	s.Add("ns", "m2", 1.0, 1000, tags2)
+	assert.Equal(t, 1, s.TagInternedCount(), "same tags in different order must share one pool entry")
+
+	key1 := seriesKey("ns", "m1", tags1)
+	key2 := seriesKey("ns", "m2", tags2)
+
+	s.mu.RLock()
+	ptr1 := uintptr(unsafe.Pointer(unsafe.SliceData(s.series[key1].Tags)))
+	ptr2 := uintptr(unsafe.Pointer(unsafe.SliceData(s.series[key2].Tags)))
+	s.mu.RUnlock()
+	assert.Equal(t, ptr1, ptr2, "unsorted and sorted variants must share the same backing array")
+}
+
+func TestTimeSeriesStorage_TagIntern_Cap(t *testing.T) {
+	s := newTimeSeriesStorage()
+
+	// Fill the pool to the cap — each series has a unique tag combination.
+	for i := 0; i < tagInternMaxSize; i++ {
+		s.Add("ns", fmt.Sprintf("m%d", i), 1.0, 1000, []string{fmt.Sprintf("unique:tag%d", i)})
+	}
+	assert.Equal(t, tagInternMaxSize, s.TagInternedCount(), "pool should be at cap")
+
+	// A new unique combination must not grow the pool past the cap.
+	s.Add("ns", "overflow", 1.0, 1000, []string{"unique:overflow"})
+	assert.Equal(t, tagInternMaxSize, s.TagInternedCount(), "pool must not exceed cap")
+
+	// A hit on an already-interned combination must not grow the pool.
+	s.Add("ns2", "m0", 1.0, 1000, []string{"unique:tag0"})
+	assert.Equal(t, tagInternMaxSize, s.TagInternedCount(), "hit on existing entry must not grow pool")
 }

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -204,7 +204,6 @@ func NewTestBench(config TestBenchConfig) (*TestBench, error) {
 		extractors:                 extractors,
 		detectors:                  detectors,
 		correlators:                correlators,
-		contextProviders:           collectContextProviders(extractors),
 		scheduler:                  &currentBehaviorPolicy{},
 		enableAccumulatedTelemetry: true,
 	})


### PR DESCRIPTION
## Summary

Stacked on #50395. Four changes to reduce observer memory and CPU:

### 1. Drop unused min/max columns
Remove `mins`/`maxes` from `seriesStats` — no active detector uses `AggregateMin`/`AggregateMax`. Saves **16 bytes per point** (40→24 bytes).

### 2. Cap points per series (`maxPointsPerSeries = 600`)
Trim oldest points when a series exceeds the cap. At 1Hz: 10 minutes of history, 20× headroom for ScanWelch's `MinPoints=30`. Prevents unbounded columnar growth.

### 3. Tag combination interning
Series with identical tag sets share one canonical `[]string` via an fnv64a-hashed intern pool. Ref-counted: pool entries are freed when the last referencing series is evicted.

### 4. Eliminate `contextRefs` string chain
Replace the three-hop enrichment path (storageKey rebuild → `contextRefs` scan → `GetContextByKey`) with direct ref-keyed lookups.

- `contextByRef map[SeriesRef]*MetricContext` — O(1) anomaly enrichment
- `contextKeyToStorageKey map[nsContextKey]string` — O(1) eviction (was O(N) scan)
- `LogMetricsExtractor`: `metricContextKey` string alloc + `patternContext` map write eliminated from hot path
- `AddResult` gains `Ref SeriesRef`; `ContextProvider` interface removed

## SMP results

Baseline: 7.78.0. Experiment: `observer_logs_anomaly_stress`.

### Commit 1: drop min/max + cap points — `f112ca04`
Run `8fd945f0`: memory 699 MiB, cpu 143 ≤ 500

### Commit 2: copy-on-trim — `d9106dc8`
Run `8601e3b2`: memory 726 MiB, cpu 145 ≤ 500

### Reference (no storage bounds) — `1a99bc9b`
Run `e862928e`: memory 631 MiB, cpu 135 ≤ 500

## Test plan
- [x] `dda inv test --targets=./comp/observer/impl/...`
- [x] SMP regression runs (see above)