### PR TITLE
dyninst: per-probe circuit breaker via recompile-and-omit 

### DIFF
--- a/pkg/dyninst/actuator/actuator.go
+++ b/pkg/dyninst/actuator/actuator.go
@@ -342,6 +342,19 @@ func (a *effects) attachToProcess(
 
 var detachLogLimiter = rate.NewLimiter(rate.Every(1*time.Minute), 10)
 
+// reportProbeError surfaces a per-probe diagnostic without detaching
+// the program. Asynchronous fire-and-forget; the state machine
+// independently flags the program for recompile.
+func (a *effects) reportProbeError(
+	ap *attachedProgram, probe ir.ProbeDefinition, reason error,
+) {
+	a.wg.Add(1)
+	go func() {
+		defer a.wg.Done()
+		ap.attachedProgram.ReportProbeError(probe, reason)
+	}()
+}
+
 // detachFromProcess detaches a program from a process.
 func (a *effects) detachFromProcess(ap *attachedProgram, failure error) {
 	a.wg.Add(1)

--- a/pkg/dyninst/actuator/dependencies.go
+++ b/pkg/dyninst/actuator/dependencies.go
@@ -36,8 +36,21 @@ type LoadedProgram interface {
 	// Attach attaches the program to a process.
 	Attach(ProcessID, Executable) (AttachedProgram, error)
 
-	// RuntimeStats returns the per-core runtime stats of the program.
+	// RuntimeStats returns the per-probe runtime stats of the program,
+	// indexed by the BPF probe_id (0..NumProbes()-1). Counter values
+	// are aggregated across CPUs by the kernel.
 	RuntimeStats() []loader.RuntimeStats
+
+	// NumProbes returns the number of distinct probes in the loaded
+	// program, equal to len(ProbeDefinitions()) and the size of the
+	// per-probe stats slice.
+	NumProbes() int
+
+	// ProbeDefinition returns the IR ProbeDefinition for the given
+	// per-program probe ID, or nil if the ID is out of range. Used to
+	// surface probe identity (config-level ID + version) for
+	// diagnostics and circuit-breaker bookkeeping.
+	ProbeDefinition(probeID uint32) ir.ProbeDefinition
 
 	// DropNotifyLostAt returns the kernel-monotonic ktime_ns of the most
 	// recent in-BPF attempt to publish a drop notification that failed
@@ -60,4 +73,10 @@ type LoadedProgram interface {
 type AttachedProgram interface {
 	// Detach detaches the program from the process.
 	Detach(reason error) error
+
+	// ReportProbeError surfaces a per-probe error diagnostic
+	// (currently used for circuit-breaker trips) without detaching the
+	// program. The probe argument is the IR ProbeDefinition for the
+	// affected probe.
+	ReportProbeError(probe ir.ProbeDefinition, reason error)
 }

--- a/pkg/dyninst/actuator/state.go
+++ b/pkg/dyninst/actuator/state.go
@@ -1147,10 +1147,12 @@ func handleHeartbeatCheck(sm *state, effects effectHandler) {
 }
 
 func checkCosts(sm *state, interval time.Duration, effects effectHandler) {
-	// Validate budget on every core independently.
-	var totalCostSPS []float64
-	var maxCostSPS []float64
-	var maxProg []*program
+	// Per-probe stats are aggregated across CPUs in BPF. Sum them
+	// per-program for the per-probe budget check, and across all
+	// programs for the all-probes budget check.
+	var totalCostSPS float64
+	var maxCostSPS float64 = -1
+	var maxProg *program
 	detachedAny := false
 	for _, prog := range sm.programs {
 		if prog.state != programStateLoaded {
@@ -1158,85 +1160,72 @@ func checkCosts(sm *state, interval time.Duration, effects effectHandler) {
 		}
 		proc, ok := sm.processes[prog.processID]
 		if !ok || proc.state != processStateAttached {
-			// Not attached.
 			continue
 		}
 		evaluateDropNotifyEviction(sm, prog)
-		perCoreStats := prog.loaded.loaded.RuntimeStats()
-		if len(prog.lastRuntimeStats) < len(perCoreStats) {
-			lastRuntimeStats := make([]loader.RuntimeStats, len(perCoreStats))
+		perProbeStats := prog.loaded.loaded.RuntimeStats()
+		if len(prog.lastRuntimeStats) < len(perProbeStats) {
+			lastRuntimeStats := make([]loader.RuntimeStats, len(perProbeStats))
 			copy(lastRuntimeStats, prog.lastRuntimeStats)
 			prog.lastRuntimeStats = lastRuntimeStats
 		}
-		for len(totalCostSPS) < len(perCoreStats) {
-			totalCostSPS = append(totalCostSPS, 0)
-			maxCostSPS = append(maxCostSPS, -1)
-			maxProg = append(maxProg, nil)
-		}
-		for core, stats := range perCoreStats {
-			lastStats := prog.lastRuntimeStats[core]
-			hits := stats.HitCnt - lastStats.HitCnt
-			execCost := stats.CPU - lastStats.CPU
+		var progCostSPS float64
+		var progHits uint64
+		var progExecCost time.Duration
+		for probeID, stats := range perProbeStats {
+			last := prog.lastRuntimeStats[probeID]
+			hits := stats.HitCnt - last.HitCnt
+			execCost := stats.CPU - last.CPU
+			prog.lastRuntimeStats[probeID] = stats
+
 			interruptCost := sm.breakerCfg.InterruptOverhead * time.Duration(hits)
-			prog.lastRuntimeStats[core] = stats
-
-			costSPS := (execCost + interruptCost).Seconds() / interval.Seconds()
-			totalCostSPS[core] += costSPS
-			if costSPS > maxCostSPS[core] {
-				maxCostSPS[core] = costSPS
-				maxProg[core] = prog
-			}
-			if costSPS > sm.breakerCfg.PerProbeCPULimit && proc.state == processStateAttached {
-				// Circuit breaker triggered for this probe, detach it.
-				prog.state = programStateDraining
-				prog.needsRecompilation = false
-				proc.state = processStateFailed
-				err := fmt.Errorf(
-					"probe exceeded CPU limit of %fcpus/s using %fcpus/s = %fcpus/s (exec) + %fcpus/s (%d interrupts) over %fs on core %d",
-					sm.breakerCfg.PerProbeCPULimit,
-					costSPS,
-					execCost.Seconds()/interval.Seconds(),
-					interruptCost.Seconds()/interval.Seconds(),
-					hits,
-					interval.Seconds(),
-					core,
-				)
-				effects.detachFromProcess(proc.attachedProgram, err)
-				proc.attachedProgram = nil
-				detachedAny = true
-				break
-			}
+			progCostSPS += (execCost + interruptCost).Seconds() / interval.Seconds()
+			progHits += hits
+			progExecCost += execCost
 		}
-	}
-
-	// Check if any core exceeded the total budget across all probes.
-	// If so, pick the most expensive probe on a core with highest total cost.
-	if len(totalCostSPS) == 0 {
-		return
-	}
-	{
-		maxCore := 0
-		for core, cost := range totalCostSPS {
-			if cost > totalCostSPS[maxCore] {
-				maxCore = core
-			}
+		totalCostSPS += progCostSPS
+		if progCostSPS > maxCostSPS {
+			maxCostSPS = progCostSPS
+			maxProg = prog
 		}
-		if !detachedAny && maxProg[maxCore] != nil && totalCostSPS[maxCore] > sm.breakerCfg.AllProbesCPULimit {
-			prog := maxProg[maxCore]
-			proc := sm.processes[prog.processID]
+		if progCostSPS > sm.breakerCfg.PerProbeCPULimit && proc.state == processStateAttached {
+			// Whole-program budget tripped — detach as before. (The
+			// per-probe enforcement that uses recompile-and-omit is
+			// added in a subsequent commit; this commit preserves
+			// existing program-level behavior with the new map shape.)
 			prog.state = programStateDraining
 			prog.needsRecompilation = false
 			proc.state = processStateFailed
+			interruptCost := sm.breakerCfg.InterruptOverhead * time.Duration(progHits)
 			err := fmt.Errorf(
-				"probes exceeded total CPU limit of %fcpus/s using %fcpus/s on core %d; detaching most expensive probe, that used %fcpus/s (mean over %fs)",
-				sm.breakerCfg.AllProbesCPULimit,
-				totalCostSPS[maxCore],
-				maxCore,
-				maxCostSPS[maxCore],
+				"probe exceeded CPU limit of %fcpus/s using %fcpus/s = %fcpus/s (exec) + %fcpus/s (%d interrupts) over %fs",
+				sm.breakerCfg.PerProbeCPULimit,
+				progCostSPS,
+				progExecCost.Seconds()/interval.Seconds(),
+				interruptCost.Seconds()/interval.Seconds(),
+				progHits,
 				interval.Seconds(),
 			)
 			effects.detachFromProcess(proc.attachedProgram, err)
+			proc.attachedProgram = nil
+			detachedAny = true
 		}
+	}
+
+	if !detachedAny && maxProg != nil && totalCostSPS > sm.breakerCfg.AllProbesCPULimit {
+		prog := maxProg
+		proc := sm.processes[prog.processID]
+		prog.state = programStateDraining
+		prog.needsRecompilation = false
+		proc.state = processStateFailed
+		err := fmt.Errorf(
+			"probes exceeded total CPU limit of %fcpus/s using %fcpus/s; detaching most expensive program, that used %fcpus/s (mean over %fs)",
+			sm.breakerCfg.AllProbesCPULimit,
+			totalCostSPS,
+			maxCostSPS,
+			interval.Seconds(),
+		)
+		effects.detachFromProcess(proc.attachedProgram, err)
 	}
 }
 

--- a/pkg/dyninst/actuator/state.go
+++ b/pkg/dyninst/actuator/state.go
@@ -632,10 +632,16 @@ func enqueueProgramForProcess(sm *state, p *process) error {
 	}
 	if len(probes) == 0 {
 		// All configured probes have been circuit-broken on this
-		// process. There is nothing to instrument; release the process
-		// state. Subsequent processesUpdated arrivals (with new probes
-		// or the same probes after eviction) will re-create it.
-		sm.deleteProcess(p.processID)
+		// process. There is nothing to instrument right now, but we
+		// must keep the process record alive so circuitBrokenProbes is
+		// preserved -- otherwise a subsequent processesUpdated that
+		// adds an unrelated probe (while a broken probe remains
+		// configured) would silently re-enable the hot probe. Park
+		// the process in Failed; subsequent changes to the configured
+		// probe set re-enter enqueueProgramForProcess via the Failed
+		// case in handleProcessUpdate.
+		p.state = processStateFailed
+		p.currentProgram = 0
 		return nil
 	}
 	slices.SortFunc(probes, func(a, b ir.ProbeDefinition) int {

--- a/pkg/dyninst/actuator/state.go
+++ b/pkg/dyninst/actuator/state.go
@@ -1235,10 +1235,17 @@ func checkCosts(sm *state, interval time.Duration, effects effectHandler) {
 			costSPS := (execCost + interruptCost).Seconds() / interval.Seconds()
 
 			// Skip probes already circuit-broken. Their cost is
-			// transient (the recompile will remove them) so do not
-			// charge it against the host-wide AllProbesCPULimit, and
-			// do not count them as candidates for that limit's victim
-			// either.
+			// transient under normal operation (the queued recompile
+			// will remove them) so do not charge it against the
+			// host-wide AllProbesCPULimit, and do not count them as
+			// candidates for that limit's victim either. Charging
+			// the cost would mean a probe destined for removal could
+			// cause a healthy sibling to be picked as the all-probes
+			// victim. Note: if recompilation is rate-limited the
+			// removal is delayed, and if disabled
+			// (recompilationRateLimit < 0) the cost stays invisible
+			// to this budget -- but in that mode the breaker can't
+			// remediate anyway.
 			if def := prog.loaded.loaded.ProbeDefinition(uint32(probeID)); def != nil {
 				key := probeKey{id: def.GetID(), version: def.GetVersion()}
 				if _, broken := proc.circuitBrokenProbes[key]; broken {

--- a/pkg/dyninst/actuator/state.go
+++ b/pkg/dyninst/actuator/state.go
@@ -237,7 +237,7 @@ func newState(cfg Config) *state {
 		}),
 		breakerCfg:             cfg.CircuitBreakerConfig,
 		bufferEvictionCfg:      cfg.BufferEvictionConfig,
-		lastHeartbeat:          time.Now(),
+		lastHeartbeat:          nowFunc(),
 		discoveredTypes:        make(map[string][]string),
 		discoveredTypesLimit:   cfg.DiscoveredTypesLimit,
 		recompilationRateLimit: cfg.RecompilationRateLimit,
@@ -1177,8 +1177,12 @@ func handleShutdown(sm *state, effects effectHandler) error {
 	return nil
 }
 
+// nowFunc returns wall-clock time. Overridden by tests to make
+// heartbeat-driven cost calculations deterministic.
+var nowFunc = time.Now
+
 func handleHeartbeatCheck(sm *state, effects effectHandler) {
-	now := time.Now()
+	now := nowFunc()
 	interval := now.Sub(sm.lastHeartbeat)
 	sm.lastHeartbeat = now
 

--- a/pkg/dyninst/actuator/state.go
+++ b/pkg/dyninst/actuator/state.go
@@ -1223,8 +1223,20 @@ func checkCosts(sm *state, interval time.Duration, effects effectHandler) {
 
 			interruptCost := sm.breakerCfg.InterruptOverhead * time.Duration(hits)
 			costSPS := (execCost + interruptCost).Seconds() / interval.Seconds()
-			totalCostSPS += costSPS
 
+			// Skip probes already circuit-broken. Their cost is
+			// transient (the recompile will remove them) so do not
+			// charge it against the host-wide AllProbesCPULimit, and
+			// do not count them as candidates for that limit's victim
+			// either.
+			if def := prog.loaded.loaded.ProbeDefinition(uint32(probeID)); def != nil {
+				key := probeKey{id: def.GetID(), version: def.GetVersion()}
+				if _, broken := proc.circuitBrokenProbes[key]; broken {
+					continue
+				}
+			}
+
+			totalCostSPS += costSPS
 			if costSPS > sm.breakerCfg.PerProbeCPULimit {
 				err := fmt.Errorf(
 					"probe exceeded CPU limit of %fcpus/s using %fcpus/s (exec %v + %d interrupts at %v each over %v)",
@@ -1236,6 +1248,9 @@ func checkCosts(sm *state, interval time.Duration, effects effectHandler) {
 					interval,
 				)
 				tripProbe(effects, prog, proc, uint32(probeID), err)
+				// Subtract this probe's cost from the running total
+				// so the all-probes limit doesn't double-count it.
+				totalCostSPS -= costSPS
 				continue
 			}
 			if costSPS > maxCost.cost {

--- a/pkg/dyninst/actuator/state.go
+++ b/pkg/dyninst/actuator/state.go
@@ -11,6 +11,7 @@ import (
 	"cmp"
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 	"time"
 
@@ -283,6 +284,14 @@ type process struct {
 	service    string
 	probes     map[probeKey]ir.ProbeDefinition
 
+	// circuitBrokenProbes is the set of probe identities that have
+	// tripped the circuit breaker on this process. They are filtered
+	// out when (re)building a program for the process. Entries persist
+	// across recompiles but are pruned on processesUpdated when the
+	// underlying probe is removed (so re-adding a probe with the same
+	// identity gives it a fresh attempt).
+	circuitBrokenProbes map[probeKey]circuitBrokenInfo
+
 	// The currently installed program, if there is one. Will be 0 if the
 	// process's program creation failed.
 	currentProgram ir.ProgramID
@@ -291,6 +300,13 @@ type process struct {
 	// same ID as the currentProgram. Will be nil if there is no program
 	// attached.
 	attachedProgram *attachedProgram
+}
+
+// circuitBrokenInfo records why a probe was circuit-broken. The reason
+// is the most recent one; if a probe is re-tripped while still in the
+// set the entry is left untouched.
+type circuitBrokenInfo struct {
+	reason error
 }
 
 func (s *state) addProcessToServiceIndex(proc *process) {
@@ -370,6 +386,11 @@ type effectHandler interface {
 
 	// Unload program resources asynchronously.
 	unloadProgram(*loadedProgram) // -> ProgramUnloaded
+
+	// Report a per-probe execution failure (used when the circuit
+	// breaker trips a single probe). Fire-and-forget; the probe is
+	// excluded from the next program for the process via a recompile.
+	reportProbeError(*attachedProgram, ir.ProbeDefinition, error)
 }
 
 // handleEvent updates the state given the event, triggering the relevant
@@ -518,6 +539,13 @@ func handleProcessesUpdated(
 			k := probeKey{id: probe.GetID(), version: probe.GetVersion()}
 			p.probes[k] = probe
 		}
+		// Prune circuit-broken entries whose probe is no longer in the
+		// configured set: removing and re-adding a probe with the same
+		// identity is treated as a fresh attempt.
+		maps.DeleteFunc(p.circuitBrokenProbes, func(k probeKey, _ circuitBrokenInfo) bool {
+			_, stillConfigured := p.probes[k]
+			return !stillConfigured
+		})
 		// If now we're in an invalid state, we need to delete the process if
 		// we have no probes, or enqueue the new program with the new probes.
 		if len(p.probes) == 0 {
@@ -588,15 +616,27 @@ func handleProcessesUpdated(
 }
 
 func enqueueProgramForProcess(sm *state, p *process) error {
-	// If the process has no probes, we don't need to enqueue a program --
-	// we're done with the process.
+	// If the process has no probes (configured or after circuit-breaker
+	// filtering), we don't need to enqueue a program -- we're done with
+	// the process.
 	if len(p.probes) == 0 {
 		sm.deleteProcess(p.processID)
 		return nil
 	}
 	probes := make([]ir.ProbeDefinition, 0, len(p.probes))
-	for _, probe := range p.probes {
+	for k, probe := range p.probes {
+		if _, broken := p.circuitBrokenProbes[k]; broken {
+			continue
+		}
 		probes = append(probes, probe)
+	}
+	if len(probes) == 0 {
+		// All configured probes have been circuit-broken on this
+		// process. There is nothing to instrument; release the process
+		// state. Subsequent processesUpdated arrivals (with new probes
+		// or the same probes after eviction) will re-create it.
+		sm.deleteProcess(p.processID)
+		return nil
 	}
 	slices.SortFunc(probes, func(a, b ir.ProbeDefinition) int {
 		return cmp.Or(
@@ -1147,13 +1187,19 @@ func handleHeartbeatCheck(sm *state, effects effectHandler) {
 }
 
 func checkCosts(sm *state, interval time.Duration, effects effectHandler) {
-	// Per-probe stats are aggregated across CPUs in BPF. Sum them
-	// per-program for the per-probe budget check, and across all
-	// programs for the all-probes budget check.
+	// Per-probe stats are aggregated across CPUs in BPF. Compare each
+	// probe's cost against PerProbeCPULimit; a tripped probe is
+	// circuit-broken on its process and a recompile is queued. After
+	// the per-probe pass, the all-probes limit (host-wide) trips the
+	// most expensive *active* probe.
 	var totalCostSPS float64
-	var maxCostSPS float64 = -1
-	var maxProg *program
-	detachedAny := false
+	type probeCost struct {
+		prog    *program
+		proc    *process
+		probeID uint32
+		cost    float64
+	}
+	var maxCost probeCost
 	for _, prog := range sm.programs {
 		if prog.state != programStateLoaded {
 			continue
@@ -1169,9 +1215,6 @@ func checkCosts(sm *state, interval time.Duration, effects effectHandler) {
 			copy(lastRuntimeStats, prog.lastRuntimeStats)
 			prog.lastRuntimeStats = lastRuntimeStats
 		}
-		var progCostSPS float64
-		var progHits uint64
-		var progExecCost time.Duration
 		for probeID, stats := range perProbeStats {
 			last := prog.lastRuntimeStats[probeID]
 			hits := stats.HitCnt - last.HitCnt
@@ -1179,54 +1222,81 @@ func checkCosts(sm *state, interval time.Duration, effects effectHandler) {
 			prog.lastRuntimeStats[probeID] = stats
 
 			interruptCost := sm.breakerCfg.InterruptOverhead * time.Duration(hits)
-			progCostSPS += (execCost + interruptCost).Seconds() / interval.Seconds()
-			progHits += hits
-			progExecCost += execCost
-		}
-		totalCostSPS += progCostSPS
-		if progCostSPS > maxCostSPS {
-			maxCostSPS = progCostSPS
-			maxProg = prog
-		}
-		if progCostSPS > sm.breakerCfg.PerProbeCPULimit && proc.state == processStateAttached {
-			// Whole-program budget tripped — detach as before. (The
-			// per-probe enforcement that uses recompile-and-omit is
-			// added in a subsequent commit; this commit preserves
-			// existing program-level behavior with the new map shape.)
-			prog.state = programStateDraining
-			prog.needsRecompilation = false
-			proc.state = processStateFailed
-			interruptCost := sm.breakerCfg.InterruptOverhead * time.Duration(progHits)
-			err := fmt.Errorf(
-				"probe exceeded CPU limit of %fcpus/s using %fcpus/s = %fcpus/s (exec) + %fcpus/s (%d interrupts) over %fs",
-				sm.breakerCfg.PerProbeCPULimit,
-				progCostSPS,
-				progExecCost.Seconds()/interval.Seconds(),
-				interruptCost.Seconds()/interval.Seconds(),
-				progHits,
-				interval.Seconds(),
-			)
-			effects.detachFromProcess(proc.attachedProgram, err)
-			proc.attachedProgram = nil
-			detachedAny = true
+			costSPS := (execCost + interruptCost).Seconds() / interval.Seconds()
+			totalCostSPS += costSPS
+
+			if costSPS > sm.breakerCfg.PerProbeCPULimit {
+				err := fmt.Errorf(
+					"probe exceeded CPU limit of %fcpus/s using %fcpus/s (exec %v + %d interrupts at %v each over %v)",
+					sm.breakerCfg.PerProbeCPULimit,
+					costSPS,
+					execCost,
+					hits,
+					sm.breakerCfg.InterruptOverhead,
+					interval,
+				)
+				tripProbe(effects, prog, proc, uint32(probeID), err)
+				continue
+			}
+			if costSPS > maxCost.cost {
+				maxCost = probeCost{
+					prog: prog, proc: proc,
+					probeID: uint32(probeID), cost: costSPS,
+				}
+			}
 		}
 	}
 
-	if !detachedAny && maxProg != nil && totalCostSPS > sm.breakerCfg.AllProbesCPULimit {
-		prog := maxProg
-		proc := sm.processes[prog.processID]
-		prog.state = programStateDraining
-		prog.needsRecompilation = false
-		proc.state = processStateFailed
+	if maxCost.prog != nil && totalCostSPS > sm.breakerCfg.AllProbesCPULimit {
 		err := fmt.Errorf(
-			"probes exceeded total CPU limit of %fcpus/s using %fcpus/s; detaching most expensive program, that used %fcpus/s (mean over %fs)",
+			"probes exceeded total CPU limit of %fcpus/s using %fcpus/s; tripping most expensive probe (%fcpus/s)",
 			sm.breakerCfg.AllProbesCPULimit,
 			totalCostSPS,
-			maxCostSPS,
-			interval.Seconds(),
+			maxCost.cost,
 		)
-		effects.detachFromProcess(proc.attachedProgram, err)
+		tripProbe(effects, maxCost.prog, maxCost.proc, maxCost.probeID, err)
 	}
+}
+
+// tripProbe records that the given probe has tripped its circuit
+// breaker on the process owning prog. The probe is added to the
+// process's circuit-broken set, a per-probe diagnostic is emitted, and
+// the program is flagged for recompilation; the recompile filters the
+// tripped probe out of the new program. Idempotent: re-tripping a
+// probe already in the set is a no-op.
+func tripProbe(
+	effects effectHandler,
+	prog *program, proc *process, probeID uint32, reason error,
+) {
+	def := prog.loaded.loaded.ProbeDefinition(probeID)
+	if def == nil {
+		// Should not happen: probeID was read from RuntimeStats whose
+		// length is bounded by NumProbes(). Log and skip.
+		log.Errorf(
+			"dyninst: tripProbe called with out-of-range probeID %d on program %d",
+			probeID, prog.id,
+		)
+		return
+	}
+	key := probeKey{id: def.GetID(), version: def.GetVersion()}
+	if _, already := proc.circuitBrokenProbes[key]; already {
+		return
+	}
+	if proc.circuitBrokenProbes == nil {
+		proc.circuitBrokenProbes = make(map[probeKey]circuitBrokenInfo)
+	}
+	proc.circuitBrokenProbes[key] = circuitBrokenInfo{reason: reason}
+	if proc.attachedProgram != nil {
+		effects.reportProbeError(proc.attachedProgram, def, reason)
+	}
+	switch prog.state {
+	case programStateLoading, programStateLoaded:
+		prog.needsRecompilation = true
+	}
+	log.Warnf(
+		"dyninst: probe %s@%d circuit-broken on process %v: %v",
+		key.id, key.version, proc.processID, reason,
+	)
 }
 
 // nowKtimeNs returns the current kernel-monotonic time in nanoseconds —

--- a/pkg/dyninst/actuator/state_effects_test.go
+++ b/pkg/dyninst/actuator/state_effects_test.go
@@ -108,6 +108,30 @@ func (e effectUnloadProgram) yamlData() map[string]any {
 	}
 }
 
+type effectReportProbeError struct {
+	programID ir.ProgramID
+	processID ProcessID
+	probeID   string
+	hasReason bool
+}
+
+func (e effectReportProbeError) yamlTag() string {
+	return "!report-probe-error"
+}
+
+func (e effectReportProbeError) yamlData() map[string]any {
+	reason := "no"
+	if e.hasReason {
+		reason = "yes"
+	}
+	return map[string]any{
+		"program_id": int(e.programID),
+		"process_id": int(e.processID.PID),
+		"probe_id":   e.probeID,
+		"reason":     reason,
+	}
+}
+
 // effectRecorder records effects for testing
 type effectRecorder struct {
 	effects []effect
@@ -175,5 +199,16 @@ func (er *effectRecorder) unloadProgram(lp *loadedProgram) {
 	// For tests we just record that the sink and program are being closed.
 	er.recordEffect(effectUnloadProgram{
 		programID: lp.programID,
+	})
+}
+
+func (er *effectRecorder) reportProbeError(
+	ap *attachedProgram, probe ir.ProbeDefinition, reason error,
+) {
+	er.recordEffect(effectReportProbeError{
+		programID: ap.programID,
+		processID: ap.processID,
+		probeID:   probe.GetID(),
+		hasReason: reason != nil,
 	})
 }

--- a/pkg/dyninst/actuator/state_event_yaml_test.go
+++ b/pkg/dyninst/actuator/state_event_yaml_test.go
@@ -428,6 +428,7 @@ type runtimeStatsYAML struct {
 }
 
 type fakeLoadedProgram struct {
+	probes       []ir.ProbeDefinition
 	runtimeStats []loader.RuntimeStats
 }
 
@@ -446,6 +447,17 @@ func (p *fakeLoadedProgram) RuntimeStats() []loader.RuntimeStats {
 			CPU:          1e3 * time.Second,
 		},
 	}
+}
+
+func (p *fakeLoadedProgram) NumProbes() int {
+	return len(p.probes)
+}
+
+func (p *fakeLoadedProgram) ProbeDefinition(probeID uint32) ir.ProbeDefinition {
+	if int(probeID) >= len(p.probes) {
+		return nil
+	}
+	return p.probes[probeID]
 }
 
 func (p *fakeLoadedProgram) setRuntimeStats(stats []loader.RuntimeStats) {

--- a/pkg/dyninst/actuator/state_event_yaml_test.go
+++ b/pkg/dyninst/actuator/state_event_yaml_test.go
@@ -29,11 +29,18 @@ type eventConfig struct {
 	discoveredTypesLimit   int
 	recompilationRateLimit float64
 	recompilationRateBurst int
+	// Circuit-breaker thresholds. Zero values mean "use the production
+	// defaults"; tests that need to exercise a trip must set these.
+	perProbeCPULimit  float64
+	allProbesCPULimit float64
 }
 
 func (e eventConfig) String() string {
-	return fmt.Sprintf("eventConfig{discoveredTypesLimit: %d, recompilationRateLimit: %g, recompilationRateBurst: %d}",
-		e.discoveredTypesLimit, e.recompilationRateLimit, e.recompilationRateBurst)
+	return fmt.Sprintf(
+		"eventConfig{discoveredTypesLimit: %d, recompilationRateLimit: %g, recompilationRateBurst: %d, perProbeCPULimit: %g, allProbesCPULimit: %g}",
+		e.discoveredTypesLimit, e.recompilationRateLimit, e.recompilationRateBurst,
+		e.perProbeCPULimit, e.allProbesCPULimit,
+	)
 }
 
 // yamlEvent represents an event that can be marshaled to and unmarshaled from
@@ -184,6 +191,12 @@ func (ye yamlEvent) MarshalYAML() (rv any, err error) {
 		}
 		if ev.recompilationRateBurst != 0 {
 			data["recompilation_rate_burst"] = ev.recompilationRateBurst
+		}
+		if ev.perProbeCPULimit != 0 {
+			data["per_probe_cpu_limit"] = ev.perProbeCPULimit
+		}
+		if ev.allProbesCPULimit != 0 {
+			data["all_probes_cpu_limit"] = ev.allProbesCPULimit
 		}
 		return encodeNodeTag("!config", data)
 
@@ -404,6 +417,8 @@ func (ye *yamlEvent) UnmarshalYAML(node *yaml.Node) error {
 			DiscoveredTypesLimit   int     `yaml:"discovered_types_limit"`
 			RecompilationRateLimit float64 `yaml:"recompilation_rate_limit"`
 			RecompilationRateBurst int     `yaml:"recompilation_rate_burst"`
+			PerProbeCPULimit       float64 `yaml:"per_probe_cpu_limit"`
+			AllProbesCPULimit      float64 `yaml:"all_probes_cpu_limit"`
 		}
 		if err := node.Decode(&eventData); err != nil {
 			return fmt.Errorf("failed to decode config event: %w", err)
@@ -412,6 +427,8 @@ func (ye *yamlEvent) UnmarshalYAML(node *yaml.Node) error {
 			discoveredTypesLimit:   eventData.DiscoveredTypesLimit,
 			recompilationRateLimit: eventData.RecompilationRateLimit,
 			recompilationRateBurst: eventData.RecompilationRateBurst,
+			perProbeCPULimit:       eventData.PerProbeCPULimit,
+			allProbesCPULimit:      eventData.AllProbesCPULimit,
 		}
 
 	default:

--- a/pkg/dyninst/actuator/state_helpers_test.go
+++ b/pkg/dyninst/actuator/state_helpers_test.go
@@ -27,9 +27,23 @@ func deepCopyState(original *state) *state {
 		return nil
 	}
 
-	// Create new state with basic fields copied.
-	copied := newState(Config{DiscoveredTypesLimit: original.discoveredTypesLimit})
-
+	// Construct the state struct directly. We avoid calling newState
+	// because it invokes nowFunc(), which would advance the snapshot
+	// test's fake clock on every event and make heartbeat intervals
+	// nondeterministic.
+	copied := &state{
+		processes:            make(map[ProcessID]*process, len(original.processes)),
+		processesByService:   make(map[string]map[ProcessID]struct{}, len(original.processesByService)),
+		programs:             make(map[ir.ProgramID]*program, len(original.programs)),
+		discoveredTypes:      make(map[string][]string, len(original.discoveredTypes)),
+		discoveredTypesLimit: original.discoveredTypesLimit,
+		breakerCfg:           original.breakerCfg,
+		bufferEvictionCfg:    original.bufferEvictionCfg,
+		lastHeartbeat:        original.lastHeartbeat,
+		queuedLoading: makeQueue(func(p *program) ir.ProgramID {
+			return p.id
+		}),
+	}
 	copied.counters = original.counters
 	copied.programIDAlloc = original.programIDAlloc
 
@@ -121,13 +135,14 @@ func deepCopyProcess(original *process) *process {
 	}
 
 	copied := &process{
-		state:           original.state,
-		processID:       original.processID,
-		executable:      original.executable,
-		service:         original.service,
-		probes:          copiedProbes,
-		currentProgram:  original.currentProgram,
-		attachedProgram: original.attachedProgram,
+		state:               original.state,
+		processID:           original.processID,
+		executable:          original.executable,
+		service:             original.service,
+		probes:              copiedProbes,
+		circuitBrokenProbes: maps.Clone(original.circuitBrokenProbes),
+		currentProgram:      original.currentProgram,
+		attachedProgram:     original.attachedProgram,
 	}
 
 	return copied

--- a/pkg/dyninst/actuator/state_snapshot_test.go
+++ b/pkg/dyninst/actuator/state_snapshot_test.go
@@ -130,6 +130,14 @@ func runSnapshotTest(t *testing.T, file string, rewrite bool) {
 			err = handleEvent(s, &effects, ev.event)
 		}
 		require.NoError(t, err)
+		// Populate fake program metadata that the production loader
+		// would have computed for us (probe definitions in BPF probe_id
+		// order). The snapshot fake constructed in
+		// state_event_yaml_test.go starts empty; do this after the
+		// eventProgramLoaded handler so prog.config is populated.
+		if loadedEvent, ok := ev.event.(eventProgramLoaded); ok {
+			populateFakeLoadedProgramProbes(s, loadedEvent.programID)
+		}
 		output[i] = generateEventOutput(t, eventNodes[i], effects, before, s)
 		outputString := string(output[i])
 		validateState(s, func(err error) {
@@ -173,6 +181,24 @@ func runSnapshotTest(t *testing.T, file string, rewrite bool) {
 		err = os.Rename(tmpFile.Name(), file)
 		require.NoError(t, err)
 	}
+}
+
+// populateFakeLoadedProgramProbes copies prog.config into the
+// fakeLoadedProgram's probes slice so that ProbeDefinition lookups
+// during checkCosts / tripProbe resolve correctly. Production code
+// derives this list from the IR program returned by the loader; in
+// the snapshot test there is no real loader, so we mirror the actuator
+// state.
+func populateFakeLoadedProgramProbes(s *state, progID ir.ProgramID) {
+	prog, ok := s.programs[progID]
+	if !ok || prog.loaded == nil {
+		return
+	}
+	flp, ok := prog.loaded.loaded.(*fakeLoadedProgram)
+	if !ok {
+		return
+	}
+	flp.probes = append(flp.probes[:0], prog.config...)
 }
 
 func handleRuntimeStatsUpdatedForTest(

--- a/pkg/dyninst/actuator/state_snapshot_test.go
+++ b/pkg/dyninst/actuator/state_snapshot_test.go
@@ -349,6 +349,28 @@ func computeStateUpdate(before, after *state) *stateUpdate {
 			allIDs[id] = true
 		}
 
+		renderProc := func(p *process) string {
+			var s string
+			if p.currentProgram != 0 {
+				s = fmt.Sprintf(
+					"%s (prog %d)",
+					p.state.String(), p.currentProgram,
+				)
+			} else {
+				s = p.state.String()
+			}
+			if len(p.circuitBrokenProbes) > 0 {
+				keys := slices.SortedFunc(
+					maps.Keys(p.circuitBrokenProbes), probeKey.cmp,
+				)
+				ids := make([]string, len(keys))
+				for i, k := range keys {
+					ids[i] = k.id
+				}
+				s += fmt.Sprintf(" circuitBroken=[%s]", strings.Join(ids, ","))
+			}
+			return s
+		}
 		for id := range allIDs {
 			beforeProc := before[id]
 			afterProc := after[id]
@@ -356,24 +378,10 @@ func computeStateUpdate(before, after *state) *stateUpdate {
 
 			var beforeState, afterState any
 			if beforeProc != nil {
-				if beforeProc.currentProgram != 0 {
-					beforeState = fmt.Sprintf(
-						"%s (prog %d)",
-						beforeProc.state.String(), beforeProc.currentProgram,
-					)
-				} else {
-					beforeState = beforeProc.state.String()
-				}
+				beforeState = renderProc(beforeProc)
 			}
 			if afterProc != nil {
-				if afterProc.currentProgram != 0 {
-					afterState = fmt.Sprintf(
-						"%s (prog %d)",
-						afterProc.state.String(), afterProc.currentProgram,
-					)
-				} else {
-					afterState = afterProc.state.String()
-				}
+				afterState = renderProc(afterProc)
 			}
 			if update.Processes == nil {
 				update.Processes = make(map[any]string)

--- a/pkg/dyninst/actuator/state_snapshot_test.go
+++ b/pkg/dyninst/actuator/state_snapshot_test.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v3"
@@ -62,6 +63,19 @@ func TestSnapshot(t *testing.T) {
 }
 
 func runSnapshotTest(t *testing.T, file string, rewrite bool) {
+	// Deterministic wall clock for the snapshot. handleHeartbeatCheck
+	// uses nowFunc() to compute the interval since the previous
+	// heartbeat; without override, the interval would be a real
+	// nanosecond gap and trip messages would carry timing-dependent
+	// floating-point values.
+	originalNow := nowFunc
+	t.Cleanup(func() { nowFunc = originalNow })
+	fakeNow := time.Unix(0, 0)
+	nowFunc = func() time.Time {
+		fakeNow = fakeNow.Add(time.Second)
+		return fakeNow
+	}
+
 	content, err := os.ReadFile(file)
 	require.NoError(t, err, "failed to read snapshot file")
 
@@ -77,6 +91,11 @@ func runSnapshotTest(t *testing.T, file string, rewrite bool) {
 	// documents. This is a sanity check to ensure that the file is valid.
 	input := documentChunks[0]
 	decoder := yaml.NewDecoder(bytes.NewReader(input))
+	// Strict decoding: any unknown YAML field in the events doc is an
+	// error. This prevents stale snapshots from silently decoding
+	// missing or renamed fields to zero values when the schema
+	// changes (e.g. runtime_stats shape evolution).
+	decoder.KnownFields(true)
 	var eventsNode yaml.Node
 	err = decoder.Decode(&eventsNode)
 	require.NoError(t, err, "failed to decode events list node")
@@ -101,11 +120,14 @@ func runSnapshotTest(t *testing.T, file string, rewrite bool) {
 	discoveredTypesLimit := defaultDiscoveredTypesLimit
 	var recompilationRateLimit float64
 	var recompilationRateBurst int
+	var breakerCfg CircuitBreakerConfig
 	if len(events) > 0 {
 		if cfg, ok := events[0].event.(eventConfig); ok {
 			discoveredTypesLimit = cfg.discoveredTypesLimit
 			recompilationRateLimit = cfg.recompilationRateLimit
 			recompilationRateBurst = cfg.recompilationRateBurst
+			breakerCfg.PerProbeCPULimit = cfg.perProbeCPULimit
+			breakerCfg.AllProbesCPULimit = cfg.allProbesCPULimit
 			events = events[1:]
 			eventNodes = eventNodes[1:]
 		}
@@ -116,6 +138,7 @@ func runSnapshotTest(t *testing.T, file string, rewrite bool) {
 		DiscoveredTypesLimit:   discoveredTypesLimit,
 		RecompilationRateLimit: recompilationRateLimit,
 		RecompilationRateBurst: recompilationRateBurst,
+		CircuitBreakerConfig:   breakerCfg,
 	})
 	effects := effectRecorder{}
 	for i, ev := range events {

--- a/pkg/dyninst/actuator/testdata/snapshot/circuit_breaker.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/circuit_breaker.yaml
@@ -114,17 +114,19 @@ state:
 ---
 event: !heartbeat-check
 effects:
-  - !detach-from-process {failure: "yes", process_id: 1001, program_id: 1}
+  - !report-probe-error {probe_id: probe1, process_id: 1001, program_id: 1, reason: "yes"}
+  - !detach-from-process {failure: "no", process_id: 1001, program_id: 1}
 state:
   currently_loading: <nil>
   queued_programs: '[]'
   processes:
-    1001: Attached (prog 1) -> Failed (prog 1)
+    1001: Attached (prog 1) -> Detaching (prog 1)
   programs:
     1: Loaded (proc 1001) -> Draining (proc 1001)
   stats:
     numAttached: 1 -> 0
-    numFailed: 0 -> 1
+    numDetaching: 0 -> 1
+    typeRecompilationsTriggered: 0 -> 1
 ---
 event: !runtime-stats
   program_id: 1
@@ -136,7 +138,7 @@ state:
   currently_loading: <nil>
   queued_programs: '[]'
   processes:
-    1001: Failed (prog 1)
+    1001: Detaching (prog 1)
   programs:
     1: Draining (proc 1001)
 ---
@@ -145,6 +147,6 @@ state:
   currently_loading: <nil>
   queued_programs: '[]'
   processes:
-    1001: Failed (prog 1)
+    1001: Detaching (prog 1)
   programs:
     1: Draining (proc 1001)

--- a/pkg/dyninst/actuator/testdata/snapshot/circuit_breaker.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/circuit_breaker.yaml
@@ -1,4 +1,6 @@
 # Tests circuit breaker behavior with runtime stat updates.
+# After the per-probe stats migration the runtime_stats list is keyed
+# by probe_id (not per-CPU); the test process has a single probe.
 - !processes-updated
   updated:
     - process_id: { pid: 1001 }
@@ -16,31 +18,22 @@
     - hit_cnt: 0
       throttled_cnt: 0
       cpu: 0s
-    - hit_cnt: 0
-      throttled_cnt: 0
-      cpu: 0s
 - !attached { program_id: 1, process_id: 1001 }
 - !heartbeat-check
 - !runtime-stats
   program_id: 1
   runtime_stats:
-    - hit_cnt: 200
+    - hit_cnt: 1200
       throttled_cnt: 0
-      cpu: 1000ns
-    - hit_cnt: 1000
-      throttled_cnt: 0
-      cpu: 2000ns
+      cpu: 3000ns
 - !heartbeat-check
 # Second heartbeat check should trigger the circuit breaker.
 - !runtime-stats
   program_id: 1
   runtime_stats:
-    - hit_cnt: 2000
+    - hit_cnt: 7000
       throttled_cnt: 0
-      cpu: 1000s
-    - hit_cnt: 5000
-      throttled_cnt: 0
-      cpu: 500s
+      cpu: 1500s
 - !heartbeat-check
 ---
 event: !processes-updated
@@ -66,9 +59,6 @@ state:
 event: !loaded
   program_id: 1
   runtime_stats:
-    - hit_cnt: 0
-      throttled_cnt: 0
-      cpu: 0s
     - hit_cnt: 0
       throttled_cnt: 0
       cpu: 0s
@@ -111,12 +101,9 @@ state:
 event: !runtime-stats
   program_id: 1
   runtime_stats:
-    - hit_cnt: 200
+    - hit_cnt: 1200
       throttled_cnt: 0
-      cpu: 1000ns
-    - hit_cnt: 1000
-      throttled_cnt: 0
-      cpu: 2000ns
+      cpu: 3000ns
 state:
   currently_loading: <nil>
   queued_programs: '[]'
@@ -142,12 +129,9 @@ state:
 event: !runtime-stats
   program_id: 1
   runtime_stats:
-    - hit_cnt: 2000
+    - hit_cnt: 7000
       throttled_cnt: 0
-      cpu: 1000s
-    - hit_cnt: 5000
-      throttled_cnt: 0
-      cpu: 500s
+      cpu: 1500s
 state:
   currently_loading: <nil>
   queued_programs: '[]'

--- a/pkg/dyninst/actuator/testdata/snapshot/circuit_breaker.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/circuit_breaker.yaml
@@ -1,6 +1,7 @@
 # Tests circuit breaker behavior with runtime stat updates.
 # After the per-probe stats migration the runtime_stats list is keyed
 # by probe_id (not per-CPU); the test process has a single probe.
+- !config { discovered_types_limit: 0, per_probe_cpu_limit: 0.01, all_probes_cpu_limit: 1000 }
 - !processes-updated
   updated:
     - process_id: { pid: 1001 }
@@ -113,6 +114,29 @@ state:
     1: Loaded (proc 1001)
 ---
 event: !heartbeat-check
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 1)
+  programs:
+    1: Loaded (proc 1001)
+---
+event: !runtime-stats
+  program_id: 1
+  runtime_stats:
+    - hit_cnt: 7000
+      throttled_cnt: 0
+      cpu: 1500s
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 1)
+  programs:
+    1: Loaded (proc 1001)
+---
+event: !heartbeat-check
 effects:
   - !report-probe-error {probe_id: probe1, process_id: 1001, program_id: 1, reason: "yes"}
   - !detach-from-process {failure: "no", process_id: 1001, program_id: 1}
@@ -128,25 +152,3 @@ state:
     numDetaching: 0 -> 1
     typeRecompilationsTriggered: 0 -> 1
 ---
-event: !runtime-stats
-  program_id: 1
-  runtime_stats:
-    - hit_cnt: 7000
-      throttled_cnt: 0
-      cpu: 1500s
-state:
-  currently_loading: <nil>
-  queued_programs: '[]'
-  processes:
-    1001: Detaching (prog 1)
-  programs:
-    1: Draining (proc 1001)
----
-event: !heartbeat-check
-state:
-  currently_loading: <nil>
-  queued_programs: '[]'
-  processes:
-    1001: Detaching (prog 1)
-  programs:
-    1: Draining (proc 1001)

--- a/pkg/dyninst/actuator/testdata/snapshot/circuit_breaker_all_broken_then_unrelated_added.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/circuit_breaker_all_broken_then_unrelated_added.yaml
@@ -1,0 +1,224 @@
+# Tests that when every probe configured on a process has been
+# circuit-broken (so there is no live program), adding a new unrelated
+# probe via processes-updated does NOT silently re-enable the broken
+# probe. The new program must contain only the newly-added probe; the
+# previously tripped probe stays in circuitBrokenProbes until it is
+# explicitly removed from the configuration and re-added.
+- !config { discovered_types_limit: 0, per_probe_cpu_limit: 0.5, all_probes_cpu_limit: 100 }
+- !processes-updated
+  updated:
+    - process_id: { pid: 1001 }
+      executable: { path: /usr/bin/test }
+      probes:
+        - { type: LOG_PROBE, id: hot, where: { methodName: hot }, captureSnapshot: true }
+- !loaded
+  program_id: 1
+  runtime_stats:
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
+- !attached { program_id: 1, process_id: 1001 }
+- !heartbeat-check
+- !runtime-stats
+  program_id: 1
+  runtime_stats:
+    - hit_cnt: 100000 # hot probe burning CPU
+      throttled_cnt: 0
+      cpu: 5s
+# This heartbeat trips the hot probe. Because it is the only configured
+# probe, the recompile path finds no probes to instrument and parks
+# the process in Invalid with circuitBrokenProbes = {hot}.
+- !heartbeat-check
+- !detached { program_id: 1, process_id: 1001 }
+- !unloaded { program_id: 1 }
+# Operator adds an unrelated probe (cold). hot remains in the
+# configuration. The new program must contain ONLY cold; hot must be
+# filtered out because it is still in circuitBrokenProbes.
+- !processes-updated
+  updated:
+    - process_id: { pid: 1001 }
+      executable: { path: /usr/bin/test }
+      probes:
+        - { type: LOG_PROBE, id: hot, where: { methodName: hot }, captureSnapshot: true }
+        - { type: LOG_PROBE, id: cold, where: { methodName: cold }, captureSnapshot: true }
+- !loaded
+  program_id: 2
+  runtime_stats:
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
+- !attached { program_id: 2, process_id: 1001 }
+---
+event: !processes-updated
+  updated:
+    - process_id: {pid: 1001}
+      executable: {path: /usr/bin/test}
+      probes:
+        - {type: LOG_PROBE, id: hot, where: {methodName: hot}, captureSnapshot: true}
+effects:
+  - !spawn-bpf-loading {executable: /usr/bin/test@0.0m0.0, probes: [hot], process_id: 1001, program_id: 1}
+state:
+  currently_loading: <nil> -> 1
+  queued_programs: '[]'
+  processes:
+    1001: <nil> -> WaitingForProgram (prog 1)
+  programs:
+    1: <nil> -> Loading (proc 1001)
+  stats:
+    numProcesses: 0 -> 1
+    numPrograms: 0 -> 1
+    numWaitingForProgram: 0 -> 1
+---
+event: !loaded
+  program_id: 1
+  runtime_stats:
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
+effects:
+  - !attach-to-process {executable: /usr/bin/test@0.0m0.0, process_id: 1001, program_id: 1}
+state:
+  currently_loading: 1 -> <nil>
+  queued_programs: '[]'
+  processes:
+    1001: WaitingForProgram (prog 1) -> Attaching (prog 1)
+  programs:
+    1: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 0 -> 1
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
+---
+event: !attached {program_id: 1, process_id: 1001}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attaching (prog 1) -> Attached (prog 1)
+  programs:
+    1: Loaded (proc 1001)
+  stats:
+    attached: 0 -> 1
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
+---
+event: !heartbeat-check
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 1)
+  programs:
+    1: Loaded (proc 1001)
+---
+event: !runtime-stats
+  program_id: 1
+  runtime_stats:
+    - hit_cnt: 100000
+      throttled_cnt: 0
+      cpu: 5s
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 1)
+  programs:
+    1: Loaded (proc 1001)
+---
+event: !heartbeat-check
+effects:
+  - !report-probe-error {probe_id: hot, process_id: 1001, program_id: 1, reason: "yes"}
+  - !detach-from-process {failure: "no", process_id: 1001, program_id: 1}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 1) -> Detaching (prog 1)
+  programs:
+    1: Loaded (proc 1001) -> Draining (proc 1001)
+  stats:
+    numAttached: 1 -> 0
+    numDetaching: 0 -> 1
+    typeRecompilationsTriggered: 0 -> 1
+---
+event: !detached {program_id: 1, process_id: 1001}
+effects:
+  - !unload-program {program_id: 1}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 1)
+  programs:
+    1: Draining (proc 1001) -> Unloading (proc 1001)
+  stats:
+    detached: 0 -> 1
+---
+event: !unloaded {program_id: 1}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 1) -> Failed
+  programs:
+    1: Unloading (proc 1001) -> <nil>
+  stats:
+    numDetaching: 1 -> 0
+    numFailed: 0 -> 1
+    numPrograms: 1 -> 0
+    unloaded: 0 -> 1
+---
+event: !processes-updated
+  updated:
+    - process_id: {pid: 1001}
+      executable: {path: /usr/bin/test}
+      probes:
+        - {type: LOG_PROBE, id: hot, where: {methodName: hot}, captureSnapshot: true}
+        - {type: LOG_PROBE, id: cold, where: {methodName: cold}, captureSnapshot: true}
+effects:
+  - !spawn-bpf-loading {executable: /usr/bin/test@0.0m0.0, probes: [cold], process_id: 1001, program_id: 2}
+state:
+  currently_loading: <nil> -> 2
+  queued_programs: '[]'
+  processes:
+    1001: Failed -> WaitingForProgram (prog 2)
+  programs:
+    2: <nil> -> Loading (proc 1001)
+  stats:
+    numFailed: 1 -> 0
+    numPrograms: 0 -> 1
+    numWaitingForProgram: 0 -> 1
+---
+event: !loaded
+  program_id: 2
+  runtime_stats:
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
+effects:
+  - !attach-to-process {executable: /usr/bin/test@0.0m0.0, process_id: 1001, program_id: 2}
+state:
+  currently_loading: 2 -> <nil>
+  queued_programs: '[]'
+  processes:
+    1001: WaitingForProgram (prog 2) -> Attaching (prog 2)
+  programs:
+    2: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 1 -> 2
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
+---
+event: !attached {program_id: 2, process_id: 1001}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attaching (prog 2) -> Attached (prog 2)
+  programs:
+    2: Loaded (proc 1001)
+  stats:
+    attached: 1 -> 2
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
+---

--- a/pkg/dyninst/actuator/testdata/snapshot/circuit_breaker_all_probes_trip.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/circuit_breaker_all_probes_trip.yaml
@@ -1,62 +1,71 @@
-# Tests that when every probe configured on a process has been
-# circuit-broken (so there is no live program), adding a new unrelated
-# probe via processes-updated does NOT silently re-enable the broken
-# probe. The new program must contain only the newly-added probe; the
-# previously tripped probe stays in circuitBrokenProbes until it is
-# explicitly removed from the configuration and re-added.
-- !config { discovered_types_limit: 0, per_probe_cpu_limit: 0.5, all_probes_cpu_limit: 100 }
+# Tests that when the host-wide AllProbesCPULimit trips (sum of probe
+# costs exceeds the limit, but no single probe exceeds
+# PerProbeCPULimit), the most expensive probe is picked as the victim
+# and circuit-broken via recompile-and-omit. The surviving probes
+# continue.
+- !config { discovered_types_limit: 0, per_probe_cpu_limit: 0.5, all_probes_cpu_limit: 1.0 }
 - !processes-updated
   updated:
     - process_id: { pid: 1001 }
       executable: { path: /usr/bin/test }
       probes:
-        - { type: LOG_PROBE, id: hot, where: { methodName: hot }, captureSnapshot: true }
+        - { type: LOG_PROBE, id: a, where: { methodName: a }, captureSnapshot: true }
+        - { type: LOG_PROBE, id: b, where: { methodName: b }, captureSnapshot: true }
+        - { type: LOG_PROBE, id: c, where: { methodName: c }, captureSnapshot: true }
 - !loaded
   program_id: 1
   runtime_stats:
     - hit_cnt: 0
       throttled_cnt: 0
       cpu: 0s
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
 - !attached { program_id: 1, process_id: 1001 }
 - !heartbeat-check
+# Each probe is under PerProbeCPULimit (0.5 cpus/s) but the sum (1.2
+# cpus/s) exceeds AllProbesCPULimit (1.0 cpus/s). c is the most
+# expensive and should be the all-probes victim.
 - !runtime-stats
   program_id: 1
   runtime_stats:
-    - hit_cnt: 100000 # hot probe burning CPU
+    - hit_cnt: 100
       throttled_cnt: 0
-      cpu: 5s
-# This heartbeat trips the hot probe. Because it is the only configured
-# probe, the recompile path finds no probes to instrument and parks
-# the process in Invalid with circuitBrokenProbes = {hot}.
+      cpu: 300ms # probe a: 0.3 cpus/s
+    - hit_cnt: 100
+      throttled_cnt: 0
+      cpu: 400ms # probe b: 0.4 cpus/s
+    - hit_cnt: 100
+      throttled_cnt: 0
+      cpu: 450ms # probe c: 0.45 cpus/s
 - !heartbeat-check
 - !detached { program_id: 1, process_id: 1001 }
 - !unloaded { program_id: 1 }
-# Operator adds an unrelated probe (cold). hot remains in the
-# configuration. The new program must contain ONLY cold; hot must be
-# filtered out because it is still in circuitBrokenProbes.
-- !processes-updated
-  updated:
-    - process_id: { pid: 1001 }
-      executable: { path: /usr/bin/test }
-      probes:
-        - { type: LOG_PROBE, id: hot, where: { methodName: hot }, captureSnapshot: true }
-        - { type: LOG_PROBE, id: cold, where: { methodName: cold }, captureSnapshot: true }
 - !loaded
   program_id: 2
   runtime_stats:
     - hit_cnt: 0
       throttled_cnt: 0
       cpu: 0s
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
 - !attached { program_id: 2, process_id: 1001 }
+- !heartbeat-check
 ---
 event: !processes-updated
   updated:
     - process_id: {pid: 1001}
       executable: {path: /usr/bin/test}
       probes:
-        - {type: LOG_PROBE, id: hot, where: {methodName: hot}, captureSnapshot: true}
+        - {type: LOG_PROBE, id: a, where: {methodName: a}, captureSnapshot: true}
+        - {type: LOG_PROBE, id: b, where: {methodName: b}, captureSnapshot: true}
+        - {type: LOG_PROBE, id: c, where: {methodName: c}, captureSnapshot: true}
 effects:
-  - !spawn-bpf-loading {executable: /usr/bin/test@0.0m0.0, probes: [hot], process_id: 1001, program_id: 1}
+  - !spawn-bpf-loading {executable: /usr/bin/test@0.0m0.0, probes: [a, b, c], process_id: 1001, program_id: 1}
 state:
   currently_loading: <nil> -> 1
   queued_programs: '[]'
@@ -72,6 +81,12 @@ state:
 event: !loaded
   program_id: 1
   runtime_stats:
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
     - hit_cnt: 0
       throttled_cnt: 0
       cpu: 0s
@@ -114,9 +129,15 @@ state:
 event: !runtime-stats
   program_id: 1
   runtime_stats:
-    - hit_cnt: 100000
+    - hit_cnt: 100
       throttled_cnt: 0
-      cpu: 5s
+      cpu: 300ms
+    - hit_cnt: 100
+      throttled_cnt: 0
+      cpu: 400ms
+    - hit_cnt: 100
+      throttled_cnt: 0
+      cpu: 450ms
 state:
   currently_loading: <nil>
   queued_programs: '[]'
@@ -127,13 +148,13 @@ state:
 ---
 event: !heartbeat-check
 effects:
-  - !report-probe-error {probe_id: hot, process_id: 1001, program_id: 1, reason: "yes"}
+  - !report-probe-error {probe_id: c, process_id: 1001, program_id: 1, reason: "yes"}
   - !detach-from-process {failure: "no", process_id: 1001, program_id: 1}
 state:
   currently_loading: <nil>
   queued_programs: '[]'
   processes:
-    1001: Attached (prog 1) -> Detaching (prog 1) circuitBroken=[hot]
+    1001: Attached (prog 1) -> Detaching (prog 1) circuitBroken=[c]
   programs:
     1: Loaded (proc 1001) -> Draining (proc 1001)
   stats:
@@ -148,50 +169,34 @@ state:
   currently_loading: <nil>
   queued_programs: '[]'
   processes:
-    1001: Detaching (prog 1) circuitBroken=[hot]
+    1001: Detaching (prog 1) circuitBroken=[c]
   programs:
     1: Draining (proc 1001) -> Unloading (proc 1001)
   stats:
     detached: 0 -> 1
 ---
 event: !unloaded {program_id: 1}
-state:
-  currently_loading: <nil>
-  queued_programs: '[]'
-  processes:
-    1001: Detaching (prog 1) circuitBroken=[hot] -> Failed circuitBroken=[hot]
-  programs:
-    1: Unloading (proc 1001) -> <nil>
-  stats:
-    numDetaching: 1 -> 0
-    numFailed: 0 -> 1
-    numPrograms: 1 -> 0
-    unloaded: 0 -> 1
----
-event: !processes-updated
-  updated:
-    - process_id: {pid: 1001}
-      executable: {path: /usr/bin/test}
-      probes:
-        - {type: LOG_PROBE, id: hot, where: {methodName: hot}, captureSnapshot: true}
-        - {type: LOG_PROBE, id: cold, where: {methodName: cold}, captureSnapshot: true}
 effects:
-  - !spawn-bpf-loading {executable: /usr/bin/test@0.0m0.0, probes: [cold], process_id: 1001, program_id: 2}
+  - !spawn-bpf-loading {executable: /usr/bin/test@0.0m0.0, probes: [a, b], process_id: 1001, program_id: 2}
 state:
   currently_loading: <nil> -> 2
   queued_programs: '[]'
   processes:
-    1001: Failed circuitBroken=[hot] -> WaitingForProgram (prog 2) circuitBroken=[hot]
+    1001: Detaching (prog 1) circuitBroken=[c] -> WaitingForProgram (prog 2) circuitBroken=[c]
   programs:
+    1: Unloading (proc 1001) -> <nil>
     2: <nil> -> Loading (proc 1001)
   stats:
-    numFailed: 1 -> 0
-    numPrograms: 0 -> 1
+    numDetaching: 1 -> 0
     numWaitingForProgram: 0 -> 1
+    unloaded: 0 -> 1
 ---
 event: !loaded
   program_id: 2
   runtime_stats:
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
     - hit_cnt: 0
       throttled_cnt: 0
       cpu: 0s
@@ -201,7 +206,7 @@ state:
   currently_loading: 2 -> <nil>
   queued_programs: '[]'
   processes:
-    1001: WaitingForProgram (prog 2) circuitBroken=[hot] -> Attaching (prog 2) circuitBroken=[hot]
+    1001: WaitingForProgram (prog 2) circuitBroken=[c] -> Attaching (prog 2) circuitBroken=[c]
   programs:
     2: Loading (proc 1001) -> Loaded (proc 1001)
   stats:
@@ -214,11 +219,20 @@ state:
   currently_loading: <nil>
   queued_programs: '[]'
   processes:
-    1001: Attaching (prog 2) circuitBroken=[hot] -> Attached (prog 2) circuitBroken=[hot]
+    1001: Attaching (prog 2) circuitBroken=[c] -> Attached (prog 2) circuitBroken=[c]
   programs:
     2: Loaded (proc 1001)
   stats:
     attached: 1 -> 2
     numAttached: 0 -> 1
     numAttaching: 1 -> 0
+---
+event: !heartbeat-check
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 2) circuitBroken=[c]
+  programs:
+    2: Loaded (proc 1001)
 ---

--- a/pkg/dyninst/actuator/testdata/snapshot/circuit_breaker_config_update_during_recompile.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/circuit_breaker_config_update_during_recompile.yaml
@@ -1,39 +1,10 @@
-# Tests that when every probe configured on a process has been
-# circuit-broken (so there is no live program), adding a new unrelated
-# probe via processes-updated does NOT silently re-enable the broken
-# probe. The new program must contain only the newly-added probe; the
-# previously tripped probe stays in circuitBrokenProbes until it is
-# explicitly removed from the configuration and re-added.
+# Tests that a processes-updated arriving while a recompile-and-omit
+# is in flight does not resurrect a circuit-broken probe, provided the
+# probe is still in the new configured set. The pruning rule in
+# handleProcessesUpdated only drops a broken-set entry when the probe
+# is *no longer* configured; if hot is still there, hot stays broken,
+# and the post-recompile program continues to omit it.
 - !config { discovered_types_limit: 0, per_probe_cpu_limit: 0.5, all_probes_cpu_limit: 100 }
-- !processes-updated
-  updated:
-    - process_id: { pid: 1001 }
-      executable: { path: /usr/bin/test }
-      probes:
-        - { type: LOG_PROBE, id: hot, where: { methodName: hot }, captureSnapshot: true }
-- !loaded
-  program_id: 1
-  runtime_stats:
-    - hit_cnt: 0
-      throttled_cnt: 0
-      cpu: 0s
-- !attached { program_id: 1, process_id: 1001 }
-- !heartbeat-check
-- !runtime-stats
-  program_id: 1
-  runtime_stats:
-    - hit_cnt: 100000 # hot probe burning CPU
-      throttled_cnt: 0
-      cpu: 5s
-# This heartbeat trips the hot probe. Because it is the only configured
-# probe, the recompile path finds no probes to instrument and parks
-# the process in Invalid with circuitBrokenProbes = {hot}.
-- !heartbeat-check
-- !detached { program_id: 1, process_id: 1001 }
-- !unloaded { program_id: 1 }
-# Operator adds an unrelated probe (cold). hot remains in the
-# configuration. The new program must contain ONLY cold; hot must be
-# filtered out because it is still in circuitBrokenProbes.
 - !processes-updated
   updated:
     - process_id: { pid: 1001 }
@@ -42,12 +13,52 @@
         - { type: LOG_PROBE, id: hot, where: { methodName: hot }, captureSnapshot: true }
         - { type: LOG_PROBE, id: cold, where: { methodName: cold }, captureSnapshot: true }
 - !loaded
+  program_id: 1
+  runtime_stats:
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
+- !attached { program_id: 1, process_id: 1001 }
+- !heartbeat-check
+- !runtime-stats
+  program_id: 1
+  runtime_stats:
+    - hit_cnt: 5
+      throttled_cnt: 0
+      cpu: 100ns
+    - hit_cnt: 100000
+      throttled_cnt: 0
+      cpu: 5s
+# Trips hot; program 1 starts draining.
+- !heartbeat-check
+- !detached { program_id: 1, process_id: 1001 }
+# Config update arrives while program 1 is still Unloading. The new
+# probe set still contains hot (the operator hasn't removed it yet)
+# but adds extra. hot must stay in circuitBrokenProbes; the
+# downstream program must contain cold and extra only.
+- !processes-updated
+  updated:
+    - process_id: { pid: 1001 }
+      executable: { path: /usr/bin/test }
+      probes:
+        - { type: LOG_PROBE, id: hot, where: { methodName: hot }, captureSnapshot: true }
+        - { type: LOG_PROBE, id: cold, where: { methodName: cold }, captureSnapshot: true }
+        - { type: LOG_PROBE, id: extra, where: { methodName: extra }, captureSnapshot: true }
+- !unloaded { program_id: 1 }
+- !loaded
   program_id: 2
   runtime_stats:
     - hit_cnt: 0
       throttled_cnt: 0
       cpu: 0s
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
 - !attached { program_id: 2, process_id: 1001 }
+- !heartbeat-check
 ---
 event: !processes-updated
   updated:
@@ -55,8 +66,9 @@ event: !processes-updated
       executable: {path: /usr/bin/test}
       probes:
         - {type: LOG_PROBE, id: hot, where: {methodName: hot}, captureSnapshot: true}
+        - {type: LOG_PROBE, id: cold, where: {methodName: cold}, captureSnapshot: true}
 effects:
-  - !spawn-bpf-loading {executable: /usr/bin/test@0.0m0.0, probes: [hot], process_id: 1001, program_id: 1}
+  - !spawn-bpf-loading {executable: /usr/bin/test@0.0m0.0, probes: [cold, hot], process_id: 1001, program_id: 1}
 state:
   currently_loading: <nil> -> 1
   queued_programs: '[]'
@@ -72,6 +84,9 @@ state:
 event: !loaded
   program_id: 1
   runtime_stats:
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
     - hit_cnt: 0
       throttled_cnt: 0
       cpu: 0s
@@ -114,6 +129,9 @@ state:
 event: !runtime-stats
   program_id: 1
   runtime_stats:
+    - hit_cnt: 5
+      throttled_cnt: 0
+      cpu: 100ns
     - hit_cnt: 100000
       throttled_cnt: 0
       cpu: 5s
@@ -154,20 +172,6 @@ state:
   stats:
     detached: 0 -> 1
 ---
-event: !unloaded {program_id: 1}
-state:
-  currently_loading: <nil>
-  queued_programs: '[]'
-  processes:
-    1001: Detaching (prog 1) circuitBroken=[hot] -> Failed circuitBroken=[hot]
-  programs:
-    1: Unloading (proc 1001) -> <nil>
-  stats:
-    numDetaching: 1 -> 0
-    numFailed: 0 -> 1
-    numPrograms: 1 -> 0
-    unloaded: 0 -> 1
----
 event: !processes-updated
   updated:
     - process_id: {pid: 1001}
@@ -175,23 +179,37 @@ event: !processes-updated
       probes:
         - {type: LOG_PROBE, id: hot, where: {methodName: hot}, captureSnapshot: true}
         - {type: LOG_PROBE, id: cold, where: {methodName: cold}, captureSnapshot: true}
+        - {type: LOG_PROBE, id: extra, where: {methodName: extra}, captureSnapshot: true}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 1) circuitBroken=[hot]
+  programs:
+    1: Unloading (proc 1001)
+---
+event: !unloaded {program_id: 1}
 effects:
-  - !spawn-bpf-loading {executable: /usr/bin/test@0.0m0.0, probes: [cold], process_id: 1001, program_id: 2}
+  - !spawn-bpf-loading {executable: /usr/bin/test@0.0m0.0, probes: [cold, extra], process_id: 1001, program_id: 2}
 state:
   currently_loading: <nil> -> 2
   queued_programs: '[]'
   processes:
-    1001: Failed circuitBroken=[hot] -> WaitingForProgram (prog 2) circuitBroken=[hot]
+    1001: Detaching (prog 1) circuitBroken=[hot] -> WaitingForProgram (prog 2) circuitBroken=[hot]
   programs:
+    1: Unloading (proc 1001) -> <nil>
     2: <nil> -> Loading (proc 1001)
   stats:
-    numFailed: 1 -> 0
-    numPrograms: 0 -> 1
+    numDetaching: 1 -> 0
     numWaitingForProgram: 0 -> 1
+    unloaded: 0 -> 1
 ---
 event: !loaded
   program_id: 2
   runtime_stats:
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
     - hit_cnt: 0
       throttled_cnt: 0
       cpu: 0s
@@ -221,4 +239,13 @@ state:
     attached: 1 -> 2
     numAttached: 0 -> 1
     numAttaching: 1 -> 0
+---
+event: !heartbeat-check
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 2) circuitBroken=[hot]
+  programs:
+    2: Loaded (proc 1001)
 ---

--- a/pkg/dyninst/actuator/testdata/snapshot/circuit_breaker_isolated_per_process.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/circuit_breaker_isolated_per_process.yaml
@@ -1,0 +1,328 @@
+# Tests that circuit-breaking a probe on one process does not affect a
+# sibling process running the same probe identity. circuitBrokenProbes
+# is per-process state and must not leak across processes that happen
+# to share probe configuration.
+- !config { discovered_types_limit: 0, per_probe_cpu_limit: 0.5, all_probes_cpu_limit: 100 }
+- !processes-updated
+  updated:
+    - process_id: { pid: 1001 }
+      executable: { path: /usr/bin/test }
+      probes:
+        - { type: LOG_PROBE, id: hot, where: { methodName: hot }, captureSnapshot: true }
+        - { type: LOG_PROBE, id: cold, where: { methodName: cold }, captureSnapshot: true }
+    - process_id: { pid: 1002 }
+      executable: { path: /usr/bin/test }
+      probes:
+        - { type: LOG_PROBE, id: hot, where: { methodName: hot }, captureSnapshot: true }
+        - { type: LOG_PROBE, id: cold, where: { methodName: cold }, captureSnapshot: true }
+- !loaded
+  program_id: 1
+  runtime_stats:
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
+- !attached { program_id: 1, process_id: 1001 }
+- !loaded
+  program_id: 2
+  runtime_stats:
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
+- !attached { program_id: 2, process_id: 1002 }
+- !heartbeat-check
+# Process 1001 has a runaway hot probe; process 1002 is well-behaved.
+- !runtime-stats
+  program_id: 1
+  runtime_stats:
+    - hit_cnt: 5
+      throttled_cnt: 0
+      cpu: 100ns
+    - hit_cnt: 100000
+      throttled_cnt: 0
+      cpu: 5s
+- !runtime-stats
+  program_id: 2
+  runtime_stats:
+    - hit_cnt: 10
+      throttled_cnt: 0
+      cpu: 200ns
+    - hit_cnt: 10
+      throttled_cnt: 0
+      cpu: 200ns
+# Trips hot on 1001 only. 1002 must remain Attached with no
+# circuitBroken set.
+- !heartbeat-check
+- !detached { program_id: 1, process_id: 1001 }
+- !unloaded { program_id: 1 }
+- !loaded
+  program_id: 3
+  runtime_stats:
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
+- !attached { program_id: 3, process_id: 1001 }
+- !heartbeat-check
+---
+event: !processes-updated
+  updated:
+    - process_id: {pid: 1001}
+      executable: {path: /usr/bin/test}
+      probes:
+        - {type: LOG_PROBE, id: hot, where: {methodName: hot}, captureSnapshot: true}
+        - {type: LOG_PROBE, id: cold, where: {methodName: cold}, captureSnapshot: true}
+    - process_id: {pid: 1002}
+      executable: {path: /usr/bin/test}
+      probes:
+        - {type: LOG_PROBE, id: hot, where: {methodName: hot}, captureSnapshot: true}
+        - {type: LOG_PROBE, id: cold, where: {methodName: cold}, captureSnapshot: true}
+effects:
+  - !spawn-bpf-loading {executable: /usr/bin/test@0.0m0.0, probes: [cold, hot], process_id: 1001, program_id: 1}
+state:
+  currently_loading: <nil> -> 1
+  queued_programs: '[] -> [2]'
+  processes:
+    1001: <nil> -> WaitingForProgram (prog 1)
+    1002: <nil> -> WaitingForProgram (prog 2)
+  programs:
+    1: <nil> -> Loading (proc 1001)
+    2: <nil> -> Queued (proc 1002)
+  stats:
+    numProcesses: 0 -> 2
+    numPrograms: 0 -> 2
+    numWaitingForProgram: 0 -> 2
+---
+event: !loaded
+  program_id: 1
+  runtime_stats:
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
+effects:
+  - !attach-to-process {executable: /usr/bin/test@0.0m0.0, process_id: 1001, program_id: 1}
+  - !spawn-bpf-loading {executable: /usr/bin/test@0.0m0.0, probes: [cold, hot], process_id: 1002, program_id: 2}
+state:
+  currently_loading: 1 -> 2
+  queued_programs: '[2] -> []'
+  processes:
+    1001: WaitingForProgram (prog 1) -> Attaching (prog 1)
+    1002: WaitingForProgram (prog 2)
+  programs:
+    1: Loading (proc 1001) -> Loaded (proc 1001)
+    2: Queued (proc 1002) -> Loading (proc 1002)
+  stats:
+    loaded: 0 -> 1
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 2 -> 1
+---
+event: !attached {program_id: 1, process_id: 1001}
+state:
+  currently_loading: "2"
+  queued_programs: '[]'
+  processes:
+    1001: Attaching (prog 1) -> Attached (prog 1)
+    1002: WaitingForProgram (prog 2)
+  programs:
+    1: Loaded (proc 1001)
+    2: Loading (proc 1002)
+  stats:
+    attached: 0 -> 1
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
+---
+event: !loaded
+  program_id: 2
+  runtime_stats:
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
+effects:
+  - !attach-to-process {executable: /usr/bin/test@0.0m0.0, process_id: 1002, program_id: 2}
+state:
+  currently_loading: 2 -> <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 1)
+    1002: WaitingForProgram (prog 2) -> Attaching (prog 2)
+  programs:
+    1: Loaded (proc 1001)
+    2: Loading (proc 1002) -> Loaded (proc 1002)
+  stats:
+    loaded: 1 -> 2
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
+---
+event: !attached {program_id: 2, process_id: 1002}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 1)
+    1002: Attaching (prog 2) -> Attached (prog 2)
+  programs:
+    1: Loaded (proc 1001)
+    2: Loaded (proc 1002)
+  stats:
+    attached: 1 -> 2
+    numAttached: 1 -> 2
+    numAttaching: 1 -> 0
+---
+event: !heartbeat-check
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 1)
+    1002: Attached (prog 2)
+  programs:
+    1: Loaded (proc 1001)
+    2: Loaded (proc 1002)
+---
+event: !runtime-stats
+  program_id: 1
+  runtime_stats:
+    - hit_cnt: 5
+      throttled_cnt: 0
+      cpu: 100ns
+    - hit_cnt: 100000
+      throttled_cnt: 0
+      cpu: 5s
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 1)
+    1002: Attached (prog 2)
+  programs:
+    1: Loaded (proc 1001)
+    2: Loaded (proc 1002)
+---
+event: !runtime-stats
+  program_id: 2
+  runtime_stats:
+    - hit_cnt: 10
+      throttled_cnt: 0
+      cpu: 200ns
+    - hit_cnt: 10
+      throttled_cnt: 0
+      cpu: 200ns
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 1)
+    1002: Attached (prog 2)
+  programs:
+    1: Loaded (proc 1001)
+    2: Loaded (proc 1002)
+---
+event: !heartbeat-check
+effects:
+  - !report-probe-error {probe_id: hot, process_id: 1001, program_id: 1, reason: "yes"}
+  - !detach-from-process {failure: "no", process_id: 1001, program_id: 1}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 1) -> Detaching (prog 1) circuitBroken=[hot]
+    1002: Attached (prog 2)
+  programs:
+    1: Loaded (proc 1001) -> Draining (proc 1001)
+    2: Loaded (proc 1002)
+  stats:
+    numAttached: 2 -> 1
+    numDetaching: 0 -> 1
+    typeRecompilationsTriggered: 0 -> 1
+---
+event: !detached {program_id: 1, process_id: 1001}
+effects:
+  - !unload-program {program_id: 1}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 1) circuitBroken=[hot]
+    1002: Attached (prog 2)
+  programs:
+    1: Draining (proc 1001) -> Unloading (proc 1001)
+    2: Loaded (proc 1002)
+  stats:
+    detached: 0 -> 1
+---
+event: !unloaded {program_id: 1}
+effects:
+  - !spawn-bpf-loading {executable: /usr/bin/test@0.0m0.0, probes: [cold], process_id: 1001, program_id: 3}
+state:
+  currently_loading: <nil> -> 3
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 1) circuitBroken=[hot] -> WaitingForProgram (prog 3) circuitBroken=[hot]
+    1002: Attached (prog 2)
+  programs:
+    1: Unloading (proc 1001) -> <nil>
+    2: Loaded (proc 1002)
+    3: <nil> -> Loading (proc 1001)
+  stats:
+    numDetaching: 1 -> 0
+    numWaitingForProgram: 0 -> 1
+    unloaded: 0 -> 1
+---
+event: !loaded
+  program_id: 3
+  runtime_stats:
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
+effects:
+  - !attach-to-process {executable: /usr/bin/test@0.0m0.0, process_id: 1001, program_id: 3}
+state:
+  currently_loading: 3 -> <nil>
+  queued_programs: '[]'
+  processes:
+    1001: WaitingForProgram (prog 3) circuitBroken=[hot] -> Attaching (prog 3) circuitBroken=[hot]
+    1002: Attached (prog 2)
+  programs:
+    2: Loaded (proc 1002)
+    3: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 2 -> 3
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
+---
+event: !attached {program_id: 3, process_id: 1001}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attaching (prog 3) circuitBroken=[hot] -> Attached (prog 3) circuitBroken=[hot]
+    1002: Attached (prog 2)
+  programs:
+    2: Loaded (proc 1002)
+    3: Loaded (proc 1001)
+  stats:
+    attached: 2 -> 3
+    numAttached: 1 -> 2
+    numAttaching: 1 -> 0
+---
+event: !heartbeat-check
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 3) circuitBroken=[hot]
+    1002: Attached (prog 2)
+  programs:
+    2: Loaded (proc 1002)
+    3: Loaded (proc 1001)
+---

--- a/pkg/dyninst/actuator/testdata/snapshot/circuit_breaker_per_probe_trip.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/circuit_breaker_per_probe_trip.yaml
@@ -1,0 +1,217 @@
+# Tests that when one probe trips PerProbeCPULimit on a multi-probe
+# program, only that probe is excluded on recompile; the surviving
+# probe continues to instrument the process.
+- !config { discovered_types_limit: 0, per_probe_cpu_limit: 0.5, all_probes_cpu_limit: 100 }
+- !processes-updated
+  updated:
+    - process_id: { pid: 1001 }
+      executable: { path: /usr/bin/test }
+      probes:
+        - { type: LOG_PROBE, id: hot, where: { methodName: hot }, captureSnapshot: true }
+        - { type: LOG_PROBE, id: cold, where: { methodName: cold }, captureSnapshot: true }
+- !loaded
+  program_id: 1
+  runtime_stats:
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
+- !attached { program_id: 1, process_id: 1001 }
+- !heartbeat-check
+- !runtime-stats
+  program_id: 1
+  runtime_stats:
+    - hit_cnt: 5      # cold probe (alphabetically first), barely any work
+      throttled_cnt: 0
+      cpu: 100ns
+    - hit_cnt: 100000 # hot probe, expensive
+      throttled_cnt: 0
+      cpu: 5s
+# This heartbeat trips the hot probe, schedules a recompile, and
+# detaches the program. The cold probe continues in the new program.
+- !heartbeat-check
+- !detached { program_id: 1, process_id: 1001 }
+- !unloaded { program_id: 1 }
+# The recompile fires once the pipeline is idle; expect a new program
+# (id 2) with only the cold probe.
+- !loaded
+  program_id: 2
+  runtime_stats:
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
+- !attached { program_id: 2, process_id: 1001 }
+- !heartbeat-check
+---
+event: !processes-updated
+  updated:
+    - process_id: {pid: 1001}
+      executable: {path: /usr/bin/test}
+      probes:
+        - {type: LOG_PROBE, id: hot, where: {methodName: hot}, captureSnapshot: true}
+        - {type: LOG_PROBE, id: cold, where: {methodName: cold}, captureSnapshot: true}
+effects:
+  - !spawn-bpf-loading {executable: /usr/bin/test@0.0m0.0, probes: [cold, hot], process_id: 1001, program_id: 1}
+state:
+  currently_loading: <nil> -> 1
+  queued_programs: '[]'
+  processes:
+    1001: <nil> -> WaitingForProgram (prog 1)
+  programs:
+    1: <nil> -> Loading (proc 1001)
+  stats:
+    numProcesses: 0 -> 1
+    numPrograms: 0 -> 1
+    numWaitingForProgram: 0 -> 1
+---
+event: !loaded
+  program_id: 1
+  runtime_stats:
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
+effects:
+  - !attach-to-process {executable: /usr/bin/test@0.0m0.0, process_id: 1001, program_id: 1}
+state:
+  currently_loading: 1 -> <nil>
+  queued_programs: '[]'
+  processes:
+    1001: WaitingForProgram (prog 1) -> Attaching (prog 1)
+  programs:
+    1: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 0 -> 1
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
+---
+event: !attached {program_id: 1, process_id: 1001}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attaching (prog 1) -> Attached (prog 1)
+  programs:
+    1: Loaded (proc 1001)
+  stats:
+    attached: 0 -> 1
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
+---
+event: !heartbeat-check
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 1)
+  programs:
+    1: Loaded (proc 1001)
+---
+event: !runtime-stats
+  program_id: 1
+  runtime_stats:
+    - hit_cnt: 5
+      throttled_cnt: 0
+      cpu: 100ns
+    - hit_cnt: 100000
+      throttled_cnt: 0
+      cpu: 5s
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 1)
+  programs:
+    1: Loaded (proc 1001)
+---
+event: !heartbeat-check
+effects:
+  - !report-probe-error {probe_id: hot, process_id: 1001, program_id: 1, reason: "yes"}
+  - !detach-from-process {failure: "no", process_id: 1001, program_id: 1}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 1) -> Detaching (prog 1)
+  programs:
+    1: Loaded (proc 1001) -> Draining (proc 1001)
+  stats:
+    numAttached: 1 -> 0
+    numDetaching: 0 -> 1
+    typeRecompilationsTriggered: 0 -> 1
+---
+event: !detached {program_id: 1, process_id: 1001}
+effects:
+  - !unload-program {program_id: 1}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 1)
+  programs:
+    1: Draining (proc 1001) -> Unloading (proc 1001)
+  stats:
+    detached: 0 -> 1
+---
+event: !unloaded {program_id: 1}
+effects:
+  - !spawn-bpf-loading {executable: /usr/bin/test@0.0m0.0, probes: [cold], process_id: 1001, program_id: 2}
+state:
+  currently_loading: <nil> -> 2
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 1) -> WaitingForProgram (prog 2)
+  programs:
+    1: Unloading (proc 1001) -> <nil>
+    2: <nil> -> Loading (proc 1001)
+  stats:
+    numDetaching: 1 -> 0
+    numWaitingForProgram: 0 -> 1
+    unloaded: 0 -> 1
+---
+event: !loaded
+  program_id: 2
+  runtime_stats:
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
+effects:
+  - !attach-to-process {executable: /usr/bin/test@0.0m0.0, process_id: 1001, program_id: 2}
+state:
+  currently_loading: 2 -> <nil>
+  queued_programs: '[]'
+  processes:
+    1001: WaitingForProgram (prog 2) -> Attaching (prog 2)
+  programs:
+    2: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 1 -> 2
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
+---
+event: !attached {program_id: 2, process_id: 1001}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attaching (prog 2) -> Attached (prog 2)
+  programs:
+    2: Loaded (proc 1001)
+  stats:
+    attached: 1 -> 2
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
+---
+event: !heartbeat-check
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 2)
+  programs:
+    2: Loaded (proc 1001)
+---

--- a/pkg/dyninst/actuator/testdata/snapshot/circuit_breaker_readdition_resets.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/circuit_breaker_readdition_resets.yaml
@@ -173,7 +173,7 @@ state:
   currently_loading: <nil>
   queued_programs: '[]'
   processes:
-    1001: Attached (prog 1) -> Detaching (prog 1)
+    1001: Attached (prog 1) -> Detaching (prog 1) circuitBroken=[hot]
   programs:
     1: Loaded (proc 1001) -> Draining (proc 1001)
   stats:
@@ -188,7 +188,7 @@ state:
   currently_loading: <nil>
   queued_programs: '[]'
   processes:
-    1001: Detaching (prog 1)
+    1001: Detaching (prog 1) circuitBroken=[hot]
   programs:
     1: Draining (proc 1001) -> Unloading (proc 1001)
   stats:
@@ -201,7 +201,7 @@ state:
   currently_loading: <nil> -> 2
   queued_programs: '[]'
   processes:
-    1001: Detaching (prog 1) -> WaitingForProgram (prog 2)
+    1001: Detaching (prog 1) circuitBroken=[hot] -> WaitingForProgram (prog 2) circuitBroken=[hot]
   programs:
     1: Unloading (proc 1001) -> <nil>
     2: <nil> -> Loading (proc 1001)
@@ -222,7 +222,7 @@ state:
   currently_loading: 2 -> <nil>
   queued_programs: '[]'
   processes:
-    1001: WaitingForProgram (prog 2) -> Attaching (prog 2)
+    1001: WaitingForProgram (prog 2) circuitBroken=[hot] -> Attaching (prog 2) circuitBroken=[hot]
   programs:
     2: Loading (proc 1001) -> Loaded (proc 1001)
   stats:
@@ -235,7 +235,7 @@ state:
   currently_loading: <nil>
   queued_programs: '[]'
   processes:
-    1001: Attaching (prog 2) -> Attached (prog 2)
+    1001: Attaching (prog 2) circuitBroken=[hot] -> Attached (prog 2) circuitBroken=[hot]
   programs:
     2: Loaded (proc 1001)
   stats:
@@ -255,7 +255,7 @@ state:
   currently_loading: <nil>
   queued_programs: '[]'
   processes:
-    1001: Attached (prog 2) -> Detaching (prog 2)
+    1001: Attached (prog 2) circuitBroken=[hot] -> Detaching (prog 2)
   programs:
     2: Loaded (proc 1001) -> Draining (proc 1001)
   stats:

--- a/pkg/dyninst/actuator/testdata/snapshot/circuit_breaker_readdition_resets.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/circuit_breaker_readdition_resets.yaml
@@ -1,0 +1,411 @@
+# Tests that removing a circuit-broken probe (via a processes-updated
+# event with a different probe set) clears its entry from
+# circuitBrokenProbes, so a later re-addition of the same probe
+# identity is treated as a fresh attempt.
+- !config { discovered_types_limit: 0, per_probe_cpu_limit: 0.5, all_probes_cpu_limit: 100 }
+- !processes-updated
+  updated:
+    - process_id: { pid: 1001 }
+      executable: { path: /usr/bin/test }
+      probes:
+        - { type: LOG_PROBE, id: hot, where: { methodName: hot }, captureSnapshot: true }
+        - { type: LOG_PROBE, id: cold, where: { methodName: cold }, captureSnapshot: true }
+- !loaded
+  program_id: 1
+  runtime_stats:
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
+- !attached { program_id: 1, process_id: 1001 }
+- !heartbeat-check
+- !runtime-stats
+  program_id: 1
+  runtime_stats:
+    - hit_cnt: 5
+      throttled_cnt: 0
+      cpu: 100ns
+    - hit_cnt: 100000
+      throttled_cnt: 0
+      cpu: 5s
+# Trip hot.
+- !heartbeat-check
+- !detached { program_id: 1, process_id: 1001 }
+- !unloaded { program_id: 1 }
+# Recompile fires; new program 2 has only cold.
+- !loaded
+  program_id: 2
+  runtime_stats:
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
+- !attached { program_id: 2, process_id: 1001 }
+# Operator removes hot from the configuration entirely.
+- !processes-updated
+  updated:
+    - process_id: { pid: 1001 }
+      executable: { path: /usr/bin/test }
+      probes:
+        - { type: LOG_PROBE, id: cold, where: { methodName: cold }, captureSnapshot: true }
+- !detached { program_id: 2, process_id: 1001 }
+- !unloaded { program_id: 2 }
+- !loaded
+  program_id: 3
+  runtime_stats:
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
+- !attached { program_id: 3, process_id: 1001 }
+# Operator re-adds hot. Without the readdition-resets logic, hot
+# would still be in circuitBrokenProbes and would be filtered out
+# on the next compile. With it, hot is freshly evaluated.
+- !processes-updated
+  updated:
+    - process_id: { pid: 1001 }
+      executable: { path: /usr/bin/test }
+      probes:
+        - { type: LOG_PROBE, id: hot, where: { methodName: hot }, captureSnapshot: true }
+        - { type: LOG_PROBE, id: cold, where: { methodName: cold }, captureSnapshot: true }
+- !detached { program_id: 3, process_id: 1001 }
+- !unloaded { program_id: 3 }
+# Expect program 4 to contain BOTH cold and hot.
+- !loaded
+  program_id: 4
+  runtime_stats:
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
+- !attached { program_id: 4, process_id: 1001 }
+---
+event: !processes-updated
+  updated:
+    - process_id: {pid: 1001}
+      executable: {path: /usr/bin/test}
+      probes:
+        - {type: LOG_PROBE, id: hot, where: {methodName: hot}, captureSnapshot: true}
+        - {type: LOG_PROBE, id: cold, where: {methodName: cold}, captureSnapshot: true}
+effects:
+  - !spawn-bpf-loading {executable: /usr/bin/test@0.0m0.0, probes: [cold, hot], process_id: 1001, program_id: 1}
+state:
+  currently_loading: <nil> -> 1
+  queued_programs: '[]'
+  processes:
+    1001: <nil> -> WaitingForProgram (prog 1)
+  programs:
+    1: <nil> -> Loading (proc 1001)
+  stats:
+    numProcesses: 0 -> 1
+    numPrograms: 0 -> 1
+    numWaitingForProgram: 0 -> 1
+---
+event: !loaded
+  program_id: 1
+  runtime_stats:
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
+effects:
+  - !attach-to-process {executable: /usr/bin/test@0.0m0.0, process_id: 1001, program_id: 1}
+state:
+  currently_loading: 1 -> <nil>
+  queued_programs: '[]'
+  processes:
+    1001: WaitingForProgram (prog 1) -> Attaching (prog 1)
+  programs:
+    1: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 0 -> 1
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
+---
+event: !attached {program_id: 1, process_id: 1001}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attaching (prog 1) -> Attached (prog 1)
+  programs:
+    1: Loaded (proc 1001)
+  stats:
+    attached: 0 -> 1
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
+---
+event: !heartbeat-check
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 1)
+  programs:
+    1: Loaded (proc 1001)
+---
+event: !runtime-stats
+  program_id: 1
+  runtime_stats:
+    - hit_cnt: 5
+      throttled_cnt: 0
+      cpu: 100ns
+    - hit_cnt: 100000
+      throttled_cnt: 0
+      cpu: 5s
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 1)
+  programs:
+    1: Loaded (proc 1001)
+---
+event: !heartbeat-check
+effects:
+  - !report-probe-error {probe_id: hot, process_id: 1001, program_id: 1, reason: "yes"}
+  - !detach-from-process {failure: "no", process_id: 1001, program_id: 1}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 1) -> Detaching (prog 1)
+  programs:
+    1: Loaded (proc 1001) -> Draining (proc 1001)
+  stats:
+    numAttached: 1 -> 0
+    numDetaching: 0 -> 1
+    typeRecompilationsTriggered: 0 -> 1
+---
+event: !detached {program_id: 1, process_id: 1001}
+effects:
+  - !unload-program {program_id: 1}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 1)
+  programs:
+    1: Draining (proc 1001) -> Unloading (proc 1001)
+  stats:
+    detached: 0 -> 1
+---
+event: !unloaded {program_id: 1}
+effects:
+  - !spawn-bpf-loading {executable: /usr/bin/test@0.0m0.0, probes: [cold], process_id: 1001, program_id: 2}
+state:
+  currently_loading: <nil> -> 2
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 1) -> WaitingForProgram (prog 2)
+  programs:
+    1: Unloading (proc 1001) -> <nil>
+    2: <nil> -> Loading (proc 1001)
+  stats:
+    numDetaching: 1 -> 0
+    numWaitingForProgram: 0 -> 1
+    unloaded: 0 -> 1
+---
+event: !loaded
+  program_id: 2
+  runtime_stats:
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
+effects:
+  - !attach-to-process {executable: /usr/bin/test@0.0m0.0, process_id: 1001, program_id: 2}
+state:
+  currently_loading: 2 -> <nil>
+  queued_programs: '[]'
+  processes:
+    1001: WaitingForProgram (prog 2) -> Attaching (prog 2)
+  programs:
+    2: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 1 -> 2
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
+---
+event: !attached {program_id: 2, process_id: 1001}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attaching (prog 2) -> Attached (prog 2)
+  programs:
+    2: Loaded (proc 1001)
+  stats:
+    attached: 1 -> 2
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
+---
+event: !processes-updated
+  updated:
+    - process_id: {pid: 1001}
+      executable: {path: /usr/bin/test}
+      probes:
+        - {type: LOG_PROBE, id: cold, where: {methodName: cold}, captureSnapshot: true}
+effects:
+  - !detach-from-process {failure: "no", process_id: 1001, program_id: 2}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 2) -> Detaching (prog 2)
+  programs:
+    2: Loaded (proc 1001) -> Draining (proc 1001)
+  stats:
+    numAttached: 1 -> 0
+    numDetaching: 0 -> 1
+---
+event: !detached {program_id: 2, process_id: 1001}
+effects:
+  - !unload-program {program_id: 2}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 2)
+  programs:
+    2: Draining (proc 1001) -> Unloading (proc 1001)
+  stats:
+    detached: 1 -> 2
+---
+event: !unloaded {program_id: 2}
+effects:
+  - !spawn-bpf-loading {executable: /usr/bin/test@0.0m0.0, probes: [cold], process_id: 1001, program_id: 3}
+state:
+  currently_loading: <nil> -> 3
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 2) -> WaitingForProgram (prog 3)
+  programs:
+    2: Unloading (proc 1001) -> <nil>
+    3: <nil> -> Loading (proc 1001)
+  stats:
+    numDetaching: 1 -> 0
+    numWaitingForProgram: 0 -> 1
+    unloaded: 1 -> 2
+---
+event: !loaded
+  program_id: 3
+  runtime_stats:
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
+effects:
+  - !attach-to-process {executable: /usr/bin/test@0.0m0.0, process_id: 1001, program_id: 3}
+state:
+  currently_loading: 3 -> <nil>
+  queued_programs: '[]'
+  processes:
+    1001: WaitingForProgram (prog 3) -> Attaching (prog 3)
+  programs:
+    3: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 2 -> 3
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
+---
+event: !attached {program_id: 3, process_id: 1001}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attaching (prog 3) -> Attached (prog 3)
+  programs:
+    3: Loaded (proc 1001)
+  stats:
+    attached: 2 -> 3
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
+---
+event: !processes-updated
+  updated:
+    - process_id: {pid: 1001}
+      executable: {path: /usr/bin/test}
+      probes:
+        - {type: LOG_PROBE, id: hot, where: {methodName: hot}, captureSnapshot: true}
+        - {type: LOG_PROBE, id: cold, where: {methodName: cold}, captureSnapshot: true}
+effects:
+  - !detach-from-process {failure: "no", process_id: 1001, program_id: 3}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 3) -> Detaching (prog 3)
+  programs:
+    3: Loaded (proc 1001) -> Draining (proc 1001)
+  stats:
+    numAttached: 1 -> 0
+    numDetaching: 0 -> 1
+---
+event: !detached {program_id: 3, process_id: 1001}
+effects:
+  - !unload-program {program_id: 3}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 3)
+  programs:
+    3: Draining (proc 1001) -> Unloading (proc 1001)
+  stats:
+    detached: 2 -> 3
+---
+event: !unloaded {program_id: 3}
+effects:
+  - !spawn-bpf-loading {executable: /usr/bin/test@0.0m0.0, probes: [cold, hot], process_id: 1001, program_id: 4}
+state:
+  currently_loading: <nil> -> 4
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 3) -> WaitingForProgram (prog 4)
+  programs:
+    3: Unloading (proc 1001) -> <nil>
+    4: <nil> -> Loading (proc 1001)
+  stats:
+    numDetaching: 1 -> 0
+    numWaitingForProgram: 0 -> 1
+    unloaded: 2 -> 3
+---
+event: !loaded
+  program_id: 4
+  runtime_stats:
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
+effects:
+  - !attach-to-process {executable: /usr/bin/test@0.0m0.0, process_id: 1001, program_id: 4}
+state:
+  currently_loading: 4 -> <nil>
+  queued_programs: '[]'
+  processes:
+    1001: WaitingForProgram (prog 4) -> Attaching (prog 4)
+  programs:
+    4: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 3 -> 4
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
+---
+event: !attached {program_id: 4, process_id: 1001}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attaching (prog 4) -> Attached (prog 4)
+  programs:
+    4: Loaded (proc 1001)
+  stats:
+    attached: 3 -> 4
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
+---

--- a/pkg/dyninst/actuator/testdata/snapshot/circuit_breaker_recompile_disabled.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/circuit_breaker_recompile_disabled.yaml
@@ -1,21 +1,28 @@
-# Tests circuit breaker behavior with runtime stat updates.
-# After the per-probe stats migration the runtime_stats list is keyed
-# by probe_id (not per-CPU); the test process has a single probe.
-- !config { discovered_types_limit: 0, per_probe_cpu_limit: 0.01, all_probes_cpu_limit: 1000 }
+# Tests circuit-breaker behavior when recompilation is disabled
+# (recompilation_rate_limit < 0). A per-probe trip records the probe
+# in circuitBrokenProbes and emits the ExecutionFailed diagnostic, but
+# no recompile is queued: the broken probe stays attached. This locks
+# in the documented degraded behavior described in the checkCosts
+# comment.
+- !config {
+    discovered_types_limit: 0,
+    per_probe_cpu_limit: 0.5,
+    all_probes_cpu_limit: 100,
+    recompilation_rate_limit: -1,
+  }
 - !processes-updated
   updated:
     - process_id: { pid: 1001 }
       executable: { path: /usr/bin/test }
       probes:
-        - {
-            type: LOG_PROBE,
-            id: probe1,
-            where: { methodName: main },
-            captureSnapshot: true,
-          }
+        - { type: LOG_PROBE, id: hot, where: { methodName: hot }, captureSnapshot: true }
+        - { type: LOG_PROBE, id: cold, where: { methodName: cold }, captureSnapshot: true }
 - !loaded
   program_id: 1
   runtime_stats:
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
     - hit_cnt: 0
       throttled_cnt: 0
       cpu: 0s
@@ -24,17 +31,27 @@
 - !runtime-stats
   program_id: 1
   runtime_stats:
-    - hit_cnt: 1200
+    - hit_cnt: 5
       throttled_cnt: 0
-      cpu: 3000ns
+      cpu: 100ns
+    - hit_cnt: 100000
+      throttled_cnt: 0
+      cpu: 5s
+# Trips hot. ExecutionFailed is reported, circuitBrokenProbes is set,
+# but no detach/recompile is scheduled.
 - !heartbeat-check
-# Second heartbeat check should trigger the circuit breaker.
+# A second heartbeat should not re-trip an already-broken probe (the
+# tripProbe idempotency check) -- even though stats still show hot
+# probe activity, no second ExecutionFailed should fire.
 - !runtime-stats
   program_id: 1
   runtime_stats:
-    - hit_cnt: 7000
+    - hit_cnt: 10
       throttled_cnt: 0
-      cpu: 1500s
+      cpu: 200ns
+    - hit_cnt: 200000
+      throttled_cnt: 0
+      cpu: 10s
 - !heartbeat-check
 ---
 event: !processes-updated
@@ -42,9 +59,10 @@ event: !processes-updated
     - process_id: {pid: 1001}
       executable: {path: /usr/bin/test}
       probes:
-        - {type: LOG_PROBE, id: probe1, where: {methodName: main}, captureSnapshot: true}
+        - {type: LOG_PROBE, id: hot, where: {methodName: hot}, captureSnapshot: true}
+        - {type: LOG_PROBE, id: cold, where: {methodName: cold}, captureSnapshot: true}
 effects:
-  - !spawn-bpf-loading {executable: /usr/bin/test@0.0m0.0, probes: [probe1], process_id: 1001, program_id: 1}
+  - !spawn-bpf-loading {executable: /usr/bin/test@0.0m0.0, probes: [cold, hot], process_id: 1001, program_id: 1}
 state:
   currently_loading: <nil> -> 1
   queued_programs: '[]'
@@ -60,6 +78,9 @@ state:
 event: !loaded
   program_id: 1
   runtime_stats:
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
     - hit_cnt: 0
       throttled_cnt: 0
       cpu: 0s
@@ -102,32 +123,12 @@ state:
 event: !runtime-stats
   program_id: 1
   runtime_stats:
-    - hit_cnt: 1200
+    - hit_cnt: 5
       throttled_cnt: 0
-      cpu: 3000ns
-state:
-  currently_loading: <nil>
-  queued_programs: '[]'
-  processes:
-    1001: Attached (prog 1)
-  programs:
-    1: Loaded (proc 1001)
----
-event: !heartbeat-check
-state:
-  currently_loading: <nil>
-  queued_programs: '[]'
-  processes:
-    1001: Attached (prog 1)
-  programs:
-    1: Loaded (proc 1001)
----
-event: !runtime-stats
-  program_id: 1
-  runtime_stats:
-    - hit_cnt: 7000
+      cpu: 100ns
+    - hit_cnt: 100000
       throttled_cnt: 0
-      cpu: 1500s
+      cpu: 5s
 state:
   currently_loading: <nil>
   queued_programs: '[]'
@@ -138,17 +139,38 @@ state:
 ---
 event: !heartbeat-check
 effects:
-  - !report-probe-error {probe_id: probe1, process_id: 1001, program_id: 1, reason: "yes"}
-  - !detach-from-process {failure: "no", process_id: 1001, program_id: 1}
+  - !report-probe-error {probe_id: hot, process_id: 1001, program_id: 1, reason: "yes"}
 state:
   currently_loading: <nil>
   queued_programs: '[]'
   processes:
-    1001: Attached (prog 1) -> Detaching (prog 1) circuitBroken=[probe1]
+    1001: Attached (prog 1) -> Attached (prog 1) circuitBroken=[hot]
   programs:
-    1: Loaded (proc 1001) -> Draining (proc 1001)
-  stats:
-    numAttached: 1 -> 0
-    numDetaching: 0 -> 1
-    typeRecompilationsTriggered: 0 -> 1
+    1: Loaded (proc 1001)
+---
+event: !runtime-stats
+  program_id: 1
+  runtime_stats:
+    - hit_cnt: 10
+      throttled_cnt: 0
+      cpu: 200ns
+    - hit_cnt: 200000
+      throttled_cnt: 0
+      cpu: 10s
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 1) circuitBroken=[hot]
+  programs:
+    1: Loaded (proc 1001)
+---
+event: !heartbeat-check
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 1) circuitBroken=[hot]
+  programs:
+    1: Loaded (proc 1001)
 ---

