### PR TITLE
[observer] Introduce handle factory

### DIFF
--- a/comp/anomalydetection/observer/impl/BUILD.bazel
+++ b/comp/anomalydetection/observer/impl/BUILD.bazel
@@ -15,5 +15,6 @@ go_test(
     name = "impl_test",
     srcs = ["observer_test.go"],
     embed = [":impl"],
+    gotags = ["test"],
     deps = ["//comp/anomalydetection/observer/def"],
 )

--- a/comp/anomalydetection/observer/impl/BUILD.bazel
+++ b/comp/anomalydetection/observer/impl/BUILD.bazel
@@ -1,9 +1,19 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "impl",
     srcs = ["observer.go"],
     importpath = "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/impl",
     visibility = ["//visibility:public"],
+    deps = [
+        "//comp/anomalydetection/observer/def",
+        "//comp/def",
+    ],
+)
+
+go_test(
+    name = "impl_test",
+    srcs = ["observer_test.go"],
+    embed = [":impl"],
     deps = ["//comp/anomalydetection/observer/def"],
 )

--- a/comp/anomalydetection/observer/impl/observer.go
+++ b/comp/anomalydetection/observer/impl/observer.go
@@ -7,30 +7,200 @@
 package observerimpl
 
 import (
-	observer "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
+	"context"
+	"sync/atomic"
+	"time"
+
+	compdef "github.com/DataDog/datadog-agent/comp/def"
+
+	observerdef "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
 )
 
