### PR TITLE
[WP] Write cws-instrumentation on directoryForRemoteCopy folder if possible

### DIFF
--- a/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
@@ -581,6 +581,14 @@ func (ci *CWSInstrumentation) injectCWSCommandInstrumentation(exec *corev1.PodEx
 
 	var cwsInstrumentationRemotePath string
 
+	// check if the input container exists, or select the default one to which the user will be redirected
+	container, err := podcmd.FindOrDefaultContainerByName(pod, exec.Container, true, nil)
+	if err != nil {
+		log.Errorf("Ignoring exec request into %s: invalid container: %v", mutatecommon.PodString(pod), err)
+		metrics.CWSExecMutationAttempts.Inc(ci.mode.String(), "false", cwsInvalidInputContainerReason)
+		return false, errors.New(metrics.InvalidInput)
+	}
+
 	switch ci.mode {
 	case InitContainer:
 		cwsInstrumentationRemotePath = filepath.Join(cwsMountPath, "cws-instrumentation")
@@ -605,9 +613,9 @@ func (ci *CWSInstrumentation) injectCWSCommandInstrumentation(exec *corev1.PodEx
 			cwsInstrumentationRemotePath = filepath.Join(cwsMountPath, cwsInstrumentationRemotePath)
 		} else {
 			// if we're not using a shared volume, we need to make sure the directory is writable
-			if ci.isDirectoryReadOnly(pod, exec.Container, ci.directoryForRemoteCopy) {
+			if ci.isDirectoryReadOnly(pod, container.Name, ci.directoryForRemoteCopy) {
 				// readonly rootfs containers can't be instrumented
-				log.Errorf("Ignoring exec request into %s, directory %q is not writable in container %s that has readonly rootfs. Try enabling admission_controller.cws_instrumentation.remote_copy.mount_volume", mutatecommon.PodString(pod), ci.directoryForRemoteCopy, exec.Container)
+				log.Errorf("Ignoring exec request into %s, directory %q is not writable in container %s that has readonly rootfs. Try enabling admission_controller.cws_instrumentation.remote_copy.mount_volume", mutatecommon.PodString(pod), ci.directoryForRemoteCopy, container.Name)
 				metrics.CWSExecMutationAttempts.Inc(ci.mode.String(), "false", cwsReadonlyFilesystemReason)
 				return false, errors.New(metrics.InvalidInput)
 			}
@@ -633,14 +641,6 @@ func (ci *CWSInstrumentation) injectCWSCommandInstrumentation(exec *corev1.PodEx
 		if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
 			log.Errorf("Ignoring exec request into %s: cannot exec into a container in a completed pod; current phase is %s", mutatecommon.PodString(pod), pod.Status.Phase)
 			metrics.CWSExecMutationAttempts.Inc(ci.mode.String(), "false", cwsCompletedPodReason)
-			return false, errors.New(metrics.InvalidInput)
-		}
-
-		// check if the input container exists, or select the default one to which the user will be redirected
-		container, err := podcmd.FindOrDefaultContainerByName(pod, exec.Container, true, nil)
-		if err != nil {
-			log.Errorf("Ignoring exec request into %s: invalid container: %v", mutatecommon.PodString(pod), err)
-			metrics.CWSExecMutationAttempts.Inc(ci.mode.String(), "false", cwsInvalidInputContainerReason)
 			return false, errors.New(metrics.InvalidInput)
 		}
 

--- a/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/wI2L/jsondiff"
@@ -447,22 +448,59 @@ func containerHasReadonlyRootfs(container corev1.Container) bool {
 	return false
 }
 
-func (ci *CWSInstrumentation) hasReadonlyRootfs(pod *corev1.Pod, container string) bool {
+func findContainerByName(pod *corev1.Pod, container string) *corev1.Container {
 	// check in the init containers
-	for _, c := range pod.Spec.InitContainers {
+	for i, c := range pod.Spec.InitContainers {
 		if c.Name == container {
-			return containerHasReadonlyRootfs(c)
+			return &pod.Spec.InitContainers[i]
 		}
 	}
 
 	// check the other containers
-	for _, c := range pod.Spec.Containers {
+	for i, c := range pod.Spec.Containers {
 		if c.Name == container {
-			return containerHasReadonlyRootfs(c)
+			return &pod.Spec.Containers[i]
 		}
 	}
+	return nil
+}
 
-	return false
+func volumeMountContainsPath(mountPath, target string) bool {
+	mountPath = filepath.Clean(mountPath)
+	target = filepath.Clean(target)
+	if mountPath == target {
+		return true
+	}
+	if mountPath == "/" {
+		return true
+	}
+	return strings.HasPrefix(target, mountPath+"/")
+}
+
+func (ci *CWSInstrumentation) isDirectoryReadOnly(pod *corev1.Pod, containerName, directory string) bool {
+	container := findContainerByName(pod, containerName)
+	if container == nil {
+		return true
+	}
+	// find the most specific VolumeMount that contains the directory
+	var matched *corev1.VolumeMount
+	matchedLen := -1
+	for i, mnt := range container.VolumeMounts {
+		mountPath := filepath.Clean(mnt.MountPath)
+		if !volumeMountContainsPath(mountPath, directory) {
+			continue
+		}
+		if len(mountPath) > matchedLen {
+			matchedLen = len(mountPath)
+			matched = &container.VolumeMounts[i]
+		}
+	}
+	// if we found a VolumeMount, check its ReadOnly flag
+	if matched != nil {
+		return matched.ReadOnly
+	}
+	// otherwise, fall back to the container's SecurityContext
+	return containerHasReadonlyRootfs(*container)
 }
 
 func (ci *CWSInstrumentation) getPod(apiClient kubernetes.Interface, name string, ns string) (*corev1.Pod, error) {
@@ -566,10 +604,10 @@ func (ci *CWSInstrumentation) injectCWSCommandInstrumentation(exec *corev1.PodEx
 			}
 			cwsInstrumentationRemotePath = filepath.Join(cwsMountPath, cwsInstrumentationRemotePath)
 		} else {
-			// check if the target pod has a read only filesystem
-			if readOnly := ci.hasReadonlyRootfs(pod, exec.Container); readOnly {
+			// if we're not using a shared volume, we need to make sure the directory is writable
+			if ci.isDirectoryReadOnly(pod, exec.Container, ci.directoryForRemoteCopy) {
 				// readonly rootfs containers can't be instrumented
-				log.Errorf("Ignoring exec request into %s, container %s has read only rootfs. Try enabling admission_controller.cws_instrumentation.remote_copy.mount_volume", mutatecommon.PodString(pod), exec.Container)
+				log.Errorf("Ignoring exec request into %s, directory %q is not writable in container %s that has readonly rootfs. Try enabling admission_controller.cws_instrumentation.remote_copy.mount_volume", mutatecommon.PodString(pod), ci.directoryForRemoteCopy, exec.Container)
 				metrics.CWSExecMutationAttempts.Inc(ci.mode.String(), "false", cwsReadonlyFilesystemReason)
 				return false, errors.New(metrics.InvalidInput)
 			}

--- a/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation_test.go
@@ -1085,3 +1085,277 @@ func Test_initCWSInitContainerResources(t *testing.T) {
 		})
 	}
 }
+
+// boolPtr returns a pointer to the provided bool value.
+func boolPtr(b bool) *bool {
+	return &b
+}
+
+// newPodWithContainer returns a pod whose single regular container is built
+// from the provided container.
+func newPodWithContainer(c corev1.Container) *corev1.Pod {
+	return &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{c},
+		},
+	}
+}
+
+func Test_isDirectoryReadOnly(t *testing.T) {
+	const (
+		targetContainer = "target"
+		directory       = "/tmp"
+	)
+
+	tests := []struct {
+		name      string
+		pod       *corev1.Pod
+		container string
+		directory string
+		want      bool
+	}{
+		{
+			name: "no VolumeMount, no SecurityContext -> writable",
+			pod: newPodWithContainer(corev1.Container{
+				Name: targetContainer,
+			}),
+			container: targetContainer,
+			directory: directory,
+			want:      false,
+		},
+		{
+			name: "no VolumeMount, ReadOnlyRootFilesystem=false -> writable",
+			pod: newPodWithContainer(corev1.Container{
+				Name: targetContainer,
+				SecurityContext: &corev1.SecurityContext{
+					ReadOnlyRootFilesystem: boolPtr(false),
+				},
+			}),
+			container: targetContainer,
+			directory: directory,
+			want:      false,
+		},
+		{
+			name: "no VolumeMount, ReadOnlyRootFilesystem=true -> read-only (fallback)",
+			pod: newPodWithContainer(corev1.Container{
+				Name: targetContainer,
+				SecurityContext: &corev1.SecurityContext{
+					ReadOnlyRootFilesystem: boolPtr(true),
+				},
+			}),
+			container: targetContainer,
+			directory: directory,
+			want:      true,
+		},
+		{
+			name: "VolumeMount on /tmp writable wins over RO rootfs (system-probe case)",
+			pod: newPodWithContainer(corev1.Container{
+				Name: targetContainer,
+				SecurityContext: &corev1.SecurityContext{
+					ReadOnlyRootFilesystem: boolPtr(true),
+				},
+				VolumeMounts: []corev1.VolumeMount{
+					{Name: "tmpdir", MountPath: "/tmp", ReadOnly: false},
+				},
+			}),
+			container: targetContainer,
+			directory: directory,
+			want:      false,
+		},
+		{
+			name: "VolumeMount on /tmp read-only wins over writable rootfs",
+			pod: newPodWithContainer(corev1.Container{
+				Name: targetContainer,
+				VolumeMounts: []corev1.VolumeMount{
+					{Name: "tmpdir", MountPath: "/tmp", ReadOnly: true},
+				},
+			}),
+			container: targetContainer,
+			directory: directory,
+			want:      true,
+		},
+		{
+			name: "VolumeMount on parent path / covers /tmp",
+			pod: newPodWithContainer(corev1.Container{
+				Name: targetContainer,
+				SecurityContext: &corev1.SecurityContext{
+					ReadOnlyRootFilesystem: boolPtr(true),
+				},
+				VolumeMounts: []corev1.VolumeMount{
+					{Name: "rootfs", MountPath: "/", ReadOnly: false},
+				},
+			}),
+			container: targetContainer,
+			directory: directory,
+			want:      false,
+		},
+		{
+			name: "most specific VolumeMount wins: / rw + /tmp ro -> /tmp ro",
+			pod: newPodWithContainer(corev1.Container{
+				Name: targetContainer,
+				VolumeMounts: []corev1.VolumeMount{
+					{Name: "rootfs", MountPath: "/", ReadOnly: false},
+					{Name: "tmpdir", MountPath: "/tmp", ReadOnly: true},
+				},
+			}),
+			container: targetContainer,
+			directory: directory,
+			want:      true,
+		},
+		{
+			name: "sibling VolumeMount does not cover /tmp (no false positive)",
+			pod: newPodWithContainer(corev1.Container{
+				Name: targetContainer,
+				SecurityContext: &corev1.SecurityContext{
+					ReadOnlyRootFilesystem: boolPtr(true),
+				},
+				VolumeMounts: []corev1.VolumeMount{
+					{Name: "tmpfoo", MountPath: "/tmpfoo", ReadOnly: false},
+				},
+			}),
+			container: targetContainer,
+			directory: directory,
+			want:      true,
+		},
+		{
+			name: "child VolumeMount does not cover parent /tmp",
+			pod: newPodWithContainer(corev1.Container{
+				Name: targetContainer,
+				SecurityContext: &corev1.SecurityContext{
+					ReadOnlyRootFilesystem: boolPtr(true),
+				},
+				VolumeMounts: []corev1.VolumeMount{
+					{Name: "subdir", MountPath: "/tmp/foo", ReadOnly: false},
+				},
+			}),
+			container: targetContainer,
+			directory: directory,
+			want:      true,
+		},
+		{
+			name: "VolumeMount mountPath with trailing slash is normalized",
+			pod: newPodWithContainer(corev1.Container{
+				Name: targetContainer,
+				SecurityContext: &corev1.SecurityContext{
+					ReadOnlyRootFilesystem: boolPtr(true),
+				},
+				VolumeMounts: []corev1.VolumeMount{
+					{Name: "tmpdir", MountPath: "/tmp/", ReadOnly: false},
+				},
+			}),
+			container: targetContainer,
+			directory: directory,
+			want:      false,
+		},
+		{
+			name: "container name does not exist -> read-only (safe default)",
+			pod: newPodWithContainer(corev1.Container{
+				Name: "other",
+				VolumeMounts: []corev1.VolumeMount{
+					{Name: "tmpdir", MountPath: "/tmp", ReadOnly: false},
+				},
+			}),
+			container: targetContainer,
+			directory: directory,
+			want:      true,
+		},
+		{
+			name: "init container is also inspected",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: targetContainer,
+							VolumeMounts: []corev1.VolumeMount{
+								{Name: "tmpdir", MountPath: "/tmp", ReadOnly: false},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								ReadOnlyRootFilesystem: boolPtr(true),
+							},
+						},
+					},
+				},
+			},
+			container: targetContainer,
+			directory: directory,
+			want:      false,
+		},
+		{
+			name: "non-default directory falls back when no mount covers it",
+			pod: newPodWithContainer(corev1.Container{
+				Name: targetContainer,
+				SecurityContext: &corev1.SecurityContext{
+					ReadOnlyRootFilesystem: boolPtr(true),
+				},
+				VolumeMounts: []corev1.VolumeMount{
+					{Name: "tmpdir", MountPath: "/tmp", ReadOnly: false},
+				},
+			}),
+			container: targetContainer,
+			directory: "/var/run",
+			want:      true,
+		},
+	}
+
+	ci := &CWSInstrumentation{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ci.isDirectoryReadOnly(tt.pod, tt.container, tt.directory)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_volumeMountContainsPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		mountPath string
+		target    string
+		want      bool
+	}{
+		{"exact match", "/tmp", "/tmp", true},
+		{"mountPath is parent", "/", "/tmp", true},
+		{"mountPath is multi-level parent", "/var", "/var/run/foo", true},
+		{"mountPath equals target with trailing slash", "/tmp/", "/tmp", true},
+		{"target with trailing slash", "/tmp", "/tmp/", true},
+		{"sibling prefix is not a match", "/tmpfoo", "/tmp", false},
+		{"target sibling of mount", "/tmp", "/tmpfoo", false},
+		{"child mount does not cover parent", "/tmp/foo", "/tmp", false},
+		{"unrelated paths", "/var", "/tmp", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, volumeMountContainsPath(tt.mountPath, tt.target))
+		})
+	}
+}
+
+func Test_findContainerByName(t *testing.T) {
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{Name: "init"},
+			},
+			Containers: []corev1.Container{
+				{Name: "app"},
+				{Name: "sidecar"},
+			},
+		},
+	}
+
+	t.Run("found in regular containers", func(t *testing.T) {
+		c := findContainerByName(pod, "sidecar")
+		require.NotNil(t, c)
+		require.Equal(t, "sidecar", c.Name)
+	})
+
+	t.Run("found in init containers", func(t *testing.T) {
+		c := findContainerByName(pod, "init")
+		require.NotNil(t, c)
+		require.Equal(t, "init", c.Name)
+	})
+
+	t.Run("not found returns nil", func(t *testing.T) {
+		require.Nil(t, findContainerByName(pod, "missing"))
+	})
+}