--- a/pkg/dyninst/actuator/testdata/snapshot/circuit_breaker_recompile_rate_limited.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/circuit_breaker_recompile_rate_limited.yaml
@@ -1,17 +1,32 @@
-# Tests that when one probe trips PerProbeCPULimit on a multi-probe
-# program, only that probe is excluded on recompile; the surviving
-# probe continues to instrument the process.
-- !config { discovered_types_limit: 0, per_probe_cpu_limit: 0.5, all_probes_cpu_limit: 100 }
+# Tests that when recompilation is rate-limited (burst=1), a per-probe
+# trip on a second probe after the first recompile has consumed the
+# token leaves the second probe marked circuit-broken with its program
+# flagged needsRecompilation, but no detach is triggered until the
+# allowance replenishes. Until the recompile actually fires, the broken
+# probe stays attached -- and its cost continues to appear in
+# RuntimeStats but is excluded from AllProbesCPULimit accounting (see
+# the comment in checkCosts).
+- !config {
+    discovered_types_limit: 0,
+    per_probe_cpu_limit: 0.5,
+    all_probes_cpu_limit: 100,
+    recompilation_rate_limit: 0.001,
+    recompilation_rate_burst: 1,
+  }
 - !processes-updated
   updated:
     - process_id: { pid: 1001 }
       executable: { path: /usr/bin/test }
       probes:
