### PR TITLE
ci(renovate): block NuGet packages with commercial license fees

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -162,6 +162,14 @@
         "matchManagers": ["bundler"],
         "matchDatasources": ["git-refs"],
         "registryUrls": []
+      },
+      {
+        "matchDepNames": ["FluentAssertions"],
+        "allowedVersions": "<8.0.0"
+      },
+      {
+        "matchDepNames": ["WixToolset.Dtf.WindowsInstaller"],
+        "allowedVersions": "<6.0.0"
       }
     ],
     "customManagers" : [

--- a/renovate.json
+++ b/renovate.json
@@ -165,11 +165,11 @@
       },
       {
         "matchDepNames": ["FluentAssertions"],
-        "allowedVersions": "<8.0.0"
+        "allowedVersions": "(,8.0.0)"
       },
       {
         "matchDepNames": ["WixToolset.Dtf.WindowsInstaller"],
-        "allowedVersions": "<6.0.0"
+        "allowedVersions": "(,6.0.0)"
       }
     ],
     "customManagers" : [


### PR DESCRIPTION
### What does this PR do?

Adds `allowedVersions` constraints in `renovate.json` to prevent Renovate from proposing updates to NuGet packages that have introduced commercial license fees:

- `FluentAssertions`: capped at `<8.0.0` (v8+ requires a paid license for commercial use)
- `WixToolset.Dtf.WindowsInstaller`: capped at `<6.0.0` (v6+ requires an Open Source Maintenance Fee for revenue-generating users)

### Motivation

Two Renovate PRs were declined because the proposed versions crossed a license boundary:
- #49107 (`FluentAssertions` v7 → v8)
- #49155 (`WixToolset.Dtf.WindowsInstaller` v5 → v6)

Using `allowedVersions` (rather than `enabled: false`) keeps patch/minor updates flowing within the free tier, while permanently blocking the paid major versions.

### Describe how you validated your changes

Verified the license change boundaries:
- FluentAssertions fee introduced in v8.0.0 (Xceed commercial license)
- WixToolset fee introduced in v6.0.0 (Open Source Maintenance Fee EULA announced with the v6.0.0 release)

### Additional Notes

All other NuGet packages tracked in the Renovate dashboard were audited and confirmed to have free/open-source licenses (MIT, Apache 2.0, BSD-3-Clause).