### PR TITLE
[ACTP] add PAR skip connection creation configuration

### DIFF
--- a/comp/privateactionrunner/def/component.go
+++ b/comp/privateactionrunner/def/component.go
@@ -21,11 +21,12 @@ var ErrNotEnabled = errors.New("private action runner is not enabled")
 // Duplicated from pkg/config/setup/privateactionrunner.go because comp/
 // packages cannot import pkg/config/setup (depguard rule).
 const (
-	PAREnabled               = "private_action_runner.enabled"
-	PARSelfEnroll            = "private_action_runner.self_enroll"
-	PARApiKeyOnlyEnrollment  = "private_action_runner.api_key_only_enrollment"
-	PARPrivateKey            = "private_action_runner.private_key"
-	PARUrn                   = "private_action_runner.urn"
-	PARActionsAllowlist      = "private_action_runner.actions_allowlist"
-	PARDefaultActionsEnabled = "private_action_runner.default_actions_enabled"
+	PAREnabled                = "private_action_runner.enabled"
+	PARSelfEnroll             = "private_action_runner.self_enroll"
+	PARApiKeyOnlyEnrollment   = "private_action_runner.api_key_only_enrollment"
+	PARSkipConnectionCreation = "private_action_runner.skip_connection_creation"
+	PARPrivateKey             = "private_action_runner.private_key"
+	PARUrn                    = "private_action_runner.urn"
+	PARActionsAllowlist       = "private_action_runner.actions_allowlist"
+	PARDefaultActionsEnabled  = "private_action_runner.default_actions_enabled"
 )

--- a/comp/privateactionrunner/impl/privateactionrunner.go
+++ b/comp/privateactionrunner/impl/privateactionrunner.go
@@ -339,8 +339,8 @@ func (p *PrivateActionRunner) performSelfEnrollment(ctx context.Context, cfg *pa
 	cfg.OrgId = urnParts.OrgID
 	cfg.RunnerId = urnParts.RunnerID
 
-	// Auto-create connections only when using app-key enrollment mode.
-	if !apiKeyOnlyEnrollment {
+	// Auto-create connections when using app-key enrollment mode and skip_connection_creation is false.
+	if !apiKeyOnlyEnrollment && !p.coreConfig.GetBool(privateactionrunner.PARSkipConnectionCreation) {
 		var actionsAllowlist = make([]string, 0, len(cfg.ActionsAllowlist))
 		for fqnPrefix := range cfg.ActionsAllowlist {
 			actionsAllowlist = append(actionsAllowlist, fqnPrefix)

--- a/pkg/config/setup/privateactionrunner.go
+++ b/pkg/config/setup/privateactionrunner.go
@@ -15,13 +15,14 @@ const (
 	PARLogFile = "private_action_runner.log_file"
 
 	// Identity / enrollment configuration
-	PARSelfEnroll           = "private_action_runner.self_enroll"
-	PARApiKeyOnlyEnrollment = "private_action_runner.api_key_only_enrollment"
-	PARIdentityFilePath     = "private_action_runner.identity_file_path"
-	PARIdentityUseK8sSecret = "private_action_runner.identity_use_k8s_secret"
-	PARIdentitySecretName   = "private_action_runner.identity_secret_name"
-	PARPrivateKey           = "private_action_runner.private_key"
-	PARUrn                  = "private_action_runner.urn"
+	PARSelfEnroll             = "private_action_runner.self_enroll"
+	PARApiKeyOnlyEnrollment   = "private_action_runner.api_key_only_enrollment"
+	PARIdentityFilePath       = "private_action_runner.identity_file_path"
+	PARIdentityUseK8sSecret   = "private_action_runner.identity_use_k8s_secret"
+	PARIdentitySecretName     = "private_action_runner.identity_secret_name"
+	PARPrivateKey             = "private_action_runner.private_key"
+	PARUrn                    = "private_action_runner.urn"
+	PARSkipConnectionCreation = "private_action_runner.skip_connection_creation"
 
 	// General config
 	PARTaskConcurrency       = "private_action_runner.task_concurrency"
@@ -63,6 +64,7 @@ func setupPrivateActionRunner(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault(PARIdentitySecretName, "private-action-runner-identity")
 	config.BindEnvAndSetDefault(PARPrivateKey, "")
 	config.BindEnvAndSetDefault(PARUrn, "")
+	config.BindEnvAndSetDefault(PARSkipConnectionCreation, false)
 
 	// General config
 	config.BindEnvAndSetDefault(PARTaskConcurrency, 5)

--- a/releasenotes/notes/par-skip-connection-creation-12d04416b02ad548.yaml
+++ b/releasenotes/notes/par-skip-connection-creation-12d04416b02ad548.yaml
@@ -1,0 +1,8 @@
+---
+enhancements:
+  - |
+    Add ``private_action_runner.skip_connection_creation`` configuration flag
+    to control auto-connection creation during Private Action Runner
+    enrollment. When set to ``true``, the runner skips creating connections
+    during app-key enrollment. Defaults to ``false``, which preserves the
+    existing behavior of auto-creating connections.


### PR DESCRIPTION
### What does this PR do?

Introduces a `skip_connection_creation` configuration property to the private action runner to allow to disable connection autocreation (false by default)

### Motivation

We want to get rid of connections for PAR so introducing this property allows us to test it internally and will also allow customers to optin / optout on the behavior 

### Describe how you validated your changes

Ran a PAR locally with and without the flag

### Additional Notes

We will want to backport this in 7.79.1 to dogfood this