-        - { type: LOG_PROBE, id: hot, where: { methodName: hot }, captureSnapshot: true }
-        - { type: LOG_PROBE, id: cold, where: { methodName: cold }, captureSnapshot: true }
+        - { type: LOG_PROBE, id: a, where: { methodName: a }, captureSnapshot: true }
+        - { type: LOG_PROBE, id: b, where: { methodName: b }, captureSnapshot: true }
+        - { type: LOG_PROBE, id: c, where: { methodName: c }, captureSnapshot: true }
 - !loaded
   program_id: 1
   runtime_stats:
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
     - hit_cnt: 0
       throttled_cnt: 0
       cpu: 0s
@@ -20,29 +35,49 @@
       cpu: 0s
 - !attached { program_id: 1, process_id: 1001 }
 - !heartbeat-check
+# Probe a is hot; b and c are cold.
 - !runtime-stats
   program_id: 1
   runtime_stats:
-    - hit_cnt: 5      # cold probe (alphabetically first), barely any work
+    - hit_cnt: 100000
       throttled_cnt: 0
-      cpu: 100ns
-    - hit_cnt: 100000 # hot probe, expensive
+      cpu: 5s     # a: 5 cpus/s -- trips PerProbeCPULimit
+    - hit_cnt: 5
       throttled_cnt: 0
