### PR TITLE
test/new-e2e/tests/autoscaling/spot: fix rebalancing timeout per-pod budget

### DIFF
--- a/test/new-e2e/tests/autoscaling/spot/deployment_test.go
+++ b/test/new-e2e/tests/autoscaling/spot/deployment_test.go
@@ -85,14 +85,15 @@ func (s *spotSchedulingSuite) TestDeploymentFallbackWhenSpotUnavailable() {
 	// 1. Set spot-disabled-until annotation on Deployment
 	// 2. Evict pending spot pods
 	// 3. New pods from ReplicaSet go to on-demand node
-	var lastDisabledUntil string
+	var disabledUntil time.Time
 	s.eventually(func(c *assert.CollectT) {
 		deploy, err := s.kubeClient.AppsV1().Deployments(s.testNamespace).Get(s.T().Context(), "nginx", metav1.GetOptions{})
 		require.NoError(c, err)
 		require.NotEmpty(c, deploy.Annotations[spotDisabledUntilAnnotation],
 			"spot-disabled-until annotation should be set on Deployment after fallback")
 
-		lastDisabledUntil = deploy.Annotations[spotDisabledUntilAnnotation]
+		disabledUntil, err = time.Parse(time.RFC3339, deploy.Annotations[spotDisabledUntilAnnotation])
+		s.Require().NoError(err)
 	})
 
 	// Wait for all 10 pods to run on on-demand (fallback mode).
@@ -106,24 +107,17 @@ func (s *spotSchedulingSuite) TestDeploymentFallbackWhenSpotUnavailable() {
 	// Uncordon and wait for all 10 pods to run on spot and on-demand due to rebalancing.
 	s.uncordonNode(s.spotNode)
 
-	const spotPods = 6 // 60% of 10 replicas
-	fallbackCount := 1
-	s.EventuallyWithT(func(c *assert.CollectT) {
-		deploy, err := s.kubeClient.AppsV1().Deployments(s.testNamespace).Get(s.T().Context(), "nginx", metav1.GetOptions{})
-		require.NoError(c, err)
-		disabledUntil := deploy.Annotations[spotDisabledUntilAnnotation]
-		if disabledUntil != "" && disabledUntil != lastDisabledUntil {
-			fallbackCount++
-			lastDisabledUntil = disabledUntil
-			s.T().Logf("spot fallback #%d, disabled until: %s", fallbackCount, disabledUntil)
-		}
+	fallbackWait := max(0, time.Until(disabledUntil))
+	s.T().Logf("Remaining fallback duration: %v", fallbackWait)
 
+	const spotPods = 6 // 60% of 10 replicas
+	s.EventuallyWithT(func(c *assert.CollectT) {
 		pods := s.listPods("deployment=nginx")
 
 		require.Len(c, pods, 10)
 		s.expectRunningSpot(c, pods, spotPods)
 		s.expectRunningOnDemand(c, pods, 4)
-	}, 2*fallbackDuration+rebalancingTimeout(spotPods), 5*time.Second)
+	}, fallbackWait+rebalancingTimeout(spotPods), 5*time.Second)
 }
 
 // TestDeploymentOptIn: create a deployment without the spot label, wait for all pods

--- a/test/new-e2e/tests/autoscaling/spot/suite_test.go
+++ b/test/new-e2e/tests/autoscaling/spot/suite_test.go
@@ -118,7 +118,12 @@ var workerNodes = []kubeComp.KindWorkerNode{
 
 // rebalancingTimeout returns the expected duration to rebalance given number of spot pods.
 func rebalancingTimeout(spotPods int) time.Duration {
-	return time.Duration(spotPods)*2*rebalanceStabilizationPeriod + 30*time.Second
+	// Each rebalance cycle costs one rebalanceStabilizationPeriod plus pod startup time: the
+	// rebalancer resets its stabilization clock when a replacement pod joins the pod set, so the
+	// next eviction can only happen once the replacement is Running and the full stabilization
+	// period has elapsed.
+	const waitUntilRunning = 30 * time.Second
+	return time.Duration(spotPods) * (rebalanceStabilizationPeriod + waitUntilRunning)
 }
 
 type spotSchedulingSuite struct {


### PR DESCRIPTION
What does this PR do
--------------------

Update rebalancingTimeout to correctly account for the actual cycle cost of the spot rebalancer. Each eviction cycle costs one rebalanceStabilizationPeriod plus the time for the replacement pod to reach Running: the rebalancer resets its stabilization clock when a replacement pod joins the pod set, so the next eviction can only happen once the replacement is up and the full stabilization period has elapsed.

Replace the implicit 2×rebalanceStabilizationPeriod per-pod budget with rebalanceStabilizationPeriod + waitUntilRunning (30 s), and document the reasoning in a comment.

Motivation
----------

Prior CI failures showed the test timing out with actual: 5 spot pods (near-miss). The per-pod budget underestimated the real cycle time by not accounting for pod startup time separately from the stabilization period.

Updates https://datadoghq.atlassian.net/browse/CASCL-1222

Describe how you validated your changes
---

Ran local e2e tests.