### PR TITLE
chore(e2e): build/test e2e jobs don't need lint jobs

### DIFF
--- a/.gitlab/deploy/e2e_testing_deploy/e2e_deploy.yml
+++ b/.gitlab/deploy/e2e_testing_deploy/e2e_deploy.yml
@@ -63,7 +63,6 @@ deploy_deb_testing-a7_x64:
       "agent_heroku_deb-x64-a7",
       "iot_agent_deb-x64",
       "dogstatsd_deb-x64",
-      "lint_linux-x64",
       "ddot_deb-x64",
     ]
   script:
@@ -88,7 +87,7 @@ deploy_deb_testing-a7_arm64:
     - !reference [.manual]
   extends:
     - .deploy_deb_testing-a7
-  needs: ["installer_deb-arm64", "agent_deb-arm64-a7", "agent_deb-arm64-a7-fips", "lint_linux-arm64", "ddot_deb-arm64"]
+  needs: ["installer_deb-arm64", "agent_deb-arm64-a7", "agent_deb-arm64-a7-fips", "ddot_deb-arm64"]
   script:
     # setup_signing_keys_package must be done *before* setup_signing
     # because setup_signing replaces gpg with gpg-vault
@@ -125,7 +124,6 @@ deploy_rpm_testing-a7_x64:
       "agent_rpm-x64-a7-fips",
       "iot_agent_rpm-x64",
       "dogstatsd_rpm-x64",
-      "lint_linux-x64",
       "ddot_rpm-x64",
     ]
   script:
@@ -143,7 +141,7 @@ deploy_rpm_testing-a7_arm64:
     - !reference [.manual]
   extends:
     - .deploy_rpm_testing-a7
-  needs: ["installer_rpm-arm64", "agent_rpm-arm64-a7", "agent_rpm-arm64-a7-fips", "lint_linux-arm64", "ddot_rpm-arm64"]
+  needs: ["installer_rpm-arm64", "agent_rpm-arm64-a7", "agent_rpm-arm64-a7-fips", "ddot_rpm-arm64"]
   script:
     - *setup_signing
     - |
@@ -167,7 +165,6 @@ deploy_suse_rpm_testing_x64-a7:
       "iot_agent_suse-x64",
       "dogstatsd_suse-x64",
       "agent_suse-x64-a7-fips",
-      "lint_linux-x64",
       "ddot_suse_rpm-x64",
     ]
   variables:
@@ -190,7 +187,7 @@ deploy_suse_rpm_testing_arm64-a7:
   stage: e2e_deploy
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy$CI_IMAGE_GITLAB_AGENT_DEPLOY_SUFFIX:$CI_IMAGE_GITLAB_AGENT_DEPLOY
   tags: ["arch:amd64", "specific:true"]
-  needs: ["installer_suse_rpm-arm64", "agent_suse-arm64-a7", "agent_suse-arm64-a7-fips", "lint_linux-arm64", "ddot_suse_rpm-arm64"]
+  needs: ["installer_suse_rpm-arm64", "agent_suse-arm64-a7", "agent_suse-arm64-a7-fips", "ddot_suse_rpm-arm64"]
   variables:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
   before_script:


### PR DESCRIPTION
lint job are still run independently (and fail CI), but they should not block building and testing.