-      cpu: 5s
-# This heartbeat trips the hot probe, schedules a recompile, and
-# detaches the program. The cold probe continues in the new program.
+      cpu: 100ns  # b: ~0 cpus/s
+    - hit_cnt: 5
+      throttled_cnt: 0
+      cpu: 100ns  # c: ~0 cpus/s
+# Heartbeat 2: trips a, consumes the recompile token, detaches.
 - !heartbeat-check
 - !detached { program_id: 1, process_id: 1001 }
 - !unloaded { program_id: 1 }
-# The recompile fires once the pipeline is idle; expect a new program
-# (id 2) with only the cold probe.
 - !loaded
   program_id: 2
   runtime_stats:
     - hit_cnt: 0
       throttled_cnt: 0
       cpu: 0s
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
 - !attached { program_id: 2, process_id: 1001 }
+- !heartbeat-check
+# Now probe b spikes. b is the second probe in stats_buf order (since
+# a was filtered out, b is index 0 and c is index 1).
+- !runtime-stats
+  program_id: 2
+  runtime_stats:
+    - hit_cnt: 100000
+      throttled_cnt: 0
+      cpu: 5s     # b: 5 cpus/s -- trips PerProbeCPULimit
+    - hit_cnt: 5
+      throttled_cnt: 0
+      cpu: 100ns  # c: ~0 cpus/s
+# Heartbeat 4: trips b. needsRecompilation is set, but the token was
+# consumed by the previous recompile and at rate=0.001 per second over
+# four 1s heartbeats only 0.004 tokens have accumulated. No detach is
+# scheduled this tick.
 - !heartbeat-check
 ---
 event: !processes-updated