### PR DESCRIPTION
### What does this PR do?
Refactors the writability check used by the CWS instrumentation admission webhook before performing a kubectl cp of cws-instrumentation into the target container. Instead of inspecting only `SecurityContext.ReadOnlyRootFilesystem`, the webhook now:

- Looks for the most specific VolumeMount in the container spec that covers `admission_controller.cws_instrumentation.remote_copy.directory`.
  - If a mount covers the path → its ReadOnly flag is authoritative.
  - Otherwise → falls back to the container's SecurityContext.ReadOnlyRootFilesystem.

Note: Init containers (and therefore native sidecar containers, K8s 1.28+) are also inspected. Defaults remain conservative: unknown container or read-only mount/rootfs → instrumentation refused.

### Motivation
The previous check rejected any container with `readOnlyRootFilesystem: true`, even when an explicit writable `emptyDir` was mounted on `admission_controller.cws_instrumentation.remote_copy.directory`.
VolumeMounts override the rootfs at their mount point in Linux, so the mount's ReadOnly flag must take precedence over the container-level RO rootfs flag. The new logic mirrors that semantic and lets remote-copy work out of the box on the standard hardened pod setup.
For example, it was impossible to instrument containers such as `system-probe`, which have a read-only rootfs but the proper `/tmp` directory mounted as RW, and forced users to enable `remote_copy.mount_volume` as a workaround.

### Describe how you validated your changes
- Unit tests in `pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation_test.go`:
  - `Test_isDirectoryReadOnly` — 13 cases covering: no mount, RO/RW rootfs fallback, mount RW over RO rootfs (the system-probe case), mount RO over RW rootfs, parent-path coverage, longest-prefix arbitration when mounts overlap, sibling/child paths that must not match, mountPath trailing-slash normalization, init container lookup, missing container safe default, configurable non-default directory.
  - `Test_volumeMountContainsPath` — exhaustive prefix matching, including the `/tmp` vs `/tmpfoo` false-positive trap.
  - `Test_findContainerByName` — lookup across init + regular containers + missing case.
- Manual validation in a local minikube cluster using the Datadog Helm chart + manual validation in a live cluster on Staging environment :
  - system-probe container (readOnlyRootFilesystem: true + emptyDir mounted on /tmp, RW) → exec is correctly instrumented; binary is copied to /tmp/cws-instrumentation. Previously refused, now accepted.
  - Custom ubuntu-readonly pod (readOnlyRootFilesystem: true, no mount on `/tmp`) → instrumentation correctly refused.
Same pod with an emptyDir added on `/tmp` → instrumentation accepted as expected.