### PR TITLE
AGTMETRICS-509 Improve point.{sent,dropped} telemetry

### DIFF
--- a/comp/forwarder/defaultforwarder/sync_forwarder.go
+++ b/comp/forwarder/defaultforwarder/sync_forwarder.go
@@ -60,13 +60,13 @@ func (f *SyncForwarder) Stop() {
 
 func (f *SyncForwarder) sendHTTPTransactions(transactions []*transaction.HTTPTransaction) error {
 	for _, t := range transactions {
-		if err := t.Process(context.Background(), f.config, f.log, f.secrets, f.client); err != nil {
+		if err := t.Process(context.Background(), f.config, f.log, f.secrets, f.client, nil); err != nil {
 			f.log.Debugf("SyncForwarder.sendHTTPTransactions first attempt: %s", err)
 			// Retry once after error
 			// The intake may have closed the connection between Lambda invocations.
 			// If so, the first attempt will fail because the closed connection will still be cached.
 			f.log.Debug("Retrying transaction")
-			if err := t.Process(context.Background(), f.config, f.log, f.secrets, f.client); err != nil {
+			if err := t.Process(context.Background(), f.config, f.log, f.secrets, f.client, nil); err != nil {
 				f.log.Warnf("SyncForwarder.sendHTTPTransactions failed to send: %s", err)
 			}
 		}

--- a/comp/forwarder/defaultforwarder/test_common.go
+++ b/comp/forwarder/defaultforwarder/test_common.go
@@ -59,7 +59,7 @@ func (t *testTransaction) GetCreatedAt() time.Time {
 	return t.Called().Get(0).(time.Time)
 }
 
-func (t *testTransaction) Process(ctx context.Context, _ config.Component, _ log.Component, _ secrets.Component, client *http.Client) error {
+func (t *testTransaction) Process(ctx context.Context, _ config.Component, _ log.Component, _ secrets.Component, client *http.Client, pointCountTelemetry transaction.PointCountTelemetry) error {
 	defer func() { t.processed <- true }()
 
 	var ret error
@@ -73,6 +73,13 @@ func (t *testTransaction) Process(ctx context.Context, _ config.Component, _ log
 
 	if t.shouldBlock {
 		<-ctx.Done()
+	}
+
+	// Mirror HTTPTransaction.internalProcess: a nil-error outcome counts the
+	// transaction's points as successfully sent. Tests of the worker rely on
+	// this to assert point.sent accounting.
+	if ret == nil && pointCountTelemetry != nil {
+		pointCountTelemetry.OnPointSuccessfullySent(t.pointCount)
 	}
 
 	return ret

--- a/comp/forwarder/defaultforwarder/transaction/transaction.go
+++ b/comp/forwarder/defaultforwarder/transaction/transaction.go
@@ -125,6 +125,15 @@ func GetClientTrace(log log.Component) *httptrace.ClientTrace {
 // Compile-time check to ensure that HTTPTransaction conforms to the Transaction interface
 var _ Transaction = &HTTPTransaction{}
 
+// PointCountTelemetry tracks the number of points that were successfully
+// delivered or dropped while processing a transaction. Implementations are
+// safe to nil-check at the call site so transactions can be processed
+// without telemetry (e.g. SyncForwarder).
+type PointCountTelemetry interface {
+	OnPointSuccessfullySent(count int)
+	OnPointDropped(count int)
+}
+
 // HTTPAttemptHandler is an event handler that will get called each time this transaction is attempted
 type HTTPAttemptHandler func(transaction *HTTPTransaction)
 
@@ -274,7 +283,7 @@ type TransactionsSerializer interface {
 
 // Transaction represents the task to process for a Worker.
 type Transaction interface {
-	Process(ctx context.Context, config config.Component, log log.Component, secrets secrets.Component, client *http.Client) error
+	Process(ctx context.Context, config config.Component, log log.Component, secrets secrets.Component, client *http.Client, pointCountTelemetry PointCountTelemetry) error
 	GetCreatedAt() time.Time
 	GetTarget() string
 	GetPriority() Priority
@@ -359,10 +368,10 @@ func (t *HTTPTransaction) GetDestination() Destination {
 }
 
 // Process sends the Payload of the transaction to the right Endpoint and Domain.
-func (t *HTTPTransaction) Process(ctx context.Context, config config.Component, log log.Component, secrets secrets.Component, client *http.Client) error {
+func (t *HTTPTransaction) Process(ctx context.Context, config config.Component, log log.Component, secrets secrets.Component, client *http.Client, pointCountTelemetry PointCountTelemetry) error {
 	t.AttemptHandler(t)
 
-	statusCode, body, err := t.internalProcess(ctx, config, log, secrets, client)
+	statusCode, body, err := t.internalProcess(ctx, config, log, secrets, client, pointCountTelemetry)
 
 	if err == nil || !t.Retryable {
 		t.CompletionHandler(t, statusCode, body, err)
@@ -379,7 +388,7 @@ func (t *HTTPTransaction) Process(ctx context.Context, config config.Component, 
 
 // internalProcess does the  work of actually sending the http request to the specified domain
 // This will return  (http status code, response body, error).
-func (t *HTTPTransaction) internalProcess(ctx context.Context, config config.Component, log log.Component, secrets secrets.Component, client *http.Client) (int, []byte, error) {
+func (t *HTTPTransaction) internalProcess(ctx context.Context, config config.Component, log log.Component, secrets secrets.Component, client *http.Client, pointCountTelemetry PointCountTelemetry) (int, []byte, error) {
 	payload := t.Payload.GetContent()
 	reader := bytes.NewReader(payload)
 	url := t.Domain + t.Endpoint.Route
@@ -446,6 +455,9 @@ func (t *HTTPTransaction) internalProcess(ctx context.Context, config config.Com
 		TransactionsDroppedByEndpoint.Add(transactionEndpointName, 1)
 		TransactionsDropped.Add(1)
 		TlmTxDropped.Inc(t.Domain, transactionEndpointName)
+		if pointCountTelemetry != nil {
+			pointCountTelemetry.OnPointDropped(t.GetPointCount())
+		}
 		return resp.StatusCode, body, nil
 	} else if resp.StatusCode == 403 {
 		// Trigger throttled secret refresh based on secret_refresh_on_api_key_failure_interval on API key error
@@ -460,6 +472,9 @@ func (t *HTTPTransaction) internalProcess(ctx context.Context, config config.Com
 		TransactionsDroppedByEndpoint.Add(transactionEndpointName, 1)
 		TransactionsDropped.Add(1)
 		TlmTxDropped.Inc(t.Domain, transactionEndpointName)
+		if pointCountTelemetry != nil {
+			pointCountTelemetry.OnPointDropped(t.GetPointCount())
+		}
 		return resp.StatusCode, body, nil
 	} else if resp.StatusCode > 400 {
 		t.ErrorCount++
@@ -468,6 +483,9 @@ func (t *HTTPTransaction) internalProcess(ctx context.Context, config config.Com
 		return resp.StatusCode, body, fmt.Errorf("error %q while sending transaction to %q, rescheduling it: %q", resp.Status, logURL, truncateBodyForLog(body))
 	}
 
+	if pointCountTelemetry != nil {
+		pointCountTelemetry.OnPointSuccessfullySent(t.GetPointCount())
+	}
 	tlmTxSuccessCount.Inc(t.Domain, transactionEndpointName, resp.Proto)
 	tlmTxSuccessBytes.Add(float64(t.GetPayloadSize()), t.Domain, transactionEndpointName)
 	TransactionsSuccessByEndpoint.Add(transactionEndpointName, 1)

--- a/comp/forwarder/defaultforwarder/transaction/transaction_test.go
+++ b/comp/forwarder/defaultforwarder/transaction/transaction_test.go
@@ -58,7 +58,7 @@ func TestProcess(t *testing.T) {
 	mockConfig := configmock.New(t)
 	log := logmock.New(t)
 	secrets := secretsmock.New(t)
-	err := transaction.Process(context.Background(), mockConfig, log, secrets, client)
+	err := transaction.Process(context.Background(), mockConfig, log, secrets, client, nil)
 	assert.NoError(t, err)
 }
 
@@ -74,7 +74,7 @@ func TestProcessInvalidDomain(t *testing.T) {
 	mockConfig := configmock.New(t)
 	log := logmock.New(t)
 	secrets := secretsmock.New(t)
-	err := transaction.Process(context.Background(), mockConfig, log, secrets, client)
+	err := transaction.Process(context.Background(), mockConfig, log, secrets, client, nil)
 	assert.NoError(t, err)
 }
 
@@ -90,7 +90,7 @@ func TestProcessNetworkError(t *testing.T) {
 	mockConfig := configmock.New(t)
 	log := logmock.New(t)
 	secrets := secretsmock.New(t)
-	err := transaction.Process(context.Background(), mockConfig, log, secrets, client)
+	err := transaction.Process(context.Background(), mockConfig, log, secrets, client, nil)
 	assert.NotNil(t, err)
 }
 
@@ -116,21 +116,21 @@ func TestProcessHTTPError(t *testing.T) {
 	secrets.SetRefreshHook(func() bool {
 		return true
 	})
-	err := transaction.Process(context.Background(), mockConfig, log, secrets, client)
+	err := transaction.Process(context.Background(), mockConfig, log, secrets, client, nil)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "error \"503 Service Unavailable\" while sending transaction")
 
 	errorCode = http.StatusBadRequest
-	err = transaction.Process(context.Background(), mockConfig, log, secrets, client)
+	err = transaction.Process(context.Background(), mockConfig, log, secrets, client, nil)
 	assert.NoError(t, err)
 
 	errorCode = http.StatusRequestEntityTooLarge
-	err = transaction.Process(context.Background(), mockConfig, log, secrets, client)
+	err = transaction.Process(context.Background(), mockConfig, log, secrets, client, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, transaction.ErrorCount, 1)
 
 	errorCode = http.StatusForbidden
-	err = transaction.Process(context.Background(), mockConfig, log, secrets, client)
+	err = transaction.Process(context.Background(), mockConfig, log, secrets, client, nil)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "API Key invalid")
 
@@ -151,7 +151,7 @@ func TestProcessCancel(t *testing.T) {
 	mockConfig := configmock.New(t)
 	log := logmock.New(t)
 	secrets := secretsmock.New(t)
-	err := transaction.Process(ctx, mockConfig, log, secrets, client)
+	err := transaction.Process(ctx, mockConfig, log, secrets, client, nil)
 	assert.NoError(t, err)
 }
 
@@ -224,7 +224,7 @@ func TestProcessDoesNotMutateHeaders(t *testing.T) {
 	mockConfig := configmock.New(t)
 	log := logmock.New(t)
 	secrets := secretsmock.New(t)
-	err := transaction.Process(context.Background(), mockConfig, log, secrets, client)
+	err := transaction.Process(context.Background(), mockConfig, log, secrets, client, nil)
 	assert.NoError(t, err)
 
 	assert.Equal(t, headersBefore, transaction.Headers, "t.Headers must not be mutated by Process")
@@ -255,7 +255,7 @@ func TestTransaction403TriggersSecretRefresh(t *testing.T) {
 	mockConfig := configmock.New(t)
 	log := logmock.New(t)
 
-	err := transaction.Process(context.Background(), mockConfig, log, secrets, client)
+	err := transaction.Process(context.Background(), mockConfig, log, secrets, client, nil)
 	assert.NotNil(t, err)
 
 	assert.True(t, triggered, "secrets.Refresh(false) should be called when transaction receives 403")
@@ -289,10 +289,147 @@ func TestTransaction403DropsWhenNoSecrets(t *testing.T) {
 		droppedByEndpointBefore = v.(*expvar.Int).Value()
 	}
 
-	err := transaction.Process(context.Background(), mockConfig, log, secrets, client)
+	err := transaction.Process(context.Background(), mockConfig, log, secrets, client, nil)
 
 	assert.NoError(t, err, "a 403 with no secrets backend should drop the transaction, not reschedule it")
 	assert.Equal(t, 0, transaction.ErrorCount, "ErrorCount should not be incremented when the transaction is dropped")
 	assert.Equal(t, droppedBefore+1, TransactionsDropped.Value(), "TransactionsDropped should be incremented")
 	assert.Equal(t, droppedByEndpointBefore+1, TransactionsDroppedByEndpoint.Get("test").(*expvar.Int).Value(), "TransactionsDroppedByEndpoint should be incremented for the endpoint")
+}
+
+// pointCountTelemetryRecorder is a minimal PointCountTelemetry that records
+// every call so tests can assert on point.sent / point.dropped accounting.
+type pointCountTelemetryRecorder struct {
+	sent    int
+	dropped int
+}
+
+func (r *pointCountTelemetryRecorder) OnPointSuccessfullySent(count int) { r.sent += count }
+func (r *pointCountTelemetryRecorder) OnPointDropped(count int)          { r.dropped += count }
+
+func newTransactionForStatusTest(domain string, pointCount int) *HTTPTransaction {
+	tr := NewHTTPTransaction()
+	tr.Domain = domain
+	tr.Endpoint.Route = "/endpoint/test"
+	tr.Endpoint.Name = "test"
+	tr.Payload = NewBytesPayload([]byte("test payload"), pointCount)
+	return tr
+}
+
+func TestProcessSuccessfulSendIncrementsPointSent(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	tr := newTransactionForStatusTest(ts.URL, 17)
+	rec := &pointCountTelemetryRecorder{}
+
+	mockConfig := configmock.New(t)
+	logger := logmock.New(t)
+	secrets := secretsmock.New(t)
+	err := tr.Process(context.Background(), mockConfig, logger, secrets, &http.Client{}, rec)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 17, rec.sent, "point.sent must be incremented by GetPointCount on a 2xx response")
+	assert.Equal(t, 0, rec.dropped, "point.dropped must not increment on success")
+}
+
+func TestProcess400DropsIncrementsPointDropped(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer ts.Close()
+
+	tr := newTransactionForStatusTest(ts.URL, 9)
+	rec := &pointCountTelemetryRecorder{}
+
+	mockConfig := configmock.New(t)
+	logger := logmock.New(t)
+	secrets := secretsmock.New(t)
+	err := tr.Process(context.Background(), mockConfig, logger, secrets, &http.Client{}, rec)
+
+	assert.NoError(t, err, "400 is non-retryable: Process should return nil error")
+	assert.Equal(t, 0, rec.sent, "point.sent must not increment on 400 drop")
+	assert.Equal(t, 9, rec.dropped, "point.dropped must be incremented by GetPointCount on 400")
+}
+
+func TestProcess413DropsIncrementsPointDropped(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusRequestEntityTooLarge)
+	}))
+	defer ts.Close()
+
+	tr := newTransactionForStatusTest(ts.URL, 4)
+	rec := &pointCountTelemetryRecorder{}
+
+	mockConfig := configmock.New(t)
+	logger := logmock.New(t)
+	secrets := secretsmock.New(t)
+	err := tr.Process(context.Background(), mockConfig, logger, secrets, &http.Client{}, rec)
+
+	assert.NoError(t, err, "413 is non-retryable: Process should return nil error")
+	assert.Equal(t, 0, rec.sent, "point.sent must not increment on 413 drop")
+	assert.Equal(t, 4, rec.dropped, "point.dropped must be incremented by GetPointCount on 413")
+}
+
+func TestProcess403NoRefreshIncrementsPointDropped(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer ts.Close()
+
+	tr := newTransactionForStatusTest(ts.URL, 3)
+	rec := &pointCountTelemetryRecorder{}
+
+	mockConfig := configmock.New(t)
+	logger := logmock.New(t)
+	secrets := secretsmock.New(t)
+	secrets.SetRefreshHook(func() bool { return false }) // refresh fails → drop path
+
+	err := tr.Process(context.Background(), mockConfig, logger, secrets, &http.Client{}, rec)
+
+	assert.NoError(t, err, "403 with no key refresh is non-retryable: Process should return nil error")
+	assert.Equal(t, 0, rec.sent, "point.sent must not increment on 403-drop")
+	assert.Equal(t, 3, rec.dropped, "point.dropped must be incremented by GetPointCount on 403-drop")
+}
+
+func TestProcess403WithRefreshDoesNotTouchPointTelemetry(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer ts.Close()
+
+	tr := newTransactionForStatusTest(ts.URL, 12)
+	rec := &pointCountTelemetryRecorder{}
+
+	mockConfig := configmock.New(t)
+	logger := logmock.New(t)
+	secrets := secretsmock.New(t)
+	secrets.SetRefreshHook(func() bool { return true }) // refresh succeeds → retryable
+
+	err := tr.Process(context.Background(), mockConfig, logger, secrets, &http.Client{}, rec)
+
+	assert.Error(t, err, "403 with successful key refresh is retryable")
+	assert.Equal(t, 0, rec.sent, "retryable failures must not credit point.sent")
+	assert.Equal(t, 0, rec.dropped, "retryable failures must not credit point.dropped")
+}
+
+func TestProcess5xxDoesNotTouchPointTelemetry(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer ts.Close()
+
+	tr := newTransactionForStatusTest(ts.URL, 6)
+	rec := &pointCountTelemetryRecorder{}
+
+	mockConfig := configmock.New(t)
+	logger := logmock.New(t)
+	secrets := secretsmock.New(t)
+	err := tr.Process(context.Background(), mockConfig, logger, secrets, &http.Client{}, rec)
+
+	assert.Error(t, err, "5xx is retryable")
+	assert.Equal(t, 0, rec.sent, "retryable 5xx must not credit point.sent")
+	assert.Equal(t, 0, rec.dropped, "retryable 5xx must not credit point.dropped")
 }

--- a/comp/forwarder/defaultforwarder/transaction/transaction_test.go
+++ b/comp/forwarder/defaultforwarder/transaction/transaction_test.go
@@ -316,120 +316,84 @@ func newTransactionForStatusTest(domain string, pointCount int) *HTTPTransaction
 	return tr
 }
 
-func TestProcessSuccessfulSendIncrementsPointSent(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer ts.Close()
+func TestProcessPointCountTelemetry(t *testing.T) {
+	cases := []struct {
+		name            string
+		status          int
+		pointCount      int
+		setRefreshHook  bool
+		refreshSucceeds bool
+		wantErr         bool
+		wantSent        int
+		wantDropped     int
+	}{
+		{
+			name:       "2xx credits point.sent",
+			status:     http.StatusOK,
+			pointCount: 17,
+			wantSent:   17,
+		},
+		{
+			name:        "400 drop credits point.dropped",
+			status:      http.StatusBadRequest,
+			pointCount:  9,
+			wantDropped: 9,
+		},
+		{
+			name:        "413 drop credits point.dropped",
+			status:      http.StatusRequestEntityTooLarge,
+			pointCount:  4,
+			wantDropped: 4,
+		},
+		{
+			name:            "403 with failed key refresh credits point.dropped",
+			status:          http.StatusForbidden,
+			pointCount:      3,
+			setRefreshHook:  true,
+			refreshSucceeds: false,
+			wantDropped:     3,
+		},
+		{
+			name:            "403 with successful key refresh is retryable",
+			status:          http.StatusForbidden,
+			pointCount:      12,
+			setRefreshHook:  true,
+			refreshSucceeds: true,
+			wantErr:         true,
+		},
+		{
+			name:       "5xx is retryable",
+			status:     http.StatusServiceUnavailable,
+			pointCount: 6,
+			wantErr:    true,
+		},
+	}
 
-	tr := newTransactionForStatusTest(ts.URL, 17)
-	rec := &pointCountTelemetryRecorder{}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+			}))
+			defer ts.Close()
 
-	mockConfig := configmock.New(t)
-	logger := logmock.New(t)
-	secrets := secretsmock.New(t)
-	err := tr.Process(context.Background(), mockConfig, logger, secrets, &http.Client{}, rec)
+			tr := newTransactionForStatusTest(ts.URL, tc.pointCount)
+			rec := &pointCountTelemetryRecorder{}
 
-	assert.NoError(t, err)
-	assert.Equal(t, 17, rec.sent, "point.sent must be incremented by GetPointCount on a 2xx response")
-	assert.Equal(t, 0, rec.dropped, "point.dropped must not increment on success")
-}
+			secrets := secretsmock.New(t)
+			if tc.setRefreshHook {
+				secrets.SetRefreshHook(func() bool { return tc.refreshSucceeds })
+			}
 
-func TestProcess400DropsIncrementsPointDropped(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusBadRequest)
-	}))
-	defer ts.Close()
+			err := tr.Process(context.Background(), configmock.New(t), logmock.New(t),
+				secrets, &http.Client{}, rec)
 
-	tr := newTransactionForStatusTest(ts.URL, 9)
-	rec := &pointCountTelemetryRecorder{}
-
-	mockConfig := configmock.New(t)
-	logger := logmock.New(t)
-	secrets := secretsmock.New(t)
-	err := tr.Process(context.Background(), mockConfig, logger, secrets, &http.Client{}, rec)
-
-	assert.NoError(t, err, "400 is non-retryable: Process should return nil error")
-	assert.Equal(t, 0, rec.sent, "point.sent must not increment on 400 drop")
-	assert.Equal(t, 9, rec.dropped, "point.dropped must be incremented by GetPointCount on 400")
-}
-
-func TestProcess413DropsIncrementsPointDropped(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusRequestEntityTooLarge)
-	}))
-	defer ts.Close()
-
-	tr := newTransactionForStatusTest(ts.URL, 4)
-	rec := &pointCountTelemetryRecorder{}
-
-	mockConfig := configmock.New(t)
-	logger := logmock.New(t)
-	secrets := secretsmock.New(t)
-	err := tr.Process(context.Background(), mockConfig, logger, secrets, &http.Client{}, rec)
-
-	assert.NoError(t, err, "413 is non-retryable: Process should return nil error")
-	assert.Equal(t, 0, rec.sent, "point.sent must not increment on 413 drop")
-	assert.Equal(t, 4, rec.dropped, "point.dropped must be incremented by GetPointCount on 413")
-}
-
-func TestProcess403NoRefreshIncrementsPointDropped(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusForbidden)
-	}))
-	defer ts.Close()
-
-	tr := newTransactionForStatusTest(ts.URL, 3)
-	rec := &pointCountTelemetryRecorder{}
-
-	mockConfig := configmock.New(t)
-	logger := logmock.New(t)
-	secrets := secretsmock.New(t)
-	secrets.SetRefreshHook(func() bool { return false }) // refresh fails → drop path
-
-	err := tr.Process(context.Background(), mockConfig, logger, secrets, &http.Client{}, rec)
-
-	assert.NoError(t, err, "403 with no key refresh is non-retryable: Process should return nil error")
-	assert.Equal(t, 0, rec.sent, "point.sent must not increment on 403-drop")
-	assert.Equal(t, 3, rec.dropped, "point.dropped must be incremented by GetPointCount on 403-drop")
-}
-
-func TestProcess403WithRefreshDoesNotTouchPointTelemetry(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusForbidden)
-	}))
-	defer ts.Close()
-
-	tr := newTransactionForStatusTest(ts.URL, 12)
-	rec := &pointCountTelemetryRecorder{}
-
-	mockConfig := configmock.New(t)
-	logger := logmock.New(t)
-	secrets := secretsmock.New(t)
-	secrets.SetRefreshHook(func() bool { return true }) // refresh succeeds → retryable
-
-	err := tr.Process(context.Background(), mockConfig, logger, secrets, &http.Client{}, rec)
-
-	assert.Error(t, err, "403 with successful key refresh is retryable")
-	assert.Equal(t, 0, rec.sent, "retryable failures must not credit point.sent")
-	assert.Equal(t, 0, rec.dropped, "retryable failures must not credit point.dropped")
-}
-
-func TestProcess5xxDoesNotTouchPointTelemetry(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusServiceUnavailable)
-	}))
-	defer ts.Close()
-
-	tr := newTransactionForStatusTest(ts.URL, 6)
-	rec := &pointCountTelemetryRecorder{}
-
-	mockConfig := configmock.New(t)
-	logger := logmock.New(t)
-	secrets := secretsmock.New(t)
-	err := tr.Process(context.Background(), mockConfig, logger, secrets, &http.Client{}, rec)
-
-	assert.Error(t, err, "5xx is retryable")
-	assert.Equal(t, 0, rec.sent, "retryable 5xx must not credit point.sent")
-	assert.Equal(t, 0, rec.dropped, "retryable 5xx must not credit point.dropped")
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tc.wantSent, rec.sent, "point.sent")
+			assert.Equal(t, tc.wantDropped, rec.dropped, "point.dropped")
+		})
+	}
 }