@@ -50,10 +85,11 @@ event: !processes-updated
     - process_id: {pid: 1001}
       executable: {path: /usr/bin/test}
       probes:
-        - {type: LOG_PROBE, id: hot, where: {methodName: hot}, captureSnapshot: true}
-        - {type: LOG_PROBE, id: cold, where: {methodName: cold}, captureSnapshot: true}
+        - {type: LOG_PROBE, id: a, where: {methodName: a}, captureSnapshot: true}
+        - {type: LOG_PROBE, id: b, where: {methodName: b}, captureSnapshot: true}
+        - {type: LOG_PROBE, id: c, where: {methodName: c}, captureSnapshot: true}
 effects:
-  - !spawn-bpf-loading {executable: /usr/bin/test@0.0m0.0, probes: [cold, hot], process_id: 1001, program_id: 1}
+  - !spawn-bpf-loading {executable: /usr/bin/test@0.0m0.0, probes: [a, b, c], process_id: 1001, program_id: 1}
 state:
   currently_loading: <nil> -> 1
   queued_programs: '[]'
@@ -69,6 +105,9 @@ state:
 event: !loaded
   program_id: 1
   runtime_stats:
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
     - hit_cnt: 0
       throttled_cnt: 0
       cpu: 0s
@@ -114,12 +153,15 @@ state:
 event: !runtime-stats
   program_id: 1
   runtime_stats:
-    - hit_cnt: 5
-      throttled_cnt: 0
-      cpu: 100ns
     - hit_cnt: 100000
       throttled_cnt: 0
       cpu: 5s
+    - hit_cnt: 5
+      throttled_cnt: 0
+      cpu: 100ns
+    - hit_cnt: 5
+      throttled_cnt: 0
+      cpu: 100ns
 state:
   currently_loading: <nil>
   queued_programs: '[]'
@@ -130,13 +172,13 @@ state:
 ---
 event: !heartbeat-check
 effects:
-  - !report-probe-error {probe_id: hot, process_id: 1001, program_id: 1, reason: "yes"}
+  - !report-probe-error {probe_id: a, process_id: 1001, program_id: 1, reason: "yes"}
   - !detach-from-process {failure: "no", process_id: 1001, program_id: 1}
 state:
   currently_loading: <nil>
   queued_programs: '[]'
   processes:
-    1001: Attached (prog 1) -> Detaching (prog 1) circuitBroken=[hot]
+    1001: Attached (prog 1) -> Detaching (prog 1) circuitBroken=[a]
   programs:
     1: Loaded (proc 1001) -> Draining (proc 1001)
   stats:
@@ -151,7 +193,7 @@ state:
   currently_loading: <nil>
   queued_programs: '[]'
   processes:
-    1001: Detaching (prog 1) circuitBroken=[hot]
+    1001: Detaching (prog 1) circuitBroken=[a]
   programs:
     1: Draining (proc 1001) -> Unloading (proc 1001)
   stats:
@@ -159,12 +201,12 @@ state:
 ---
 event: !unloaded {program_id: 1}
 effects:
-  - !spawn-bpf-loading {executable: /usr/bin/test@0.0m0.0, probes: [cold], process_id: 1001, program_id: 2}
+  - !spawn-bpf-loading {executable: /usr/bin/test@0.0m0.0, probes: [b, c], process_id: 1001, program_id: 2}
 state:
   currently_loading: <nil> -> 2
   queued_programs: '[]'
   processes:
-    1001: Detaching (prog 1) circuitBroken=[hot] -> WaitingForProgram (prog 2) circuitBroken=[hot]
+    1001: Detaching (prog 1) circuitBroken=[a] -> WaitingForProgram (prog 2) circuitBroken=[a]
   programs:
     1: Unloading (proc 1001) -> <nil>
     2: <nil> -> Loading (proc 1001)
@@ -179,13 +221,16 @@ event: !loaded
     - hit_cnt: 0
       throttled_cnt: 0
       cpu: 0s
+    - hit_cnt: 0
+      throttled_cnt: 0
+      cpu: 0s
 effects:
   - !attach-to-process {executable: /usr/bin/test@0.0m0.0, process_id: 1001, program_id: 2}
 state:
   currently_loading: 2 -> <nil>
   queued_programs: '[]'
   processes:
-    1001: WaitingForProgram (prog 2) circuitBroken=[hot] -> Attaching (prog 2) circuitBroken=[hot]
+    1001: WaitingForProgram (prog 2) circuitBroken=[a] -> Attaching (prog 2) circuitBroken=[a]
   programs:
     2: Loading (proc 1001) -> Loaded (proc 1001)
   stats:
@@ -198,7 +243,7 @@ state:
   currently_loading: <nil>
   queued_programs: '[]'
   processes:
-    1001: Attaching (prog 2) circuitBroken=[hot] -> Attached (prog 2) circuitBroken=[hot]
+    1001: Attaching (prog 2) circuitBroken=[a] -> Attached (prog 2) circuitBroken=[a]
   programs:
     2: Loaded (proc 1001)
   stats:
@@ -211,7 +256,35 @@ state:
   currently_loading: <nil>
   queued_programs: '[]'
   processes:
-    1001: Attached (prog 2) circuitBroken=[hot]
+    1001: Attached (prog 2) circuitBroken=[a]
+  programs:
+    2: Loaded (proc 1001)
+---
+event: !runtime-stats
+  program_id: 2
+  runtime_stats:
+    - hit_cnt: 100000
+      throttled_cnt: 0
+      cpu: 5s
+    - hit_cnt: 5
+      throttled_cnt: 0
+      cpu: 100ns
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 2) circuitBroken=[a]
+  programs:
+    2: Loaded (proc 1001)
+---
+event: !heartbeat-check
+effects:
+  - !report-probe-error {probe_id: b, process_id: 1001, program_id: 2, reason: "yes"}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 2) circuitBroken=[a] -> Attached (prog 2) circuitBroken=[a,b]
   programs:
     2: Loaded (proc 1001)
 ---

