### PR TITLE
[autoscaling/cluster] Use target NodePool as base for replica

### DIFF
--- a/pkg/clusteragent/autoscaling/cluster/controller.go
+++ b/pkg/clusteragent/autoscaling/cluster/controller.go
@@ -206,23 +206,25 @@ func (c *Controller) syncNodePool(ctx context.Context, name string, datadogNp *k
 func (c *Controller) createNodePool(ctx context.Context, targetNp *karpenterv1.NodePool, npi model.NodePoolInternal) error {
 	log.Infof("Creating NodePool: %s", npi.Name())
 
-	knp := npi.KarpenterNodePool()
-	if knp == nil {
-		return fmt.Errorf("NodePool %s has no manifest, cannot create", npi.Name())
-	}
-	knp = knp.DeepCopy()
-	// If the manifest omits NodeClassRef and a target NodePool exists, prefer its NodeClassRef
-	if knp.Spec.Template.Spec.NodeClassRef == nil && targetNp != nil {
-		knp.Spec.Template.Spec.NodeClassRef = targetNp.Spec.Template.Spec.NodeClassRef.DeepCopy()
+	var knp *karpenterv1.NodePool
+	if targetNp != nil {
+		// Replica path: use the target NodePool as the base and apply RC values on top.
+		knp = npi.BuildReplicaNodePool(targetNp)
+		if knp == nil {
+			return fmt.Errorf("NodePool %s has no manifest, cannot create", npi.Name())
+		}
+	} else {
+		// Standalone path: build from the RC manifest only.
+		knp = npi.KarpenterNodePool()
+		if knp == nil {
+			return fmt.Errorf("NodePool %s has no manifest, cannot create", npi.Name())
+		}
+		knp = knp.DeepCopy()
 	}
 	var err error
 	knp, err = c.checkValidNodeClass(ctx, knp)
 	if err != nil {
 		return fmt.Errorf("unable to update NodePool with node class: %s, err: %v", npi.Name(), err)
-	}
-	// Update the weight if replica NodePool
-	if knp.Spec.Weight == nil && targetNp != nil {
-		knp.Spec.Weight = model.GetNodePoolWeight(targetNp)
 	}
 	// Ensure Datadog autoscaling node label is always present
 	if knp.Spec.Template.ObjectMeta.Labels == nil {
@@ -254,29 +256,34 @@ func (c *Controller) createNodePool(ctx context.Context, targetNp *karpenterv1.N
 }
 
 func (c *Controller) updateNodePool(ctx context.Context, targetNp *karpenterv1.NodePool, datadogNp *karpenterv1.NodePool, npi model.NodePoolInternal) error {
-	desired := npi.KarpenterNodePool()
-	if desired == nil {
-		return fmt.Errorf("NodePool %s has no manifest, cannot update", npi.Name())
+	var desired *karpenterv1.NodePool
+	if targetNp != nil {
+		// Replica path: use the target NodePool as the base and apply RC values on top.
+		desired = npi.BuildReplicaNodePool(targetNp)
+		if desired == nil {
+			return fmt.Errorf("NodePool %s has no manifest, cannot update", npi.Name())
+		}
+	} else {
+		// Standalone path: build from the RC manifest only.
+		desired = npi.KarpenterNodePool()
+		if desired == nil {
+			return fmt.Errorf("NodePool %s has no manifest, cannot update", npi.Name())
+		}
+		desired = desired.DeepCopy()
+		// Use the NodeClass in the live NodePool if the manifest omits it.
+		if desired.Spec.Template.Spec.NodeClassRef == nil && datadogNp.Spec.Template.Spec.NodeClassRef != nil {
+			desired.Spec.Template.Spec.NodeClassRef = datadogNp.Spec.Template.Spec.NodeClassRef.DeepCopy()
+		}
 	}
-	desired = desired.DeepCopy()
 	if desired.Labels == nil {
 		desired.Labels = make(map[string]string)
 	}
 	desired.Labels[model.DatadogCreatedLabelKey] = "true"
 
-	// Use the NodeClass in the live NodePool if the manifest omits it
-	if desired.Spec.Template.Spec.NodeClassRef == nil && datadogNp.Spec.Template.Spec.NodeClassRef != nil {
-		desired.Spec.Template.Spec.NodeClassRef = datadogNp.Spec.Template.Spec.NodeClassRef.DeepCopy()
-	}
 	var err error
 	desired, err = c.checkValidNodeClass(ctx, desired)
 	if err != nil {
 		return fmt.Errorf("unable to update NodePool with node class: %s, err: %v", npi.Name(), err)
-	}
-
-	// Update the weight if replica NodePool
-	if desired.Spec.Weight == nil && targetNp != nil {
-		desired.Spec.Weight = model.GetNodePoolWeight(targetNp)
 	}
 
 	// Ensure Datadog autoscaling node label is always present

--- a/pkg/clusteragent/autoscaling/cluster/controller.go
+++ b/pkg/clusteragent/autoscaling/cluster/controller.go
@@ -207,13 +207,13 @@ func (c *Controller) createNodePool(ctx context.Context, targetNp *karpenterv1.N
 
 	var knp *karpenterv1.NodePool
 	if targetNp != nil {
-		// Replica path: use the target NodePool as the base and apply RC values on top.
+		// Replica path: use the target NodePool as the base and apply RC values on top
 		knp = npi.BuildReplicaNodePool(targetNp)
 		if knp == nil {
 			return fmt.Errorf("NodePool %s has no manifest, cannot create", npi.Name())
 		}
 	} else {
-		// Standalone path: build from the RC manifest only.
+		// Standalone path: build from the RC manifest only
 		knp = npi.KarpenterNodePool()
 		if knp == nil {
 			return fmt.Errorf("NodePool %s has no manifest, cannot create", npi.Name())
@@ -257,19 +257,19 @@ func (c *Controller) createNodePool(ctx context.Context, targetNp *karpenterv1.N
 func (c *Controller) updateNodePool(ctx context.Context, targetNp *karpenterv1.NodePool, datadogNp *karpenterv1.NodePool, npi model.NodePoolInternal) error {
 	var desired *karpenterv1.NodePool
 	if targetNp != nil {
-		// Replica path: use the target NodePool as the base and apply RC values on top.
+		// Replica path: use the target NodePool as the base and apply RC values on top
 		desired = npi.BuildReplicaNodePool(targetNp)
 		if desired == nil {
 			return fmt.Errorf("NodePool %s has no manifest, cannot update", npi.Name())
 		}
 	} else {
-		// Standalone path: build from the RC manifest only.
+		// Standalone path: build from the RC manifest only
 		desired = npi.KarpenterNodePool()
 		if desired == nil {
 			return fmt.Errorf("NodePool %s has no manifest, cannot update", npi.Name())
 		}
 		desired = desired.DeepCopy()
-		// Use the NodeClass in the live NodePool if the manifest omits it.
+		// Use the NodeClass in the live NodePool if the manifest omits it
 		if desired.Spec.Template.Spec.NodeClassRef == nil && datadogNp.Spec.Template.Spec.NodeClassRef != nil {
 			desired.Spec.Template.Spec.NodeClassRef = datadogNp.Spec.Template.Spec.NodeClassRef.DeepCopy()
 		}

--- a/pkg/clusteragent/autoscaling/cluster/controller.go
+++ b/pkg/clusteragent/autoscaling/cluster/controller.go
@@ -167,10 +167,9 @@ func (c *Controller) syncNodePool(ctx context.Context, name string, datadogNp *k
 				return autoscaling.Requeue
 			}
 
-			// Only create or update if the TargetHash has not changed
+			// Log if the TargetHash has changed since recommendation was generated
 			if npi.TargetHash() != targetNp.GetAnnotations()[model.KarpenterNodePoolHashAnnotationKey] {
-				log.Infof("NodePool: %s TargetHash (%s) has changed since recommendation was generated; no action will be applied.", npi.Name(), npi.TargetHash())
-				return autoscaling.NoRequeue
+				log.Infof("NodePool: %s TargetHash (%s) has changed since recommendation was generated.", npi.Name(), npi.TargetHash())
 			}
 		}
 

--- a/pkg/clusteragent/autoscaling/cluster/model/node_pool_internal.go
+++ b/pkg/clusteragent/autoscaling/cluster/model/node_pool_internal.go
@@ -178,7 +178,7 @@ func (n *NodePoolInternal) BuildReplicaNodePool(targetNp *karpenterv1.NodePool) 
 	if len(rc.Spec.Limits) > 0 {
 		merged.Spec.Limits = rc.Spec.Limits
 	}
-	if rc.Spec.Disruption.ConsolidationPolicy != "" {
+	if rc.Spec.Disruption.ConsolidationPolicy != "" || rc.Spec.Disruption.ConsolidateAfter.Duration != nil || len(rc.Spec.Disruption.Budgets) > 0 {
 		merged.Spec.Disruption = rc.Spec.Disruption
 	}
 
@@ -204,7 +204,7 @@ func (n *NodePoolInternal) BuildReplicaNodePool(targetNp *karpenterv1.NodePool) 
 	merged.Spec.Template.Spec.Taints = mergeSlices(rc.Spec.Template.Spec.Taints, merged.Spec.Template.Spec.Taints)
 	merged.Spec.Template.Spec.StartupTaints = mergeSlices(rc.Spec.Template.Spec.StartupTaints, merged.Spec.Template.Spec.StartupTaints)
 	merged.Spec.Template.Spec.TerminationGracePeriod = mergePtrs(rc.Spec.Template.Spec.TerminationGracePeriod, merged.Spec.Template.Spec.TerminationGracePeriod)
-	if rc.Spec.Template.Spec.ExpireAfter.Duration != nil || len(rc.Spec.Template.Spec.ExpireAfter.Raw) > 0 {
+	if rc.Spec.Template.Spec.ExpireAfter.Duration != nil {
 		merged.Spec.Template.Spec.ExpireAfter = rc.Spec.Template.Spec.ExpireAfter
 	}
 

--- a/pkg/clusteragent/autoscaling/cluster/model/node_pool_internal.go
+++ b/pkg/clusteragent/autoscaling/cluster/model/node_pool_internal.go
@@ -8,6 +8,8 @@
 package model
 
 import (
+	"maps"
+	"reflect"
 	"strings"
 
 	// AWS Karpenter provider registers some variables in shared packages
@@ -143,6 +145,78 @@ func (n *NodePoolInternal) TargetHash() string {
 // KarpenterNodePool returns the fully-formed NodePool from the manifest, or nil if the manifest was absent or invalid.
 func (n *NodePoolInternal) KarpenterNodePool() *karpenterv1.NodePool {
 	return n.karpenterNodePool
+}
+
+// BuildReplicaNodePool produces a NodePool for a Datadog-managed replica of an existing target NodePool.
+// The target is used as the base and RC values are applied on top:
+//   - Top-level labels/annotations and Spec.Template.Spec.Requirements are always replaced from RC, even if RC's values are empty.
+//   - Other fields are only overwritten if RC explicitly set them; otherwise the target's value is preserved.
+//   - Spec.Weight defaults to GetNodePoolWeight(targetNp) when RC omits it.
+//   - Template-level labels/annotations from RC are merged on top of the target's (RC keys win, target keys preserved).
+func (n *NodePoolInternal) BuildReplicaNodePool(targetNp *karpenterv1.NodePool) *karpenterv1.NodePool {
+	if n.karpenterNodePool == nil || targetNp == nil {
+		return nil
+	}
+	rc := n.karpenterNodePool
+
+	merged := targetNp.DeepCopy()
+	merged.TypeMeta = rc.TypeMeta
+	merged.Status = karpenterv1.NodePoolStatus{}
+	merged.Name = rc.Name
+
+	// Top-level metadata: completely replace from RC.
+	merged.Labels = maps.Clone(rc.Labels)
+	merged.Annotations = maps.Clone(rc.Annotations)
+
+	// NodePoolSpec fields.
+	if rc.Spec.Weight != nil {
+		merged.Spec.Weight = rc.Spec.Weight
+	} else {
+		merged.Spec.Weight = GetNodePoolWeight(targetNp)
+	}
+	if rc.Spec.Replicas != nil {
+		merged.Spec.Replicas = rc.Spec.Replicas
+	}
+	if len(rc.Spec.Limits) > 0 {
+		merged.Spec.Limits = rc.Spec.Limits
+	}
+	if !reflect.DeepEqual(rc.Spec.Disruption, karpenterv1.Disruption{}) {
+		merged.Spec.Disruption = rc.Spec.Disruption
+	}
+
+	// Template ObjectMeta: merge RC keys on top of target's.
+	for k, v := range rc.Spec.Template.ObjectMeta.Labels {
+		if merged.Spec.Template.ObjectMeta.Labels == nil {
+			merged.Spec.Template.ObjectMeta.Labels = map[string]string{}
+		}
+		merged.Spec.Template.ObjectMeta.Labels[k] = v
+	}
+	for k, v := range rc.Spec.Template.ObjectMeta.Annotations {
+		if merged.Spec.Template.ObjectMeta.Annotations == nil {
+			merged.Spec.Template.ObjectMeta.Annotations = map[string]string{}
+		}
+		merged.Spec.Template.ObjectMeta.Annotations[k] = v
+	}
+
+	// NodeClaimTemplateSpec fields.
+	merged.Spec.Template.Spec.Requirements = rc.Spec.Template.Spec.Requirements
+	if rc.Spec.Template.Spec.NodeClassRef != nil {
+		merged.Spec.Template.Spec.NodeClassRef = rc.Spec.Template.Spec.NodeClassRef.DeepCopy()
+	}
+	if len(rc.Spec.Template.Spec.Taints) > 0 {
+		merged.Spec.Template.Spec.Taints = rc.Spec.Template.Spec.Taints
+	}
+	if len(rc.Spec.Template.Spec.StartupTaints) > 0 {
+		merged.Spec.Template.Spec.StartupTaints = rc.Spec.Template.Spec.StartupTaints
+	}
+	if rc.Spec.Template.Spec.TerminationGracePeriod != nil {
+		merged.Spec.Template.Spec.TerminationGracePeriod = rc.Spec.Template.Spec.TerminationGracePeriod
+	}
+	if !reflect.DeepEqual(rc.Spec.Template.Spec.ExpireAfter, karpenterv1.NillableDuration{}) {
+		merged.Spec.Template.Spec.ExpireAfter = rc.Spec.Template.Spec.ExpireAfter
+	}
+
+	return merged
 }
 
 func GetNodePoolWeight(replicaNp *karpenterv1.NodePool) *int32 {

--- a/pkg/clusteragent/autoscaling/cluster/model/node_pool_internal.go
+++ b/pkg/clusteragent/autoscaling/cluster/model/node_pool_internal.go
@@ -9,7 +9,6 @@ package model
 
 import (
 	"maps"
-	"reflect"
 	"strings"
 
 	// AWS Karpenter provider registers some variables in shared packages
@@ -147,6 +146,24 @@ func (n *NodePoolInternal) KarpenterNodePool() *karpenterv1.NodePool {
 	return n.karpenterNodePool
 }
 
+// mergePtrs returns rc if non-nil, otherwise target. Used in BuildReplicaNodePool
+// to apply "RC wins if set, else preserve target" semantics for pointer fields.
+func mergePtrs[T any](rc, target *T) *T {
+	if rc != nil {
+		return rc
+	}
+	return target
+}
+
+// mergeSlices returns rc if non-empty, otherwise target. Used in BuildReplicaNodePool
+// to apply "RC wins if set, else preserve target" semantics for slice fields.
+func mergeSlices[T any](rc, target []T) []T {
+	if len(rc) > 0 {
+		return rc
+	}
+	return target
+}
+
 // BuildReplicaNodePool produces a NodePool for a Datadog-managed replica of an existing target NodePool.
 // The target is used as the base and RC values are applied on top:
 //   - Top-level labels/annotations and Spec.Template.Spec.Requirements are always replaced from RC, even if RC's values are empty.
@@ -165,30 +182,28 @@ func (n *NodePoolInternal) BuildReplicaNodePool(targetNp *karpenterv1.NodePool) 
 
 	// Top-level metadata: completely replace from RC. Constructing a fresh ObjectMeta
 	// drops server-set fields (ResourceVersion, UID, Generation, CreationTimestamp,
-	// ManagedFields, ...) that the target carries from the cluster
+	// ManagedFields, ...) that the target carries from the cluster.
 	merged.ObjectMeta = metav1.ObjectMeta{
 		Name:        rc.Name,
 		Labels:      maps.Clone(rc.Labels),
 		Annotations: maps.Clone(rc.Annotations),
 	}
 
-	// NodePoolSpec fields.
+	// NodePoolSpec fields: RC wins if set, else target preserved.
 	if rc.Spec.Weight != nil {
 		merged.Spec.Weight = rc.Spec.Weight
 	} else {
 		merged.Spec.Weight = GetNodePoolWeight(targetNp)
 	}
-	if rc.Spec.Replicas != nil {
-		merged.Spec.Replicas = rc.Spec.Replicas
-	}
+	merged.Spec.Replicas = mergePtrs(rc.Spec.Replicas, merged.Spec.Replicas)
 	if len(rc.Spec.Limits) > 0 {
 		merged.Spec.Limits = rc.Spec.Limits
 	}
-	if !reflect.DeepEqual(rc.Spec.Disruption, karpenterv1.Disruption{}) {
+	if rc.Spec.Disruption.ConsolidationPolicy != "" {
 		merged.Spec.Disruption = rc.Spec.Disruption
 	}
 
-	// Template ObjectMeta: merge RC keys on top of target's.
+	// Template ObjectMeta: RC keys merged on top of target's.
 	for k, v := range rc.Spec.Template.ObjectMeta.Labels {
 		if merged.Spec.Template.ObjectMeta.Labels == nil {
 			merged.Spec.Template.ObjectMeta.Labels = map[string]string{}
@@ -202,21 +217,15 @@ func (n *NodePoolInternal) BuildReplicaNodePool(targetNp *karpenterv1.NodePool) 
 		merged.Spec.Template.ObjectMeta.Annotations[k] = v
 	}
 
-	// NodeClaimTemplateSpec fields.
+	// NodeClaimTemplateSpec fields: RC wins if set, else target preserved.
 	merged.Spec.Template.Spec.Requirements = rc.Spec.Template.Spec.Requirements
 	if rc.Spec.Template.Spec.NodeClassRef != nil {
 		merged.Spec.Template.Spec.NodeClassRef = rc.Spec.Template.Spec.NodeClassRef.DeepCopy()
 	}
-	if len(rc.Spec.Template.Spec.Taints) > 0 {
-		merged.Spec.Template.Spec.Taints = rc.Spec.Template.Spec.Taints
-	}
-	if len(rc.Spec.Template.Spec.StartupTaints) > 0 {
-		merged.Spec.Template.Spec.StartupTaints = rc.Spec.Template.Spec.StartupTaints
-	}
-	if rc.Spec.Template.Spec.TerminationGracePeriod != nil {
-		merged.Spec.Template.Spec.TerminationGracePeriod = rc.Spec.Template.Spec.TerminationGracePeriod
-	}
-	if !reflect.DeepEqual(rc.Spec.Template.Spec.ExpireAfter, karpenterv1.NillableDuration{}) {
+	merged.Spec.Template.Spec.Taints = mergeSlices(rc.Spec.Template.Spec.Taints, merged.Spec.Template.Spec.Taints)
+	merged.Spec.Template.Spec.StartupTaints = mergeSlices(rc.Spec.Template.Spec.StartupTaints, merged.Spec.Template.Spec.StartupTaints)
+	merged.Spec.Template.Spec.TerminationGracePeriod = mergePtrs(rc.Spec.Template.Spec.TerminationGracePeriod, merged.Spec.Template.Spec.TerminationGracePeriod)
+	if rc.Spec.Template.Spec.ExpireAfter.Duration != nil || len(rc.Spec.Template.Spec.ExpireAfter.Raw) > 0 {
 		merged.Spec.Template.Spec.ExpireAfter = rc.Spec.Template.Spec.ExpireAfter
 	}
 

--- a/pkg/clusteragent/autoscaling/cluster/model/node_pool_internal.go
+++ b/pkg/clusteragent/autoscaling/cluster/model/node_pool_internal.go
@@ -162,11 +162,15 @@ func (n *NodePoolInternal) BuildReplicaNodePool(targetNp *karpenterv1.NodePool) 
 	merged := targetNp.DeepCopy()
 	merged.TypeMeta = rc.TypeMeta
 	merged.Status = karpenterv1.NodePoolStatus{}
-	merged.Name = rc.Name
 
-	// Top-level metadata: completely replace from RC.
-	merged.Labels = maps.Clone(rc.Labels)
-	merged.Annotations = maps.Clone(rc.Annotations)
+	// Top-level metadata: completely replace from RC. Constructing a fresh ObjectMeta
+	// drops server-set fields (ResourceVersion, UID, Generation, CreationTimestamp,
+	// ManagedFields, ...) that the target carries from the cluster
+	merged.ObjectMeta = metav1.ObjectMeta{
+		Name:        rc.Name,
+		Labels:      maps.Clone(rc.Labels),
+		Annotations: maps.Clone(rc.Annotations),
+	}
 
 	// NodePoolSpec fields.
 	if rc.Spec.Weight != nil {

--- a/pkg/clusteragent/autoscaling/cluster/model/node_pool_internal.go
+++ b/pkg/clusteragent/autoscaling/cluster/model/node_pool_internal.go
@@ -146,30 +146,11 @@ func (n *NodePoolInternal) KarpenterNodePool() *karpenterv1.NodePool {
 	return n.karpenterNodePool
 }
 
-// mergePtrs returns rc if non-nil, otherwise target. Used in BuildReplicaNodePool
-// to apply "RC wins if set, else preserve target" semantics for pointer fields.
-func mergePtrs[T any](rc, target *T) *T {
-	if rc != nil {
-		return rc
-	}
-	return target
-}
-
-// mergeSlices returns rc if non-empty, otherwise target. Used in BuildReplicaNodePool
-// to apply "RC wins if set, else preserve target" semantics for slice fields.
-func mergeSlices[T any](rc, target []T) []T {
-	if len(rc) > 0 {
-		return rc
-	}
-	return target
-}
-
-// BuildReplicaNodePool produces a NodePool for a Datadog-managed replica of an existing target NodePool.
+// BuildReplicaNodePool produces a NodePool for a Datadog-managed replica of an existing target NodePool
 // The target is used as the base and RC values are applied on top:
-//   - Top-level labels/annotations and Spec.Template.Spec.Requirements are always replaced from RC, even if RC's values are empty.
-//   - Other fields are only overwritten if RC explicitly set them; otherwise the target's value is preserved.
-//   - Spec.Weight defaults to GetNodePoolWeight(targetNp) when RC omits it.
-//   - Template-level labels/annotations from RC are merged on top of the target's (RC keys win, target keys preserved).
+//   - Top-level labels/annotations are always replaced from RC
+//   - Other fields are only overwritten if RC explicitly set them; otherwise the target's value is preserved
+//   - Template-level labels/annotations from RC are merged on top of the target's
 func (n *NodePoolInternal) BuildReplicaNodePool(targetNp *karpenterv1.NodePool) *karpenterv1.NodePool {
 	if n.karpenterNodePool == nil || targetNp == nil {
 		return nil
@@ -180,20 +161,18 @@ func (n *NodePoolInternal) BuildReplicaNodePool(targetNp *karpenterv1.NodePool) 
 	merged.TypeMeta = rc.TypeMeta
 	merged.Status = karpenterv1.NodePoolStatus{}
 
-	// Top-level metadata: completely replace from RC. Constructing a fresh ObjectMeta
-	// drops server-set fields (ResourceVersion, UID, Generation, CreationTimestamp,
-	// ManagedFields, ...) that the target carries from the cluster.
+	// Construct top-level metadata from RC
 	merged.ObjectMeta = metav1.ObjectMeta{
 		Name:        rc.Name,
 		Labels:      maps.Clone(rc.Labels),
 		Annotations: maps.Clone(rc.Annotations),
 	}
 
-	// NodePoolSpec fields: RC wins if set, else target preserved.
+	// NodePoolSpec fields: use RC values if set, else fallback to target
 	if rc.Spec.Weight != nil {
 		merged.Spec.Weight = rc.Spec.Weight
 	} else {
-		merged.Spec.Weight = GetNodePoolWeight(targetNp)
+		merged.Spec.Weight = getNodePoolWeight(targetNp)
 	}
 	merged.Spec.Replicas = mergePtrs(rc.Spec.Replicas, merged.Spec.Replicas)
 	if len(rc.Spec.Limits) > 0 {
@@ -203,7 +182,7 @@ func (n *NodePoolInternal) BuildReplicaNodePool(targetNp *karpenterv1.NodePool) 
 		merged.Spec.Disruption = rc.Spec.Disruption
 	}
 
-	// Template ObjectMeta: RC keys merged on top of target's.
+	// Template ObjectMeta: RC keys merged on top of target's
 	for k, v := range rc.Spec.Template.ObjectMeta.Labels {
 		if merged.Spec.Template.ObjectMeta.Labels == nil {
 			merged.Spec.Template.ObjectMeta.Labels = map[string]string{}
@@ -217,8 +196,8 @@ func (n *NodePoolInternal) BuildReplicaNodePool(targetNp *karpenterv1.NodePool) 
 		merged.Spec.Template.ObjectMeta.Annotations[k] = v
 	}
 
-	// NodeClaimTemplateSpec fields: RC wins if set, else target preserved.
-	merged.Spec.Template.Spec.Requirements = rc.Spec.Template.Spec.Requirements
+	// NodeClaimTemplateSpec fields: use RC values if set, else fallback to target
+	merged.Spec.Template.Spec.Requirements = mergeSlices(rc.Spec.Template.Spec.Requirements, merged.Spec.Template.Spec.Requirements)
 	if rc.Spec.Template.Spec.NodeClassRef != nil {
 		merged.Spec.Template.Spec.NodeClassRef = rc.Spec.Template.Spec.NodeClassRef.DeepCopy()
 	}
@@ -232,7 +211,7 @@ func (n *NodePoolInternal) BuildReplicaNodePool(targetNp *karpenterv1.NodePool) 
 	return merged
 }
 
-func GetNodePoolWeight(replicaNp *karpenterv1.NodePool) *int32 {
+func getNodePoolWeight(replicaNp *karpenterv1.NodePool) *int32 {
 	weight := int32(1)
 	if replicaNp.Spec.Weight != nil {
 		if *replicaNp.Spec.Weight == 100 {
@@ -241,4 +220,20 @@ func GetNodePoolWeight(replicaNp *karpenterv1.NodePool) *int32 {
 		weight = min(*replicaNp.Spec.Weight+1, 100)
 	}
 	return &weight
+}
+
+// mergePtrs returns rc if non-nil, otherwise target
+func mergePtrs[T any](rc, target *T) *T {
+	if rc != nil {
+		return rc
+	}
+	return target
+}
+
+// mergeSlices returns rc if non-empty, otherwise target
+func mergeSlices[T any](rc, target []T) []T {
+	if len(rc) > 0 {
+		return rc
+	}
+	return target
 }

--- a/pkg/clusteragent/autoscaling/cluster/model/node_pool_internal_test.go
+++ b/pkg/clusteragent/autoscaling/cluster/model/node_pool_internal_test.go
@@ -268,14 +268,11 @@ func TestGetNodePoolWeight(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			np := &karpenterv1.NodePool{}
 			np.Spec.Weight = tt.weight
-			assert.Equal(t, tt.expectedWeight, *GetNodePoolWeight(np))
+			assert.Equal(t, tt.expectedWeight, *getNodePoolWeight(np))
 		})
 	}
 }
 
-// targetNodePoolFixture returns a populated target NodePool used as the merge base in BuildReplicaNodePool tests.
-// Server-set ObjectMeta fields (ResourceVersion, UID, Generation, ...) are populated to mimic an object
-// fetched from the API server, so tests verify the merge does not leak them into a Create payload.
 func targetNodePoolFixture() *karpenterv1.NodePool {
 	weight := int32(5)
 	terminationGrace := metav1.Duration{Duration: 30 * time.Minute}
@@ -322,7 +319,6 @@ func targetNodePoolFixture() *karpenterv1.NodePool {
 	}
 }
 
-// rcNodePoolFromManifest returns a NodePoolInternal whose karpenterNodePool was built from the given manifest.
 func rcNodePoolFromManifest(t *testing.T, m *KarpenterV1NodePool) NodePoolInternal {
 	t.Helper()
 	npi := NewNodePoolInternal(ClusterAutoscalingValues{
@@ -366,11 +362,10 @@ func TestBuildReplicaNodePool_AlwaysReplacedFields(t *testing.T) {
 	assert.Equal(t, "dd-pool", merged.Name)
 	assert.Equal(t, metav1.TypeMeta{Kind: "NodePool", APIVersion: "karpenter.sh/v1"}, merged.TypeMeta)
 	assert.Equal(t, karpenterv1.NodePoolStatus{}, merged.Status, "status must be reset")
-	// Top-level metadata is completely replaced (Datadog labels/annotations are added by the controller, not here).
+	// Top-level metadata is completely replaced
 	assert.Equal(t, map[string]string{"rc-label": "rc"}, merged.Labels)
 	assert.Equal(t, map[string]string{"rc-ann": "rc"}, merged.Annotations)
-	// Server-set ObjectMeta fields from the target must not leak through; otherwise the API server rejects
-	// the Create with "resourceVersion should not be set on objects to be created".
+	// Server-set ObjectMeta fields from the target must not leak through
 	assert.Empty(t, merged.ResourceVersion, "ResourceVersion must be cleared")
 	assert.Empty(t, merged.UID, "UID must be cleared")
 	assert.Zero(t, merged.Generation, "Generation must be cleared")
@@ -427,49 +422,68 @@ func TestBuildReplicaNodePool_Weight(t *testing.T) {
 }
 
 func TestBuildReplicaNodePool_Requirements(t *testing.T) {
-	t.Run("RC has requirements: replaces target", func(t *testing.T) {
-		rcReqs := []karpenterv1.NodeSelectorRequirementWithMinValues{
-			{Key: "node.kubernetes.io/instance-type", Operator: corev1.NodeSelectorOpIn, Values: []string{"c5.large", "c5.xlarge"}},
-		}
-		npi := rcNodePoolFromManifest(t, &KarpenterV1NodePool{
-			Metadata: Metadata{Name: "dd-pool"},
-			Spec: &karpenterv1.NodePoolSpec{Template: karpenterv1.NodeClaimTemplate{Spec: karpenterv1.NodeClaimTemplateSpec{
+	rcReqs := []karpenterv1.NodeSelectorRequirementWithMinValues{
+		{Key: "node.kubernetes.io/instance-type", Operator: corev1.NodeSelectorOpIn, Values: []string{"c5.large", "c5.xlarge"}},
+	}
+	tests := []struct {
+		name     string
+		rcSpec   *karpenterv1.NodePoolSpec
+		expected []karpenterv1.NodeSelectorRequirementWithMinValues
+	}{
+		{
+			name: "RC set: overrides target",
+			rcSpec: &karpenterv1.NodePoolSpec{Template: karpenterv1.NodeClaimTemplate{Spec: karpenterv1.NodeClaimTemplateSpec{
 				Requirements: rcReqs,
 			}}},
+			expected: rcReqs,
+		},
+		{
+			name:     "RC unset: target preserved",
+			rcSpec:   &karpenterv1.NodePoolSpec{},
+			expected: targetNodePoolFixture().Spec.Template.Spec.Requirements,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			npi := rcNodePoolFromManifest(t, &KarpenterV1NodePool{
+				Metadata: Metadata{Name: "dd-pool"},
+				Spec:     tt.rcSpec,
+			})
+			merged := npi.BuildReplicaNodePool(targetNodePoolFixture())
+			assert.Equal(t, tt.expected, merged.Spec.Template.Spec.Requirements)
 		})
-		merged := npi.BuildReplicaNodePool(targetNodePoolFixture())
-		assert.Equal(t, rcReqs, merged.Spec.Template.Spec.Requirements)
-	})
-	t.Run("RC has no requirements: target wiped", func(t *testing.T) {
-		npi := rcNodePoolFromManifest(t, &KarpenterV1NodePool{
-			Metadata: Metadata{Name: "dd-pool"},
-			Spec:     &karpenterv1.NodePoolSpec{},
-		})
-		merged := npi.BuildReplicaNodePool(targetNodePoolFixture())
-		assert.Empty(t, merged.Spec.Template.Spec.Requirements)
-	})
+	}
 }
 
 func TestBuildReplicaNodePool_NodeClassRef(t *testing.T) {
-	t.Run("RC sets NodeClassRef: overrides target", func(t *testing.T) {
-		rcRef := &karpenterv1.NodeClassReference{Group: "karpenter.k8s.aws", Kind: "EC2NodeClass", Name: "rc-nc"}
-		npi := rcNodePoolFromManifest(t, &KarpenterV1NodePool{
-			Metadata: Metadata{Name: "dd-pool"},
-			Spec: &karpenterv1.NodePoolSpec{Template: karpenterv1.NodeClaimTemplate{Spec: karpenterv1.NodeClaimTemplateSpec{
-				NodeClassRef: rcRef,
+	tests := []struct {
+		name     string
+		rcSpec   *karpenterv1.NodePoolSpec
+		expected string
+	}{
+		{
+			name: "RC set: overrides target",
+			rcSpec: &karpenterv1.NodePoolSpec{Template: karpenterv1.NodeClaimTemplate{Spec: karpenterv1.NodeClaimTemplateSpec{
+				NodeClassRef: &karpenterv1.NodeClassReference{Group: "karpenter.k8s.aws", Kind: "EC2NodeClass", Name: "rc-nc"},
 			}}},
+			expected: "rc-nc",
+		},
+		{
+			name:     "RC unset: target preserved",
+			rcSpec:   &karpenterv1.NodePoolSpec{},
+			expected: "target-nc",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			npi := rcNodePoolFromManifest(t, &KarpenterV1NodePool{
+				Metadata: Metadata{Name: "dd-pool"},
+				Spec:     tt.rcSpec,
+			})
+			merged := npi.BuildReplicaNodePool(targetNodePoolFixture())
+			assert.Equal(t, tt.expected, merged.Spec.Template.Spec.NodeClassRef.Name)
 		})
-		merged := npi.BuildReplicaNodePool(targetNodePoolFixture())
-		assert.Equal(t, "rc-nc", merged.Spec.Template.Spec.NodeClassRef.Name)
-	})
-	t.Run("RC nil: target preserved", func(t *testing.T) {
-		npi := rcNodePoolFromManifest(t, &KarpenterV1NodePool{
-			Metadata: Metadata{Name: "dd-pool"},
-			Spec:     &karpenterv1.NodePoolSpec{},
-		})
-		merged := npi.BuildReplicaNodePool(targetNodePoolFixture())
-		assert.Equal(t, "target-nc", merged.Spec.Template.Spec.NodeClassRef.Name)
-	})
+	}
 }
 
 func TestBuildReplicaNodePool_Disruption(t *testing.T) {
@@ -478,62 +492,79 @@ func TestBuildReplicaNodePool_Disruption(t *testing.T) {
 		ConsolidationPolicy: karpenterv1.ConsolidationPolicyWhenEmptyOrUnderutilized,
 		ConsolidateAfter:    karpenterv1.NillableDuration{Duration: &rcConsolidateAfter},
 	}
-
-	t.Run("target set, RC unset: target preserved", func(t *testing.T) {
-		npi := rcNodePoolFromManifest(t, &KarpenterV1NodePool{
-			Metadata: Metadata{Name: "dd-pool"},
-			Spec:     &karpenterv1.NodePoolSpec{},
+	bareTarget := &karpenterv1.NodePool{
+		Spec: karpenterv1.NodePoolSpec{Template: karpenterv1.NodeClaimTemplate{Spec: karpenterv1.NodeClaimTemplateSpec{
+			NodeClassRef: &karpenterv1.NodeClassReference{Name: "nc"},
+			Requirements: []karpenterv1.NodeSelectorRequirementWithMinValues{},
+		}}},
+	}
+	tests := []struct {
+		name     string
+		target   *karpenterv1.NodePool
+		rcSpec   *karpenterv1.NodePoolSpec
+		expected karpenterv1.Disruption
+	}{
+		{
+			name:     "RC unset: target preserved",
+			target:   targetNodePoolFixture(),
+			rcSpec:   &karpenterv1.NodePoolSpec{},
+			expected: targetNodePoolFixture().Spec.Disruption,
+		},
+		{
+			name:     "RC set: overrides target",
+			target:   targetNodePoolFixture(),
+			rcSpec:   &karpenterv1.NodePoolSpec{Disruption: rcDisruption},
+			expected: rcDisruption,
+		},
+		{
+			name:     "target unset, RC unset: zero value",
+			target:   bareTarget,
+			rcSpec:   &karpenterv1.NodePoolSpec{},
+			expected: karpenterv1.Disruption{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			npi := rcNodePoolFromManifest(t, &KarpenterV1NodePool{
+				Metadata: Metadata{Name: "dd-pool"},
+				Spec:     tt.rcSpec,
+			})
+			merged := npi.BuildReplicaNodePool(tt.target)
+			assert.Equal(t, tt.expected, merged.Spec.Disruption)
 		})
-		target := targetNodePoolFixture()
-		merged := npi.BuildReplicaNodePool(target)
-		assert.Equal(t, target.Spec.Disruption, merged.Spec.Disruption)
-	})
-	t.Run("target set, RC set: RC overrides", func(t *testing.T) {
-		npi := rcNodePoolFromManifest(t, &KarpenterV1NodePool{
-			Metadata: Metadata{Name: "dd-pool"},
-			Spec:     &karpenterv1.NodePoolSpec{Disruption: rcDisruption},
-		})
-		merged := npi.BuildReplicaNodePool(targetNodePoolFixture())
-		assert.Equal(t, rcDisruption, merged.Spec.Disruption)
-	})
-	t.Run("target unset, RC unset: zero value", func(t *testing.T) {
-		npi := rcNodePoolFromManifest(t, &KarpenterV1NodePool{
-			Metadata: Metadata{Name: "dd-pool"},
-			Spec:     &karpenterv1.NodePoolSpec{},
-		})
-		bareTarget := &karpenterv1.NodePool{
-			Spec: karpenterv1.NodePoolSpec{Template: karpenterv1.NodeClaimTemplate{Spec: karpenterv1.NodeClaimTemplateSpec{
-				NodeClassRef: &karpenterv1.NodeClassReference{Name: "nc"},
-				Requirements: []karpenterv1.NodeSelectorRequirementWithMinValues{},
-			}}},
-		}
-		merged := npi.BuildReplicaNodePool(bareTarget)
-		assert.Equal(t, karpenterv1.Disruption{}, merged.Spec.Disruption)
-	})
+	}
 }
 
 func TestBuildReplicaNodePool_ExpireAfter(t *testing.T) {
 	rcExpire := 12 * time.Hour
-	t.Run("target set, RC unset: target preserved", func(t *testing.T) {
-		npi := rcNodePoolFromManifest(t, &KarpenterV1NodePool{
-			Metadata: Metadata{Name: "dd-pool"},
-			Spec:     &karpenterv1.NodePoolSpec{},
-		})
-		target := targetNodePoolFixture()
-		merged := npi.BuildReplicaNodePool(target)
-		assert.Equal(t, target.Spec.Template.Spec.ExpireAfter, merged.Spec.Template.Spec.ExpireAfter)
-	})
-	t.Run("target set, RC set: RC overrides", func(t *testing.T) {
-		npi := rcNodePoolFromManifest(t, &KarpenterV1NodePool{
-			Metadata: Metadata{Name: "dd-pool"},
-			Spec: &karpenterv1.NodePoolSpec{Template: karpenterv1.NodeClaimTemplate{Spec: karpenterv1.NodeClaimTemplateSpec{
+	tests := []struct {
+		name     string
+		rcSpec   *karpenterv1.NodePoolSpec
+		expected karpenterv1.NillableDuration
+	}{
+		{
+			name:     "RC unset: target preserved",
+			rcSpec:   &karpenterv1.NodePoolSpec{},
+			expected: targetNodePoolFixture().Spec.Template.Spec.ExpireAfter,
+		},
+		{
+			name: "RC set: overrides target",
+			rcSpec: &karpenterv1.NodePoolSpec{Template: karpenterv1.NodeClaimTemplate{Spec: karpenterv1.NodeClaimTemplateSpec{
 				ExpireAfter: karpenterv1.NillableDuration{Duration: &rcExpire},
 			}}},
+			expected: karpenterv1.NillableDuration{Duration: &rcExpire},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			npi := rcNodePoolFromManifest(t, &KarpenterV1NodePool{
+				Metadata: Metadata{Name: "dd-pool"},
+				Spec:     tt.rcSpec,
+			})
+			merged := npi.BuildReplicaNodePool(targetNodePoolFixture())
+			assert.Equal(t, tt.expected, merged.Spec.Template.Spec.ExpireAfter)
 		})
-		merged := npi.BuildReplicaNodePool(targetNodePoolFixture())
-		require.NotNil(t, merged.Spec.Template.Spec.ExpireAfter.Duration)
-		assert.Equal(t, rcExpire, *merged.Spec.Template.Spec.ExpireAfter.Duration)
-	})
+	}
 }
 
 func TestBuildReplicaNodePool_TemplateMetadataMerged(t *testing.T) {
@@ -559,46 +590,158 @@ func TestBuildReplicaNodePool_TemplateMetadataMerged(t *testing.T) {
 	}, merged.Spec.Template.ObjectMeta.Annotations)
 }
 
-func TestBuildReplicaNodePool_OtherSmartMergeFields(t *testing.T) {
-	rcGrace := metav1.Duration{Duration: time.Minute}
+func TestBuildReplicaNodePool_Replicas(t *testing.T) {
 	rcReplicas := int64(7)
+	tests := []struct {
+		name     string
+		rcSpec   *karpenterv1.NodePoolSpec
+		expected *int64
+	}{
+		{
+			name:     "RC set: overrides target",
+			rcSpec:   &karpenterv1.NodePoolSpec{Replicas: &rcReplicas},
+			expected: &rcReplicas,
+		},
+		{
+			name:     "RC unset: nil preserved",
+			rcSpec:   &karpenterv1.NodePoolSpec{},
+			expected: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			npi := rcNodePoolFromManifest(t, &KarpenterV1NodePool{
+				Metadata: Metadata{Name: "dd-pool"},
+				Spec:     tt.rcSpec,
+			})
+			merged := npi.BuildReplicaNodePool(targetNodePoolFixture())
+			assert.Equal(t, tt.expected, merged.Spec.Replicas)
+		})
+	}
+}
+
+func TestBuildReplicaNodePool_Limits(t *testing.T) {
 	rcLimits := karpenterv1.Limits{corev1.ResourceMemory: resource.MustParse("64Gi")}
+	tests := []struct {
+		name     string
+		rcSpec   *karpenterv1.NodePoolSpec
+		expected karpenterv1.Limits
+	}{
+		{
+			name:     "RC set: overrides target",
+			rcSpec:   &karpenterv1.NodePoolSpec{Limits: rcLimits},
+			expected: rcLimits,
+		},
+		{
+			name:     "RC unset: target preserved",
+			rcSpec:   &karpenterv1.NodePoolSpec{},
+			expected: targetNodePoolFixture().Spec.Limits,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			npi := rcNodePoolFromManifest(t, &KarpenterV1NodePool{
+				Metadata: Metadata{Name: "dd-pool"},
+				Spec:     tt.rcSpec,
+			})
+			merged := npi.BuildReplicaNodePool(targetNodePoolFixture())
+			assert.Equal(t, tt.expected, merged.Spec.Limits)
+		})
+	}
+}
+
+func TestBuildReplicaNodePool_Taints(t *testing.T) {
 	rcTaints := []corev1.Taint{{Key: "rc-taint", Effect: corev1.TaintEffectPreferNoSchedule}}
+	tests := []struct {
+		name     string
+		rcSpec   *karpenterv1.NodePoolSpec
+		expected []corev1.Taint
+	}{
+		{
+			name: "RC set: overrides target",
+			rcSpec: &karpenterv1.NodePoolSpec{Template: karpenterv1.NodeClaimTemplate{Spec: karpenterv1.NodeClaimTemplateSpec{
+				Taints: rcTaints,
+			}}},
+			expected: rcTaints,
+		},
+		{
+			name:     "RC unset: target preserved",
+			rcSpec:   &karpenterv1.NodePoolSpec{},
+			expected: targetNodePoolFixture().Spec.Template.Spec.Taints,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			npi := rcNodePoolFromManifest(t, &KarpenterV1NodePool{
+				Metadata: Metadata{Name: "dd-pool"},
+				Spec:     tt.rcSpec,
+			})
+			merged := npi.BuildReplicaNodePool(targetNodePoolFixture())
+			assert.Equal(t, tt.expected, merged.Spec.Template.Spec.Taints)
+		})
+	}
+}
+
+func TestBuildReplicaNodePool_StartupTaints(t *testing.T) {
 	rcStartupTaints := []corev1.Taint{{Key: "rc-startup", Effect: corev1.TaintEffectNoExecute}}
-
-	t.Run("RC sets all: overrides target", func(t *testing.T) {
-		npi := rcNodePoolFromManifest(t, &KarpenterV1NodePool{
-			Metadata: Metadata{Name: "dd-pool"},
-			Spec: &karpenterv1.NodePoolSpec{
-				Replicas: &rcReplicas,
-				Limits:   rcLimits,
-				Template: karpenterv1.NodeClaimTemplate{Spec: karpenterv1.NodeClaimTemplateSpec{
-					Taints:                 rcTaints,
-					StartupTaints:          rcStartupTaints,
-					TerminationGracePeriod: &rcGrace,
-				}},
-			},
+	tests := []struct {
+		name     string
+		rcSpec   *karpenterv1.NodePoolSpec
+		expected []corev1.Taint
+	}{
+		{
+			name: "RC set: overrides target",
+			rcSpec: &karpenterv1.NodePoolSpec{Template: karpenterv1.NodeClaimTemplate{Spec: karpenterv1.NodeClaimTemplateSpec{
+				StartupTaints: rcStartupTaints,
+			}}},
+			expected: rcStartupTaints,
+		},
+		{
+			name:     "RC unset: target preserved",
+			rcSpec:   &karpenterv1.NodePoolSpec{},
+			expected: targetNodePoolFixture().Spec.Template.Spec.StartupTaints,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			npi := rcNodePoolFromManifest(t, &KarpenterV1NodePool{
+				Metadata: Metadata{Name: "dd-pool"},
+				Spec:     tt.rcSpec,
+			})
+			merged := npi.BuildReplicaNodePool(targetNodePoolFixture())
+			assert.Equal(t, tt.expected, merged.Spec.Template.Spec.StartupTaints)
 		})
-		merged := npi.BuildReplicaNodePool(targetNodePoolFixture())
-		require.NotNil(t, merged.Spec.Replicas)
-		assert.Equal(t, rcReplicas, *merged.Spec.Replicas)
-		assert.Equal(t, rcLimits, merged.Spec.Limits)
-		assert.Equal(t, rcTaints, merged.Spec.Template.Spec.Taints)
-		assert.Equal(t, rcStartupTaints, merged.Spec.Template.Spec.StartupTaints)
-		assert.Equal(t, &rcGrace, merged.Spec.Template.Spec.TerminationGracePeriod)
-	})
+	}
+}
 
-	t.Run("RC unset: target preserved", func(t *testing.T) {
-		npi := rcNodePoolFromManifest(t, &KarpenterV1NodePool{
-			Metadata: Metadata{Name: "dd-pool"},
-			Spec:     &karpenterv1.NodePoolSpec{},
+func TestBuildReplicaNodePool_TerminationGracePeriod(t *testing.T) {
+	rcGrace := metav1.Duration{Duration: time.Minute}
+	tests := []struct {
+		name     string
+		rcSpec   *karpenterv1.NodePoolSpec
+		expected *metav1.Duration
+	}{
+		{
+			name: "RC set: overrides target",
+			rcSpec: &karpenterv1.NodePoolSpec{Template: karpenterv1.NodeClaimTemplate{Spec: karpenterv1.NodeClaimTemplateSpec{
+				TerminationGracePeriod: &rcGrace,
+			}}},
+			expected: &rcGrace,
+		},
+		{
+			name:     "RC unset: target preserved",
+			rcSpec:   &karpenterv1.NodePoolSpec{},
+			expected: targetNodePoolFixture().Spec.Template.Spec.TerminationGracePeriod,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			npi := rcNodePoolFromManifest(t, &KarpenterV1NodePool{
+				Metadata: Metadata{Name: "dd-pool"},
+				Spec:     tt.rcSpec,
+			})
+			merged := npi.BuildReplicaNodePool(targetNodePoolFixture())
+			assert.Equal(t, tt.expected, merged.Spec.Template.Spec.TerminationGracePeriod)
 		})
-		target := targetNodePoolFixture()
-		merged := npi.BuildReplicaNodePool(target)
-		assert.Nil(t, merged.Spec.Replicas)
-		assert.Equal(t, target.Spec.Limits, merged.Spec.Limits)
-		assert.Equal(t, target.Spec.Template.Spec.Taints, merged.Spec.Template.Spec.Taints)
-		assert.Empty(t, merged.Spec.Template.Spec.StartupTaints)
-		assert.Equal(t, target.Spec.Template.Spec.TerminationGracePeriod, merged.Spec.Template.Spec.TerminationGracePeriod)
-	})
+	}
 }

--- a/pkg/clusteragent/autoscaling/cluster/model/node_pool_internal_test.go
+++ b/pkg/clusteragent/autoscaling/cluster/model/node_pool_internal_test.go
@@ -274,6 +274,8 @@ func TestGetNodePoolWeight(t *testing.T) {
 }
 
 // targetNodePoolFixture returns a populated target NodePool used as the merge base in BuildReplicaNodePool tests.
+// Server-set ObjectMeta fields (ResourceVersion, UID, Generation, ...) are populated to mimic an object
+// fetched from the API server, so tests verify the merge does not leak them into a Create payload.
 func targetNodePoolFixture() *karpenterv1.NodePool {
 	weight := int32(5)
 	terminationGrace := metav1.Duration{Duration: 30 * time.Minute}
@@ -282,9 +284,14 @@ func targetNodePoolFixture() *karpenterv1.NodePool {
 	return &karpenterv1.NodePool{
 		TypeMeta: metav1.TypeMeta{Kind: "NodePool", APIVersion: "karpenter.sh/v1"},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "user-pool",
-			Labels:      map[string]string{"target-label": "target"},
-			Annotations: map[string]string{"target-ann": "target"},
+			Name:              "user-pool",
+			Labels:            map[string]string{"target-label": "target"},
+			Annotations:       map[string]string{"target-ann": "target"},
+			ResourceVersion:   "12345",
+			UID:               "11111111-2222-3333-4444-555555555555",
+			Generation:        7,
+			CreationTimestamp: metav1.Time{Time: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
+			ManagedFields:     []metav1.ManagedFieldsEntry{{Manager: "kubectl", Operation: metav1.ManagedFieldsOperationApply}},
 		},
 		Spec: karpenterv1.NodePoolSpec{
 			Weight: &weight,
@@ -362,6 +369,13 @@ func TestBuildReplicaNodePool_AlwaysReplacedFields(t *testing.T) {
 	// Top-level metadata is completely replaced (Datadog labels/annotations are added by the controller, not here).
 	assert.Equal(t, map[string]string{"rc-label": "rc"}, merged.Labels)
 	assert.Equal(t, map[string]string{"rc-ann": "rc"}, merged.Annotations)
+	// Server-set ObjectMeta fields from the target must not leak through; otherwise the API server rejects
+	// the Create with "resourceVersion should not be set on objects to be created".
+	assert.Empty(t, merged.ResourceVersion, "ResourceVersion must be cleared")
+	assert.Empty(t, merged.UID, "UID must be cleared")
+	assert.Zero(t, merged.Generation, "Generation must be cleared")
+	assert.True(t, merged.CreationTimestamp.IsZero(), "CreationTimestamp must be cleared")
+	assert.Nil(t, merged.ManagedFields, "ManagedFields must be cleared")
 }
 
 func TestBuildReplicaNodePool_TargetNotMutated(t *testing.T) {

--- a/pkg/clusteragent/autoscaling/cluster/model/node_pool_internal_test.go
+++ b/pkg/clusteragent/autoscaling/cluster/model/node_pool_internal_test.go
@@ -517,6 +517,26 @@ func TestBuildReplicaNodePool_Disruption(t *testing.T) {
 			expected: rcDisruption,
 		},
 		{
+			name:   "RC sets only Budgets: overrides target",
+			target: targetNodePoolFixture(),
+			rcSpec: &karpenterv1.NodePoolSpec{Disruption: karpenterv1.Disruption{
+				Budgets: []karpenterv1.Budget{{Nodes: "10%"}},
+			}},
+			expected: karpenterv1.Disruption{
+				Budgets: []karpenterv1.Budget{{Nodes: "10%"}},
+			},
+		},
+		{
+			name:   "RC sets only ConsolidateAfter: overrides target",
+			target: targetNodePoolFixture(),
+			rcSpec: &karpenterv1.NodePoolSpec{Disruption: karpenterv1.Disruption{
+				ConsolidateAfter: karpenterv1.NillableDuration{Duration: &rcConsolidateAfter},
+			}},
+			expected: karpenterv1.Disruption{
+				ConsolidateAfter: karpenterv1.NillableDuration{Duration: &rcConsolidateAfter},
+			},
+		},
+		{
 			name:     "target unset, RC unset: zero value",
 			target:   bareTarget,
 			rcSpec:   &karpenterv1.NodePoolSpec{},

--- a/pkg/clusteragent/autoscaling/cluster/model/node_pool_internal_test.go
+++ b/pkg/clusteragent/autoscaling/cluster/model/node_pool_internal_test.go
@@ -9,7 +9,10 @@ package model
 
 import (
 	"testing"
+	"time"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	karpenterv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 
@@ -268,4 +271,320 @@ func TestGetNodePoolWeight(t *testing.T) {
 			assert.Equal(t, tt.expectedWeight, *GetNodePoolWeight(np))
 		})
 	}
+}
+
+// targetNodePoolFixture returns a populated target NodePool used as the merge base in BuildReplicaNodePool tests.
+func targetNodePoolFixture() *karpenterv1.NodePool {
+	weight := int32(5)
+	terminationGrace := metav1.Duration{Duration: 30 * time.Minute}
+	expireAfterDur := 24 * time.Hour
+	consolidateAfterDur := 30 * time.Second
+	return &karpenterv1.NodePool{
+		TypeMeta: metav1.TypeMeta{Kind: "NodePool", APIVersion: "karpenter.sh/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "user-pool",
+			Labels:      map[string]string{"target-label": "target"},
+			Annotations: map[string]string{"target-ann": "target"},
+		},
+		Spec: karpenterv1.NodePoolSpec{
+			Weight: &weight,
+			Limits: karpenterv1.Limits{corev1.ResourceCPU: resource.MustParse("100")},
+			Disruption: karpenterv1.Disruption{
+				ConsolidationPolicy: karpenterv1.ConsolidationPolicyWhenEmpty,
+				ConsolidateAfter:    karpenterv1.NillableDuration{Duration: &consolidateAfterDur},
+			},
+			Template: karpenterv1.NodeClaimTemplate{
+				ObjectMeta: karpenterv1.ObjectMeta{
+					Labels:      map[string]string{"tmpl-label": "target", "shared": "target"},
+					Annotations: map[string]string{"tmpl-ann": "target"},
+				},
+				Spec: karpenterv1.NodeClaimTemplateSpec{
+					NodeClassRef: &karpenterv1.NodeClassReference{Group: "karpenter.k8s.aws", Kind: "EC2NodeClass", Name: "target-nc"},
+					Requirements: []karpenterv1.NodeSelectorRequirementWithMinValues{
+						{Key: "node.kubernetes.io/instance-type", Operator: corev1.NodeSelectorOpIn, Values: []string{"m5.large"}},
+					},
+					Taints:                 []corev1.Taint{{Key: "target-taint", Effect: corev1.TaintEffectNoSchedule}},
+					TerminationGracePeriod: &terminationGrace,
+					ExpireAfter:            karpenterv1.NillableDuration{Duration: &expireAfterDur},
+				},
+			},
+		},
+		Status: karpenterv1.NodePoolStatus{
+			Resources: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("12")},
+		},
+	}
+}
+
+// rcNodePoolFromManifest returns a NodePoolInternal whose karpenterNodePool was built from the given manifest.
+func rcNodePoolFromManifest(t *testing.T, m *KarpenterV1NodePool) NodePoolInternal {
+	t.Helper()
+	npi := NewNodePoolInternal(ClusterAutoscalingValues{
+		TargetName: "user-pool",
+		TargetHash: "h1",
+		Type:       TypeKarpenterV1,
+		Manifest:   Manifest{KarpenterV1: m},
+	})
+	require.NotNil(t, npi.KarpenterNodePool())
+	return npi
+}
+
+func TestBuildReplicaNodePool_NilInputs(t *testing.T) {
+	t.Run("nil target", func(t *testing.T) {
+		npi := rcNodePoolFromManifest(t, &KarpenterV1NodePool{
+			Metadata: Metadata{Name: "dd-pool"},
+			Spec:     &karpenterv1.NodePoolSpec{},
+		})
+		assert.Nil(t, npi.BuildReplicaNodePool(nil))
+	})
+	t.Run("no manifest", func(t *testing.T) {
+		npi := NewNodePoolInternal(ClusterAutoscalingValues{TargetName: "user-pool"})
+		assert.Nil(t, npi.BuildReplicaNodePool(targetNodePoolFixture()))
+	})
+}
+
+func TestBuildReplicaNodePool_AlwaysReplacedFields(t *testing.T) {
+	target := targetNodePoolFixture()
+	npi := rcNodePoolFromManifest(t, &KarpenterV1NodePool{
+		Metadata: Metadata{
+			Name:        "dd-pool",
+			Labels:      Labels{{Key: "rc-label", Value: "rc"}},
+			Annotations: Annotations{{Key: "rc-ann", Value: "rc"}},
+		},
+		Spec: &karpenterv1.NodePoolSpec{},
+	})
+
+	merged := npi.BuildReplicaNodePool(target)
+	require.NotNil(t, merged)
+
+	assert.Equal(t, "dd-pool", merged.Name)
+	assert.Equal(t, metav1.TypeMeta{Kind: "NodePool", APIVersion: "karpenter.sh/v1"}, merged.TypeMeta)
+	assert.Equal(t, karpenterv1.NodePoolStatus{}, merged.Status, "status must be reset")
+	// Top-level metadata is completely replaced (Datadog labels/annotations are added by the controller, not here).
+	assert.Equal(t, map[string]string{"rc-label": "rc"}, merged.Labels)
+	assert.Equal(t, map[string]string{"rc-ann": "rc"}, merged.Annotations)
+}
+
+func TestBuildReplicaNodePool_TargetNotMutated(t *testing.T) {
+	target := targetNodePoolFixture()
+	originalTargetName := target.Name
+	originalTargetLabels := map[string]string{}
+	for k, v := range target.Labels {
+		originalTargetLabels[k] = v
+	}
+
+	npi := rcNodePoolFromManifest(t, &KarpenterV1NodePool{
+		Metadata: Metadata{Name: "dd-pool", Labels: Labels{{Key: "rc", Value: "v"}}},
+		Spec:     &karpenterv1.NodePoolSpec{},
+	})
+	_ = npi.BuildReplicaNodePool(target)
+
+	assert.Equal(t, originalTargetName, target.Name)
+	assert.Equal(t, originalTargetLabels, target.Labels)
+}
+
+func TestBuildReplicaNodePool_Weight(t *testing.T) {
+	tests := []struct {
+		name           string
+		rcWeight       *int32
+		expectedWeight int32
+	}{
+		{
+			name:           "RC weight overrides target",
+			rcWeight:       func() *int32 { w := int32(42); return &w }(),
+			expectedWeight: 42,
+		},
+		{
+			name:           "RC nil falls back to target+1",
+			rcWeight:       nil,
+			expectedWeight: 6, // target weight 5 + 1
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			npi := rcNodePoolFromManifest(t, &KarpenterV1NodePool{
+				Metadata: Metadata{Name: "dd-pool"},
+				Spec:     &karpenterv1.NodePoolSpec{Weight: tt.rcWeight},
+			})
+			merged := npi.BuildReplicaNodePool(targetNodePoolFixture())
+			require.NotNil(t, merged.Spec.Weight)
+			assert.Equal(t, tt.expectedWeight, *merged.Spec.Weight)
+		})
+	}
+}
+
+func TestBuildReplicaNodePool_Requirements(t *testing.T) {
+	t.Run("RC has requirements: replaces target", func(t *testing.T) {
+		rcReqs := []karpenterv1.NodeSelectorRequirementWithMinValues{
+			{Key: "node.kubernetes.io/instance-type", Operator: corev1.NodeSelectorOpIn, Values: []string{"c5.large", "c5.xlarge"}},
+		}
+		npi := rcNodePoolFromManifest(t, &KarpenterV1NodePool{
+			Metadata: Metadata{Name: "dd-pool"},
+			Spec: &karpenterv1.NodePoolSpec{Template: karpenterv1.NodeClaimTemplate{Spec: karpenterv1.NodeClaimTemplateSpec{
+				Requirements: rcReqs,
+			}}},
+		})
+		merged := npi.BuildReplicaNodePool(targetNodePoolFixture())
+		assert.Equal(t, rcReqs, merged.Spec.Template.Spec.Requirements)
+	})
+	t.Run("RC has no requirements: target wiped", func(t *testing.T) {
+		npi := rcNodePoolFromManifest(t, &KarpenterV1NodePool{
+			Metadata: Metadata{Name: "dd-pool"},
+			Spec:     &karpenterv1.NodePoolSpec{},
+		})
+		merged := npi.BuildReplicaNodePool(targetNodePoolFixture())
+		assert.Empty(t, merged.Spec.Template.Spec.Requirements)
+	})
+}
+
+func TestBuildReplicaNodePool_NodeClassRef(t *testing.T) {
+	t.Run("RC sets NodeClassRef: overrides target", func(t *testing.T) {
+		rcRef := &karpenterv1.NodeClassReference{Group: "karpenter.k8s.aws", Kind: "EC2NodeClass", Name: "rc-nc"}
+		npi := rcNodePoolFromManifest(t, &KarpenterV1NodePool{
+			Metadata: Metadata{Name: "dd-pool"},
+			Spec: &karpenterv1.NodePoolSpec{Template: karpenterv1.NodeClaimTemplate{Spec: karpenterv1.NodeClaimTemplateSpec{
+				NodeClassRef: rcRef,
+			}}},
+		})
+		merged := npi.BuildReplicaNodePool(targetNodePoolFixture())
+		assert.Equal(t, "rc-nc", merged.Spec.Template.Spec.NodeClassRef.Name)
+	})
+	t.Run("RC nil: target preserved", func(t *testing.T) {
+		npi := rcNodePoolFromManifest(t, &KarpenterV1NodePool{
+			Metadata: Metadata{Name: "dd-pool"},
+			Spec:     &karpenterv1.NodePoolSpec{},
+		})
+		merged := npi.BuildReplicaNodePool(targetNodePoolFixture())
+		assert.Equal(t, "target-nc", merged.Spec.Template.Spec.NodeClassRef.Name)
+	})
+}
+
+func TestBuildReplicaNodePool_Disruption(t *testing.T) {
+	rcConsolidateAfter := 5 * time.Minute
+	rcDisruption := karpenterv1.Disruption{
+		ConsolidationPolicy: karpenterv1.ConsolidationPolicyWhenEmptyOrUnderutilized,
+		ConsolidateAfter:    karpenterv1.NillableDuration{Duration: &rcConsolidateAfter},
+	}
+
+	t.Run("target set, RC unset: target preserved", func(t *testing.T) {
+		npi := rcNodePoolFromManifest(t, &KarpenterV1NodePool{
+			Metadata: Metadata{Name: "dd-pool"},
+			Spec:     &karpenterv1.NodePoolSpec{},
+		})
+		target := targetNodePoolFixture()
+		merged := npi.BuildReplicaNodePool(target)
+		assert.Equal(t, target.Spec.Disruption, merged.Spec.Disruption)
+	})
+	t.Run("target set, RC set: RC overrides", func(t *testing.T) {
+		npi := rcNodePoolFromManifest(t, &KarpenterV1NodePool{
+			Metadata: Metadata{Name: "dd-pool"},
+			Spec:     &karpenterv1.NodePoolSpec{Disruption: rcDisruption},
+		})
+		merged := npi.BuildReplicaNodePool(targetNodePoolFixture())
+		assert.Equal(t, rcDisruption, merged.Spec.Disruption)
+	})
+	t.Run("target unset, RC unset: zero value", func(t *testing.T) {
+		npi := rcNodePoolFromManifest(t, &KarpenterV1NodePool{
+			Metadata: Metadata{Name: "dd-pool"},
+			Spec:     &karpenterv1.NodePoolSpec{},
+		})
+		bareTarget := &karpenterv1.NodePool{
+			Spec: karpenterv1.NodePoolSpec{Template: karpenterv1.NodeClaimTemplate{Spec: karpenterv1.NodeClaimTemplateSpec{
+				NodeClassRef: &karpenterv1.NodeClassReference{Name: "nc"},
+				Requirements: []karpenterv1.NodeSelectorRequirementWithMinValues{},
+			}}},
+		}
+		merged := npi.BuildReplicaNodePool(bareTarget)
+		assert.Equal(t, karpenterv1.Disruption{}, merged.Spec.Disruption)
+	})
+}
+
+func TestBuildReplicaNodePool_ExpireAfter(t *testing.T) {
+	rcExpire := 12 * time.Hour
+	t.Run("target set, RC unset: target preserved", func(t *testing.T) {
+		npi := rcNodePoolFromManifest(t, &KarpenterV1NodePool{
+			Metadata: Metadata{Name: "dd-pool"},
+			Spec:     &karpenterv1.NodePoolSpec{},
+		})
+		target := targetNodePoolFixture()
+		merged := npi.BuildReplicaNodePool(target)
+		assert.Equal(t, target.Spec.Template.Spec.ExpireAfter, merged.Spec.Template.Spec.ExpireAfter)
+	})
+	t.Run("target set, RC set: RC overrides", func(t *testing.T) {
+		npi := rcNodePoolFromManifest(t, &KarpenterV1NodePool{
+			Metadata: Metadata{Name: "dd-pool"},
+			Spec: &karpenterv1.NodePoolSpec{Template: karpenterv1.NodeClaimTemplate{Spec: karpenterv1.NodeClaimTemplateSpec{
+				ExpireAfter: karpenterv1.NillableDuration{Duration: &rcExpire},
+			}}},
+		})
+		merged := npi.BuildReplicaNodePool(targetNodePoolFixture())
+		require.NotNil(t, merged.Spec.Template.Spec.ExpireAfter.Duration)
+		assert.Equal(t, rcExpire, *merged.Spec.Template.Spec.ExpireAfter.Duration)
+	})
+}
+
+func TestBuildReplicaNodePool_TemplateMetadataMerged(t *testing.T) {
+	npi := rcNodePoolFromManifest(t, &KarpenterV1NodePool{
+		Metadata: Metadata{Name: "dd-pool"},
+		TemplateMetadata: &Metadata{
+			Labels:      Labels{{Key: "rc-label", Value: "rc"}, {Key: "shared", Value: "rc"}},
+			Annotations: Annotations{{Key: "rc-ann", Value: "rc"}},
+		},
+		Spec: &karpenterv1.NodePoolSpec{},
+	})
+
+	merged := npi.BuildReplicaNodePool(targetNodePoolFixture())
+	// Target keys preserved; RC keys added; shared keys overridden by RC.
+	assert.Equal(t, map[string]string{
+		"tmpl-label": "target",
+		"rc-label":   "rc",
+		"shared":     "rc",
+	}, merged.Spec.Template.ObjectMeta.Labels)
+	assert.Equal(t, map[string]string{
+		"tmpl-ann": "target",
+		"rc-ann":   "rc",
+	}, merged.Spec.Template.ObjectMeta.Annotations)
+}
+
+func TestBuildReplicaNodePool_OtherSmartMergeFields(t *testing.T) {
+	rcGrace := metav1.Duration{Duration: time.Minute}
+	rcReplicas := int64(7)
+	rcLimits := karpenterv1.Limits{corev1.ResourceMemory: resource.MustParse("64Gi")}
+	rcTaints := []corev1.Taint{{Key: "rc-taint", Effect: corev1.TaintEffectPreferNoSchedule}}
+	rcStartupTaints := []corev1.Taint{{Key: "rc-startup", Effect: corev1.TaintEffectNoExecute}}
+
+	t.Run("RC sets all: overrides target", func(t *testing.T) {
+		npi := rcNodePoolFromManifest(t, &KarpenterV1NodePool{
+			Metadata: Metadata{Name: "dd-pool"},
+			Spec: &karpenterv1.NodePoolSpec{
+				Replicas: &rcReplicas,
+				Limits:   rcLimits,
+				Template: karpenterv1.NodeClaimTemplate{Spec: karpenterv1.NodeClaimTemplateSpec{
+					Taints:                 rcTaints,
+					StartupTaints:          rcStartupTaints,
+					TerminationGracePeriod: &rcGrace,
+				}},
+			},
+		})
+		merged := npi.BuildReplicaNodePool(targetNodePoolFixture())
+		require.NotNil(t, merged.Spec.Replicas)
+		assert.Equal(t, rcReplicas, *merged.Spec.Replicas)
+		assert.Equal(t, rcLimits, merged.Spec.Limits)
+		assert.Equal(t, rcTaints, merged.Spec.Template.Spec.Taints)
+		assert.Equal(t, rcStartupTaints, merged.Spec.Template.Spec.StartupTaints)
+		assert.Equal(t, &rcGrace, merged.Spec.Template.Spec.TerminationGracePeriod)
+	})
+
+	t.Run("RC unset: target preserved", func(t *testing.T) {
+		npi := rcNodePoolFromManifest(t, &KarpenterV1NodePool{
+			Metadata: Metadata{Name: "dd-pool"},
+			Spec:     &karpenterv1.NodePoolSpec{},
+		})
+		target := targetNodePoolFixture()
+		merged := npi.BuildReplicaNodePool(target)
+		assert.Nil(t, merged.Spec.Replicas)
+		assert.Equal(t, target.Spec.Limits, merged.Spec.Limits)
+		assert.Equal(t, target.Spec.Template.Spec.Taints, merged.Spec.Template.Spec.Taints)
+		assert.Empty(t, merged.Spec.Template.Spec.StartupTaints)
+		assert.Equal(t, target.Spec.Template.Spec.TerminationGracePeriod, merged.Spec.Template.Spec.TerminationGracePeriod)
+	})
 }


### PR DESCRIPTION
### What does this PR do?

When the cluster-agent autoscaling controller produces a Datadog-managed replica from a user-created target NodePool, use the target as the merge base and overlay RC values selectively, instead of building from RC alone.

- **Always replaced from RC** (even if empty): top-level labels/annotations, `Spec.Template.Spec.Requirements`
- **RC-overrides-when-set, else target preserved**: `NodeClassRef`, `Disruption`, `ExpireAfter`, `Limits`, `Taints`, `StartupTaints`, `TerminationGracePeriod`, `Replicas`
- **Weight**: RC if set, else `target.Weight + 1`
- **Template labels/annotations**: RC merged on top of target's 
- ⚠️ **Removes the blocking targetHash check**: we now proceed to update/create a NodePool even if the target has changed since the recommendation so we can pull in changes to target NodePool faster

Standalone path (no target) is unchanged.

### Motivation

Restores merge semantics from #42171. Without this, operator-edited fields on the target silently disappear from the replica because the RC manifest only carries what the recommendation engine knows about.

### Describe how you validated your changes

- Unit tests in `pkg/clusteragent/autoscaling/cluster/model/` cover all merge cases.
- Manual validation in a live cluster: target with operator-set Limits, Disruption, ExpireAfter, TerminationGracePeriod, Weight, labels/annotations → replica preserved target spec fields, replaced top-level metadata from RC, merged template metadata, narrowed requirements per RC, and `Spec.Weight = target+1`.

### Additional Notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)