### PR TITLE
[observer] Separate testbench from observer binary <- Refacto

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -196,6 +196,13 @@ exports_files(glob(
 # gazelle:exclude comp/anomalydetection/recorder/fx-noop
 # gazelle:exclude comp/anomalydetection/recorder/impl
 # gazelle:exclude comp/anomalydetection/recorder/impl-noop
+# gazelle:exclude comp/anomalydetection/reporter/def
+# gazelle:exclude comp/anomalydetection/reporter/fx
+# gazelle:exclude comp/anomalydetection/reporter/fx-noop
+# gazelle:exclude comp/anomalydetection/reporter/fx-testbench
+# gazelle:exclude comp/anomalydetection/reporter/impl
+# gazelle:exclude comp/anomalydetection/reporter/impl-testbench
+# gazelle:exclude comp/anomalydetection/reporter/mock
 # gazelle:exclude comp/otelcol/collector
 # gazelle:exclude comp/otelcol/collector-contrib/fx
 # gazelle:exclude comp/otelcol/collector-contrib/impl

--- a/comp/README.md
+++ b/comp/README.md
@@ -792,9 +792,8 @@ Package recorder provides a middleware component for recording and replaying obs
 
 *Datadog Team*: q-branch
 
-Package reporter provides the injectable reporter component for the observer.
-It is intentionally standalone — reporter/def has no dependency on observer/def.
-The observer/impl converts its internal types to ReportOutput before calling Report.
+Package reporter defines the reporter component contracts.
+Concrete reporters are provided through the `anomalydetection_reporters` Fx group.
 
 ### [comp/autoscaling/datadogclient](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/autoscaling/datadogclient)
 

--- a/comp/anomalydetection/observer/impl/agent_internal_logs_test.go
+++ b/comp/anomalydetection/observer/impl/agent_internal_logs_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	reporterdef "github.com/DataDog/datadog-agent/comp/anomalydetection/reporter/def"
 	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/mock"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
@@ -35,7 +36,7 @@ func TestAgentInternalLogsFlowIntoObserver(t *testing.T) {
 	provides := NewComponent(Requires{
 		Telemetry: telemetry.New(t),
 		Config:    cfg,
-		Reporter:  &noopTestReporter{},
+		Reporters: []reporterdef.Reporter{&noopTestReporter{}},
 	})
 	obs, ok := provides.Comp.(*observerImpl)
 	require.True(t, ok)

--- a/comp/anomalydetection/observer/impl/debug.go
+++ b/comp/anomalydetection/observer/impl/debug.go
@@ -34,12 +34,6 @@ type DebugView interface {
 	AddTelemetry(name string, value float64, timestamp int64, tags []string)
 }
 
-// CorrelationSender sends Datadog events for detected anomaly correlations.
-// Obtain one via NewLiveCorrelationSender.
-type CorrelationSender interface {
-	Send(c observerdef.ActiveCorrelation) error
-}
-
 // StateView is a read-only window into engine state.
 // All methods correspond to existing methods on the unexported stateView struct
 // in stateview.go — they are being promoted to a public interface.

--- a/comp/anomalydetection/observer/impl/debug.go
+++ b/comp/anomalydetection/observer/impl/debug.go
@@ -39,6 +39,14 @@ type DebugView interface {
 	// StorageReader returns a read-only view of the engine's time-series storage.
 	// Used by the testbench to compute windowed log rates in change messages.
 	StorageReader() observerdef.StorageReader
+	// IngestLogSync feeds a log directly into the engine, bypassing the
+	// dispatch channel. Synchronous: returns after IngestLog and any
+	// scheduler-triggered advances complete. Testbench-only — never call
+	// from production hot paths; not safe to interleave with live ObserveLog.
+	IngestLogSync(source string, msg observerdef.LogView)
+	// IngestMetricSync feeds a metric directly into the engine, bypassing
+	// the dispatch channel. Synchronous; same caveats as IngestLogSync.
+	IngestMetricSync(source string, sample observerdef.MetricView)
 }
 
 // StateView is a read-only window into engine state.

--- a/comp/anomalydetection/observer/impl/debug.go
+++ b/comp/anomalydetection/observer/impl/debug.go
@@ -32,13 +32,13 @@ type DebugView interface {
 	// AddTelemetry writes a data point into the engine's telemetry namespace.
 	// Used by the testbench to store per-detector timing stats for UI display.
 	AddTelemetry(name string, value float64, timestamp int64, tags []string)
-	// ReplayStoredData resets the analysis state (lastAnalyzedDataTime, detector
-	// and correlator state, anomaly/correlation history) then replays all data
-	// currently in storage through the scheduler in chronological order.
-	// Storage is NOT cleared — metrics and log-derived series fed before this
-	// call remain available to detectors during the replay.
-	// Call after Flush() to ensure all pending observations have been stored.
+	// ReplayStoredData resets analysis state (preserving extractor context and
+	// contextRefs) then replays all data currently in storage through the
+	// scheduler in chronological order. Call after Flush().
 	ReplayStoredData()
+	// StorageReader returns a read-only view of the engine's time-series storage.
+	// Used by the testbench to compute windowed log rates in change messages.
+	StorageReader() observerdef.StorageReader
 }
 
 // StateView is a read-only window into engine state.

--- a/comp/anomalydetection/observer/impl/debug.go
+++ b/comp/anomalydetection/observer/impl/debug.go
@@ -32,6 +32,13 @@ type DebugView interface {
 	// AddTelemetry writes a data point into the engine's telemetry namespace.
 	// Used by the testbench to store per-detector timing stats for UI display.
 	AddTelemetry(name string, value float64, timestamp int64, tags []string)
+	// ReplayStoredData resets the analysis state (lastAnalyzedDataTime, detector
+	// and correlator state, anomaly/correlation history) then replays all data
+	// currently in storage through the scheduler in chronological order.
+	// Storage is NOT cleared — metrics and log-derived series fed before this
+	// call remain available to detectors during the replay.
+	// Call after Flush() to ensure all pending observations have been stored.
+	ReplayStoredData()
 }
 
 // StateView is a read-only window into engine state.

--- a/comp/anomalydetection/observer/impl/engine.go
+++ b/comp/anomalydetection/observer/impl/engine.go
@@ -889,6 +889,36 @@ func (e *engine) resetFull() {
 	e.resetCorrelations()
 }
 
+// resetAnalysisState resets detector and correlator state, anomaly tracking,
+// telemetry, and correlations — but does NOT reset extractors and does NOT
+// clear contextRefs. Used before batch replay so that:
+//   - enrichAnomaly can still call provider.GetContextByKey (extractor context intact)
+//   - contextRefs still maps series storage keys to their context keys
+//
+// Detectors and correlators ARE reset so they start from a clean slate and
+// produce correct anomaly/correlation results during the replay.
+func (e *engine) resetAnalysisState() {
+	e.mu.Lock()
+	e.lastAnalyzedDataTime = 0
+	e.latestDataTime = 0
+	e.mu.Unlock()
+
+	for _, detector := range e.detectors {
+		if resetter, ok := detector.(interface{ Reset() }); ok {
+			resetter.Reset()
+		}
+	}
+	for _, correlator := range e.correlators {
+		correlator.Reset()
+	}
+	// Extractors and contextRefs are intentionally NOT reset: their state was
+	// built during log ingestion and is needed by enrichAnomaly during replay.
+
+	e.resetRawAnomalies()
+	e.resetTelemetry()
+	e.resetCorrelations()
+}
+
 // ResetForReplay reconfigures with new components, clears all state, and replaces storage.
 func (e *engine) ResetForReplay(detectors []observerdef.Detector, correlators []observerdef.Correlator, extractors []observerdef.LogMetricsExtractor) {
 	e.SetDetectors(detectors)

--- a/comp/anomalydetection/observer/impl/events.go
+++ b/comp/anomalydetection/observer/impl/events.go
@@ -7,6 +7,7 @@ package observerimpl
 
 import (
 	observerdef "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
+	reporterdef "github.com/DataDog/datadog-agent/comp/anomalydetection/reporter/def"
 )
 
 // engineEventKind identifies the type of engine event.
@@ -58,19 +59,19 @@ type eventSink interface {
 	onEngineEvent(engineEvent)
 }
 
-// reporterEventSink bridges engine events to the existing Reporter interface.
+// reporterEventSink bridges engine events to the reporter group.
 // When an advance completes, it populates ReportOutput with anomalies from
 // the event and active correlations from the stateView, then calls Report
 // on all registered reporters.
 type reporterEventSink struct {
-	reporters []observerdef.Reporter
+	reporters []reporterdef.Reporter
 	state     *stateView // for querying current correlations on advance
 }
 
 func (s *reporterEventSink) onEngineEvent(evt engineEvent) {
 	if evt.kind == eventAdvanceCompleted {
 		ac := evt.advanceCompleted
-		output := observerdef.ReportOutput{
+		output := reporterdef.ReportOutput{
 			AdvancedToSec: ac.advancedToSec,
 			NewAnomalies:  ac.anomalies,
 		}

--- a/comp/anomalydetection/observer/impl/events_test.go
+++ b/comp/anomalydetection/observer/impl/events_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	observerdef "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
+	reporterdef "github.com/DataDog/datadog-agent/comp/anomalydetection/reporter/def"
 )
 
 // collectingSink collects all events for test assertions.
@@ -609,7 +610,7 @@ func TestReporterEventSink(t *testing.T) {
 	reporter := &countingReporter{count: &reported}
 
 	sink := &reporterEventSink{
-		reporters: []observerdef.Reporter{reporter},
+		reporters: []reporterdef.Reporter{reporter},
 	}
 
 	// advanceCompleted should trigger Report.
@@ -637,7 +638,7 @@ type countingReporter struct {
 }
 
 func (r *countingReporter) Name() string                      { return "counting" }
-func (r *countingReporter) Report(_ observerdef.ReportOutput) { *r.count++ }
+func (r *countingReporter) Report(_ reporterdef.ReportOutput) { *r.count++ }
 
 func TestFindingM1_DedupKeyTooCoarse(t *testing.T) {
 	anomalies := []observerdef.Anomaly{

--- a/comp/anomalydetection/observer/impl/log_detector_connection_errors.go
+++ b/comp/anomalydetection/observer/impl/log_detector_connection_errors.go
@@ -31,25 +31,63 @@ func DefaultConnectionErrorExtractorConfig() ConnectionErrorExtractorConfig {
 
 // ConnectionErrorExtractor is a log detector that detects connection errors
 // and converts them into a connection.errors metric.
-type ConnectionErrorExtractor struct{}
+// It implements observer.ContextProvider so that anomalies detected on the
+// emitted metric can be enriched with the matched pattern and an example log line.
+type ConnectionErrorExtractor struct {
+	// patternContext tracks the matched pattern and an example log line for
+	// each (metric, tags) combination so enrichAnomaly can format a
+	// human-readable description instead of a raw tag dump.
+	patternContext map[string]observer.MetricContext
+}
 
 // Name returns the detector name.
 func (c *ConnectionErrorExtractor) Name() string {
 	return "connection_error_extractor"
 }
 
+// Reset clears the context map; called when the engine resets for replay.
+func (c *ConnectionErrorExtractor) Reset() {
+	c.patternContext = nil
+}
+
+// GetContextByKey implements observer.ContextProvider.
+func (c *ConnectionErrorExtractor) GetContextByKey(key string) (observer.MetricContext, bool) {
+	if c.patternContext == nil {
+		return observer.MetricContext{}, false
+	}
+	ctx, ok := c.patternContext[key]
+	return ctx, ok
+}
+
 // ProcessLog checks if a log contains connection error patterns and returns a metric if so.
 // Anomaly detection is handled by metrics detection on the count aggregation of the emitted metric.
 func (c *ConnectionErrorExtractor) ProcessLog(log observer.LogView) observer.LogMetricsExtractorOutput {
 	content := strings.ToLower(string(log.GetContent()))
+	tags := log.GetTags()
 
 	for _, pattern := range connectionErrorPatterns {
 		if strings.Contains(content, pattern) {
+			contextKey := metricContextKey("connection.errors", tags)
+
+			if c.patternContext == nil {
+				c.patternContext = make(map[string]observer.MetricContext)
+			}
+			// Store the matched pattern + a truncated example log line so
+			// enrichAnomaly can produce "Log pattern change rate detected:
+			//   pattern: connection refused
+			//   example: <log line>" instead of a raw tag dump.
+			c.patternContext[contextKey] = observer.MetricContext{
+				Pattern: pattern,
+				Example: truncate(string(log.GetContent()), 160),
+				Source:  "connection_error_extractor",
+			}
+
 			return observer.LogMetricsExtractorOutput{
 				Metrics: []observer.MetricOutput{{
-					Name:  "connection.errors",
-					Value: 1.0,
-					Tags:  log.GetTags(),
+					Name:       "connection.errors",
+					Value:      1.0,
+					Tags:       tags,
+					ContextKey: contextKey,
 				}},
 			}
 		}

--- a/comp/anomalydetection/observer/impl/log_metrics_extractor.go
+++ b/comp/anomalydetection/observer/impl/log_metrics_extractor.go
@@ -114,7 +114,7 @@ func (a *LogMetricsExtractor) ProcessLog(log observer.LogView) observer.LogMetri
 
 	// For JSON logs, also extract numeric field metrics
 	if isJSONObject(content) {
-		metrics = append(metrics, a.extractJSONFieldMetrics(content, tags)...)
+		metrics = append(metrics, a.extractJSONFieldMetrics(content, tags, string(content))...)
 	}
 
 	return observer.LogMetricsExtractorOutput{Metrics: metrics}
@@ -126,14 +126,19 @@ func isJSONObject(b []byte) bool {
 }
 
 // extractJSONFieldMetrics extracts numeric field metrics from JSON content.
-// Pattern metrics are handled separately in Detect().
-func (a *LogMetricsExtractor) extractJSONFieldMetrics(content []byte, tags []string) []observer.MetricOutput {
+// example is the raw log line stored in context so enrichAnomaly can show a
+// representative log rather than a raw tag dump when an anomaly is detected.
+func (a *LogMetricsExtractor) extractJSONFieldMetrics(content []byte, tags []string, example string) []observer.MetricOutput {
 	dec := json.NewDecoder(bytes.NewReader(content))
 	dec.UseNumber()
 
 	var obj map[string]any
 	if err := dec.Decode(&obj); err != nil {
 		return nil
+	}
+
+	if a.patternContext == nil {
+		a.patternContext = make(map[string]observer.MetricContext)
 	}
 
 	var out []observer.MetricOutput
@@ -154,10 +159,19 @@ func (a *LogMetricsExtractor) extractJSONFieldMetrics(content []byte, tags []str
 			continue
 		}
 
+		metricName := "log.field." + sanitizeMetricFragment(k)
+		contextKey := metricContextKey(metricName, tags)
+		a.patternContext[contextKey] = observer.MetricContext{
+			Pattern: k,
+			Example: truncate(example, 160),
+			Source:  "log_metrics_extractor",
+		}
+
 		out = append(out, observer.MetricOutput{
-			Name:  "log.field." + sanitizeMetricFragment(k),
-			Value: f,
-			Tags:  tags,
+			Name:       metricName,
+			Value:      f,
+			Tags:       tags,
+			ContextKey: contextKey,
 		})
 	}
 

--- a/comp/anomalydetection/observer/impl/observer.go
+++ b/comp/anomalydetection/observer/impl/observer.go
@@ -836,6 +836,17 @@ func (o *observerImpl) AddTelemetry(name string, value float64, timestamp int64,
 	_ = o.engine.storage.Add(observerdef.TelemetryNamespace, name, value, timestamp, tags)
 }
 
+// ReplayStoredData resets the analysis state without clearing storage, then
+// replays all stored data through the scheduler in chronological order.
+// Implements DebugView.
+func (o *observerImpl) ReplayStoredData() {
+	// resetFull resets lastAnalyzedDataTime, detector/correlator/extractor state,
+	// anomaly tracking, and correlation history — but does NOT clear storage.
+	// This lets ReplayStoredData see all data fed since the last Reset() call.
+	o.engine.resetFull()
+	o.engine.ReplayStoredData()
+}
+
 // handle is the lightweight observation interface passed to other components.
 // It only holds a channel and source name - all processing happens in the observer.
 type handle struct {

--- a/comp/anomalydetection/observer/impl/observer.go
+++ b/comp/anomalydetection/observer/impl/observer.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -460,6 +461,14 @@ type observerImpl struct {
 	// and log-derived virtual metrics produced inside the engine by
 	// LogMetricsExtractors are unaffected because they bypass the handle.
 	ingestMetricsEnabled bool
+
+	// replayMu serialises engine access between the run() dispatch loop and
+	// the testbench's IngestLogSync/IngestMetricSync direct-ingest path.
+	// In production the sync methods are never called so this mutex is always
+	// uncontended. In the testbench it prevents a data race between the
+	// agent-internal-log observer (which can post to obsCh while run() is
+	// processing) and a concurrent IngestLogSync call.
+	replayMu sync.Mutex
 }
 
 // run is the main dispatch loop, processing all observations sequentially.
@@ -469,6 +478,7 @@ func (o *observerImpl) run() {
 			close(obs.flush)
 			continue
 		}
+		o.replayMu.Lock()
 		var requests []advanceRequest
 		if obs.metric != nil {
 			requests = o.engine.IngestMetric(obs.source, obs.metric)
@@ -484,6 +494,7 @@ func (o *observerImpl) run() {
 			result := o.engine.advanceWithReason(req.upToSec, req.reason)
 			o.telemetryHandler.handleTelemetry(result.telemetry)
 		}
+		o.replayMu.Unlock()
 	}
 }
 
@@ -867,6 +878,7 @@ func (o *observerImpl) IngestLogSync(source string, msg observerdef.LogView) {
 		hostname:    msg.GetHostname(),
 		timestampMs: timestampMs,
 	}
+	o.replayMu.Lock()
 	requests, logTelemetry := o.engine.IngestLog(source, lo)
 	if len(logTelemetry) > 0 {
 		o.telemetryHandler.handleTelemetry(logTelemetry)
@@ -875,6 +887,7 @@ func (o *observerImpl) IngestLogSync(source string, msg observerdef.LogView) {
 		result := o.engine.advanceWithReason(req.upToSec, req.reason)
 		o.telemetryHandler.handleTelemetry(result.telemetry)
 	}
+	o.replayMu.Unlock()
 }
 
 // IngestMetricSync feeds a metric directly into the engine, bypassing the
@@ -895,11 +908,13 @@ func (o *observerImpl) IngestMetricSync(source string, sample observerdef.Metric
 		tags:      copyTags(sample.GetRawTags()),
 		timestamp: timestamp,
 	}
+	o.replayMu.Lock()
 	requests := o.engine.IngestMetric(source, mo)
 	for _, req := range requests {
 		result := o.engine.advanceWithReason(req.upToSec, req.reason)
 		o.telemetryHandler.handleTelemetry(result.telemetry)
 	}
+	o.replayMu.Unlock()
 }
 
 // handle is the lightweight observation interface passed to other components.

--- a/comp/anomalydetection/observer/impl/observer.go
+++ b/comp/anomalydetection/observer/impl/observer.go
@@ -46,10 +46,11 @@ type Requires struct {
 	// If provided, all handles will be wrapped to record metrics to parquet files.
 	Recorder option.Option[recorderdef.Component]
 
-	// Reporter receives report outputs after each detection cycle.
-	// Use reporter/fx for the live agent, reporter/fx-testbench for the testbench,
-	// or reporter/fx-noop for unit tests.
-	Reporter reporterdef.Component
+	// Reporters are provided by reporter/fx, reporter/fx-testbench, etc. via the
+	// `anomalydetection_reporters` Fx group. Each reporter gets its own subscription
+	// so it receives advance events independently. StorageConsumer reporters receive
+	// storage for windowed log-rate annotations.
+	Reporters []reporterdef.Reporter `group:"anomalydetection_reporters"`
 
 	// WMeta, FilterStore, Tagger are optional — required only when
 	// observer.high_frequency_container_checks.enabled is true.
@@ -185,12 +186,18 @@ func NewComponent(deps Requires) Provides {
 		scheduler:        &currentBehaviorPolicy{},
 	})
 
-	// Wire the injected reporter via a conversion adapter that maps internal
-	// observerdef.ReportOutput to reporterdef.ReportOutput.
-	eng.Subscribe(&reporterEventSink{
-		reporters: []observerdef.Reporter{&reporterdefAdapter{reporter: deps.Reporter}},
-		state:     eng.StateView(),
-	})
+	// Wire each injected reporter into its own reporterEventSink subscription.
+	// StorageConsumer reporters receive engine storage for windowed log-rate annotations.
+	for _, r := range deps.Reporters {
+		r := r
+		if sc, ok := r.(reporterdef.StorageConsumer); ok {
+			sc.SetStorage(eng.Storage())
+		}
+		eng.Subscribe(&reporterEventSink{
+			reporters: []reporterdef.Reporter{r},
+			state:     eng.StateView(),
+		})
+	}
 
 	telemetryComp := deps.Telemetry
 	if telemetryComp == nil {
@@ -257,19 +264,6 @@ func NewComponent(deps Requires) Provides {
 					_ = advRec.close()
 				}
 			}
-		}
-	}
-
-	// Optionally add the event reporter when sending is enabled via config.
-	if cfg.GetBool("observer.event_reporter.sending_enabled") {
-		if sender, err := newEventSender(deps.Config, deps.Log, eng.Storage()); err != nil {
-			deps.Log.Warnf("[observer] event_reporter disabled: %v", err)
-		} else {
-			eventReporter := &EventReporter{sender: sender, logger: deps.Log}
-			eng.Subscribe(&reporterEventSink{
-				reporters: []observerdef.Reporter{eventReporter},
-				state:     eng.StateView(),
-			})
 		}
 	}
 
@@ -956,50 +950,4 @@ func copyBytes(b []byte) []byte {
 	result := make([]byte, len(b))
 	copy(result, b)
 	return result
-}
-
-// --- reporterdef adapter ---
-
-// reporterdefAdapter wraps a reporterdef.Component so it can be registered with
-// the engine's reporterEventSink, which expects observerdef.Reporter.
-// It converts observerdef.ReportOutput → reporterdef.ReportOutput before calling Report.
-type reporterdefAdapter struct {
-	reporter reporterdef.Component
-}
-
-func (a *reporterdefAdapter) Name() string { return a.reporter.Name() }
-
-func (a *reporterdefAdapter) Report(output observerdef.ReportOutput) {
-	a.reporter.Report(toReporterOutput(output))
-}
-
-func toReporterOutput(o observerdef.ReportOutput) reporterdef.ReportOutput {
-	anomalies := make([]reporterdef.Anomaly, len(o.NewAnomalies))
-	for i, a := range o.NewAnomalies {
-		score := a.Score
-		anomalies[i] = reporterdef.Anomaly{
-			DetectorName: a.DetectorName,
-			Title:        a.Title,
-			Description:  a.Description,
-			Timestamp:    a.Timestamp,
-			Score:        score,
-			SeriesName:   a.Source.Name,
-			Tags:         a.Source.Tags,
-		}
-	}
-	correlations := make([]reporterdef.ActiveCorrelation, len(o.ActiveCorrelations))
-	for i, ac := range o.ActiveCorrelations {
-		correlations[i] = reporterdef.ActiveCorrelation{
-			Pattern:     ac.Pattern,
-			Title:       ac.Title,
-			MemberCount: len(ac.Members),
-			FirstSeen:   ac.FirstSeen,
-			LastUpdated: ac.LastUpdated,
-		}
-	}
-	return reporterdef.ReportOutput{
-		AdvancedToSec:      o.AdvancedToSec,
-		NewAnomalies:       anomalies,
-		ActiveCorrelations: correlations,
-	}
 }

--- a/comp/anomalydetection/observer/impl/observer.go
+++ b/comp/anomalydetection/observer/impl/observer.go
@@ -854,6 +854,54 @@ func (o *observerImpl) StorageReader() observerdef.StorageReader {
 	return o.engine.storage
 }
 
+// IngestLogSync feeds a log directly into the engine, bypassing the dispatch
+// channel. It replicates what the dispatcher run() loop does for a log
+// observation: build logObs, call engine.IngestLog, drive any advance
+// requests, and forward telemetry. Implements DebugView.
+func (o *observerImpl) IngestLogSync(source string, msg observerdef.LogView) {
+	timestampMs := msg.GetTimestampUnixMilli()
+	lo := &logObs{
+		content:     copyBytes(msg.GetContent()),
+		status:      msg.GetStatus(),
+		tags:        copyTags(msg.GetTags()),
+		hostname:    msg.GetHostname(),
+		timestampMs: timestampMs,
+	}
+	requests, logTelemetry := o.engine.IngestLog(source, lo)
+	if len(logTelemetry) > 0 {
+		o.telemetryHandler.handleTelemetry(logTelemetry)
+	}
+	for _, req := range requests {
+		result := o.engine.advanceWithReason(req.upToSec, req.reason)
+		o.telemetryHandler.handleTelemetry(result.telemetry)
+	}
+}
+
+// IngestMetricSync feeds a metric directly into the engine, bypassing the
+// dispatch channel. Mirrors the handle.ObserveMetricAndReportDrop path without
+// the non-blocking channel send. Implements DebugView.
+func (o *observerImpl) IngestMetricSync(source string, sample observerdef.MetricView) {
+	name := sample.GetName()
+	if strings.HasPrefix(name, "datadog.") {
+		return
+	}
+	timestamp := sample.GetTimestampUnix()
+	if timestamp == 0 {
+		timestamp = time.Now().Unix()
+	}
+	mo := &metricObs{
+		name:      name,
+		value:     sample.GetValue(),
+		tags:      copyTags(sample.GetRawTags()),
+		timestamp: timestamp,
+	}
+	requests := o.engine.IngestMetric(source, mo)
+	for _, req := range requests {
+		result := o.engine.advanceWithReason(req.upToSec, req.reason)
+		o.telemetryHandler.handleTelemetry(result.telemetry)
+	}
+}
+
 // handle is the lightweight observation interface passed to other components.
 // It only holds a channel and source name - all processing happens in the observer.
 type handle struct {

--- a/comp/anomalydetection/observer/impl/observer.go
+++ b/comp/anomalydetection/observer/impl/observer.go
@@ -836,15 +836,22 @@ func (o *observerImpl) AddTelemetry(name string, value float64, timestamp int64,
 	_ = o.engine.storage.Add(observerdef.TelemetryNamespace, name, value, timestamp, tags)
 }
 
-// ReplayStoredData resets the analysis state without clearing storage, then
+// ReplayStoredData resets analysis state (preserving extractor context) then
 // replays all stored data through the scheduler in chronological order.
 // Implements DebugView.
 func (o *observerImpl) ReplayStoredData() {
-	// resetFull resets lastAnalyzedDataTime, detector/correlator/extractor state,
-	// anomaly tracking, and correlation history — but does NOT clear storage.
-	// This lets ReplayStoredData see all data fed since the last Reset() call.
-	o.engine.resetFull()
+	// resetAnalysisState resets detectors/correlators and tracking state but
+	// preserves extractor state (contextRefs + provider pattern registry) so
+	// enrichAnomaly can still attach log pattern context during replay.
+	o.engine.resetAnalysisState()
 	o.engine.ReplayStoredData()
+}
+
+// StorageReader returns a read-only view of the engine's time-series storage.
+// Used by the testbench to compute windowed log rates in change messages.
+// Implements DebugView.
+func (o *observerImpl) StorageReader() observerdef.StorageReader {
+	return o.engine.storage
 }
 
 // handle is the lightweight observation interface passed to other components.

--- a/comp/anomalydetection/observer/impl/test_helpers_test.go
+++ b/comp/anomalydetection/observer/impl/test_helpers_test.go
@@ -15,7 +15,7 @@ import (
 // noopTestReporter is a no-op reporter.Component for tests.
 type noopTestReporter struct{}
 
-func (r *noopTestReporter) Name() string                    { return "noop" }
+func (r *noopTestReporter) Name() string                      { return "noop" }
 func (r *noopTestReporter) Report(_ reporterdef.ReportOutput) {}
 
 // mockLogView implements observer.LogView for testing.

--- a/comp/anomalydetection/recorder/impl/parquet_metric_reader.go
+++ b/comp/anomalydetection/recorder/impl/parquet_metric_reader.go
@@ -46,7 +46,7 @@ func newParquetReader(dirPath string) (*parquetMetricReader, error) {
 	}
 
 	if len(parquetFiles) == 0 {
-		return nil, fmt.Errorf("no parquet files found in %s", dirPath)
+		return &parquetMetricReader{}, nil
 	}
 
 	// Read all metrics from all files, skipping any that fail to parse.
@@ -110,15 +110,18 @@ func (r *parquetMetricReader) EndTime() int64 {
 // minParquetFileSize is the minimum valid size for a parquet file
 const minParquetFileSize = 20
 
-// findParquetFiles recursively finds all .parquet files in a directory,
+// findParquetFiles finds observer-metrics-*.parquet files in a directory,
 // skipping files that are too small to be valid parquet files.
+// It only matches metric parquet files (not log, trace, or trace-stats parquets)
+// to avoid misreading other parquet formats as FGM metric records.
 func findParquetFiles(dirPath string) ([]string, error) {
 	var files []string
 	err := filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
-		if !info.IsDir() && strings.HasSuffix(path, ".parquet") {
+		name := info.Name()
+		if !info.IsDir() && strings.HasPrefix(name, "observer-metrics-") && strings.HasSuffix(name, ".parquet") {
 			if info.Size() < minParquetFileSize {
 				fmt.Printf("[parquet-reader] Skipping %s: file too small (%d bytes)\n", path, info.Size())
 				return nil

--- a/comp/anomalydetection/reporter/def/component.go
+++ b/comp/anomalydetection/reporter/def/component.go
@@ -3,48 +3,46 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Package reporter provides the injectable reporter component for the observer.
-// It is intentionally standalone — reporter/def has no dependency on observer/def.
-// The observer/impl converts its internal types to ReportOutput before calling Report.
+// Package reporter defines the reporter component contracts.
+// Concrete reporters are provided through the `anomalydetection_reporters` Fx group.
 package reporter
 
 // team: q-branch
 
-// ReportOutput carries the data reporters receive after each detection cycle.
-type ReportOutput struct {
-	// AdvancedToSec is the data time the engine advanced to.
-	AdvancedToSec int64
-	// NewAnomalies are anomalies detected in this advance cycle.
-	NewAnomalies []Anomaly
-	// ActiveCorrelations are the current correlation patterns.
-	ActiveCorrelations []ActiveCorrelation
-}
+import observerdef "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
 
-// Anomaly is the reporter's view of a detected anomaly.
-type Anomaly struct {
-	DetectorName string
-	Title        string
-	Description  string
-	Timestamp    int64
-	Score        *float64
-	SeriesName   string
-	Tags         []string
-}
-
-// ActiveCorrelation is the reporter's view of a detected correlation pattern.
-type ActiveCorrelation struct {
-	Pattern     string
-	Title       string
-	MemberCount int
-	FirstSeen   int64
-	LastUpdated int64
-}
-
-// Component is the injectable reporter.
-// The live implementation sends Datadog events; the testbench pushes to SSE clients.
-type Component interface {
+// Reporter is the per-reporter contract delivered through the
+// `anomalydetection_reporters` Fx group.
+type Reporter interface {
 	// Name returns the reporter name for identification.
 	Name() string
 	// Report is called by the observer after each detection cycle.
 	Report(output ReportOutput)
+}
+
+// ReportOutput carries the data reporters receive after each detection cycle.
+// It re-uses observerdef types directly so reporters can build rich messages
+// (log-rate annotations, debug info, correlation members) without lossy conversion.
+// reporter/def therefore depends on observer/def — observer/def owns the canonical schema.
+type ReportOutput struct {
+	// AdvancedToSec is the data time the engine advanced to.
+	AdvancedToSec int64
+	// NewAnomalies are anomalies detected in this advance cycle.
+	NewAnomalies []observerdef.Anomaly
+	// ActiveCorrelations are the current correlation patterns across all correlators.
+	ActiveCorrelations []observerdef.ActiveCorrelation
+}
+
+// StorageConsumer is an optional interface for reporters that need access to
+// the engine's time-series storage (e.g. for windowed log-rate annotations).
+// The observer calls SetStorage exactly once after engine construction, before
+// the first Report call.
+type StorageConsumer interface {
+	SetStorage(storage observerdef.StorageReader)
+}
+
+// CorrelationSender sends Datadog events for detected anomaly correlations.
+// Obtain one via reporterimpl.NewLiveCorrelationSender.
+type CorrelationSender interface {
+	Send(c observerdef.ActiveCorrelation) error
 }

--- a/comp/anomalydetection/reporter/def/component.go
+++ b/comp/anomalydetection/reporter/def/component.go
@@ -11,6 +11,12 @@ package reporter
 
 import observerdef "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
 
+// Component is the top-level marker interface required by the component linter.
+// Concrete reporters register via the `anomalydetection_reporters` Fx group as
+// Reporter values rather than through this interface.
+// Component is the top-level marker required by the component linter.
+type Component = any
+
 // Reporter is the per-reporter contract delivered through the
 // `anomalydetection_reporters` Fx group.
 type Reporter interface {

--- a/comp/anomalydetection/reporter/fx-noop/fx.go
+++ b/comp/anomalydetection/reporter/fx-noop/fx.go
@@ -1,6 +1,6 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
-// This product includessbury.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
 // Package fx provides a no-op fx module for the reporter component.
@@ -21,14 +21,14 @@ func Module() fxutil.Module {
 
 type noopReporterRequires struct{}
 type noopReporterProvides struct {
-	Comp reporter.Component
+	Reporter reporter.Reporter `group:"anomalydetection_reporters"`
 }
 
 func newNoopReporter(_ noopReporterRequires) noopReporterProvides {
-	return noopReporterProvides{Comp: &noopReporter{}}
+	return noopReporterProvides{Reporter: &noopReporter{}}
 }
 
 type noopReporter struct{}
 
-func (r *noopReporter) Name() string                      { return "noop_reporter" }
-func (r *noopReporter) Report(_ reporter.ReportOutput)    {}
+func (r *noopReporter) Name() string                   { return "noop_reporter" }
+func (r *noopReporter) Report(_ reporter.ReportOutput) {}

--- a/comp/anomalydetection/reporter/impl-testbench/reporter.go
+++ b/comp/anomalydetection/reporter/impl-testbench/reporter.go
@@ -20,7 +20,7 @@ type TestbenchReporter struct {
 }
 
 // Ensure TestbenchReporter satisfies both interfaces.
-var _ reporter.Component = (*TestbenchReporter)(nil)
+var _ reporter.Reporter = (*TestbenchReporter)(nil)
 var _ SSEAccess = (*TestbenchReporter)(nil)
 
 // Requires defines dependencies for the testbench reporter component.
@@ -28,14 +28,14 @@ type Requires struct{}
 
 // Provides defines the output of the testbench reporter component.
 type Provides struct {
-	Comp      reporter.Component
+	Reporter  reporter.Reporter `group:"anomalydetection_reporters"`
 	SSEAccess SSEAccess
 }
 
 // NewComponent is the fx constructor for the testbench reporter.
 func NewComponent(_ Requires) Provides {
 	r := NewTestbenchReporter()
-	return Provides{Comp: r, SSEAccess: r}
+	return Provides{Reporter: r, SSEAccess: r}
 }
 
 // NewTestbenchReporter creates a new testbench SSE reporter.
@@ -47,9 +47,9 @@ func (r *TestbenchReporter) Name() string { return "testbench_reporter" }
 
 func (r *TestbenchReporter) Report(output reporter.ReportOutput) {
 	type advancePayload struct {
-		AdvancedToSec  int64 `json:"advancedToSec"`
-		NewAnomalies   int   `json:"newAnomalies"`
-		Correlations   int   `json:"correlations"`
+		AdvancedToSec int64 `json:"advancedToSec"`
+		NewAnomalies  int   `json:"newAnomalies"`
+		Correlations  int   `json:"correlations"`
 	}
 	data, _ := json.Marshal(advancePayload{
 		AdvancedToSec: output.AdvancedToSec,

--- a/comp/anomalydetection/reporter/impl-testbench/sse.go
+++ b/comp/anomalydetection/reporter/impl-testbench/sse.go
@@ -43,8 +43,8 @@ type sseHub struct {
 // StatusNotify is a 1-buffered channel used as a wakeup signal when new status
 // is available. The actual payload is read from hub.LatestStatus under lock.
 type SSEClient struct {
-	Events       chan SSEEvent   // buffered channel for ephemeral events
-	StatusNotify chan struct{}   // 1-buffered; signals new status available
+	Events       chan SSEEvent // buffered channel for ephemeral events
+	StatusNotify chan struct{} // 1-buffered; signals new status available
 }
 
 func newSSEHub() *sseHub {

--- a/comp/anomalydetection/reporter/impl-testbench/sse.go
+++ b/comp/anomalydetection/reporter/impl-testbench/sse.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Package reportertestbenchimpl provides the testbench SSE reporter implementation.
+// Package testbenchimpl provides the testbench SSE reporter implementation.
 package testbenchimpl
 
 import (

--- a/comp/anomalydetection/reporter/impl/notify.go
+++ b/comp/anomalydetection/reporter/impl/notify.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package observerimpl
+package reporterimpl
 
 import (
 	"context"
@@ -19,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 
 	observerdef "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
+	reporterdef "github.com/DataDog/datadog-agent/comp/anomalydetection/reporter/def"
 	config "github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 )
@@ -34,7 +35,15 @@ const (
 	// absolute change guards against large relative swings near zero.
 	logRateChangeRelThreshold = 0.3
 	logRateChangeAbsThreshold = 2
+
+	// Canonical namespace names matching the extractor implementations in observer/impl.
+	logPatternExtractorNamespace = "log_pattern_extractor"
+	logMetricsExtractorNamespace = "log_metrics_extractor"
 )
+
+// splitTagKeyOrder is the canonical ordered list of tag dimensions used to split
+// log series, matching log_tagged_pattern_clusterer in observer/impl.
+var splitTagKeyOrder = []string{"source", "service", "env", "host"}
 
 // eventSender formats and dispatches one Datadog event per correlation.
 // When api is nil, send prints to stdout (dry-run mode) instead of calling the API.
@@ -45,13 +54,11 @@ type eventSender struct {
 	storage observerdef.StorageReader
 }
 
-// newEventSender creates an eventSender. It reads observer.event_reporter.sending_enabled
-// from cfg; when false, api is left nil and events are only logged (dry-run mode).
-// storage is used to compute windowed log rates for display in event messages.
+// newEventSender creates an eventSender. If api_key is not set in cfg the sender
+// operates in dry-run mode (events are logged to stdout only). storage is used
+// to compute windowed log rates for display in event messages; it may be nil and
+// will be set later via EventReporter.SetStorage.
 func newEventSender(cfg config.Component, logger log.Component, storage observerdef.StorageReader) (*eventSender, error) {
-	if !cfg.GetBool("observer.event_reporter.sending_enabled") {
-		return &eventSender{logger: logger, storage: storage}, nil
-	}
 	apiKey := cfg.GetString("api_key")
 	if apiKey == "" {
 		return nil, errors.New("api_key is not set in configuration")
@@ -119,14 +126,13 @@ func logRatePart(a observerdef.Anomaly, storage observerdef.StorageReader) strin
 	return fmt.Sprintf("\n\trate: %.1flog/s", curr)
 }
 
-// send formats a correlation into a change event and either prints or posts it.
-// Send implements CorrelationSender.
+// Send implements reporterdef.CorrelationSender.
 func (s *eventSender) Send(c observerdef.ActiveCorrelation) error {
 	return s.send(c)
 }
 
 func (s *eventSender) send(c observerdef.ActiveCorrelation) error {
-	msg := buildChangeMessage(c, s.storage)
+	msg := BuildChangeMessage(c, s.storage)
 	ts := time.Unix(c.FirstSeen, 0).UTC().Format(time.RFC3339)
 	aggKey := "observer:" + c.Pattern
 
@@ -146,7 +152,7 @@ func (s *eventSender) send(c observerdef.ActiveCorrelation) error {
 				Title:          c.Title,
 				Message:        datadog.PtrString(msg),
 				Category:       datadogV2.EVENTCATEGORY_CHANGE,
-				Tags:           buildEventTags(c),
+				Tags:           BuildEventTags(c),
 				Timestamp:      datadog.PtrString(ts),
 				AggregationKey: datadog.PtrString(aggKey),
 				Attributes:     attrs,
@@ -164,20 +170,20 @@ func (s *eventSender) send(c observerdef.ActiveCorrelation) error {
 	return err
 }
 
-// buildEventTags returns the Datadog event tags for a correlation.
+// BuildEventTags returns the Datadog event tags for a correlation.
 // It always includes "source:agent-q-branch-observer" and "pattern:{pattern}".
 // It adds "anomaly_type:metric" and/or "anomaly_type:log" depending on which
 // anomaly types are present (log-derived metric anomalies count as log).
 // It also propagates "service:", "env:", and "host:" dimensions collected from
 // each anomaly's source tags and from Context.SplitTags (set by the log pattern
 // extractor for sub-clustered log series).
-func buildEventTags(c observerdef.ActiveCorrelation) []string {
+func BuildEventTags(c observerdef.ActiveCorrelation) []string {
 	hasMetric := false
 	hasLog := false
 	dimensionSet := make(map[string]struct{})
 
 	for _, a := range c.Anomalies {
-		if a.Type == observerdef.AnomalyTypeLog || isLogDerivedAnomaly(a) {
+		if a.Type == observerdef.AnomalyTypeLog || IsLogDerivedAnomaly(a) {
 			hasLog = true
 		} else {
 			hasMetric = true
@@ -351,7 +357,7 @@ func buildChangeMetadata(c observerdef.ActiveCorrelation) map[string]interface{}
 				entry["context"] = ctx
 			}
 		}
-		if a.Type == observerdef.AnomalyTypeLog || isLogDerivedAnomaly(a) {
+		if a.Type == observerdef.AnomalyTypeLog || IsLogDerivedAnomaly(a) {
 			logAnomalies = append(logAnomalies, entry)
 		} else {
 			metricAnomalies = append(metricAnomalies, entry)
@@ -379,16 +385,17 @@ func buildChangeMetadata(c observerdef.ActiveCorrelation) map[string]interface{}
 	return meta
 }
 
-// buildChangeMessage creates a compact human-readable summary for a correlation (Datadog
-// change events, testbench JSON output, and replay-reported events).
-func buildChangeMessage(c observerdef.ActiveCorrelation, storage observerdef.StorageReader) string {
+// BuildChangeMessage creates a compact human-readable summary for a correlation
+// (Datadog change events, testbench JSON output, and replay-reported events).
+// storage may be nil; log-rate annotations fall back to DebugInfo.CurrentValue.
+func BuildChangeMessage(c observerdef.ActiveCorrelation, storage observerdef.StorageReader) string {
 	var lines []string
 	lines = append(lines, fmt.Sprintf("Correlated behavior change detected: %d anomalies in pattern %q", len(c.Anomalies), c.Pattern))
 	lines = append(lines, "")
 
 	anomalyLines := []string{}
 	for _, a := range c.Anomalies {
-		if isLogDerivedAnomaly(a) {
+		if IsLogDerivedAnomaly(a) {
 			anomalyLines = append(anomalyLines, "- "+logDerivedDescription(a, storage))
 		} else if a.DebugInfo != nil {
 			display := anomalyDisplayKey(a)
@@ -419,17 +426,17 @@ func anomalyDisplayKey(a observerdef.Anomaly) string {
 	return a.Source.String()
 }
 
-// isLogDerivedAnomaly returns true for metric anomalies that originate from
+// IsLogDerivedAnomaly returns true for metric anomalies that originate from
 // log pattern extraction. These should be presented as log anomalies with
 // pattern/example/rate context rather than raw metric descriptions.
-func isLogDerivedAnomaly(a observerdef.Anomaly) bool {
+func IsLogDerivedAnomaly(a observerdef.Anomaly) bool {
 	if a.Type == observerdef.AnomalyTypeLog || a.Context == nil {
 		return false
 	}
 	switch a.Source.Namespace {
-	case LogPatternExtractorName:
+	case logPatternExtractorNamespace:
 		return strings.TrimSpace(a.Context.Pattern) != ""
-	case LogMetricsExtractorName:
+	case logMetricsExtractorNamespace:
 		return strings.TrimSpace(a.Context.Pattern) != "" || strings.TrimSpace(a.Context.Example) != ""
 	}
 	return false
@@ -438,7 +445,7 @@ func isLogDerivedAnomaly(a observerdef.Anomaly) bool {
 // logDerivedDescription builds a human-readable description for a log-derived
 // metric anomaly, including pattern, example, and windowed average rate.
 func logDerivedDescription(a observerdef.Anomaly, storage observerdef.StorageReader) string {
-	if a.Source.Namespace == LogMetricsExtractorName {
+	if a.Source.Namespace == logMetricsExtractorNamespace {
 		return logFrequencyDerivedDescription(a, storage)
 	}
 	pattern := strings.TrimSpace(a.Context.Pattern)
@@ -477,7 +484,7 @@ func logFrequencyDerivedDescription(a observerdef.Anomaly, storage observerdef.S
 
 // NewLiveCorrelationSender creates a CorrelationSender backed by the Datadog Events API.
 // Returns an error if api_key is not configured.
-func NewLiveCorrelationSender(cfg config.Component, logger log.Component, storage observerdef.StorageReader) (CorrelationSender, error) {
+func NewLiveCorrelationSender(cfg config.Component, logger log.Component, storage observerdef.StorageReader) (reporterdef.CorrelationSender, error) {
 	apiKey := cfg.GetString("api_key")
 	if apiKey == "" {
 		return nil, errors.New("api_key is not set in configuration")

--- a/comp/anomalydetection/reporter/impl/notify_test.go
+++ b/comp/anomalydetection/reporter/impl/notify_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package observerimpl
+package reporterimpl
 
 import (
 	"fmt"
@@ -16,8 +16,7 @@ import (
 )
 
 // sumRangeStorage is a minimal StorageReader that answers SumRange calls via a
-// user-supplied function and panics on all other methods (they are unused in
-// notify_test.go).
+// user-supplied function and panics on all other methods (they are unused here).
 type sumRangeStorage struct {
 	fn func(handle observerdef.SeriesRef, start, end int64, agg observerdef.Aggregate) float64
 }
@@ -44,35 +43,35 @@ func (s *sumRangeStorage) SeriesGeneration() uint64                      { panic
 func TestIsLogDerivedAnomaly_LogMetricsExtractorWithPattern(t *testing.T) {
 	a := observerdef.Anomaly{
 		Type:   observerdef.AnomalyTypeMetric,
-		Source: observerdef.SeriesDescriptor{Namespace: LogMetricsExtractorName},
+		Source: observerdef.SeriesDescriptor{Namespace: logMetricsExtractorNamespace},
 		Context: &observerdef.MetricContext{
 			Pattern: "C3:C8_C1",
 			Example: "ERROR: connection refused to db.prod:5432",
 		},
 	}
-	assert.True(t, isLogDerivedAnomaly(a))
+	assert.True(t, IsLogDerivedAnomaly(a))
 }
 
 func TestIsLogDerivedAnomaly_LogMetricsExtractorExampleOnlyNoPattern(t *testing.T) {
 	// Even with an empty pattern, a non-empty example qualifies.
 	a := observerdef.Anomaly{
 		Type:   observerdef.AnomalyTypeMetric,
-		Source: observerdef.SeriesDescriptor{Namespace: LogMetricsExtractorName},
+		Source: observerdef.SeriesDescriptor{Namespace: logMetricsExtractorNamespace},
 		Context: &observerdef.MetricContext{
 			Pattern: "",
 			Example: "some log line",
 		},
 	}
-	assert.True(t, isLogDerivedAnomaly(a))
+	assert.True(t, IsLogDerivedAnomaly(a))
 }
 
 func TestIsLogDerivedAnomaly_LogMetricsExtractorNoContext(t *testing.T) {
 	a := observerdef.Anomaly{
 		Type:    observerdef.AnomalyTypeMetric,
-		Source:  observerdef.SeriesDescriptor{Namespace: LogMetricsExtractorName},
+		Source:  observerdef.SeriesDescriptor{Namespace: logMetricsExtractorNamespace},
 		Context: nil,
 	}
-	assert.False(t, isLogDerivedAnomaly(a))
+	assert.False(t, IsLogDerivedAnomaly(a))
 }
 
 func TestBuildChangeMessage_LogMetricsExtractorUsesExample(t *testing.T) {
@@ -81,7 +80,7 @@ func TestBuildChangeMessage_LogMetricsExtractorUsesExample(t *testing.T) {
 		Anomalies: []observerdef.Anomaly{
 			{
 				Type:   observerdef.AnomalyTypeMetric,
-				Source: observerdef.SeriesDescriptor{Namespace: LogMetricsExtractorName},
+				Source: observerdef.SeriesDescriptor{Namespace: logMetricsExtractorNamespace},
 				Context: &observerdef.MetricContext{
 					Pattern: "C3:C8_C1",
 					Example: "ERROR: connection refused to db.prod:5432",
@@ -89,7 +88,7 @@ func TestBuildChangeMessage_LogMetricsExtractorUsesExample(t *testing.T) {
 			},
 		},
 	}
-	msg := buildChangeMessage(c, nil)
+	msg := BuildChangeMessage(c, nil)
 	assert.Contains(t, msg, "Log frequency change detected")
 	assert.Contains(t, msg, "ERROR: connection refused to db.prod:5432")
 	assert.NotContains(t, msg, "C3:C8_C1") // tokenized signature should not appear
@@ -101,7 +100,7 @@ func TestBuildChangeMessage_LogMetricsExtractorFallsBackToPatternWhenNoExample(t
 		Anomalies: []observerdef.Anomaly{
 			{
 				Type:   observerdef.AnomalyTypeMetric,
-				Source: observerdef.SeriesDescriptor{Namespace: LogMetricsExtractorName},
+				Source: observerdef.SeriesDescriptor{Namespace: logMetricsExtractorNamespace},
 				Context: &observerdef.MetricContext{
 					Pattern: "C3:C8_C1",
 					Example: "",
@@ -109,7 +108,7 @@ func TestBuildChangeMessage_LogMetricsExtractorFallsBackToPatternWhenNoExample(t
 			},
 		},
 	}
-	msg := buildChangeMessage(c, nil)
+	msg := BuildChangeMessage(c, nil)
 	assert.Contains(t, msg, "Log frequency change detected")
 	assert.Contains(t, msg, "C3:C8_C1")
 }
@@ -120,7 +119,7 @@ func TestBuildEventTags_LogMetricsExtractorTreatedAsLog(t *testing.T) {
 		Anomalies: []observerdef.Anomaly{
 			{
 				Type:   observerdef.AnomalyTypeMetric,
-				Source: observerdef.SeriesDescriptor{Namespace: LogMetricsExtractorName},
+				Source: observerdef.SeriesDescriptor{Namespace: logMetricsExtractorNamespace},
 				Context: &observerdef.MetricContext{
 					Pattern: "C3:C8_C1",
 					Example: "some log line",
@@ -128,14 +127,14 @@ func TestBuildEventTags_LogMetricsExtractorTreatedAsLog(t *testing.T) {
 			},
 		},
 	}
-	tags := buildEventTags(c)
+	tags := BuildEventTags(c)
 	assert.Contains(t, tags, "anomaly_type:log")
 	assert.NotContains(t, tags, "anomaly_type:metric")
 }
 
 func TestBuildEventTags_BaseTagsAlwaysPresent(t *testing.T) {
 	c := observerdef.ActiveCorrelation{Pattern: "kernel_bottleneck"}
-	tags := buildEventTags(c)
+	tags := BuildEventTags(c)
 	assert.Contains(t, tags, "source:agent-q-branch-observer")
 	assert.Contains(t, tags, "pattern:kernel_bottleneck")
 }
@@ -147,7 +146,7 @@ func TestBuildEventTags_MetricAnomalyType(t *testing.T) {
 			{Type: observerdef.AnomalyTypeMetric, Source: observerdef.SeriesDescriptor{Namespace: "dogstatsd"}},
 		},
 	}
-	tags := buildEventTags(c)
+	tags := BuildEventTags(c)
 	assert.Contains(t, tags, "anomaly_type:metric")
 	assert.NotContains(t, tags, "anomaly_type:log")
 }
@@ -159,7 +158,7 @@ func TestBuildEventTags_LogAnomalyType(t *testing.T) {
 			{Type: observerdef.AnomalyTypeLog, Source: observerdef.SeriesDescriptor{Namespace: "log_detector"}},
 		},
 	}
-	tags := buildEventTags(c)
+	tags := BuildEventTags(c)
 	assert.Contains(t, tags, "anomaly_type:log")
 	assert.NotContains(t, tags, "anomaly_type:metric")
 }
@@ -173,7 +172,7 @@ func TestBuildEventTags_LogDerivedMetricAnomaly(t *testing.T) {
 			{
 				Type: observerdef.AnomalyTypeMetric,
 				Source: observerdef.SeriesDescriptor{
-					Namespace: LogPatternExtractorName,
+					Namespace: logPatternExtractorNamespace,
 				},
 				Context: &observerdef.MetricContext{
 					Pattern: "some log pattern",
@@ -181,7 +180,7 @@ func TestBuildEventTags_LogDerivedMetricAnomaly(t *testing.T) {
 			},
 		},
 	}
-	tags := buildEventTags(c)
+	tags := BuildEventTags(c)
 	assert.Contains(t, tags, "anomaly_type:log")
 	assert.NotContains(t, tags, "anomaly_type:metric")
 }
@@ -194,7 +193,7 @@ func TestBuildEventTags_BothTypes(t *testing.T) {
 			{Type: observerdef.AnomalyTypeLog, Source: observerdef.SeriesDescriptor{Namespace: "log_detector"}},
 		},
 	}
-	tags := buildEventTags(c)
+	tags := BuildEventTags(c)
 	assert.Contains(t, tags, "anomaly_type:metric")
 	assert.Contains(t, tags, "anomaly_type:log")
 }
@@ -212,7 +211,7 @@ func TestBuildEventTags_DimensionalTagsFromSourceTags(t *testing.T) {
 			},
 		},
 	}
-	tags := buildEventTags(c)
+	tags := BuildEventTags(c)
 	assert.Contains(t, tags, "service:web")
 	assert.Contains(t, tags, "env:prod")
 	assert.Contains(t, tags, "host:h1")
@@ -226,7 +225,7 @@ func TestBuildEventTags_DimensionalTagsFromSplitTags(t *testing.T) {
 		Anomalies: []observerdef.Anomaly{
 			{
 				Type:   observerdef.AnomalyTypeMetric,
-				Source: observerdef.SeriesDescriptor{Namespace: LogPatternExtractorName},
+				Source: observerdef.SeriesDescriptor{Namespace: logPatternExtractorNamespace},
 				Context: &observerdef.MetricContext{
 					Pattern: "some log pattern",
 					SplitTags: map[string]string{
@@ -238,7 +237,7 @@ func TestBuildEventTags_DimensionalTagsFromSplitTags(t *testing.T) {
 			},
 		},
 	}
-	tags := buildEventTags(c)
+	tags := BuildEventTags(c)
 	assert.Contains(t, tags, "service:api")
 	assert.Contains(t, tags, "env:staging")
 	assert.Contains(t, tags, "host:h2")
@@ -258,7 +257,7 @@ func TestBuildEventTags_DeduplicatesDimensions(t *testing.T) {
 			},
 		},
 	}
-	tags := buildEventTags(c)
+	tags := BuildEventTags(c)
 	count := 0
 	for _, t := range tags {
 		if t == "service:web" {
@@ -278,7 +277,7 @@ func TestBuildEventTags_SourceAndPatternAreFirstTwo(t *testing.T) {
 			},
 		},
 	}
-	tags := buildEventTags(c)
+	tags := BuildEventTags(c)
 	assert.Equal(t, "source:agent-q-branch-observer", tags[0])
 	assert.Equal(t, "pattern:mypat", tags[1])
 	// Remaining tags are sorted
@@ -315,7 +314,7 @@ func TestIsSignificantRateChange_RateDrops(t *testing.T) {
 	assert.True(t, isSignificantRateChange(5.0, 1.0))
 }
 
-// --- rate display in buildChangeMessage ---
+// --- rate display in BuildChangeMessage ---
 
 // makeStorageWithRates returns a sumRangeStorage whose SumRange returns
 // prevTotal for the earlier window and currTotal for the current window,
@@ -335,7 +334,7 @@ func makeLogPatternAnomaly(ts int64) observerdef.Anomaly {
 	return observerdef.Anomaly{
 		Type:      observerdef.AnomalyTypeMetric,
 		Timestamp: ts,
-		Source:    observerdef.SeriesDescriptor{Namespace: LogPatternExtractorName},
+		Source:    observerdef.SeriesDescriptor{Namespace: logPatternExtractorNamespace},
 		SourceRef: &observerdef.QueryHandle{Ref: observerdef.SeriesRef(42)},
 		Context: &observerdef.MetricContext{
 			Pattern: "connection refused",
@@ -352,7 +351,7 @@ func TestBuildChangeMessage_RateChangedDisplay(t *testing.T) {
 		Pattern:   "p",
 		Anomalies: []observerdef.Anomaly{makeLogPatternAnomaly(ts)},
 	}
-	msg := buildChangeMessage(c, storage)
+	msg := BuildChangeMessage(c, storage)
 	assert.Contains(t, msg, fmt.Sprintf("rate: %.1flog/s (was %.1flog/s last minutes)", 0.5, 6.0))
 }
 
@@ -364,7 +363,7 @@ func TestBuildChangeMessage_RateUnchanged_ShowsPlainRate(t *testing.T) {
 		Pattern:   "p",
 		Anomalies: []observerdef.Anomaly{makeLogPatternAnomaly(ts)},
 	}
-	msg := buildChangeMessage(c, storage)
+	msg := BuildChangeMessage(c, storage)
 	assert.Contains(t, msg, fmt.Sprintf("\n\trate: %.1flog/s", 3.0))
 	// No previous rate display
 	assert.NotContains(t, msg, "was")
@@ -378,13 +377,13 @@ func TestBuildChangeMessage_LogFrequency_RateChangedDisplay(t *testing.T) {
 	a := observerdef.Anomaly{
 		Type:      observerdef.AnomalyTypeMetric,
 		Timestamp: ts,
-		Source:    observerdef.SeriesDescriptor{Namespace: LogMetricsExtractorName},
+		Source:    observerdef.SeriesDescriptor{Namespace: logMetricsExtractorNamespace},
 		SourceRef: &observerdef.QueryHandle{Ref: observerdef.SeriesRef(7)},
 		Context: &observerdef.MetricContext{
 			Example: "panic: runtime error",
 		},
 	}
 	c := observerdef.ActiveCorrelation{Pattern: "p", Anomalies: []observerdef.Anomaly{a}}
-	msg := buildChangeMessage(c, storage)
+	msg := BuildChangeMessage(c, storage)
 	assert.Contains(t, msg, fmt.Sprintf("rate: %.1flog/s (was %.1flog/s last minutes)", 5.0, 0.2))
 }

--- a/comp/anomalydetection/reporter/impl/reporter.go
+++ b/comp/anomalydetection/reporter/impl/reporter.go
@@ -11,6 +11,7 @@ package reporterimpl
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	reporterdef "github.com/DataDog/datadog-agent/comp/anomalydetection/reporter/def"
 	config "github.com/DataDog/datadog-agent/comp/core/config"
@@ -57,8 +58,12 @@ func (r *stdoutReporter) Report(output reporterdef.ReportOutput) {
 		return
 	}
 	for _, ac := range output.ActiveCorrelations {
-		fmt.Printf("[observer] correlation: %s — %s (%d series)\n",
+		fmt.Printf("[observer] report: pattern=%s — %s (%d series)\n",
 			ac.Pattern, ac.Title, len(ac.Members))
+		for _, a := range ac.Anomalies {
+			ts := time.Unix(a.Timestamp, 0).UTC().Format(time.RFC3339)
+			fmt.Printf("  - %s [%s] at %s\n", a.Source.DisplayName(), a.DetectorName, ts)
+		}
 	}
 	if len(output.NewAnomalies) > 0 {
 		names := make([]string, 0, len(output.NewAnomalies))

--- a/comp/anomalydetection/reporter/impl/reporter.go
+++ b/comp/anomalydetection/reporter/impl/reporter.go
@@ -3,50 +3,67 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Package reporterimpl provides the live reporter component implementation.
-// It prints correlation reports to stdout.
+// Package reporterimpl provides the live reporter implementations:
+// a stdout reporter (always active) and an optional Datadog event reporter
+// (active when observer.event_reporter.sending_enabled=true).
 package reporterimpl
 
 import (
 	"fmt"
 	"strings"
 
-	reporter "github.com/DataDog/datadog-agent/comp/anomalydetection/reporter/def"
-	compdef "github.com/DataDog/datadog-agent/comp/def"
+	reporterdef "github.com/DataDog/datadog-agent/comp/anomalydetection/reporter/def"
+	config "github.com/DataDog/datadog-agent/comp/core/config"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 )
 
 // Requires defines the dependencies for the live reporter component.
 type Requires struct {
-	Lifecycle compdef.Lifecycle
+	Config config.Component
+	Log    log.Component
 }
 
 // Provides defines the output of the live reporter component.
+// Reporters are provided via the anomalydetection_reporters Fx group so the
+// observer can subscribe multiple reporters independently.
 type Provides struct {
-	Comp reporter.Component
+	Reporters []reporterdef.Reporter `group:"anomalydetection_reporters,flatten"`
 }
 
-// NewComponent creates the live reporter component (stdout).
-func NewComponent(_ Requires) (Provides, error) {
-	return Provides{Comp: &stdoutReporter{}}, nil
+// NewComponent creates the live reporter component. It always provides a
+// stdoutReporter and, when observer.event_reporter.sending_enabled=true, also
+// provides an EventReporter that posts Datadog change events.
+func NewComponent(req Requires) (Provides, error) {
+	reporters := []reporterdef.Reporter{&stdoutReporter{}}
+
+	if req.Config.GetBool("observer.event_reporter.sending_enabled") {
+		sender, err := newEventSender(req.Config, req.Log, nil)
+		if err != nil {
+			req.Log.Warnf("[reporter] event_reporter disabled: %v", err)
+		} else {
+			reporters = append(reporters, &EventReporter{sender: sender, logger: req.Log})
+		}
+	}
+
+	return Provides{Reporters: reporters}, nil
 }
 
 type stdoutReporter struct{}
 
 func (r *stdoutReporter) Name() string { return "stdout_reporter" }
 
-func (r *stdoutReporter) Report(output reporter.ReportOutput) {
+func (r *stdoutReporter) Report(output reporterdef.ReportOutput) {
 	if len(output.ActiveCorrelations) == 0 {
 		return
 	}
 	for _, ac := range output.ActiveCorrelations {
-		members := fmt.Sprintf("%d series", ac.MemberCount)
-		fmt.Printf("[observer] correlation: %s — %s (%s)\n",
-			ac.Pattern, ac.Title, members)
+		fmt.Printf("[observer] correlation: %s — %s (%d series)\n",
+			ac.Pattern, ac.Title, len(ac.Members))
 	}
 	if len(output.NewAnomalies) > 0 {
 		names := make([]string, 0, len(output.NewAnomalies))
 		for _, a := range output.NewAnomalies {
-			names = append(names, a.DetectorName+":"+a.SeriesName)
+			names = append(names, a.DetectorName+":"+a.Source.Name)
 		}
 		fmt.Printf("[observer] new anomalies: %s\n", strings.Join(names, ", "))
 	}

--- a/comp/anomalydetection/reporter/impl/reporter_event.go
+++ b/comp/anomalydetection/reporter/impl/reporter_event.go
@@ -3,29 +3,44 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package observerimpl
+package reporterimpl
 
 import (
 	observerdef "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
+	reporterdef "github.com/DataDog/datadog-agent/comp/anomalydetection/reporter/def"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 )
 
 // EventReporter sends Datadog events for new correlations via eventSender.
-// It tracks seen correlations and only fires when a correlation first appears.
+// It tracks seen correlations and only fires when a correlation first appears
+// or reappears after going inactive.
+// It implements reporterdef.StorageConsumer so the observer can inject engine
+// storage post-construction for windowed log-rate annotations in change messages.
 type EventReporter struct {
 	sender           *eventSender
 	logger           log.Component
 	seenCorrelations map[string]bool // pattern -> reported
 }
 
+// Ensure EventReporter satisfies both interfaces at compile time.
+var _ reporterdef.Reporter = (*EventReporter)(nil)
+var _ reporterdef.StorageConsumer = (*EventReporter)(nil)
+
 // Name returns the reporter name.
 func (r *EventReporter) Name() string {
 	return "event_reporter"
 }
 
-// Report checks for new correlations and sends an event for each one.
+// SetStorage implements reporterdef.StorageConsumer.
+// Called by the observer after engine construction to enable windowed log-rate
+// annotations in change-event messages.
+func (r *EventReporter) SetStorage(storage observerdef.StorageReader) {
+	r.sender.storage = storage
+}
+
+// Report checks for new correlations and sends a Datadog change event for each one.
 // Correlations are provided via output.ActiveCorrelations from the engine's event subscription.
-func (r *EventReporter) Report(output observerdef.ReportOutput) {
+func (r *EventReporter) Report(output reporterdef.ReportOutput) {
 	if r.seenCorrelations == nil {
 		r.seenCorrelations = make(map[string]bool)
 	}

--- a/comp/anomalydetection/reporter/mock/mock.go
+++ b/comp/anomalydetection/reporter/mock/mock.go
@@ -5,7 +5,7 @@
 
 //go:build test
 
-// Package mock provides a mock for the reporter component
+// Package mock provides a mock for the reporter component.
 package mock
 
 import (
@@ -14,8 +14,12 @@ import (
 	reporter "github.com/DataDog/datadog-agent/comp/anomalydetection/reporter/def"
 )
 
-// Mock returns a mock for reporter component.
-func Mock(t *testing.T) reporter.Component {
-	// TODO: Implement the reporter mock
-	return nil
+type noopReporter struct{}
+
+func (r *noopReporter) Name() string                   { return "mock_reporter" }
+func (r *noopReporter) Report(_ reporter.ReportOutput) {}
+
+// Mock returns a no-op reporter for use in tests.
+func Mock(_ *testing.T) reporter.Reporter {
+	return &noopReporter{}
 }

--- a/internal/qbranch/anomalydetection-testbench/bench/bench.go
+++ b/internal/qbranch/anomalydetection-testbench/bench/bench.go
@@ -599,8 +599,14 @@ func (tb *Bench) rerunDetectorsLocked() {
 		tb.debug.AddTelemetry(telemetryTbInputLogsCount, 1, ts, nil)
 	}
 
-	// Flush ensures all observations are processed.
+	// Flush ensures all observations (metrics + logs) are stored.
 	tb.debug.Flush()
+
+	// Run the full batch replay: reset analysis state (not storage), advance
+	// through every stored timestamp so detectors see the full accumulated
+	// dataset at each step. This matches what the old testbench achieved via
+	// engine.ReplayStoredData() after pre-loading all data into storage.
+	tb.debug.ReplayStoredData()
 
 	sv := tb.debug.StateView()
 

--- a/internal/qbranch/anomalydetection-testbench/bench/bench.go
+++ b/internal/qbranch/anomalydetection-testbench/bench/bench.go
@@ -623,7 +623,7 @@ func (tb *Bench) rerunDetectorsLocked() {
 	tb.corrGeneration++
 
 	// Build reported events from correlation history.
-	tb.reportedEvents = buildReportedEvents(sv.CorrelationHistory(), sv)
+	tb.reportedEvents = buildReportedEvents(sv.CorrelationHistory(), tb.debug.StorageReader())
 
 	// Compute replay stats.
 	detectorStats := computeDetectorProcessingStatsFromStateView(sv)

--- a/internal/qbranch/anomalydetection-testbench/bench/bench.go
+++ b/internal/qbranch/anomalydetection-testbench/bench/bench.go
@@ -1196,39 +1196,6 @@ func (tb *Bench) loadDemoScenario() error {
 	}
 	fmt.Printf("  Generated %d demo log entries\n", len(tb.rawLogs))
 
-	// Add hardcoded log anomalies from two detectors.
-	score := func(v float64) *float64 { return &v }
-	type demoAnomaly struct {
-		ts           int64
-		detectorName string
-		title        string
-		description  string
-		score        *float64
-		service      string
-	}
-	demoAnomalies := []demoAnomaly{
-		{baseTimestamp + 30, "connection_error_extractor", "Connection pool exhausted", "connection pool exhausted: max connections reached", score(0.91), "service_a"},
-		{baseTimestamp + 35, "connection_error_extractor", "Circuit breaker opened", "circuit breaker open: too many recent failures", score(0.95), "service_a"},
-		{baseTimestamp + 40, "connection_error_extractor", "Retry storm detected", "retry limit exceeded after 3 attempts", score(0.88), "service_a"},
-		{baseTimestamp + 45, "connection_error_extractor", "Memory pressure rejecting requests", "memory pressure: request rejected", score(0.82), "service_b"},
-		{baseTimestamp + 26, "log_metrics_extractor", "Log rate ramp-up detected", "Log emission rate increased 2.5x above baseline", score(0.74), "service_a"},
-		{baseTimestamp + 32, "log_metrics_extractor", "Log rate spike at incident peak", "Log emission rate spiked 10x above baseline", score(0.97), "service_a"},
-		{baseTimestamp + 38, "log_metrics_extractor", "Sustained high log rate", "Log rate remains elevated: 1 log/s vs baseline 1 log/5s", score(0.85), "service_b"},
-	}
-	for _, a := range demoAnomalies {
-		anomaly := observerdef.Anomaly{
-			Type:         observerdef.AnomalyTypeLog,
-			Source:       observerdef.SeriesDescriptor{Name: "logs", Tags: []string{"service:" + a.service}},
-			DetectorName: a.detectorName,
-			Title:        a.title,
-			Description:  a.description,
-			Timestamp:    a.ts,
-			Score:        a.score,
-		}
-		tb.logAnomalies = append(tb.logAnomalies, anomaly)
-		tb.logAnomaliesByDetector[a.detectorName] = append(tb.logAnomaliesByDetector[a.detectorName], anomaly)
-	}
-
 	tb.rerunDetectorsLocked()
 	sv := tb.debug.StateView()
 	rs := tb.replayStats

--- a/internal/qbranch/anomalydetection-testbench/bench/bench.go
+++ b/internal/qbranch/anomalydetection-testbench/bench/bench.go
@@ -146,6 +146,7 @@ type Bench struct {
 	episodeInfo    *EpisodeInfo
 
 	rawLogs                []observerdef.LogView
+	rawMetrics             []*parquetMetricView
 	logAnomalies           []observerdef.Anomaly
 	logAnomaliesByDetector map[string][]observerdef.Anomaly
 
@@ -304,6 +305,7 @@ func (tb *Bench) LoadScenario(name string) error {
 	tb.mu.Lock()
 
 	tb.rawLogs = nil
+	tb.rawMetrics = nil
 	tb.logAnomalies = []observerdef.Anomaly{}
 	tb.logAnomaliesByDetector = make(map[string][]observerdef.Anomaly)
 	tb.liveAdvanceTimes = nil
@@ -389,8 +391,6 @@ func (tb *Bench) loadParquetDir(dir string) error {
 		return errors.New("recorder component not configured - cannot load parquet files")
 	}
 
-	handle := tb.obs.GetHandle("testbench-replay")
-
 	if tb.config.LogsOnly {
 		fmt.Printf("  Logs-only mode: skipping parquet metrics and trace stats\n")
 	} else {
@@ -401,36 +401,16 @@ func (tb *Bench) loadParquetDir(dir string) error {
 
 		fmt.Printf("  Loading %d samples from parquet files\n", len(metrics))
 
-		byTimestampCounter := make(map[int64]int64)
-		byTimestampCardinality := make(map[int64]map[string]struct{})
-
 		var droppedCount int
 		for _, m := range metrics {
-			metricName := m.Name
-
-			if strings.HasPrefix(metricName, "datadog.") {
+			if strings.HasPrefix(m.Name, "datadog.") {
 				continue
 			}
-
 			if tb.config.SkipDroppedMetrics && m.Dropped {
 				droppedCount++
 				continue
 			}
-
-			byTimestampCounter[m.Timestamp]++
-
-			if _, ok := byTimestampCardinality[m.Timestamp]; !ok {
-				byTimestampCardinality[m.Timestamp] = make(map[string]struct{})
-			}
-			seriesKey := m.Name + "|" + strings.Join(m.Tags, ",")
-			isNew := false
-			if _, seen := byTimestampCardinality[m.Timestamp][seriesKey]; !seen {
-				byTimestampCardinality[m.Timestamp][seriesKey] = struct{}{}
-				isNew = true
-			}
-			_ = isNew
-
-			handle.ObserveMetric(&parquetMetricView{
+			tb.rawMetrics = append(tb.rawMetrics, &parquetMetricView{
 				name:      m.Name,
 				value:     m.Value,
 				tags:      m.Tags,
@@ -441,33 +421,8 @@ func (tb *Bench) loadParquetDir(dir string) error {
 			fmt.Printf("  Skipped %d dropped observations from parquet\n", droppedCount)
 		}
 
-		// Telemetry for input metrics count by timestamp
-		type byTimestampEntry struct {
-			Timestamp int64
-			Count     int64
-		}
-		byTimestampOrdered := make([]byTimestampEntry, 0, len(byTimestampCounter))
-		for timestamp, count := range byTimestampCounter {
-			byTimestampOrdered = append(byTimestampOrdered, byTimestampEntry{Timestamp: timestamp, Count: count})
-		}
-		sort.Slice(byTimestampOrdered, func(i, j int) bool {
-			return byTimestampOrdered[i].Timestamp < byTimestampOrdered[j].Timestamp
-		})
-		for _, entry := range byTimestampOrdered {
-			tb.debug.AddTelemetry(telemetryTbInputMetricsCount, float64(entry.Count), entry.Timestamp, nil)
-		}
-
-		// Telemetry for cardinality by timestamp
-		byCardOrdered := make([]byTimestampEntry, 0, len(byTimestampCardinality))
-		for timestamp, set := range byTimestampCardinality {
-			byCardOrdered = append(byCardOrdered, byTimestampEntry{Timestamp: timestamp, Count: int64(len(set))})
-		}
-		sort.Slice(byCardOrdered, func(i, j int) bool {
-			return byCardOrdered[i].Timestamp < byCardOrdered[j].Timestamp
-		})
-		for _, entry := range byCardOrdered {
-			tb.debug.AddTelemetry(telemetryTbInputMetricsCardinality, float64(entry.Count), entry.Timestamp, nil)
-		}
+		handle := tb.obs.GetHandle("testbench-replay")
+		tb.feedRawMetrics(handle)
 	}
 
 	parquetLogs, err := tb.config.Recorder.ReadAllLogs(dir)
@@ -481,6 +436,54 @@ func (tb *Bench) loadParquetDir(dir string) error {
 	}
 
 	return nil
+}
+
+// feedRawMetrics feeds tb.rawMetrics through the observer handle and re-adds
+// per-timestamp telemetry counters. It flushes every 500 metrics to prevent
+// the observation channel (capacity 1000) from filling up and silently dropping
+// samples. Called from both loadParquetDir (initial load) and rerunDetectorsLocked
+// (after engine reset on component toggle).
+func (tb *Bench) feedRawMetrics(handle observerdef.Handle) {
+	const flushEvery = 500
+	for i, m := range tb.rawMetrics {
+		handle.ObserveMetric(m)
+		if (i+1)%flushEvery == 0 {
+			tb.debug.Flush()
+		}
+	}
+
+	// Re-add per-timestamp telemetry. These counters live in TelemetryNamespace
+	// which is also cleared by debug.Reset(), so they must be restored on every
+	// call to feedRawMetrics (not just the initial load).
+	type byTimestampEntry struct {
+		Timestamp int64
+		Count     int64
+	}
+	byTimestampCounter := make(map[int64]int64)
+	byTimestampCardinality := make(map[int64]map[string]struct{})
+	for _, m := range tb.rawMetrics {
+		byTimestampCounter[m.timestamp]++
+		if _, ok := byTimestampCardinality[m.timestamp]; !ok {
+			byTimestampCardinality[m.timestamp] = make(map[string]struct{})
+		}
+		byTimestampCardinality[m.timestamp][m.name+"|"+strings.Join(m.tags, ",")] = struct{}{}
+	}
+	countOrdered := make([]byTimestampEntry, 0, len(byTimestampCounter))
+	for ts, count := range byTimestampCounter {
+		countOrdered = append(countOrdered, byTimestampEntry{ts, count})
+	}
+	sort.Slice(countOrdered, func(i, j int) bool { return countOrdered[i].Timestamp < countOrdered[j].Timestamp })
+	for _, e := range countOrdered {
+		tb.debug.AddTelemetry(telemetryTbInputMetricsCount, float64(e.Count), e.Timestamp, nil)
+	}
+	cardOrdered := make([]byTimestampEntry, 0, len(byTimestampCardinality))
+	for ts, set := range byTimestampCardinality {
+		cardOrdered = append(cardOrdered, byTimestampEntry{ts, int64(len(set))})
+	}
+	sort.Slice(cardOrdered, func(i, j int) bool { return cardOrdered[i].Timestamp < cardOrdered[j].Timestamp })
+	for _, e := range cardOrdered {
+		tb.debug.AddTelemetry(telemetryTbInputMetricsCardinality, float64(e.Count), e.Timestamp, nil)
+	}
 }
 
 // parquetMetricView wraps a metric record to satisfy observerdef.MetricView.
@@ -581,11 +584,15 @@ func (tb *Bench) isComponentEnabled(name string) bool {
 // rerunDetectorsLocked re-runs all detectors and correlators on current data.
 // Caller must hold lock.
 func (tb *Bench) rerunDetectorsLocked() {
-	// Reset engine with current settings.
+	// Reset engine with current settings (clears all storage).
 	tb.debug.Reset(tb.settings)
 
-	// Feed raw logs through the observer handle.
 	handle := tb.obs.GetHandle("testbench-replay")
+
+	// Re-feed parquet metrics into the fresh storage.
+	tb.feedRawMetrics(handle)
+
+	// Feed raw logs through the observer handle.
 	for _, logEntry := range tb.rawLogs {
 		handle.ObserveLog(logEntry)
 		ts := logEntry.GetTimestampUnixMilli() / 1000
@@ -1102,6 +1109,7 @@ func (tb *Bench) loadDemoScenario() error {
 	tb.mu.Lock()
 
 	tb.rawLogs = nil
+	tb.rawMetrics = nil
 	tb.logAnomalies = []observerdef.Anomaly{}
 	tb.logAnomaliesByDetector = make(map[string][]observerdef.Anomaly)
 	tb.ready = false
@@ -1111,7 +1119,6 @@ func (tb *Bench) loadDemoScenario() error {
 
 	fmt.Println("Generating demo scenario data...")
 
-	handle := tb.obs.GetHandle("testbench-demo")
 	baseTimestamp := int64(1000000)
 	const totalSeconds = 70
 
@@ -1140,7 +1147,7 @@ func (tb *Bench) loadDemoScenario() error {
 				{"connection.errors", getDemoConnectionErrorsValue(elapsed) * 0.6, []string{"service:worker"}},
 			}
 			for _, obs := range observations {
-				handle.ObserveMetric(&parquetMetricView{
+				tb.rawMetrics = append(tb.rawMetrics, &parquetMetricView{
 					name:      obs.name,
 					value:     obs.value,
 					tags:      obs.tags,

--- a/internal/qbranch/anomalydetection-testbench/bench/bench.go
+++ b/internal/qbranch/anomalydetection-testbench/bench/bench.go
@@ -23,6 +23,7 @@ import (
 	observerdef "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
 	observerimpl "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/impl"
 	recorderdef "github.com/DataDog/datadog-agent/comp/anomalydetection/recorder/def"
+	reporterimpl "github.com/DataDog/datadog-agent/comp/anomalydetection/reporter/impl"
 	testbenchimpl "github.com/DataDog/datadog-agent/comp/anomalydetection/reporter/impl-testbench"
 	config "github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
@@ -36,10 +37,10 @@ type logDataView struct {
 // Ensure logDataView implements observerdef.LogView.
 var _ observerdef.LogView = (*logDataView)(nil)
 
-func (v *logDataView) GetContent() []byte        { return v.data.Content }
-func (v *logDataView) GetStatus() string         { return v.data.Status }
-func (v *logDataView) GetHostname() string       { return v.data.Hostname }
-func (v *logDataView) GetTags() []string         { return v.data.Tags }
+func (v *logDataView) GetContent() []byte           { return v.data.Content }
+func (v *logDataView) GetStatus() string            { return v.data.Status }
+func (v *logDataView) GetHostname() string          { return v.data.Hostname }
+func (v *logDataView) GetTags() []string            { return v.data.Tags }
 func (v *logDataView) GetTimestampUnixMilli() int64 { return v.data.TimestampMs }
 
 // EpisodePhase represents a time phase within an episode (baseline, disruption, cooldown, warmup).
@@ -490,9 +491,9 @@ type parquetMetricView struct {
 	timestamp int64
 }
 
-func (m *parquetMetricView) GetName() string       { return m.name }
-func (m *parquetMetricView) GetValue() float64     { return m.value }
-func (m *parquetMetricView) GetRawTags() []string  { return m.tags }
+func (m *parquetMetricView) GetName() string         { return m.name }
+func (m *parquetMetricView) GetValue() float64       { return m.value }
+func (m *parquetMetricView) GetRawTags() []string    { return m.tags }
 func (m *parquetMetricView) GetTimestampUnix() int64 { return m.timestamp }
 func (m *parquetMetricView) GetSampleRate() float64  { return 1.0 }
 
@@ -600,7 +601,7 @@ func (tb *Bench) rerunDetectorsLocked() {
 	tb.logAnomalies = []observerdef.Anomaly{}
 	tb.logAnomaliesByDetector = make(map[string][]observerdef.Anomaly)
 	for _, a := range sv.Anomalies() {
-		if a.Type == observerdef.AnomalyTypeLog || isLogDerivedAnomaly(a) {
+		if a.Type == observerdef.AnomalyTypeLog || reporterimpl.IsLogDerivedAnomaly(a) {
 			tb.logAnomalies = append(tb.logAnomalies, a)
 			tb.logAnomaliesByDetector[a.DetectorName] = append(tb.logAnomaliesByDetector[a.DetectorName], a)
 		}
@@ -623,23 +624,6 @@ func (tb *Bench) rerunDetectorsLocked() {
 	}
 
 	tb.ready = true
-}
-
-// isLogDerivedAnomaly returns true for metric anomalies that originate from
-// log pattern extraction.
-func isLogDerivedAnomaly(a observerdef.Anomaly) bool {
-	if a.Type == observerdef.AnomalyTypeLog || a.Context == nil {
-		return false
-	}
-	const logPatternExtractorName = "log_pattern_extractor"
-	const logMetricsExtractorName = "log_metrics_extractor"
-	switch a.Source.Namespace {
-	case logPatternExtractorName:
-		return strings.TrimSpace(a.Context.Pattern) != ""
-	case logMetricsExtractorName:
-		return strings.TrimSpace(a.Context.Pattern) != "" || strings.TrimSpace(a.Context.Example) != ""
-	}
-	return false
 }
 
 // GetComponents returns all registered components.
@@ -1067,7 +1051,7 @@ func (tb *Bench) RunSendAnomalyEvents(scenario string) error {
 	defer tb.mu.RUnlock()
 
 	// Pass nil as storage; log rate annotations are optional.
-	sender, err := observerimpl.NewLiveCorrelationSender(tb.config.Cfg, tb.config.Logger, nil)
+	sender, err := reporterimpl.NewLiveCorrelationSender(tb.config.Cfg, tb.config.Logger, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/qbranch/anomalydetection-testbench/bench/bench.go
+++ b/internal/qbranch/anomalydetection-testbench/bench/bench.go
@@ -421,8 +421,7 @@ func (tb *Bench) loadParquetDir(dir string) error {
 			fmt.Printf("  Skipped %d dropped observations from parquet\n", droppedCount)
 		}
 
-		handle := tb.obs.GetHandle("testbench-replay")
-		tb.feedRawMetrics(handle)
+		tb.feedRawMetrics()
 	}
 
 	parquetLogs, err := tb.config.Recorder.ReadAllLogs(dir)
@@ -438,18 +437,14 @@ func (tb *Bench) loadParquetDir(dir string) error {
 	return nil
 }
 
-// feedRawMetrics feeds tb.rawMetrics through the observer handle and re-adds
-// per-timestamp telemetry counters. It flushes every 500 metrics to prevent
-// the observation channel (capacity 1000) from filling up and silently dropping
-// samples. Called from both loadParquetDir (initial load) and rerunDetectorsLocked
-// (after engine reset on component toggle).
-func (tb *Bench) feedRawMetrics(handle observerdef.Handle) {
-	const flushEvery = 500
-	for i, m := range tb.rawMetrics {
-		handle.ObserveMetric(m)
-		if (i+1)%flushEvery == 0 {
-			tb.debug.Flush()
-		}
+// feedRawMetrics feeds tb.rawMetrics synchronously into the engine and re-adds
+// per-timestamp telemetry counters. Uses IngestMetricSync to bypass the
+// dispatch channel, so no data is lost regardless of volume. Called from both
+// loadParquetDir (initial load) and rerunDetectorsLocked (after engine reset on
+// component toggle).
+func (tb *Bench) feedRawMetrics() {
+	for _, m := range tb.rawMetrics {
+		tb.debug.IngestMetricSync("testbench-replay", m)
 	}
 
 	// Re-add per-timestamp telemetry. These counters live in TelemetryNamespace
@@ -587,20 +582,16 @@ func (tb *Bench) rerunDetectorsLocked() {
 	// Reset engine with current settings (clears all storage).
 	tb.debug.Reset(tb.settings)
 
-	handle := tb.obs.GetHandle("testbench-replay")
+	// Re-feed parquet metrics synchronously into the fresh storage.
+	tb.feedRawMetrics()
 
-	// Re-feed parquet metrics into the fresh storage.
-	tb.feedRawMetrics(handle)
-
-	// Feed raw logs through the observer handle.
+	// Feed raw logs synchronously into the engine. IngestLogSync bypasses the
+	// dispatch channel so no logs are dropped regardless of volume.
 	for _, logEntry := range tb.rawLogs {
-		handle.ObserveLog(logEntry)
+		tb.debug.IngestLogSync("testbench-replay", logEntry)
 		ts := logEntry.GetTimestampUnixMilli() / 1000
 		tb.debug.AddTelemetry(telemetryTbInputLogsCount, 1, ts, nil)
 	}
-
-	// Flush ensures all observations (metrics + logs) are stored.
-	tb.debug.Flush()
 
 	// Run the full batch replay: reset analysis state (not storage), advance
 	// through every stored timestamp so detectors see the full accumulated

--- a/internal/qbranch/anomalydetection-testbench/bench/output.go
+++ b/internal/qbranch/anomalydetection-testbench/bench/output.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"os"
 	"sort"
+
+	reporterimpl "github.com/DataDog/datadog-agent/comp/anomalydetection/reporter/impl"
 )
 
 // ObserverOutput is the top-level JSON structure produced by headless mode.
@@ -109,7 +111,7 @@ func (tb *Bench) WriteObserverOutput(path string, verbose bool) error {
 
 		if verbose {
 			oc.Title = corr.Title
-			oc.Message = buildLocalChangeMessage(corr)
+			oc.Message = reporterimpl.BuildChangeMessage(corr, nil)
 			oc.Tags = []string{"source:agent-q-branch-observer", "pattern:" + corr.Pattern}
 			oc.MemberSeries = make([]string, len(corr.Members))
 			for j, m := range corr.Members {

--- a/internal/qbranch/anomalydetection-testbench/bench/reporter.go
+++ b/internal/qbranch/anomalydetection-testbench/bench/reporter.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	observerdef "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
-	observerimpl "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/impl"
 	reporterimpl "github.com/DataDog/datadog-agent/comp/anomalydetection/reporter/impl"
 )
 
@@ -27,13 +26,13 @@ type ReportedEvent struct {
 	FormattedTime string `json:"formattedTime"`
 }
 
-// buildReportedEvents builds the set of ReportedEvents from a correlation history
-// (used after replay to compute the final event log).
-// storage is nil — log rate annotations fall back to DebugInfo.CurrentValue.
-func buildReportedEvents(correlations []observerdef.ActiveCorrelation, _ observerimpl.StateView) []ReportedEvent {
+// buildReportedEvents builds the set of ReportedEvents from a correlation history.
+// storage is used for windowed log-rate annotations; pass nil to fall back to
+// DebugInfo.CurrentValue (less accurate but still shows pattern/example).
+func buildReportedEvents(correlations []observerdef.ActiveCorrelation, storage observerdef.StorageReader) []ReportedEvent {
 	events := make([]ReportedEvent, 0, len(correlations))
 	for _, ac := range correlations {
-		msg := reporterimpl.BuildChangeMessage(ac, nil)
+		msg := reporterimpl.BuildChangeMessage(ac, storage)
 		tags := reporterimpl.BuildEventTags(ac)
 		events = append(events, ReportedEvent{
 			Pattern:       ac.Pattern,

--- a/internal/qbranch/anomalydetection-testbench/bench/reporter.go
+++ b/internal/qbranch/anomalydetection-testbench/bench/reporter.go
@@ -6,14 +6,11 @@
 package bench
 
 import (
-	"fmt"
-	"slices"
-	"sort"
-	"strings"
 	"time"
 
 	observerdef "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
 	observerimpl "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/impl"
+	reporterimpl "github.com/DataDog/datadog-agent/comp/anomalydetection/reporter/impl"
 )
 
 // ReportedEvent captures a single event that would be sent to the Datadog backend
@@ -30,60 +27,14 @@ type ReportedEvent struct {
 	FormattedTime string `json:"formattedTime"`
 }
 
-// replayReporter mirrors EventReporter.Report() during testbench replay.
-// It tracks which patterns are currently active and appends a new ReportedEvent
-// each time a pattern first appears or reappears after going inactive.
-type replayReporter struct {
-	seenPatterns map[string]bool
-	events       []ReportedEvent
-	sv           observerimpl.StateView
-}
-
-// Name satisfies observerdef.Reporter.
-func (r *replayReporter) Name() string { return "replay_reporter" }
-
-// Report fires a new ReportedEvent for each pattern that is newly active.
-func (r *replayReporter) Report(output observerdef.ReportOutput) {
-	if r.seenPatterns == nil {
-		r.seenPatterns = make(map[string]bool)
-	}
-
-	currentlyActive := make(map[string]bool, len(output.ActiveCorrelations))
-	for _, ac := range output.ActiveCorrelations {
-		currentlyActive[ac.Pattern] = true
-	}
-
-	for _, ac := range output.ActiveCorrelations {
-		if !r.seenPatterns[ac.Pattern] {
-			msg := buildLocalChangeMessage(ac)
-			tags := buildLocalEventTags(ac)
-			r.events = append(r.events, ReportedEvent{
-				Pattern:       ac.Pattern,
-				Title:         ac.Title,
-				Message:       msg,
-				Tags:          tags,
-				FirstSeen:     ac.FirstSeen,
-				LastUpdated:   ac.LastUpdated,
-				FormattedTime: time.Unix(ac.FirstSeen, 0).UTC().Format(time.RFC3339),
-			})
-			r.seenPatterns[ac.Pattern] = true
-		}
-	}
-
-	for pattern := range r.seenPatterns {
-		if !currentlyActive[pattern] {
-			delete(r.seenPatterns, pattern)
-		}
-	}
-}
-
 // buildReportedEvents builds the set of ReportedEvents from a correlation history
 // (used after replay to compute the final event log).
+// storage is nil — log rate annotations fall back to DebugInfo.CurrentValue.
 func buildReportedEvents(correlations []observerdef.ActiveCorrelation, _ observerimpl.StateView) []ReportedEvent {
 	events := make([]ReportedEvent, 0, len(correlations))
 	for _, ac := range correlations {
-		msg := buildLocalChangeMessage(ac)
-		tags := buildLocalEventTags(ac)
+		msg := reporterimpl.BuildChangeMessage(ac, nil)
+		tags := reporterimpl.BuildEventTags(ac)
 		events = append(events, ReportedEvent{
 			Pattern:       ac.Pattern,
 			Title:         ac.Title,
@@ -95,82 +46,4 @@ func buildReportedEvents(correlations []observerdef.ActiveCorrelation, _ observe
 		})
 	}
 	return events
-}
-
-// buildLocalChangeMessage creates a compact human-readable summary for a correlation.
-func buildLocalChangeMessage(c observerdef.ActiveCorrelation) string {
-	var lines []string
-	lines = append(lines, fmt.Sprintf("Correlated behavior change detected: %d anomalies in pattern %q", len(c.Anomalies), c.Pattern))
-	lines = append(lines, "")
-
-	anomalyLines := []string{}
-	for _, a := range c.Anomalies {
-		if a.DebugInfo != nil {
-			display := a.Source.DisplayName()
-			if display == "" {
-				display = a.Source.String()
-			}
-			anomalyLines = append(anomalyLines, fmt.Sprintf("- %s: %.2f (baseline mean: %.2f, %.1f sigma)", display, a.DebugInfo.CurrentValue, a.DebugInfo.BaselineMean, a.DebugInfo.DeviationSigma))
-		} else if a.Description != "" {
-			anomalyLines = append(anomalyLines, "- "+a.Description)
-		} else {
-			display := a.Source.DisplayName()
-			if display == "" {
-				display = a.Source.String()
-			}
-			anomalyLines = append(anomalyLines, "- "+display)
-		}
-	}
-
-	slices.Sort(anomalyLines)
-	lines = append(lines, slices.Compact(anomalyLines)...)
-	text := strings.Join(lines, "\n")
-	const maxLen = 4000
-	if len(text) > maxLen {
-		text = text[:maxLen-3] + "..."
-	}
-	return text
-}
-
-// buildLocalEventTags returns the Datadog event tags for a correlation.
-func buildLocalEventTags(c observerdef.ActiveCorrelation) []string {
-	hasMetric := false
-	hasLog := false
-	dimensionSet := make(map[string]struct{})
-
-	for _, a := range c.Anomalies {
-		if a.Type == observerdef.AnomalyTypeLog {
-			hasLog = true
-		} else {
-			hasMetric = true
-		}
-		for _, t := range a.Source.Tags {
-			for _, prefix := range []string{"service:", "env:", "host:"} {
-				if strings.HasPrefix(t, prefix) {
-					dimensionSet[t] = struct{}{}
-					break
-				}
-			}
-		}
-		if a.Context != nil {
-			for _, k := range []string{"service", "env", "host"} {
-				if v, ok := a.Context.SplitTags[k]; ok {
-					dimensionSet[k+":"+v] = struct{}{}
-				}
-			}
-		}
-	}
-
-	tags := []string{"source:agent-q-branch-observer", "pattern:" + c.Pattern}
-	if hasMetric {
-		tags = append(tags, "anomaly_type:metric")
-	}
-	if hasLog {
-		tags = append(tags, "anomaly_type:log")
-	}
-	for t := range dimensionSet {
-		tags = append(tags, t)
-	}
-	sort.Strings(tags[2:])
-	return tags
 }

--- a/internal/qbranch/anomalydetection-testbench/go.mod
+++ b/internal/qbranch/anomalydetection-testbench/go.mod
@@ -6,11 +6,15 @@ replace github.com/DataDog/datadog-agent => ../../../
 
 require (
 	github.com/DataDog/datadog-agent v0.0.0-00010101000000-000000000000
+	github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/comp/anomalydetection/recorder/def v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/comp/anomalydetection/recorder/fx v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/comp/core/config v0.77.0-devel.0.20260213154712-e02b9359151a
 	github.com/DataDog/datadog-agent/comp/core/log/def v0.77.0-devel.0.20260213154712-e02b9359151a
+	github.com/DataDog/datadog-agent/comp/core/tagger/def v0.77.0-devel.0.20260213154712-e02b9359151a
 	github.com/DataDog/datadog-agent/pkg/util/fxutil v0.77.0-devel.0.20260213154712-e02b9359151a
+	github.com/DataDog/datadog-agent/pkg/util/option v0.77.0-devel.0.20260213154712-e02b9359151a
+	github.com/DataDog/datadog-api-client-go/v2 v2.59.0
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/fx v1.24.0
 )
@@ -21,7 +25,6 @@ require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 // indirect
 	github.com/AdamKorcz/go-118-fuzz-build v0.0.0-20231105174938-2b5cbb29f3e2 // indirect
 	github.com/DataDog/agent-payload/v5 v5.0.193 // indirect
-	github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/comp/anomalydetection/recorder/impl v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/comp/api/api/def v0.76.0-rc.4 // indirect
 	github.com/DataDog/datadog-agent/comp/core/delegatedauth v0.0.0-00010101000000-000000000000 // indirect
@@ -38,7 +41,6 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/secrets/noop-impl v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/utils v0.72.0-devel // indirect
 	github.com/DataDog/datadog-agent/comp/core/status v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
-	github.com/DataDog/datadog-agent/comp/core/tagger/def v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
 	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.77.0 // indirect
 	github.com/DataDog/datadog-agent/comp/core/tagger/tags v0.64.0-devel // indirect
 	github.com/DataDog/datadog-agent/comp/core/tagger/types v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
@@ -108,7 +110,6 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common/namespace v0.77.0-devel.0.20260211235139-a5361978c2b6 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/log v0.78.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/log/setup v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
-	github.com/DataDog/datadog-agent/pkg/util/option v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
 	github.com/DataDog/datadog-agent/pkg/util/pointer v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
 	github.com/DataDog/datadog-agent/pkg/util/prometheus v0.64.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/quantile v0.79.0-devel.0.20260402163801-bfa4eff6c991 // indirect
@@ -119,7 +120,6 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/system v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
 	github.com/DataDog/datadog-agent/pkg/version v0.78.0 // indirect
-	github.com/DataDog/datadog-api-client-go/v2 v2.59.0 // indirect
 	github.com/DataDog/datadog-go/v5 v5.8.3 // indirect
 	github.com/DataDog/go-acl v1.0.1 // indirect
 	github.com/DataDog/go-tuf v1.1.1-0.5.2 // indirect


### PR DESCRIPTION
### What does this PR do?

- We can display log rates (access to context)
- We can have multiple reporters
- Metrics ingestion + anomaly detection wasn't working correctly in the testbench -> fixed
- We lost log anomaly formatting for reporters -> fixed

### Motivation

### Describe how you validated your changes

### Additional Notes