--- a/pkg/dyninst/circuit_breaker_test.go
+++ b/pkg/dyninst/circuit_breaker_test.go
@@ -108,20 +108,35 @@ func testCircuitBreaker(
 	// Start the busy loop.
 	sampleStdin.Write([]byte("\n"))
 
+	// Wait for the hot probe (a, on main.noop) to receive an
+	// ExecutionFailed diagnostic.
 	deadline := time.Now().Add(10 * time.Second)
-	var diags []receivedDiag
-	for time.Now().Before(deadline) {
-		diags = testServer.getDiags()
-		if len(diags) > 0 && diags[len(diags)-1].diagnosticMessage.Debugger.Diagnostic.Status == uploader.StatusError {
-			break
+	var noopFailed *uploader.Diagnostic
+	for time.Now().Before(deadline) && noopFailed == nil {
+		for _, rd := range testServer.getDiags() {
+			d := rd.diagnosticMessage.Debugger.Diagnostic
+			if d.ProbeID == "a" && d.Status == uploader.StatusError {
+				cp := d
+				noopFailed = &cp
+				break
+			}
 		}
-		time.Sleep(5 * time.Millisecond)
+		if noopFailed == nil {
+			time.Sleep(5 * time.Millisecond)
+		}
 	}
-	require.Greater(t, len(diags), 0)
-	d := diags[len(diags)-1].diagnosticMessage.Debugger.Diagnostic
-	require.Equal(t, d.Status, uploader.StatusError)
-	e := d.DiagnosticException
-	require.NotNil(t, e)
-	require.Equal(t, "ExecutionFailed", e.Type)
-	require.Contains(t, e.Message, "exceeded CPU limit")
+	require.NotNil(t, noopFailed, "expected ExecutionFailed diagnostic for probe a")
+	require.NotNil(t, noopFailed.DiagnosticException)
+	require.Equal(t, "ExecutionFailed", noopFailed.DiagnosticException.Type)
+	require.Contains(t, noopFailed.DiagnosticException.Message, "exceeded CPU limit")
+
+	// Per-probe enforcement: the cold probe (b, on main.busyloop)
+	// must not receive an ExecutionFailed diagnostic, even after the
+	// recompile that excludes probe a.
+	for _, rd := range testServer.getDiags() {
+		d := rd.diagnosticMessage.Debugger.Diagnostic
+		if d.ProbeID == "b" && d.Status == uploader.StatusError {
+			t.Fatalf("probe b should not have failed: %+v", d.DiagnosticException)
+		}
+	}
 }

--- a/pkg/dyninst/compiler/generate.go
+++ b/pkg/dyninst/compiler/generate.go
@@ -44,6 +44,7 @@ type Program struct {
 	Functions        []Function
 	Types            []ir.Type
 	Throttlers       []Throttler
+	NumProbes        uint32
 	GoModuledataInfo ir.GoModuledataInfo
 	GoMapHashInfo    ir.GoMapHashInfo
 	CommonTypes      ir.CommonTypes
@@ -216,6 +217,7 @@ func GenerateProgram(program *ir.Program) (Program, error) {
 		Functions:        g.functions,
 		Types:            types,
 		Throttlers:       throttlers,
+		NumProbes:        uint32(len(program.Probes)),
 		GoModuledataInfo: program.GoModuledataInfo,
 		GoMapHashInfo:    program.GoMapHashInfo,
 		CommonTypes:      program.CommonTypes,

--- a/pkg/dyninst/ebpf/event.c
+++ b/pkg/dyninst/ebpf/event.c
@@ -366,26 +366,37 @@ probe_run(uint64_t start_ns, const probe_params_t* params, struct pt_regs* regs)
   return;
 }
 
-// Cumulative stats aggregated throughout probe lifetime.
+// Cumulative per-probe stats. ARRAY (not PERCPU_ARRAY) so we can size
+// it to num_probes and key by probe_id; updates use __sync atomics to
+// remain race-free across CPUs. Resized to num_probes at load time.
+struct {
+  __uint(type, BPF_MAP_TYPE_ARRAY);
+  __uint(max_entries, 0);
+  __type(key, uint32_t);
+  __type(value, stats_t);
+} stats_buf SEC(".maps");
+
+// Cumulative counter for hits whose attach cookie does not resolve to a
+// valid probe_params slot (should never happen in practice; surfaces
+// cookie misconfigurations). PERCPU since it's the slow/error path
+// only.
 struct {
   __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
   __uint(max_entries, 1);
   __type(key, uint32_t);
   __type(value, stats_t);
-} stats_buf SEC(".maps");
+} orphan_stats SEC(".maps");
 
 SEC("uprobe")
 int probe_run_with_cookie(struct pt_regs* regs) {
   uint64_t start_ns = bpf_ktime_get_ns();
 
-  stats_t* stats = bpf_map_lookup_elem(&stats_buf, &zero_uint32);
-  if (!stats) {
-    return 0;
-  }
-  stats->hit_cnt++;
-
   const uint64_t cookie = bpf_get_attach_cookie(regs);
   if (cookie >= num_probe_params) {
+    stats_t* orphan = bpf_map_lookup_elem(&orphan_stats, &zero_uint32);
+    if (orphan) {
+      orphan->hit_cnt++;
+    }
     return 0;
   }
   const probe_params_t* params = bpf_map_lookup_elem(&probe_params, &cookie);
@@ -393,13 +404,20 @@ int probe_run_with_cookie(struct pt_regs* regs) {
     return 0;
   }
 
+  uint32_t probe_id = params->probe_id;
+  stats_t* stats = bpf_map_lookup_elem(&stats_buf, &probe_id);
+  if (!stats) {
+    return 0;
+  }
+  __sync_fetch_and_add(&stats->hit_cnt, 1);
+
   if (params->throttle_mode == THROTTLE_AT_START && should_throttle(params->throttler_idx, start_ns)) {
-    stats->throttled_cnt++;
+    __sync_fetch_and_add(&stats->throttled_cnt, 1);
   } else {
     probe_run(start_ns, params, regs);
   }
 
-  stats->cpu_ns += bpf_ktime_get_ns() - start_ns;
+  __sync_fetch_and_add(&stats->cpu_ns, bpf_ktime_get_ns() - start_ns);
   return 0;
 }
 

--- a/pkg/dyninst/ebpf/event.c
+++ b/pkg/dyninst/ebpf/event.c
@@ -367,8 +367,8 @@ probe_run(uint64_t start_ns, const probe_params_t* params, struct pt_regs* regs)
 }
 
 // Cumulative per-probe stats. ARRAY (not PERCPU_ARRAY) so we can size
-// it to num_probes and key by probe_id; updates use __sync atomics to
-// remain race-free across CPUs. Resized to num_probes at load time.
+// it per IR probe count and key by probe_id; updates use __sync atomics
+// to remain race-free across CPUs. max_entries is set by the loader.
 struct {
   __uint(type, BPF_MAP_TYPE_ARRAY);
   __uint(max_entries, 0);
@@ -376,27 +376,12 @@ struct {
   __type(value, stats_t);
 } stats_buf SEC(".maps");
 
-// Cumulative counter for hits whose attach cookie does not resolve to a
-// valid probe_params slot (should never happen in practice; surfaces
-// cookie misconfigurations). PERCPU since it's the slow/error path
-// only.
-struct {
-  __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-  __uint(max_entries, 1);
-  __type(key, uint32_t);
-  __type(value, stats_t);
-} orphan_stats SEC(".maps");
-
 SEC("uprobe")
 int probe_run_with_cookie(struct pt_regs* regs) {
   uint64_t start_ns = bpf_ktime_get_ns();
 
   const uint64_t cookie = bpf_get_attach_cookie(regs);
   if (cookie >= num_probe_params) {
-    stats_t* orphan = bpf_map_lookup_elem(&orphan_stats, &zero_uint32);
-    if (orphan) {
-      orphan->hit_cnt++;
-    }
     return 0;
   }
   const probe_params_t* params = bpf_map_lookup_elem(&probe_params, &cookie);

--- a/pkg/dyninst/ebpf/program.h
+++ b/pkg/dyninst/ebpf/program.h
@@ -57,13 +57,6 @@ struct {
 } probe_params SEC(".maps");
 volatile const uint32_t num_probe_params = 0;
 
-// num_probes is the count of distinct IR probes (always >= 1, since
-// stats_buf is sized to it and BPF_MAP_TYPE_ARRAY requires nonzero
-// max_entries). Note that probe_params has one entry per
-// (probe x event-kind x injection PC), while stats_buf has one entry
-// per probe; multiple probe_params slots can share a probe_id.
-volatile const uint32_t num_probes = 0;
-
 struct {
   __uint(type, BPF_MAP_TYPE_ARRAY);
   __uint(max_entries, 0);

--- a/pkg/dyninst/ebpf/program.h
+++ b/pkg/dyninst/ebpf/program.h
@@ -57,6 +57,13 @@ struct {
 } probe_params SEC(".maps");
 volatile const uint32_t num_probe_params = 0;
 
+// num_probes is the count of distinct IR probes (always >= 1, since
+// stats_buf is sized to it and BPF_MAP_TYPE_ARRAY requires nonzero
+// max_entries). Note that probe_params has one entry per
+// (probe x event-kind x injection PC), while stats_buf has one entry
+// per probe; multiple probe_params slots can share a probe_id.
+volatile const uint32_t num_probes = 0;
+
 struct {
   __uint(type, BPF_MAP_TYPE_ARRAY);
   __uint(max_entries, 0);

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.23.11.yaml
@@ -11,8 +11,26 @@ Probes:
         - subprogram: {subprogram: 1}
           events:
             - Kind: Entry
-              Type: 107 EventRootType Probe[main.noop]
+              Type: 110 EventRootType Probe[main.noop]
               InjectionPoints: [{PC: "0x4a5f60", Frameless: true}]
+              Condition: null
+    - id: b
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.busyloop}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 2}
+          events:
+            - Kind: Entry
+              Type: 111 EventRootType Probe[main.busyloop]
+              InjectionPoints: [{PC: "0x4a5f8e", Frameless: false}]
+              Condition: null
+            - Kind: Return
+              Type: 112 EventRootType Probe[main.busyloop]Return
+              InjectionPoints: [{PC: "0x4a6131", Frameless: false}]
               Condition: null
 Subprograms:
     - ID: 1
@@ -20,6 +38,97 @@ Subprograms:
       OutOfLinePCRanges: [0x4a5f60..0x4a5f61]
       InlinePCRanges: []
       Variables: []
+      DictRegister: null
+    - ID: 2
+      Name: main.busyloop
+      OutOfLinePCRanges: [0x4a5f80..0x4a6155]
+      InlinePCRanges: []
+      Variables:
+        - Name: concurrency
+          Type: 11 BaseType int
+          Locations:
+            - Range: 0x4a5f80..0x4a5fa3
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4a5fa3..0x4a6155
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: duration
+          Type: 101 BaseType time.Duration
+          Locations:
+            - Range: 0x4a5f80..0x4a5fa5
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0x4a5fa5..0x4a6155
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: ~r0
+          Type: 19 BaseType float64
+          Locations: [{Range: 0x4a5f80..0x4a6155, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ready
+          Type: 102 GoChannelType chan struct {}
+          Locations:
+            - Range: 0x4a5faa..0x4a5fb8
+              Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4a5fb8..0x4a6155
+              Pieces: [{Size: 0, Op: {CfaOffset: -32}}]
+          Role: Local
+          DictIndex: -1
+        - Name: start
+          Type: 102 GoChannelType chan struct {}
+          Locations:
+            - Range: 0x4a5fbd..0x4a5fcb
+              Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4a5fcb..0x4a6155
+              Pieces: [{Size: 0, Op: {CfaOffset: -40}}]
+          Role: Local
+          DictIndex: -1
+        - Name: stop
+          Type: 102 GoChannelType chan struct {}
+          Locations:
+            - Range: 0x4a5fd0..0x4a5fde
+              Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4a5fde..0x4a6155
+              Pieces: [{Size: 0, Op: {CfaOffset: -48}}]
+          Role: Local
+          DictIndex: -1
+        - Name: counts
+          Type: 103 GoChannelType chan int
+          Locations:
+            - Range: 0x4a5fe5..0x4a5ff1
+              Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4a5ff1..0x4a6006
+              Pieces: [{Size: 0, Op: {CfaOffset: -24}}]
+            - Range: 0x4a6006..0x4a6155
+              Pieces: [{Size: 0, Op: {CfaOffset: -24}}]
+          Role: Local
+          DictIndex: -1
+        - Name: total
+          Type: 11 BaseType int
+          Locations:
+            - Range: 0x4a60da..0x4a60f2
+              Pieces: [{Size: 8, Op: {CfaOffset: -88}}]
+            - Range: 0x4a60f2..0x4a6107
+              Pieces: [{Size: 8, Op: {CfaOffset: -88}}]
+            - Range: 0x4a6107..0x4a6155
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+          Role: Local
+          DictIndex: -1
+        - Name: i
+          Type: 11 BaseType int
+          Locations:
+            - Range: 0x4a600b..0x4a6013
+              Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
+            - Range: 0x4a6013..0x4a6029
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0x4a6029..0x4a607f
+              Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
+            - Range: 0x4a607f..0x4a6084
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+          Role: Local
+          DictIndex: -1
       DictRegister: null
 Types:
     - __kind: PointerType
@@ -30,15 +139,15 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 104
+      ID: 107
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 103 GoSliceDataType []uint8.array
+      Pointee: 106 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 106
+      ID: 109
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 105 GoSliceDataType []uintptr.array
+      Pointee: 108 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 7
       Name: '*bool'
@@ -159,10 +268,10 @@ Types:
       GoKind: 22
       Pointee: 12 GoStringHeaderType string
     - __kind: PointerType
-      ID: 102
+      ID: 105
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 101 GoStringDataType string.str
+      Pointee: 104 GoStringDataType string.str
     - __kind: PointerType
       ID: 99
       Name: '*uint'
@@ -214,7 +323,58 @@ Types:
       Name: '@trace_context'
       ByteSize: 40
     - __kind: EventRootType
-      ID: 107
+      ID: 111
+      Name: Probe[main.busyloop]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: concurrency
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 11 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: concurrency}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: duration
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 101 BaseType time.Duration
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 1, name: duration}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 112
+      Name: Probe[main.busyloop]Return
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: '@return'
+          Offset: 1
+          Kind: return
+          Expression:
+            Type: 19 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 2, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 110
       Name: Probe[main.noop]
     - __kind: ArrayType
       ID: 87
@@ -326,9 +486,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 103 GoSliceDataType []uint8.array
+      Data: 106 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 103
+      ID: 106
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -349,9 +509,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 105 GoSliceDataType []uintptr.array
+      Data: 108 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 105
+      ID: 108
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -362,6 +522,16 @@ Types:
       ByteSize: 1
       GoRuntimeType: 37824
       GoKind: 1
+    - __kind: GoChannelType
+      ID: 103
+      Name: chan int
+      GoRuntimeType: 38912
+      GoKind: 18
+    - __kind: GoChannelType
+      ID: 102
+      Name: chan struct {}
+      GoRuntimeType: 38976
+      GoKind: 18
     - __kind: BaseType
       ID: 92
       Name: complex128
@@ -1259,16 +1429,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 102 PointerType *string.str
+          Type: 105 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 101 GoStringDataType string.str
+      Data: 104 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 101
+      ID: 104
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
+    - __kind: BaseType
+      ID: 101
+      Name: time.Duration
+      ByteSize: 8
+      GoKind: 6
     - __kind: BaseType
       ID: 17
       Name: uint
@@ -1311,7 +1486,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 37888
       GoKind: 26
-MaxTypeID: 107
+MaxTypeID: 112
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x572260", TypesOffset: 296}
 GoMapHashInfo: {UseAeshashAddr: "0x59ba4a", AeskeyschedAddr: "0x59c120"}

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.24.3.yaml
@@ -11,8 +11,26 @@ Probes:
         - subprogram: {subprogram: 1}
           events:
             - Kind: Entry
-              Type: 112 EventRootType Probe[main.noop]
+              Type: 115 EventRootType Probe[main.noop]
               InjectionPoints: [{PC: "0x4a7fe0", Frameless: true}]
+              Condition: null
+    - id: b
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.busyloop}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 2}
+          events:
+            - Kind: Entry
+              Type: 116 EventRootType Probe[main.busyloop]
+              InjectionPoints: [{PC: "0x4a800e", Frameless: false}]
+              Condition: null
+            - Kind: Return
+              Type: 117 EventRootType Probe[main.busyloop]Return
+              InjectionPoints: [{PC: "0x4a81b1", Frameless: false}]
               Condition: null
 Subprograms:
     - ID: 1
@@ -20,6 +38,97 @@ Subprograms:
       OutOfLinePCRanges: [0x4a7fe0..0x4a7fe1]
       InlinePCRanges: []
       Variables: []
+      DictRegister: null
+    - ID: 2
+      Name: main.busyloop
+      OutOfLinePCRanges: [0x4a8000..0x4a81d5]
+      InlinePCRanges: []
+      Variables:
+        - Name: concurrency
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x4a8000..0x4a8023
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4a8023..0x4a81d5
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: duration
+          Type: 106 BaseType time.Duration
+          Locations:
+            - Range: 0x4a8000..0x4a8025
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0x4a8025..0x4a81d5
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: ~r0
+          Type: 20 BaseType float64
+          Locations: [{Range: 0x4a8000..0x4a81d5, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ready
+          Type: 107 GoChannelType chan struct {}
+          Locations:
+            - Range: 0x4a802a..0x4a8036
+              Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4a8036..0x4a81d5
+              Pieces: [{Size: 0, Op: {CfaOffset: -32}}]
+          Role: Local
+          DictIndex: -1
+        - Name: start
+          Type: 107 GoChannelType chan struct {}
+          Locations:
+            - Range: 0x4a803d..0x4a8049
+              Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4a8049..0x4a81d5
+              Pieces: [{Size: 0, Op: {CfaOffset: -40}}]
+          Role: Local
+          DictIndex: -1
+        - Name: stop
+          Type: 107 GoChannelType chan struct {}
+          Locations:
+            - Range: 0x4a8050..0x4a805c
+              Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4a805c..0x4a81d5
+              Pieces: [{Size: 0, Op: {CfaOffset: -48}}]
+          Role: Local
+          DictIndex: -1
+        - Name: counts
+          Type: 108 GoChannelType chan int
+          Locations:
+            - Range: 0x4a8065..0x4a8071
+              Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4a8071..0x4a8086
+              Pieces: [{Size: 0, Op: {CfaOffset: -24}}]
+            - Range: 0x4a8086..0x4a81d5
+              Pieces: [{Size: 0, Op: {CfaOffset: -24}}]
+          Role: Local
+          DictIndex: -1
+        - Name: total
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x4a815a..0x4a8172
+              Pieces: [{Size: 8, Op: {CfaOffset: -88}}]
+            - Range: 0x4a8172..0x4a8187
+              Pieces: [{Size: 8, Op: {CfaOffset: -88}}]
+            - Range: 0x4a8187..0x4a81d5
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+          Role: Local
+          DictIndex: -1
+        - Name: i
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x4a808b..0x4a8093
+              Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
+            - Range: 0x4a8093..0x4a80a9
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0x4a80a9..0x4a80ff
+              Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
+            - Range: 0x4a80ff..0x4a8104
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+          Role: Local
+          DictIndex: -1
       DictRegister: null
 Types:
     - __kind: PointerType
@@ -30,15 +139,15 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 109
+      ID: 112
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 108 GoSliceDataType []uint8.array
+      Pointee: 111 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 111
+      ID: 114
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 110 GoSliceDataType []uintptr.array
+      Pointee: 113 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 13
       Name: '*bool'
@@ -166,10 +275,10 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 107
+      ID: 110
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 106 GoStringDataType string.str
+      Pointee: 109 GoStringDataType string.str
     - __kind: PointerType
       ID: 104
       Name: '*uint'
@@ -221,7 +330,58 @@ Types:
       Name: '@trace_context'
       ByteSize: 40
     - __kind: EventRootType
-      ID: 112
+      ID: 116
+      Name: Probe[main.busyloop]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: concurrency
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: concurrency}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: duration
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 106 BaseType time.Duration
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 1, name: duration}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 117
+      Name: Probe[main.busyloop]Return
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: '@return'
+          Offset: 1
+          Kind: return
+          Expression:
+            Type: 20 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 2, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 115
       Name: Probe[main.noop]
     - __kind: ArrayType
       ID: 94
@@ -349,9 +509,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 108 GoSliceDataType []uint8.array
+      Data: 111 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 108
+      ID: 111
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -372,9 +532,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 110 GoSliceDataType []uintptr.array
+      Data: 113 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 110
+      ID: 113
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -385,6 +545,16 @@ Types:
       ByteSize: 1
       GoRuntimeType: 41632
       GoKind: 1
+    - __kind: GoChannelType
+      ID: 108
+      Name: chan int
+      GoRuntimeType: 42720
+      GoKind: 18
+    - __kind: GoChannelType
+      ID: 107
+      Name: chan struct {}
+      GoRuntimeType: 42784
+      GoKind: 18
     - __kind: BaseType
       ID: 97
       Name: complex128
@@ -1320,16 +1490,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 107 PointerType *string.str
+          Type: 110 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 106 GoStringDataType string.str
+      Data: 109 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 106
+      ID: 109
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
+    - __kind: BaseType
+      ID: 106
+      Name: time.Duration
+      ByteSize: 8
+      GoKind: 6
     - __kind: BaseType
       ID: 18
       Name: uint
@@ -1372,7 +1547,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 41696
       GoKind: 26
-MaxTypeID: 112
+MaxTypeID: 117
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x57d340", TypesOffset: 296}
 GoMapHashInfo: {UseAeshashAddr: "0x5a666a", AeskeyschedAddr: "0x5a6d60"}

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.25.0.yaml
@@ -11,8 +11,26 @@ Probes:
         - subprogram: {subprogram: 1}
           events:
             - Kind: Entry
-              Type: 117 EventRootType Probe[main.noop]
+              Type: 120 EventRootType Probe[main.noop]
               InjectionPoints: [{PC: "0x4ae5e0", Frameless: true}]
+              Condition: null
+    - id: b
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.busyloop}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 2}
+          events:
+            - Kind: Entry
+              Type: 121 EventRootType Probe[main.busyloop]
+              InjectionPoints: [{PC: "0x4ae60e", Frameless: false}]
+              Condition: null
+            - Kind: Return
+              Type: 122 EventRootType Probe[main.busyloop]Return
+              InjectionPoints: [{PC: "0x4ae7ae", Frameless: false}]
               Condition: null
 Subprograms:
     - ID: 1
@@ -20,6 +38,97 @@ Subprograms:
       OutOfLinePCRanges: [0x4ae5e0..0x4ae5e1]
       InlinePCRanges: []
       Variables: []
+      DictRegister: null
+    - ID: 2
+      Name: main.busyloop
+      OutOfLinePCRanges: [0x4ae600..0x4ae7d4]
+      InlinePCRanges: []
+      Variables:
+        - Name: concurrency
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x4ae600..0x4ae623
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4ae623..0x4ae7d4
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: duration
+          Type: 108 BaseType time.Duration
+          Locations:
+            - Range: 0x4ae600..0x4ae625
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0x4ae625..0x4ae7d4
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: ~r0
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x4ae600..0x4ae7d4, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ready
+          Type: 109 GoChannelType chan struct {}
+          Locations:
+            - Range: 0x4ae62a..0x4ae636
+              Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4ae636..0x4ae7d4
+              Pieces: [{Size: 0, Op: {CfaOffset: -32}}]
+          Role: Local
+          DictIndex: -1
+        - Name: start
+          Type: 109 GoChannelType chan struct {}
+          Locations:
+            - Range: 0x4ae63d..0x4ae649
+              Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4ae649..0x4ae7d4
+              Pieces: [{Size: 0, Op: {CfaOffset: -40}}]
+          Role: Local
+          DictIndex: -1
+        - Name: stop
+          Type: 109 GoChannelType chan struct {}
+          Locations:
+            - Range: 0x4ae650..0x4ae65c
+              Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4ae65c..0x4ae7d4
+              Pieces: [{Size: 0, Op: {CfaOffset: -48}}]
+          Role: Local
+          DictIndex: -1
+        - Name: counts
+          Type: 110 GoChannelType chan int
+          Locations:
+            - Range: 0x4ae665..0x4ae671
+              Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4ae671..0x4ae686
+              Pieces: [{Size: 0, Op: {CfaOffset: -24}}]
+            - Range: 0x4ae686..0x4ae7d4
+              Pieces: [{Size: 0, Op: {CfaOffset: -24}}]
+          Role: Local
+          DictIndex: -1
+        - Name: total
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x4ae75a..0x4ae772
+              Pieces: [{Size: 8, Op: {CfaOffset: -88}}]
+            - Range: 0x4ae772..0x4ae784
+              Pieces: [{Size: 8, Op: {CfaOffset: -88}}]
+            - Range: 0x4ae784..0x4ae7d4
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+          Role: Local
+          DictIndex: -1
+        - Name: i
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x4ae68b..0x4ae693
+              Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
+            - Range: 0x4ae693..0x4ae6a9
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0x4ae6a9..0x4ae6ff
+              Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
+            - Range: 0x4ae6ff..0x4ae704
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+          Role: Local
+          DictIndex: -1
       DictRegister: null
 Types:
     - __kind: PointerType
@@ -29,10 +138,10 @@ Types:
       GoKind: 22
       Pointee: 66 PointerType *runtime.p
     - __kind: PointerType
-      ID: 116
+      ID: 119
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 115 GoSliceDataType []*runtime.p.array
+      Pointee: 118 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -41,15 +150,15 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 111
+      ID: 114
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 110 GoSliceDataType []uint8.array
+      Pointee: 113 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 113
+      ID: 116
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 112 GoSliceDataType []uintptr.array
+      Pointee: 115 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 13
       Name: '*bool'
@@ -147,7 +256,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 66496
       GoKind: 22
-      Pointee: 114 UnresolvedPointeeType runtime.p
+      Pointee: 117 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 43
       Name: '*runtime.sudog'
@@ -184,10 +293,10 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 109
+      ID: 112
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 108 GoStringDataType string.str
+      Pointee: 111 GoStringDataType string.str
     - __kind: PointerType
       ID: 106
       Name: '*uint'
@@ -239,7 +348,58 @@ Types:
       Name: '@trace_context'
       ByteSize: 40
     - __kind: EventRootType
-      ID: 117
+      ID: 121
+      Name: Probe[main.busyloop]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: concurrency
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: concurrency}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: duration
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 108 BaseType time.Duration
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 1, name: duration}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 122
+      Name: Probe[main.busyloop]Return
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: '@return'
+          Offset: 1
+          Kind: return
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 2, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 120
       Name: Probe[main.noop]
     - __kind: ArrayType
       ID: 94
@@ -356,9 +516,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 115 GoSliceDataType []*runtime.p.array
+      Data: 118 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 115
+      ID: 118
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -383,9 +543,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 110 GoSliceDataType []uint8.array
+      Data: 113 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 110
+      ID: 113
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -406,9 +566,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 112 GoSliceDataType []uintptr.array
+      Data: 115 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 112
+      ID: 115
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -419,6 +579,16 @@ Types:
       ByteSize: 1
       GoRuntimeType: 43040
       GoKind: 1
+    - __kind: GoChannelType
+      ID: 110
+      Name: chan int
+      GoRuntimeType: 44128
+      GoKind: 18
+    - __kind: GoChannelType
+      ID: 109
+      Name: chan struct {}
+      GoRuntimeType: 44192
+      GoKind: 18
     - __kind: BaseType
       ID: 99
       Name: complex128