-type component struct{}
-
-type handle struct{}
-
-// NewComponent creates a new observer component.
-func NewComponent() observer.Component {
-	return component{}
+// Requires declares the input types to the observer component constructor.
+type Requires struct {
+	Lifecycle compdef.Lifecycle
 }
 
-// GetHandle returns a no-op handle for the named source.
-func (component) GetHandle(_ string) observer.Handle {
-	return handle{}
+// Provides defines the output of the observer component.
+type Provides struct {
+	Comp observerdef.Component
+}
+
+// observation is a message sent from handles to the observer.
+type observation struct {
+	source string
+	metric *metricObs
+	log    *logObs
+}
+
+// metricObs contains copied metric data and implements observerdef.MetricView.
+type metricObs struct {
+	name      string
+	value     float64
+	tags      []string
+	timestamp int64
+}
+
+var _ observerdef.MetricView = (*metricObs)(nil)
+
+func (m *metricObs) GetName() string         { return m.name }
+func (m *metricObs) GetValue() float64       { return m.value }
+func (m *metricObs) GetRawTags() []string    { return m.tags }
+func (m *metricObs) GetTimestampUnix() int64 { return m.timestamp }
+func (m *metricObs) GetSampleRate() float64  { return 1.0 }
+
+// logObs contains copied log data and implements observerdef.LogView.
+type logObs struct {
+	content     []byte
+	status      string
+	tags        []string
+	hostname    string
+	timestampMs int64
+}
+
+var _ observerdef.LogView = (*logObs)(nil)
+
+func (l *logObs) GetContent() []byte           { return l.content }
+func (l *logObs) GetStatus() string            { return l.status }
+func (l *logObs) GetTags() []string            { return l.tags }
+func (l *logObs) GetHostname() string          { return l.hostname }
+func (l *logObs) GetTimestampUnixMilli() int64 { return l.timestampMs }
+
+// observerImpl is the implementation of the observer component.
+type observerImpl struct {
+	obsCh      chan observation
+	handleFunc observerdef.HandleFunc
+}
+
+// NewComponent creates an observer.Component.
+func NewComponent(deps Requires) Provides {
+	obs := &observerImpl{
+		obsCh: make(chan observation, 1000),
+	}
+	obs.handleFunc = obs.innerHandle
+
+	ch := obs.obsCh
+	deps.Lifecycle.Append(compdef.Hook{
+		OnStop: func(_ context.Context) error {
+			close(ch)
+			return nil
+		},
+	})
+
+	go obs.run()
+
+	return Provides{Comp: obs}
+}
+
+// run drains the observation channel. The engine is wired in a later wave;
+// until then observations are discarded to keep overhead at zero.
+func (o *observerImpl) run() {
+	for range o.obsCh {
+	}
+}
+
+// GetHandle returns a lightweight handle for a named source.
+func (o *observerImpl) GetHandle(name string) observerdef.Handle {
+	return o.handleFunc(name)
 }
 
 // DumpMetrics writes all stored metrics to the specified file (for debugging).
-func (component) DumpMetrics(_ string) error {
+func (o *observerImpl) DumpMetrics(_ string) error {
 	return nil
 }
 
+// innerHandle creates a channel-backed handle for the given source name.
+func (o *observerImpl) innerHandle(name string) observerdef.Handle {
+	return &handle{ch: o.obsCh, source: name}
+}
+
+// noopHandle returns a handle that discards all observations.
+func (o *observerImpl) noopHandle(_ string) observerdef.Handle {
+	return &noopObserveHandle{}
+}
+
+// handle is the lightweight observation interface passed to other components.
+// It holds a channel reference and source name; all heavy processing happens
+// in the observer's run loop.
+type handle struct {
+	ch        chan<- observation
+	source    string
+	dropCount atomic.Int64
+}
+
+var _ observerdef.Handle = (*handle)(nil)
+
 // ObserveMetric observes a DogStatsD metric sample.
-func (handle) ObserveMetric(_ observer.MetricView) {}
+func (h *handle) ObserveMetric(sample observerdef.MetricView) {
+	timestamp := sample.GetTimestampUnix()
+	if timestamp == 0 {
+		timestamp = time.Now().Unix()
+	}
+
+	obs := observation{
+		source: h.source,
+		metric: &metricObs{
+			name:      sample.GetName(),
+			value:     sample.GetValue(),
+			tags:      copyTags(sample.GetRawTags()),
+			timestamp: timestamp,
+		},
+	}
+
+	select {
+	case h.ch <- obs:
+	default:
+		h.dropCount.Add(1)
+	}
+}
 
 // ObserveLog observes a log message.
-func (handle) ObserveLog(_ observer.LogView) {}
+func (h *handle) ObserveLog(msg observerdef.LogView) {
+	timestampMs := msg.GetTimestampUnixMilli()
+	if timestampMs == 0 {
+		timestampMs = time.Now().UnixMilli()
+	}
+
+	obs := observation{
+		source: h.source,
+		log: &logObs{
+			content:     copyBytes(msg.GetContent()),
+			status:      msg.GetStatus(),
+			tags:        copyTags(msg.GetTags()),
+			hostname:    msg.GetHostname(),
+			timestampMs: timestampMs,
+		},
+	}
+
+	select {
+	case h.ch <- obs:
+	default:
+		h.dropCount.Add(1)
+	}
+}
+
+// noopObserveHandle discards all observations.
+type noopObserveHandle struct{}
+
+var _ observerdef.Handle = (*noopObserveHandle)(nil)
+
+func (h *noopObserveHandle) ObserveMetric(_ observerdef.MetricView) {}
+func (h *noopObserveHandle) ObserveLog(_ observerdef.LogView)       {}
+
+func copyTags(tags []string) []string {
+	if tags == nil {
+		return nil
+	}
+	out := make([]string, len(tags))
+	copy(out, tags)
+	return out
+}
+
+func copyBytes(b []byte) []byte {
+	if b == nil {
+		return nil
+	}
+	out := make([]byte, len(b))
+	copy(out, b)
+	return out
+}

--- a/comp/anomalydetection/observer/impl/observer.go
+++ b/comp/anomalydetection/observer/impl/observer.go
@@ -95,7 +95,7 @@ func NewComponent(deps Requires) Provides {
 // run drains the observation channel. The engine is wired in a later wave;
 // until then observations are discarded to keep overhead at zero.
 func (o *observerImpl) run() {
-	for range o.obsCh {
+	for range o.obsCh { //nolint:revive // empty-block intentional: drain-and-discard until Wave 3
 	}
 }
 

--- a/comp/anomalydetection/observer/impl/observer_test.go
+++ b/comp/anomalydetection/observer/impl/observer_test.go
@@ -1,0 +1,110 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"testing"
+
+	observerdef "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
+)
+
+// stubMetric is a minimal MetricView for tests.
+type stubMetric struct{}
+
+func (stubMetric) GetName() string         { return "test.metric" }
+func (stubMetric) GetValue() float64       { return 1.0 }
+func (stubMetric) GetRawTags() []string    { return []string{"env:test"} }
+func (stubMetric) GetTimestampUnix() int64 { return 1000 }
+func (stubMetric) GetSampleRate() float64  { return 1.0 }
+
+// stubLog is a minimal LogView for tests.
+type stubLog struct{}
+
+func (stubLog) GetContent() []byte           { return []byte("hello") }
+func (stubLog) GetStatus() string            { return "info" }
+func (stubLog) GetTags() []string            { return []string{"service:test"} }
+func (stubLog) GetHostname() string          { return "host1" }
+func (stubLog) GetTimestampUnixMilli() int64 { return 1000000 }
+
+// newTestObserver creates an observerImpl without fx for unit tests.
+func newTestObserver() *observerImpl {
+	obs := &observerImpl{
+		obsCh: make(chan observation, 100),
+	}
+	obs.handleFunc = obs.innerHandle
+	go obs.run()
+	return obs
+}
+
+func TestGetHandleNotNil(t *testing.T) {
+	obs := newTestObserver()
+	h := obs.GetHandle("test-source")
+	if h == nil {
+		t.Fatal("GetHandle returned nil")
+	}
+}
+
+func TestObserveMetricNoPanic(t *testing.T) {
+	obs := newTestObserver()
+	h := obs.GetHandle("test-source")
+	h.ObserveMetric(stubMetric{})
+}
+
+func TestObserveLogNoPanic(t *testing.T) {
+	obs := newTestObserver()
+	h := obs.GetHandle("test-source")
+	h.ObserveLog(stubLog{})
+}
+
+func TestHandleDropsWhenFull(t *testing.T) {
+	// Do NOT start run() so the channel fills up.
+	obs := &observerImpl{
+		obsCh: make(chan observation, 2),
+	}
+	obs.handleFunc = obs.innerHandle
+
+	h := obs.GetHandle("overload")
+	h.ObserveMetric(stubMetric{})
+	h.ObserveMetric(stubMetric{})
+	// Channel full — these must not block.
+	h.ObserveMetric(stubMetric{})
+	h.ObserveMetric(stubMetric{})
+
+	if h.(*handle).dropCount.Load() < 2 {
+		t.Errorf("expected at least 2 drops, got %d", h.(*handle).dropCount.Load())
+	}
+}
+
+func TestNoopHandleDiscards(t *testing.T) {
+	obs := newTestObserver()
+	obs.handleFunc = obs.noopHandle
+	h := obs.GetHandle("noop-source")
+
+	if _, ok := h.(*noopObserveHandle); !ok {
+		t.Fatalf("expected *noopObserveHandle, got %T", h)
+	}
+	h.ObserveMetric(stubMetric{})
+	h.ObserveLog(stubLog{})
+}
+
+func TestCopyTagsAndBytes(t *testing.T) {
+	tags := []string{"a", "b"}
+	copied := copyTags(tags)
+	tags[0] = "mutated"
+	if copied[0] != "a" {
+		t.Error("copyTags did not deep-copy")
+	}
+
+	b := []byte("hello")
+	cb := copyBytes(b)
+	b[0] = 'X'
+	if cb[0] != 'h' {
+		t.Error("copyBytes did not deep-copy")
+	}
+}
+
+// Ensure observerImpl satisfies the Component interface at compile time.
+var _ observerdef.Component = (*observerImpl)(nil)

--- a/comp/anomalydetection/observer/impl/observer_test.go
+++ b/comp/anomalydetection/observer/impl/observer_test.go
@@ -47,13 +47,13 @@ func TestGetHandleNotNil(t *testing.T) {
 	}
 }
 
-func TestObserveMetricNoPanic(t *testing.T) {
+func TestObserveMetricNoPanic(_ *testing.T) {
 	obs := newTestObserver()
 	h := obs.GetHandle("test-source")
 	h.ObserveMetric(stubMetric{})
 }
 
-func TestObserveLogNoPanic(t *testing.T) {
+func TestObserveLogNoPanic(_ *testing.T) {
 	obs := newTestObserver()
 	h := obs.GetHandle("test-source")
 	h.ObserveLog(stubLog{})


### PR DESCRIPTION
## Summary

Replace the no-op observer stub with a real channel-backed handle factory.

## What does this PR do?

Introduces the handle factory infrastructure so other components can call `GetHandle(name)` and send observations (metrics and logs) into the observer.

Adds:
- `observerImpl` struct with channel-based observation dispatch
- Real `handle` struct that non-blockingly sends observations (with race-safe copying)
- `innerHandle` factory creating real handles; `noopHandle` for future config-gating
- `run()` goroutine that drains observations from the channel (engine wiring deferred to Wave 3)
- Full test coverage: handle creation, ObserveMetric/ObserveLog no-panic, drop-on-full, noop path, copy safety

## Describe how you validated your changes

- Bazel build: \`bazel build //comp/anomalydetection/observer/...\` ✅
- Unit tests: \`bazel test //comp/anomalydetection/observer/impl:impl_test\` (6 tests pass) ✅

## Wave

Wave 2 (metrics handle factory foundation).

## Notes

- Engine (storage, detectors, reporters) is not included — the \`run()\` loop discards observations for now (0 overhead).
- Config-gating (observer.analysis.enabled) deferred to Wave 2 proper when config keys are registered.
- This is the Wave 1/2 boundary: the API works, but no analysis runs yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)