--- a/comp/forwarder/defaultforwarder/worker.go
+++ b/comp/forwarder/defaultforwarder/worker.go
@@ -37,9 +37,9 @@ type Worker struct {
 	// RequeueChan is the channel used to send failed transaction back to the Forwarder.
 	RequeueChan chan<- transaction.Transaction
 
-	stopped               chan struct{}
-	blockedList           *blockedEndpoints
-	pointSuccessfullySent PointSuccessfullySent
+	stopped             chan struct{}
+	blockedList         *blockedEndpoints
+	pointCountTelemetry PointCountTelemetry
 
 	// The maximum number of HTTP requests we can have inflight at any one time.
 	maxConcurrentRequests *semaphore.Weighted
@@ -48,9 +48,11 @@ type Worker struct {
 	requestWg             sync.WaitGroup
 }
 
-// PointSuccessfullySent is called when sending successfully a point to the intake.
-type PointSuccessfullySent interface {
-	OnPointSuccessfullySent(int)
+// PointCountTelemetry tracks the number of points that were either
+// successfully delivered or dropped by the forwarder.
+type PointCountTelemetry interface {
+	OnPointSuccessfullySent(count int)
+	OnPointDropped(count int)
 }
 
 // NewWorker returns a new worker to consume Transaction from inputChan
@@ -63,7 +65,7 @@ func NewWorker(
 	lowPrioChan <-chan transaction.Transaction,
 	requeueChan chan<- transaction.Transaction,
 	blocked *blockedEndpoints,
-	pointSuccessfullySent PointSuccessfullySent,
+	pointCountTelemetry PointCountTelemetry,
 	httpClient *SharedConnection,
 ) *Worker {
 	maxConcurrentRequests := config.GetInt64("forwarder_max_concurrent_requests")
@@ -84,7 +86,7 @@ func NewWorker(
 		stopped:               make(chan struct{}),
 		Client:                httpClient,
 		blockedList:           blocked,
-		pointSuccessfullySent: pointSuccessfullySent,
+		pointCountTelemetry:   pointCountTelemetry,
 		maxConcurrentRequests: semaphore.NewWeighted(maxConcurrentRequests),
 		workerCtx:             workerCtx,
 		cancel:                cancel,
@@ -198,12 +200,11 @@ func (w *Worker) process(ctx context.Context, t transaction.Transaction) {
 	if w.blockedList.isBlockForSend(target, time.Now()) {
 		w.requeue(t)
 		w.log.Warnf("Too many errors for endpoint '%s': retrying later", target)
-	} else if err := t.Process(ctx, w.config, w.log, w.secrets, w.Client.GetClient()); err != nil {
+	} else if err := t.Process(ctx, w.config, w.log, w.secrets, w.Client.GetClient(), w.pointCountTelemetry); err != nil {
 		w.blockedList.close(target, time.Now())
 		w.requeue(t)
 		w.log.Errorf("Error while processing transaction: %v", err)
 	} else {
-		w.pointSuccessfullySent.OnPointSuccessfullySent(t.GetPointCount())
 		w.blockedList.recover(target, time.Now())
 	}
 }
@@ -212,6 +213,7 @@ func (w *Worker) requeue(t transaction.Transaction) {
 	select {
 	case w.RequeueChan <- t:
 	default:
+		w.pointCountTelemetry.OnPointDropped(t.GetPointCount())
 		w.log.Errorf("dropping transaction because the retry goroutine is too busy to handle another one")
 	}
 }

--- a/comp/forwarder/defaultforwarder/worker_test.go
+++ b/comp/forwarder/defaultforwarder/worker_test.go
@@ -374,7 +374,7 @@ func TestWorkerRequeueDropsTracksPointsDropped(t *testing.T) {
 	mockConfig := mock.New(t)
 	log := logmock.New(t)
 	secrets := secretsmock.New(t)
-	w := NewWorker(mockConfig, log, secrets, highPrio, lowPrio, requeue, newBlockedEndpoints(mockConfig, log), sender, NewSharedConnection(log, false, 1, mockConfig))
+	w := NewWorker(mockConfig, log, secrets, highPrio, lowPrio, requeue, newBlockedEndpoints(mockConfig, log), sender, NewSharedConnection(log, false, 1, mockConfig, nil))
 
 	// Fill the requeue channel so the next requeue call falls into the default branch and drops.
 	filler := newTestTransaction()

--- a/comp/forwarder/defaultforwarder/worker_test.go
+++ b/comp/forwarder/defaultforwarder/worker_test.go
@@ -366,10 +366,38 @@ func TestWorkerPurgeOnStop(t *testing.T) {
 	mockRetryTransaction.AssertNumberOfCalls(t, "Process", 0)
 }
 
+func TestWorkerRequeueDropsTracksPointsDropped(t *testing.T) {
+	highPrio := make(chan transaction.Transaction)
+	lowPrio := make(chan transaction.Transaction)
+	requeue := make(chan transaction.Transaction, 1)
+	sender := &PointSuccessfullySentMock{}
+	mockConfig := mock.New(t)
+	log := logmock.New(t)
+	secrets := secretsmock.New(t)
+	w := NewWorker(mockConfig, log, secrets, highPrio, lowPrio, requeue, newBlockedEndpoints(mockConfig, log), sender, NewSharedConnection(log, false, 1, mockConfig))
+
+	// Fill the requeue channel so the next requeue call falls into the default branch and drops.
+	filler := newTestTransaction()
+	requeue <- filler
+
+	dropped := newTestTransaction()
+	dropped.pointCount = 7
+
+	w.requeue(dropped)
+
+	assert.Equal(t, int64(7), sender.dropped.Load(), "point.dropped must reflect points lost when RequeueChan is full")
+	assert.Equal(t, int64(0), sender.count.Load(), "no points were successfully sent")
+}
+
 type PointSuccessfullySentMock struct {
-	count atomic.Int64
+	count   atomic.Int64
+	dropped atomic.Int64
 }
 
 func (m *PointSuccessfullySentMock) OnPointSuccessfullySent(count int) {
 	m.count.Add(int64(count))
+}
+
+func (m *PointSuccessfullySentMock) OnPointDropped(count int) {
+	m.dropped.Add(int64(count))
 }


### PR DESCRIPTION
### What does this PR do?


point.sent metric previously included points from transactions that were attempted, but received a non-retryable http error. This is now more accurately counted as point.dropped.

Points lost due to failure to insert transaction into RequeueChan produced an error, but not were not counted in either metric. They are now included in point.dropped.

### Motivation

Make telemetry more accurate.

### Describe how you validated your changes

Unit tests

### Additional Notes