@@ -1236,7 +1406,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 3 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 114
+      ID: 117
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
@@ -1361,16 +1531,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 109 PointerType *string.str
+          Type: 112 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 108 GoStringDataType string.str
+      Data: 111 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 108
+      ID: 111
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
+    - __kind: BaseType
+      ID: 108
+      Name: time.Duration
+      ByteSize: 8
+      GoKind: 6
     - __kind: BaseType
       ID: 19
       Name: uint
@@ -1413,7 +1588,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 43104
       GoKind: 26
-MaxTypeID: 117
+MaxTypeID: 122
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x58b3a0", TypesOffset: 296}
 GoMapHashInfo: {UseAeshashAddr: "0x5b4dca", AeskeyschedAddr: "0x5b5460"}

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.26rc1.yaml
@@ -11,8 +11,26 @@ Probes:
         - subprogram: {subprogram: 1}
           events:
             - Kind: Entry
-              Type: 122 EventRootType Probe[main.noop]
+              Type: 125 EventRootType Probe[main.noop]
               InjectionPoints: [{PC: "0x4c1d20", Frameless: true}]
+              Condition: null
+    - id: b
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.busyloop}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 2}
+          events:
+            - Kind: Entry
+              Type: 126 EventRootType Probe[main.busyloop]
+              InjectionPoints: [{PC: "0x4c1d4e", Frameless: false}]
+              Condition: null
+            - Kind: Return
+              Type: 127 EventRootType Probe[main.busyloop]Return
+              InjectionPoints: [{PC: "0x4c1f03", Frameless: false}]
               Condition: null
 Subprograms:
     - ID: 1
@@ -20,6 +38,97 @@ Subprograms:
       OutOfLinePCRanges: [0x4c1d20..0x4c1d21]
       InlinePCRanges: []
       Variables: []
+      DictRegister: null
+    - ID: 2
+      Name: main.busyloop
+      OutOfLinePCRanges: [0x4c1d40..0x4c1f27]
+      InlinePCRanges: []
+      Variables:
+        - Name: concurrency
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x4c1d40..0x4c1d66
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4c1d66..0x4c1f27
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: duration
+          Type: 113 BaseType time.Duration
+          Locations:
+            - Range: 0x4c1d40..0x4c1d68
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0x4c1d68..0x4c1f27
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: ~r0
+          Type: 15 BaseType float64
+          Locations: [{Range: 0x4c1d40..0x4c1f27, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ready
+          Type: 114 GoChannelType chan struct {}
+          Locations:
+            - Range: 0x4c1d6d..0x4c1d79
+              Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4c1d79..0x4c1f27
+              Pieces: [{Size: 0, Op: {CfaOffset: -32}}]
+          Role: Local
+          DictIndex: -1
+        - Name: start
+          Type: 114 GoChannelType chan struct {}
+          Locations:
+            - Range: 0x4c1d85..0x4c1d91
+              Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4c1d91..0x4c1f27
+              Pieces: [{Size: 0, Op: {CfaOffset: -40}}]
+          Role: Local
+          DictIndex: -1
+        - Name: stop
+          Type: 114 GoChannelType chan struct {}
+          Locations:
+            - Range: 0x4c1d98..0x4c1da4
+              Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4c1da4..0x4c1f27
+              Pieces: [{Size: 0, Op: {CfaOffset: -48}}]
+          Role: Local
+          DictIndex: -1
+        - Name: counts
+          Type: 115 GoChannelType chan int
+          Locations:
+            - Range: 0x4c1dab..0x4c1db7
+              Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4c1db7..0x4c1dcc
+              Pieces: [{Size: 0, Op: {CfaOffset: -24}}]
+            - Range: 0x4c1dcc..0x4c1f27
+              Pieces: [{Size: 0, Op: {CfaOffset: -24}}]
+          Role: Local
+          DictIndex: -1
+        - Name: total
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x4c1eaf..0x4c1ec7
+              Pieces: [{Size: 8, Op: {CfaOffset: -88}}]
+            - Range: 0x4c1ec7..0x4c1ed9
+              Pieces: [{Size: 8, Op: {CfaOffset: -88}}]
+            - Range: 0x4c1ed9..0x4c1f27
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+          Role: Local
+          DictIndex: -1
+        - Name: i
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x4c1dd1..0x4c1dd9
+              Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
+            - Range: 0x4c1dd9..0x4c1df4
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0x4c1df4..0x4c1e4f
+              Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
+            - Range: 0x4c1e4f..0x4c1e54
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+          Role: Local
+          DictIndex: -1
       DictRegister: null
 Types:
     - __kind: PointerType
@@ -29,10 +138,10 @@ Types:
       GoKind: 22
       Pointee: 70 PointerType *runtime.p
     - __kind: PointerType
-      ID: 121
+      ID: 124
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 120 GoSliceDataType []*runtime.p.array
+      Pointee: 123 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
       ID: 42
       Name: '*[]runtime.ancestorInfo'
@@ -41,15 +150,15 @@ Types:
       GoKind: 22
       Pointee: 43 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 116
+      ID: 119
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 115 GoSliceDataType []uint8.array
+      Pointee: 118 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 118
+      ID: 121
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 117 GoSliceDataType []uintptr.array
+      Pointee: 120 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 13
       Name: '*bool'
@@ -154,7 +263,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 70368
       GoKind: 22
-      Pointee: 119 UnresolvedPointeeType runtime.p
+      Pointee: 122 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 44
       Name: '*runtime.sudog'
@@ -198,10 +307,10 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 114
+      ID: 117
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 113 GoStringDataType string.str
+      Pointee: 116 GoStringDataType string.str
     - __kind: PointerType
       ID: 111
       Name: '*uint'
@@ -253,7 +362,58 @@ Types:
       Name: '@trace_context'
       ByteSize: 40
     - __kind: EventRootType
-      ID: 122
+      ID: 126
+      Name: Probe[main.busyloop]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: concurrency
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: concurrency}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: duration
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 113 BaseType time.Duration
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 1, name: duration}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 127
+      Name: Probe[main.busyloop]Return
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: '@return'
+          Offset: 1
+          Kind: return
+          Expression:
+            Type: 15 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 2, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 125
       Name: Probe[main.noop]
     - __kind: ArrayType
       ID: 97
@@ -370,9 +530,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 120 GoSliceDataType []*runtime.p.array
+      Data: 123 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 120
+      ID: 123
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -397,9 +557,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 115 GoSliceDataType []uint8.array
+      Data: 118 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 115
+      ID: 118
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -420,9 +580,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 117 GoSliceDataType []uintptr.array
+      Data: 120 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 117
+      ID: 120
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -433,6 +593,16 @@ Types:
       ByteSize: 1
       GoRuntimeType: 45536
       GoKind: 1
+    - __kind: GoChannelType
+      ID: 115
+      Name: chan int
+      GoRuntimeType: 46688
+      GoKind: 18
+    - __kind: GoChannelType
+      ID: 114
+      Name: chan struct {}
+      GoRuntimeType: 46752
+      GoKind: 18
     - __kind: BaseType
       ID: 20
       Name: complex128
@@ -1263,7 +1433,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 3 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 119
+      ID: 122
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
@@ -1402,16 +1572,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 114 PointerType *string.str
+          Type: 117 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 113 GoStringDataType string.str
+      Data: 116 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 113
+      ID: 116
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
+    - __kind: BaseType
+      ID: 113
+      Name: time.Duration
+      ByteSize: 8
+      GoKind: 6
     - __kind: BaseType
       ID: 16
       Name: uint
@@ -1454,7 +1629,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 45600
       GoKind: 26
-MaxTypeID: 122
+MaxTypeID: 127
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x5b7320", TypesOffset: 296}
 GoMapHashInfo: {UseAeshashAddr: "0x5e432a", AeskeyschedAddr: "0x5e49e0"}

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.23.11.yaml
@@ -11,8 +11,26 @@ Probes:
         - subprogram: {subprogram: 1}
           events:
             - Kind: Entry
-              Type: 108 EventRootType Probe[main.noop]
+              Type: 111 EventRootType Probe[main.noop]
               InjectionPoints: [{PC: "0xb5290", Frameless: true}]
+              Condition: null
+    - id: b
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.busyloop}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 2}
+          events:
+            - Kind: Entry
+              Type: 112 EventRootType Probe[main.busyloop]
+              InjectionPoints: [{PC: "0xb52b8", Frameless: false}]
+              Condition: null
+            - Kind: Return
+              Type: 113 EventRootType Probe[main.busyloop]Return
+              InjectionPoints: [{PC: "0xb5444", Frameless: false}]
               Condition: null
 Subprograms:
     - ID: 1
@@ -20,6 +38,97 @@ Subprograms:
       OutOfLinePCRanges: [0xb5290..0xb52a0]
       InlinePCRanges: []
       Variables: []
+      DictRegister: null
+    - ID: 2
+      Name: main.busyloop
+      OutOfLinePCRanges: [0xb52a0..0xb5470]
+      InlinePCRanges: []
+      Variables:
+        - Name: concurrency
+          Type: 11 BaseType int
+          Locations:
+            - Range: 0xb52a0..0xb52c8
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xb52c8..0xb5470
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: duration
+          Type: 102 BaseType time.Duration
+          Locations:
+            - Range: 0xb52a0..0xb52cc
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0xb52cc..0xb5470
+              Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: ~r0
+          Type: 19 BaseType float64
+          Locations: [{Range: 0xb52a0..0xb5470, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ready
+          Type: 103 GoChannelType chan struct {}
+          Locations:
+            - Range: 0xb52d0..0xb52e0
+              Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xb52e0..0xb5470
+              Pieces: [{Size: 0, Op: {CfaOffset: -24}}]
+          Role: Local
+          DictIndex: -1
+        - Name: start
+          Type: 103 GoChannelType chan struct {}
+          Locations:
+            - Range: 0xb52e4..0xb52f4
+              Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xb52f4..0xb5470
+              Pieces: [{Size: 0, Op: {CfaOffset: -32}}]
+          Role: Local
+          DictIndex: -1
+        - Name: stop
+          Type: 103 GoChannelType chan struct {}
+          Locations:
+            - Range: 0xb52f8..0xb5308
+              Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xb5308..0xb5470
+              Pieces: [{Size: 0, Op: {CfaOffset: -40}}]
+          Role: Local
+          DictIndex: -1
+        - Name: counts
+          Type: 104 GoChannelType chan int
+          Locations:
+            - Range: 0xb530c..0xb5318
+              Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xb5318..0xb532c
+              Pieces: [{Size: 0, Op: {CfaOffset: -16}}]
+            - Range: 0xb532c..0xb5470
+              Pieces: [{Size: 0, Op: {CfaOffset: -16}}]
+          Role: Local
+          DictIndex: -1
+        - Name: total
+          Type: 11 BaseType int
+          Locations:
+            - Range: 0xb53fc..0xb5408
+              Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
+            - Range: 0xb5408..0xb5420
+              Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
+            - Range: 0xb5420..0xb5470
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          Role: Local
+          DictIndex: -1
+        - Name: i
+          Type: 11 BaseType int
+          Locations:
+            - Range: 0xb5330..0xb5338
+              Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
+            - Range: 0xb5338..0xb5350
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0xb5350..0xb53a4
+              Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
+            - Range: 0xb53a4..0xb53a8
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          Role: Local
+          DictIndex: -1
       DictRegister: null
 Types:
     - __kind: PointerType
@@ -30,15 +139,15 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 105
+      ID: 108
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 104 GoSliceDataType []uint8.array
+      Pointee: 107 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 107
+      ID: 110
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 106 GoSliceDataType []uintptr.array
+      Pointee: 109 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 7
       Name: '*bool'
@@ -159,10 +268,10 @@ Types:
       GoKind: 22
       Pointee: 12 GoStringHeaderType string
     - __kind: PointerType
-      ID: 103
+      ID: 106
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 102 GoStringDataType string.str
+      Pointee: 105 GoStringDataType string.str
     - __kind: PointerType
       ID: 100
       Name: '*uint'
@@ -214,7 +323,58 @@ Types:
       Name: '@trace_context'
       ByteSize: 40
     - __kind: EventRootType
-      ID: 108
+      ID: 112
+      Name: Probe[main.busyloop]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: concurrency
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 11 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: concurrency}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: duration
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 102 BaseType time.Duration
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 1, name: duration}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 113
+      Name: Probe[main.busyloop]Return
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: '@return'
+          Offset: 1
+          Kind: return
+          Expression:
+            Type: 19 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 2, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 111
       Name: Probe[main.noop]
     - __kind: ArrayType
       ID: 87
@@ -326,9 +486,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 104 GoSliceDataType []uint8.array
+      Data: 107 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 104
+      ID: 107
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -349,9 +509,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 106 GoSliceDataType []uintptr.array
+      Data: 109 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 106
+      ID: 109
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -362,6 +522,16 @@ Types:
       ByteSize: 1
       GoRuntimeType: 37792
       GoKind: 1
+    - __kind: GoChannelType
+      ID: 104
+      Name: chan int
+      GoRuntimeType: 38880
+      GoKind: 18
+    - __kind: GoChannelType
+      ID: 103
+      Name: chan struct {}
+      GoRuntimeType: 38944
+      GoKind: 18
     - __kind: BaseType
       ID: 93
       Name: complex128
@@ -1265,16 +1435,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 103 PointerType *string.str
+          Type: 106 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 102 GoStringDataType string.str
+      Data: 105 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 102
+      ID: 105
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
+    - __kind: BaseType
+      ID: 102
+      Name: time.Duration
+      ByteSize: 8
+      GoKind: 6
     - __kind: BaseType
       ID: 14
       Name: uint
@@ -1317,7 +1492,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 37856
       GoKind: 26
-MaxTypeID: 108
+MaxTypeID: 113
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x191240", TypesOffset: 296}
 GoMapHashInfo: {UseAeshashAddr: "0x1c0e89", AeskeyschedAddr: "0x1c1560"}

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.24.3.yaml
@@ -11,8 +11,26 @@ Probes:
         - subprogram: {subprogram: 1}
           events:
             - Kind: Entry
-              Type: 113 EventRootType Probe[main.noop]
+              Type: 116 EventRootType Probe[main.noop]
               InjectionPoints: [{PC: "0xb5170", Frameless: true}]
+              Condition: null
+    - id: b
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.busyloop}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 2}
+          events:
+            - Kind: Entry
+              Type: 117 EventRootType Probe[main.busyloop]
+              InjectionPoints: [{PC: "0xb5198", Frameless: false}]
+              Condition: null
+            - Kind: Return
+              Type: 118 EventRootType Probe[main.busyloop]Return
+              InjectionPoints: [{PC: "0xb5324", Frameless: false}]
               Condition: null
 Subprograms:
     - ID: 1
@@ -20,6 +38,97 @@ Subprograms:
       OutOfLinePCRanges: [0xb5170..0xb5180]
       InlinePCRanges: []
       Variables: []
+      DictRegister: null
+    - ID: 2
+      Name: main.busyloop
+      OutOfLinePCRanges: [0xb5180..0xb5350]
+      InlinePCRanges: []
+      Variables:
+        - Name: concurrency
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xb5180..0xb51a8
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xb51a8..0xb5350
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: duration
+          Type: 107 BaseType time.Duration
+          Locations:
+            - Range: 0xb5180..0xb51ac
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0xb51ac..0xb5350
+              Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: ~r0
+          Type: 20 BaseType float64
+          Locations: [{Range: 0xb5180..0xb5350, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ready
+          Type: 108 GoChannelType chan struct {}
+          Locations:
+            - Range: 0xb51b0..0xb51bc
+              Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xb51bc..0xb5350
+              Pieces: [{Size: 0, Op: {CfaOffset: -24}}]
+          Role: Local
+          DictIndex: -1
+        - Name: start
+          Type: 108 GoChannelType chan struct {}
+          Locations:
+            - Range: 0xb51c4..0xb51d0
+              Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xb51d0..0xb5350
+              Pieces: [{Size: 0, Op: {CfaOffset: -32}}]
+          Role: Local
+          DictIndex: -1
+        - Name: stop
+          Type: 108 GoChannelType chan struct {}
+          Locations:
+            - Range: 0xb51d8..0xb51e4
+              Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xb51e4..0xb5350
+              Pieces: [{Size: 0, Op: {CfaOffset: -40}}]
+          Role: Local
+          DictIndex: -1
+        - Name: counts
+          Type: 109 GoChannelType chan int
+          Locations:
+            - Range: 0xb51ec..0xb51f8
+              Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xb51f8..0xb520c
+              Pieces: [{Size: 0, Op: {CfaOffset: -16}}]
+            - Range: 0xb520c..0xb5350
+              Pieces: [{Size: 0, Op: {CfaOffset: -16}}]
+          Role: Local
+          DictIndex: -1
+        - Name: total
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xb52dc..0xb52e8
+              Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
+            - Range: 0xb52e8..0xb5300
+              Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
+            - Range: 0xb5300..0xb5350
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          Role: Local
+          DictIndex: -1
+        - Name: i
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xb5210..0xb5218
+              Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
+            - Range: 0xb5218..0xb5230
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0xb5230..0xb5284
+              Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
+            - Range: 0xb5284..0xb5288
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          Role: Local
+          DictIndex: -1
       DictRegister: null
 Types:
     - __kind: PointerType
@@ -30,15 +139,15 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 110
+      ID: 113
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 109 GoSliceDataType []uint8.array
+      Pointee: 112 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 112
+      ID: 115
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 111 GoSliceDataType []uintptr.array
+      Pointee: 114 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 13
       Name: '*bool'
@@ -166,10 +275,10 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 108
+      ID: 111
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 107 GoStringDataType string.str
+      Pointee: 110 GoStringDataType string.str
     - __kind: PointerType
       ID: 105
       Name: '*uint'
@@ -221,7 +330,58 @@ Types:
       Name: '@trace_context'
       ByteSize: 40
     - __kind: EventRootType
-      ID: 113
+      ID: 117
+      Name: Probe[main.busyloop]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: concurrency
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: concurrency}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: duration
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 107 BaseType time.Duration
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 1, name: duration}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 118
+      Name: Probe[main.busyloop]Return
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: '@return'
+          Offset: 1
+          Kind: return
+          Expression:
+            Type: 20 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 2, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 116
       Name: Probe[main.noop]
     - __kind: ArrayType
       ID: 94
@@ -349,9 +509,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 109 GoSliceDataType []uint8.array
+      Data: 112 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 109
+      ID: 112
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -372,9 +532,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 111 GoSliceDataType []uintptr.array
+      Data: 114 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 111
+      ID: 114
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -385,6 +545,16 @@ Types:
       ByteSize: 1
       GoRuntimeType: 41600
       GoKind: 1
+    - __kind: GoChannelType
+      ID: 109
+      Name: chan int
+      GoRuntimeType: 42688
+      GoKind: 18
+    - __kind: GoChannelType
+      ID: 108
+      Name: chan struct {}
+      GoRuntimeType: 42752
+      GoKind: 18
     - __kind: BaseType
       ID: 98
       Name: complex128
@@ -1326,16 +1496,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 108 PointerType *string.str
+          Type: 111 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 107 GoStringDataType string.str
+      Data: 110 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 107
+      ID: 110
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
+    - __kind: BaseType
+      ID: 107
+      Name: time.Duration
+      ByteSize: 8
+      GoKind: 6
     - __kind: BaseType
       ID: 12
       Name: uint
@@ -1378,7 +1553,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 41664
       GoKind: 26
-MaxTypeID: 113
+MaxTypeID: 118
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x191360", TypesOffset: 296}
 GoMapHashInfo: {UseAeshashAddr: "0x1c0ae9", AeskeyschedAddr: "0x1c11e0"}

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.25.0.yaml
@@ -11,8 +11,26 @@ Probes:
         - subprogram: {subprogram: 1}
           events:
             - Kind: Entry
-              Type: 118 EventRootType Probe[main.noop]
+              Type: 121 EventRootType Probe[main.noop]
               InjectionPoints: [{PC: "0xb7d10", Frameless: true}]
+              Condition: null
+    - id: b
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.busyloop}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 2}
+          events:
+            - Kind: Entry
+              Type: 122 EventRootType Probe[main.busyloop]
+              InjectionPoints: [{PC: "0xb7d38", Frameless: false}]
+              Condition: null
+            - Kind: Return
+              Type: 123 EventRootType Probe[main.busyloop]Return
+              InjectionPoints: [{PC: "0xb7eb4", Frameless: false}]
               Condition: null
 Subprograms:
     - ID: 1
@@ -20,6 +38,93 @@ Subprograms:
       OutOfLinePCRanges: [0xb7d10..0xb7d20]
       InlinePCRanges: []
       Variables: []
+      DictRegister: null
+    - ID: 2
+      Name: main.busyloop
+      OutOfLinePCRanges: [0xb7d20..0xb7ee0]
+      InlinePCRanges: []
+      Variables:
+        - Name: concurrency
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xb7d20..0xb7d48
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xb7d48..0xb7ee0
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: duration
+          Type: 109 BaseType time.Duration
+          Locations:
+            - Range: 0xb7d20..0xb7d4c
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0xb7d4c..0xb7ee0
+              Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: ~r0
+          Type: 18 BaseType float64
+          Locations: [{Range: 0xb7d20..0xb7ee0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ready
+          Type: 110 GoChannelType chan struct {}
+          Locations:
+            - Range: 0xb7d50..0xb7d5c
+              Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xb7d5c..0xb7ee0
+              Pieces: [{Size: 0, Op: {CfaOffset: -24}}]
+          Role: Local
+          DictIndex: -1
+        - Name: start
+          Type: 110 GoChannelType chan struct {}
+          Locations:
+            - Range: 0xb7d64..0xb7d70
+              Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xb7d70..0xb7ee0
+              Pieces: [{Size: 0, Op: {CfaOffset: -32}}]
+          Role: Local
+          DictIndex: -1
+        - Name: stop
+          Type: 110 GoChannelType chan struct {}
+          Locations:
+            - Range: 0xb7d78..0xb7d84
+              Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xb7d84..0xb7ee0
+              Pieces: [{Size: 0, Op: {CfaOffset: -40}}]
+          Role: Local
+          DictIndex: -1
+        - Name: counts
+          Type: 111 GoChannelType chan int
+          Locations:
+            - Range: 0xb7d8c..0xb7d98
+              Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xb7d98..0xb7da4
+              Pieces: [{Size: 0, Op: {CfaOffset: -16}}]
+            - Range: 0xb7da4..0xb7ee0
+              Pieces: [{Size: 0, Op: {CfaOffset: -16}}]
+          Role: Local
+          DictIndex: -1
+        - Name: total
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xb7d48..0xb7e18
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xb7e6c..0xb7e78
+              Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
+            - Range: 0xb7e78..0xb7e90
+              Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
+            - Range: 0xb7e90..0xb7ee0
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          Role: Local
+          DictIndex: -1
+        - Name: i
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xb7d48..0xb7e18
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Local
+          DictIndex: -1
       DictRegister: null
 Types:
     - __kind: PointerType
@@ -29,10 +134,10 @@ Types:
       GoKind: 22
       Pointee: 66 PointerType *runtime.p
     - __kind: PointerType
-      ID: 117
+      ID: 120
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 116 GoSliceDataType []*runtime.p.array
+      Pointee: 119 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -41,15 +146,15 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 112
+      ID: 115
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 111 GoSliceDataType []uint8.array
+      Pointee: 114 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 114
+      ID: 117
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 113 GoSliceDataType []uintptr.array
+      Pointee: 116 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 13
       Name: '*bool'
@@ -147,7 +252,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 66400
       GoKind: 22
-      Pointee: 115 UnresolvedPointeeType runtime.p
+      Pointee: 118 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 43
       Name: '*runtime.sudog'
@@ -184,10 +289,10 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 110
+      ID: 113
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 109 GoStringDataType string.str
+      Pointee: 112 GoStringDataType string.str
     - __kind: PointerType
       ID: 107
       Name: '*uint'
@@ -239,7 +344,58 @@ Types:
       Name: '@trace_context'
       ByteSize: 40
     - __kind: EventRootType
-      ID: 118
+      ID: 122
+      Name: Probe[main.busyloop]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: concurrency
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: concurrency}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: duration
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 109 BaseType time.Duration
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 1, name: duration}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 123
+      Name: Probe[main.busyloop]Return
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: '@return'
+          Offset: 1
+          Kind: return
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 2, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 121
       Name: Probe[main.noop]
     - __kind: ArrayType
       ID: 94
