### PR TITLE
[workloadmeta] Add cluster-agent collector catalog

### DIFF
--- a/cmd/agent/subcommands/check/command.go
+++ b/cmd/agent/subcommands/check/command.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
+	wmcatalog "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/catalog"
 	"github.com/DataDog/datadog-agent/pkg/cli/subcommands/check"
 )
 
@@ -24,7 +25,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			ConfigName:           command.ConfigName,
 			LoggerName:           command.LoggerName,
 		}
-	})
+	}, wmcatalog.GetCatalog())
 
 	return []*cobra.Command{cmd}
 }

--- a/cmd/cluster-agent/subcommands/check/command.go
+++ b/cmd/cluster-agent/subcommands/check/command.go
@@ -10,6 +10,7 @@ package check
 
 import (
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/command"
+	wmcatalog "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/catalog-clusteragent"
 	"github.com/DataDog/datadog-agent/pkg/cli/subcommands/check"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	pkgcommon "github.com/DataDog/datadog-agent/pkg/util/common"
@@ -32,7 +33,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			ConfigName:   command.ConfigName,
 			LoggerName:   command.LoggerName,
 		}
-	})
+	}, wmcatalog.GetCatalog())
 
 	return []*cobra.Command{cmd}
 }

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -55,7 +55,7 @@ import (
 	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/def"
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	workloadfilterfx "github.com/DataDog/datadog-agent/comp/core/workloadfilter/fx"
-	wmcatalog "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/catalog"
+	wmcatalog "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/catalog-clusteragent"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafx "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx"
 	workloadmetainit "github.com/DataDog/datadog-agent/comp/core/workloadmeta/init"

--- a/comp/core/workloadmeta/collectors/catalog-clusteragent/catalog.go
+++ b/comp/core/workloadmeta/collectors/catalog-clusteragent/catalog.go
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package catalog is a wrapper that loads the available workloadmeta
+// collectors. This is the catalog used by the cluster agent.
+package catalog
+
+import (
+	"go.uber.org/fx"
+)
+
+// GetCatalog returns the set of FX options to populate the catalog
+func GetCatalog() fx.Option {
+	options := getCollectorOptions()
+
+	// remove nil options
+	opts := make([]fx.Option, 0, len(options))
+	for _, item := range options {
+		if item != nil {
+			opts = append(opts, item)
+		}
+	}
+	return fx.Options(opts...)
+}

--- a/comp/core/workloadmeta/collectors/catalog-clusteragent/options.go
+++ b/comp/core/workloadmeta/collectors/catalog-clusteragent/options.go
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package catalog
+
+import (
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/kubeapiserver"
+)
+
+func getCollectorOptions() []fx.Option {
+	return []fx.Option{
+		kubeapiserver.GetFxOptions(),
+	}
+}

--- a/comp/core/workloadmeta/collectors/catalog/options.go
+++ b/comp/core/workloadmeta/collectors/catalog/options.go
@@ -17,7 +17,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/crio"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/docker"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/ecs"
-	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/kubeapiserver"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/kubelet"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/kubemetadata"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/nvml"
@@ -34,7 +33,6 @@ func getCollectorOptions() []fx.Option {
 		crio.GetFxOptions(),
 		docker.GetFxOptions(),
 		ecs.GetFxOptions(),
-		kubeapiserver.GetFxOptions(),
 		kubelet.GetFxOptions(),
 		kubemetadata.GetFxOptions(),
 		podman.GetFxOptions(),

--- a/pkg/cli/subcommands/check/command.go
+++ b/pkg/cli/subcommands/check/command.go
@@ -51,7 +51,6 @@ import (
 	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/def"
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	workloadfilterfx "github.com/DataDog/datadog-agent/comp/core/workloadfilter/fx"
-	wmcatalog "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/catalog"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/defaults"
 	workloadmetafx "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx"
@@ -144,7 +143,7 @@ type GlobalParams struct {
 }
 
 // MakeCommand returns a `check` command to be used by agent binaries.
-func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
+func MakeCommand(globalParamsGetter func() GlobalParams, wmCatalog fx.Option) *cobra.Command {
 	cliParams := &cliParams{}
 	cmd := &cobra.Command{
 		Use:   "check <check_name>",
@@ -175,7 +174,7 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 				hostnameimpl.Module(),
 
 				// workloadmeta setup
-				wmcatalog.GetCatalog(),
+				wmCatalog,
 				workloadmetafx.Module(defaults.DefaultParams()),
 				apiimpl.Module(),
 				grpcNonefx.Module(),

--- a/pkg/cli/subcommands/check/command_test.go
+++ b/pkg/cli/subcommands/check/command_test.go
@@ -27,6 +27,7 @@ import (
 	secretsmock "github.com/DataDog/datadog-agent/comp/core/secrets/mock"
 	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
 	workloadfilterfxmock "github.com/DataDog/datadog-agent/comp/core/workloadfilter/fx-mock"
+	wmcatalog "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/catalog"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -43,7 +44,7 @@ func TestCommand(t *testing.T) {
 			return GlobalParams{
 				ConfFilePath: config,
 			}
-		}),
+		}, wmcatalog.GetCatalog()),
 	}
 
 	fxutil.TestOneShotSubcommand(t,
@@ -115,7 +116,7 @@ func TestCommandWithInstanceID(t *testing.T) {
 			return GlobalParams{
 				ConfFilePath: config,
 			}
-		}),
+		}, wmcatalog.GetCatalog()),
 	}
 
 	fxutil.TestOneShotSubcommand(t,


### PR DESCRIPTION
### What does this PR do?

This PR adds a new workloadmeta catalog specific to the cluster-agent.

This is similar to what already exists for other agents: there's a catalog for dogstatsd, otel, etc.

The reason I'm doing this is that the cluster-agent only needs one collector from the catalog: kubeapiserver. And this collector isn't needed in any other sub-agent. I think having a dedicated catalog makes the code easier to reason about, and avoids pulling in dependencies we don't need (not many in this case).

This change also helps simplify another PR I have open: https://github.com/DataDog/datadog-agent/pull/50305

I think there's something else we can do about workloadmeta catalogs. There's a "global" catalog, but I think most places that use it could use the "core" catalog instead. I'll leave this for a future PR to avoid introducing too many changes at once.

### Describe how you validated your changes

CI + deployed locally on a kind cluster. I verified that kubeapiserver collector still works in the DCA by checking `agent workload-list`. Also verified that the `agent check` command still works in the DCA (`agent check kubernetes_apiserver`).