@@ -356,9 +512,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 116 GoSliceDataType []*runtime.p.array
+      Data: 119 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 116
+      ID: 119
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -383,9 +539,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 111 GoSliceDataType []uint8.array
+      Data: 114 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 111
+      ID: 114
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -406,9 +562,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 113 GoSliceDataType []uintptr.array
+      Data: 116 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 113
+      ID: 116
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -419,6 +575,16 @@ Types:
       ByteSize: 1
       GoRuntimeType: 43040
       GoKind: 1
+    - __kind: GoChannelType
+      ID: 111
+      Name: chan int
+      GoRuntimeType: 44128
+      GoKind: 18
+    - __kind: GoChannelType
+      ID: 110
+      Name: chan struct {}
+      GoRuntimeType: 44192
+      GoKind: 18
     - __kind: BaseType
       ID: 100
       Name: complex128
@@ -1242,7 +1408,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 3 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 115
+      ID: 118
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
@@ -1367,16 +1533,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 110 PointerType *string.str
+          Type: 113 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 109 GoStringDataType string.str
+      Data: 112 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 109
+      ID: 112
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
+    - __kind: BaseType
+      ID: 109
+      Name: time.Duration
+      ByteSize: 8
+      GoKind: 6
     - __kind: BaseType
       ID: 12
       Name: uint
@@ -1419,7 +1590,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 43104
       GoKind: 26
-MaxTypeID: 118
+MaxTypeID: 123
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1a13a0", TypesOffset: 296}
 GoMapHashInfo: {UseAeshashAddr: "0x1d1369", AeskeyschedAddr: "0x1d1a00"}

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.26rc1.yaml
@@ -11,8 +11,26 @@ Probes:
         - subprogram: {subprogram: 1}
           events:
             - Kind: Entry
-              Type: 123 EventRootType Probe[main.noop]
+              Type: 126 EventRootType Probe[main.noop]
               InjectionPoints: [{PC: "0xc8080", Frameless: true}]
+              Condition: null
+    - id: b
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.busyloop}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 2}
+          events:
+            - Kind: Entry
+              Type: 127 EventRootType Probe[main.busyloop]
+              InjectionPoints: [{PC: "0xc80a8", Frameless: false}]
+              Condition: null
+            - Kind: Return
+              Type: 128 EventRootType Probe[main.busyloop]Return
+              InjectionPoints: [{PC: "0xc822c", Frameless: false}]
               Condition: null
 Subprograms:
     - ID: 1
@@ -20,6 +38,93 @@ Subprograms:
       OutOfLinePCRanges: [0xc8080..0xc8090]
       InlinePCRanges: []
       Variables: []
+      DictRegister: null
+    - ID: 2
+      Name: main.busyloop
+      OutOfLinePCRanges: [0xc8090..0xc8250]
+      InlinePCRanges: []
+      Variables:
+        - Name: concurrency
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xc8090..0xc80b8
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xc80b8..0xc8250
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: duration
+          Type: 114 BaseType time.Duration
+          Locations:
+            - Range: 0xc8090..0xc80bc
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0xc80bc..0xc8250
+              Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: ~r0
+          Type: 16 BaseType float64
+          Locations: [{Range: 0xc8090..0xc8250, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ready
+          Type: 115 GoChannelType chan struct {}
+          Locations:
+            - Range: 0xc80c0..0xc80cc
+              Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xc80cc..0xc8250
+              Pieces: [{Size: 0, Op: {CfaOffset: -24}}]
+          Role: Local
+          DictIndex: -1
+        - Name: start
+          Type: 115 GoChannelType chan struct {}
+          Locations:
+            - Range: 0xc80d4..0xc80e0
+              Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xc80e0..0xc8250
+              Pieces: [{Size: 0, Op: {CfaOffset: -32}}]
+          Role: Local
+          DictIndex: -1
+        - Name: stop
+          Type: 115 GoChannelType chan struct {}
+          Locations:
+            - Range: 0xc80e8..0xc80f4
+              Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xc80f4..0xc8250
+              Pieces: [{Size: 0, Op: {CfaOffset: -40}}]
+          Role: Local
+          DictIndex: -1
+        - Name: counts
+          Type: 116 GoChannelType chan int
+          Locations:
+            - Range: 0xc80fc..0xc8108
+              Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xc8108..0xc8114
+              Pieces: [{Size: 0, Op: {CfaOffset: -16}}]
+            - Range: 0xc8114..0xc8250
+              Pieces: [{Size: 0, Op: {CfaOffset: -16}}]
+          Role: Local
+          DictIndex: -1
+        - Name: total
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xc80b8..0xc8190
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xc81e4..0xc81f0
+              Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
+            - Range: 0xc81f0..0xc8208
+              Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
+            - Range: 0xc8208..0xc8250
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          Role: Local
+          DictIndex: -1
+        - Name: i
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xc80b8..0xc8190
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Local
+          DictIndex: -1
       DictRegister: null
 Types:
     - __kind: PointerType
@@ -29,10 +134,10 @@ Types:
       GoKind: 22
       Pointee: 70 PointerType *runtime.p
     - __kind: PointerType
-      ID: 122
+      ID: 125
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 121 GoSliceDataType []*runtime.p.array
+      Pointee: 124 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
       ID: 42
       Name: '*[]runtime.ancestorInfo'
@@ -41,15 +146,15 @@ Types:
       GoKind: 22
       Pointee: 43 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 117
+      ID: 120
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 116 GoSliceDataType []uint8.array
+      Pointee: 119 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 119
+      ID: 122
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 118 GoSliceDataType []uintptr.array
+      Pointee: 121 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 12
       Name: '*bool'
@@ -154,7 +259,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 70176
       GoKind: 22
-      Pointee: 120 UnresolvedPointeeType runtime.p
+      Pointee: 123 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 44
       Name: '*runtime.sudog'
@@ -198,10 +303,10 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 115
+      ID: 118
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 114 GoStringDataType string.str
+      Pointee: 117 GoStringDataType string.str
     - __kind: PointerType
       ID: 112
       Name: '*uint'
@@ -253,7 +358,58 @@ Types:
       Name: '@trace_context'
       ByteSize: 40
     - __kind: EventRootType
-      ID: 123
+      ID: 127
+      Name: Probe[main.busyloop]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: concurrency
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: concurrency}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: duration
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 114 BaseType time.Duration
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 1, name: duration}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 128
+      Name: Probe[main.busyloop]Return
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: '@return'
+          Offset: 1
+          Kind: return
+          Expression:
+            Type: 16 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 2, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 126
       Name: Probe[main.noop]
     - __kind: ArrayType
       ID: 97
@@ -370,9 +526,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 121 GoSliceDataType []*runtime.p.array
+      Data: 124 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 121
+      ID: 124
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -397,9 +553,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 116 GoSliceDataType []uint8.array
+      Data: 119 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 116
+      ID: 119
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -420,9 +576,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 118 GoSliceDataType []uintptr.array
+      Data: 121 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 118
+      ID: 121
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -433,6 +589,16 @@ Types:
       ByteSize: 1
       GoRuntimeType: 45440
       GoKind: 1
+    - __kind: GoChannelType
+      ID: 116
+      Name: chan int
+      GoRuntimeType: 46592
+      GoKind: 18
+    - __kind: GoChannelType
+      ID: 115
+      Name: chan struct {}
+      GoRuntimeType: 46656
+      GoKind: 18
     - __kind: BaseType
       ID: 20
       Name: complex128
@@ -1269,7 +1435,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 3 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 120
+      ID: 123
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
@@ -1408,16 +1574,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 115 PointerType *string.str
+          Type: 118 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 114 GoStringDataType string.str
+      Data: 117 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 114
+      ID: 117
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
+    - __kind: BaseType
+      ID: 114
+      Name: time.Duration
+      ByteSize: 8
+      GoKind: 6
     - __kind: BaseType
       ID: 13
       Name: uint
@@ -1460,7 +1631,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 45504
       GoKind: 26
-MaxTypeID: 123
+MaxTypeID: 128
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1c0320", TypesOffset: 296}
 GoMapHashInfo: {UseAeshashAddr: "0x1f38e9", AeskeyschedAddr: "0x1f3fa0"}

--- a/pkg/dyninst/loader/loader.go
+++ b/pkg/dyninst/loader/loader.go
@@ -252,7 +252,7 @@ func (p *Program) Close() {
 	}
 }
 
-// RuntimeStats are cumulative stats aggregated throughout program lifetime.
+// RuntimeStats are cumulative stats aggregated throughout probe lifetime.
 type RuntimeStats struct {
 	// Aggregated cpu time spent in probe execution (excluding interrupt overhead).
 	CPU time.Duration
@@ -262,22 +262,37 @@ type RuntimeStats struct {
 	ThrottledCnt uint64
 }
 
-// RuntimeStats returns the per-core runtime stats for the program.
+// RuntimeStats returns the per-probe runtime stats for the program,
+// indexed by the IR probe_id (the same value used as stats_buf key in
+// eBPF). The returned slice has length equal to the program's probe
+// count.
 func (p *Program) RuntimeStats() []RuntimeStats {
 	statsMap, ok := p.Collection.Maps["stats_buf"]
 	if !ok {
 		return nil
 	}
+	n := int(statsMap.MaxEntries())
+	out := make([]RuntimeStats, n)
+	if n == 0 {
+		return out
+	}
+	// stats and RuntimeStats have the same layout — see
+	// TestRuntimeStatsHasSameLayoutAsStats. Read directly into the
+	// output slice as []stats.
+	view := unsafe.Slice(
+		(*stats)(unsafe.Pointer(unsafe.SliceData(out))),
+		n,
+	)
 	entries := statsMap.Iterate()
 	var key uint32
-	var stats []stats
-	_ = entries.Next(&key, &stats)
-	// This is safe because these two structs have the same layout.
-	// See TestRuntimeStatsHasSameLayoutAsStats for more details.
-	return unsafe.Slice(
-		(*RuntimeStats)(unsafe.Pointer(unsafe.SliceData(stats))),
-		len(stats),
-	)
+	var value stats
+	for entries.Next(&key, &value) {
+		if int(key) >= n {
+			continue
+		}
+		view[key] = value
+	}
+	return out
 }
 
 const defaultRingbufSize = 1 << 20 // 1 MiB
@@ -435,6 +450,7 @@ func (l *Loader) loadData(
 	const throttlerMapName = "throttler_params"
 	const throttlerStateMapName = "throttler_buf"
 	const probeParamsMapName = "probe_params"
+	const statsBufMapName = "stats_buf"
 	const goRuntimeTypeIDsMapName = "go_runtime_type_ids"
 	const goRuntimeTypesMapName = "go_runtime_types"
 
@@ -612,6 +628,22 @@ func (l *Loader) loadData(
 	err = setVariable(spec, "num_probe_params", uint32(len(serialized.probeParams)))
 	if err != nil {
 		return nil, fmt.Errorf("failed to set num_probe_params: %w", err)
+	}
+
+	// Size stats_buf to one entry per IR probe. BPF_MAP_TYPE_ARRAY
+	// requires max_entries >= 1, so clamp degenerate zero-probe
+	// programs (the verifier still requires the map to exist).
+	statsBufSize := serialized.numProbes
+	if statsBufSize == 0 {
+		statsBufSize = 1
+	}
+	statsBufMapSpec, ok := spec.Maps[statsBufMapName]
+	if !ok {
+		return nil, errors.New("stats_buf map not found in eBPF spec")
+	}
+	statsBufMapSpec.MaxEntries = statsBufSize
+	if err := setVariable(spec, "num_probes", serialized.numProbes); err != nil {
+		return nil, fmt.Errorf("failed to set num_probes: %w", err)
 	}
 
 	if l.config.dyninstDebugEnabled {

--- a/pkg/dyninst/loader/loader.go
+++ b/pkg/dyninst/loader/loader.go
@@ -642,9 +642,6 @@ func (l *Loader) loadData(
 		return nil, errors.New("stats_buf map not found in eBPF spec")
 	}
 	statsBufMapSpec.MaxEntries = statsBufSize
-	if err := setVariable(spec, "num_probes", serialized.numProbes); err != nil {
-		return nil, fmt.Errorf("failed to set num_probes: %w", err)
-	}
 
 	if l.config.dyninstDebugEnabled {
 		err = setVariable(spec, "debug_level", uint32(l.config.dyninstDebugLevel))

--- a/pkg/dyninst/loader/serialize.go
+++ b/pkg/dyninst/loader/serialize.go
@@ -34,6 +34,12 @@ type serializedProgram struct {
 	probeParams     []probeParams
 	bpfAttachPoints []BPFAttachPoint
 
+	// numProbes is the count of distinct IR probes. It defines the size
+	// of the per-probe stats_buf map and is always >= 1 in the serialized
+	// program (clamped at load time to satisfy BPF_MAP_TYPE_ARRAY's
+	// nonzero-max-entries requirement).
+	numProbes uint32
+
 	goRuntimeTypeIDs goRuntimeTypeIDs
 	goModuledataInfo ir.GoModuledataInfo
 	goMapHashInfo    ir.GoMapHashInfo
@@ -117,6 +123,7 @@ func serializeProgram(
 		programID: program.ID,
 		code:      buf.Bytes(),
 		maxOpLen:  metadata.MaxOpLen,
+		numProbes: program.NumProbes,
 	}
 	var ok bool
 	serialized.chasePointersEntrypoint, ok = metadata.FunctionLoc[compiler.ChasePointers{}]

--- a/pkg/dyninst/loader/serialize.go
+++ b/pkg/dyninst/loader/serialize.go
@@ -34,10 +34,10 @@ type serializedProgram struct {
 	probeParams     []probeParams
 	bpfAttachPoints []BPFAttachPoint
 
-	// numProbes is the count of distinct IR probes. It defines the size
-	// of the per-probe stats_buf map and is always >= 1 in the serialized
-	// program (clamped at load time to satisfy BPF_MAP_TYPE_ARRAY's
-	// nonzero-max-entries requirement).
+	// numProbes is the raw IR probe count and may be 0. It defines the
+	// size of the per-probe stats_buf map; the loader clamps stats_buf's
+	// MaxEntries to at least 1 to satisfy BPF_MAP_TYPE_ARRAY's
+	// nonzero-max-entries requirement.
 	numProbes uint32
 
 	goRuntimeTypeIDs goRuntimeTypeIDs

--- a/pkg/dyninst/module/dependencies.go
+++ b/pkg/dyninst/module/dependencies.go
@@ -68,11 +68,22 @@ type KernelLoader interface {
 	Load(compiler.Program) (*loader.Program, error)
 }
 
-// Attacher connects a loaded program to a target process.
+// Attacher connects a loaded program to a target process. The
+// returned AttachedProgram is wrapped by the runtime in
+// attachedProgramImpl before it reaches the actuator, so it only
+// needs to satisfy the inner Detach contract.
 type Attacher interface {
 	Attach(
 		*loader.Program, actuator.Executable, actuator.ProcessID,
-	) (actuator.AttachedProgram, error)
+	) (InnerAttachedProgram, error)
+}
+
+// InnerAttachedProgram is the contract the module runtime requires of
+// an attached uprobe handle (the inner side of attachedProgramImpl).
+// It is intentionally narrower than actuator.AttachedProgram: the
+// runtime adds the per-probe diagnostic plumbing on top.
+type InnerAttachedProgram interface {
+	Detach(reason error) error
 }
 
 // DecoderFactory is a factory for creating decoders.

--- a/pkg/dyninst/module/module_test.go
+++ b/pkg/dyninst/module/module_test.go
@@ -713,7 +713,7 @@ func (f *fakeAttacher) Attach(
 	_ *loader.Program,
 	_ actuator.Executable,
 	_ actuator.ProcessID,
-) (actuator.AttachedProgram, error) {
+) (module.InnerAttachedProgram, error) {
 	if f.err != nil {
 		return nil, f.err
 	}

--- a/pkg/dyninst/module/runtime_impl.go
+++ b/pkg/dyninst/module/runtime_impl.go
@@ -289,6 +289,17 @@ func (l *loadedProgramImpl) RuntimeStats() []loader.RuntimeStats {
 	return l.loadedProgram.RuntimeStats()
 }
 
+func (l *loadedProgramImpl) NumProbes() int {
+	return len(l.ir.Probes)
+}
+
+func (l *loadedProgramImpl) ProbeDefinition(probeID uint32) ir.ProbeDefinition {
+	if int(probeID) >= len(l.ir.Probes) {
+		return nil
+	}
+	return l.ir.Probes[probeID].ProbeDefinition
+}
+
 func (l *loadedProgramImpl) DropNotifyLostAt() uint64 {
 	return l.loadedProgram.DropNotifyLostAt()
 }
@@ -316,7 +327,7 @@ type attachedProgramImpl struct {
 	runtimeID procRuntimeID
 	programID ir.ProgramID
 	probes    []ir.ProbeDefinition
-	inner     actuator.AttachedProgram
+	inner     InnerAttachedProgram
 }
 
 var detachLogLimiter = rate.NewLimiter(rate.Every(time.Minute), 10)
@@ -333,6 +344,12 @@ func (a *attachedProgramImpl) Detach(failure error) error {
 	}
 	a.runtime.onProgramDetached(a.programID)
 	return err
+}
+
+func (a *attachedProgramImpl) ReportProbeError(
+	probe ir.ProbeDefinition, reason error,
+) {
+	a.runtime.diagnostics.reportError(a.runtimeID, probe, reason, "ExecutionFailed")
 }
 
 func (rt *runtimeImpl) onProgramAttached(
@@ -386,7 +403,7 @@ func (defaultAttacher) Attach(
 	program *loader.Program,
 	executable actuator.Executable,
 	processID actuator.ProcessID,
-) (actuator.AttachedProgram, error) {
+) (InnerAttachedProgram, error) {
 	return uprobe.Attach(program, executable, processID)
 }
 

--- a/pkg/dyninst/testprogs/testdata/probes/busyloop.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/busyloop.yaml
@@ -5,3 +5,8 @@ probes:
   captureSnapshot: true
   where:
     methodName: main.noop
+- id: b
+  type: LOG_PROBE
+  captureSnapshot: true
+  where:
+    methodName: main.busyloop

--- a/pkg/dyninst/throttler_test.go
+++ b/pkg/dyninst/throttler_test.go
@@ -55,6 +55,12 @@ func enforcesBudget(t *testing.T, busyloopPath string) {
 		t, tempDir, busyloopPath, "busyloop", irgen.WithSkipReturnEvents(true),
 	)
 
+	// The busyloop probe set has multiple probes; the throttler test
+	// only exercises the hot one (id "a"). Reduce to that probe so
+	// the throttling assertions below are not contaminated by the
+	// other probe's hits.
+	keepProbeWithID(&irp.Probes, "a")
+
 	// Adjust throttling parameters.
 	// Practically infinite period, with specific event count.
 	require.Equal(t, 1, len(irp.Probes))
@@ -141,6 +147,7 @@ func refreshesBudget(t *testing.T, busyloopPath string) {
 
 	// Adjust throttling parameters.
 	// Small period, and budget.
+	keepProbeWithID(&irp.Probes, "a")
 	require.Equal(t, 1, len(irp.Probes))
 	irp.Probes[0].ProbeDefinition = &overriddenThrottle{
 		ProbeDefinition: irp.Probes[0].ProbeDefinition,
@@ -182,6 +189,19 @@ func refreshesBudget(t *testing.T, busyloopPath string) {
 		_, err := rd.Read()
 		require.NoError(t, err)
 	}
+}
+
+// keepProbeWithID filters the IR's probe list down to a single probe
+// matching id, panicking if not found. Used by tests that share the
+// busyloop probe set with multi-probe tests but only exercise one.
+func keepProbeWithID(probes *[]*ir.Probe, id string) {
+	out := (*probes)[:0]
+	for _, p := range *probes {
+		if p.ProbeDefinition.GetID() == id {
+			out = append(out, p)
+		}
+	}
+	*probes = out
 }
 
 type overriddenThrottle struct {

--- a/pkg/dyninst/throttler_test.go
+++ b/pkg/dyninst/throttler_test.go
@@ -107,11 +107,11 @@ func enforcesBudget(t *testing.T, busyloopPath string) {
 	var stats loader.RuntimeStats
 	for {
 		stats = loader.RuntimeStats{}
-		perCoreStats := program.RuntimeStats()
-		for _, coreStats := range perCoreStats {
-			stats.HitCnt += coreStats.HitCnt
-			stats.ThrottledCnt += coreStats.ThrottledCnt
-			stats.CPU += coreStats.CPU
+		perProbeStats := program.RuntimeStats()
+		for _, probeStats := range perProbeStats {
+			stats.HitCnt += probeStats.HitCnt
+			stats.ThrottledCnt += probeStats.ThrottledCnt
+			stats.CPU += probeStats.CPU
 		}
 		if int(stats.ThrottledCnt) > 0 {
 			break


### PR DESCRIPTION
### What does this PR do?

Adds per-probe circuit breaking to dyninst. When a single probe exceeds `PerProbeCPULimit` (or is picked as the most-expensive victim under `AllProbesCPULimit`), only that probe is removed via recompile-and-omit; the rest of the process keeps running. Re-adding the probe later gives it a fresh attempt.

Stack of four commits:

1. **Per-probe stats_buf with atomic counters** — replace the single-slot `BPF_MAP_TYPE_PERCPU_ARRAY` with a `BPF_MAP_TYPE_ARRAY` keyed by `probe_id`, using `__sync_fetch_and_add`. Adds an `orphan_stats` counter for the cookie-misconfig path. `RuntimeStats()` now returns one entry per probe.
2. **Per-probe circuit breaker via recompile-and-omit** — record offenders in `process.circuitBrokenProbes`, emit a per-probe `ExecutionFailed` diagnostic, and flag for recompile; the new program filters them out. Pruned on `processesUpdated` when probe identity disappears. Adds `LoadedProgram.NumProbes/ProbeDefinition` and `AttachedProgram.ReportProbeError`; narrows the `Attacher` contract to `InnerAttachedProgram`.
3. **Exclude circuit-broken probes from all-probes accounting** — don't charge their transient cost against `AllProbesCPULimit` or let them be picked as the all-probes victim while the recompile is in flight.
4. **Tests** — new snapshots (`circuit_breaker_per_probe_trip`, `circuit_breaker_readdition_resets`), a two-probe busyloop set, deterministic `nowFunc` for heartbeat costs, and strict YAML decoding so stale snapshots fail loudly.

### Motivation

A single misbehaving probe used to trip the program-wide circuit breaker and take all sibling probes down with it. Per-probe isolation lets cold probes keep running while only the offender is removed.

### Describe how you validated your changes

- `circuit_breaker_test.go` extended to two probes; asserts only the hot probe gets `ExecutionFailed`.
- Snapshot tests cover the per-probe trip and the re-addition-resets paths.
- `throttler_test.go` and the irgen `busyloop` snapshots updated for the two-probe set and per-probe stats layout.

### Additional Notes

The recompile path reuses the existing `needsRecompilation` pipeline; no new control flow for shedding probes. Heartbeat-cost determinism in tests required threading `time.Now()` through `nowFunc`.