### PR TITLE
[SBOM] Fix DiffID and path alignment in overlayfs scans

### DIFF
--- a/pkg/util/trivy/containerd.go
+++ b/pkg/util/trivy/containerd.go
@@ -252,6 +252,11 @@ func (c *Collector) ScanContainerdImageFromSnapshotter(ctx context.Context, imgM
 		return nil, fmt.Errorf("unable to extract layers from overlayfs mounts %+v for image %s", mounts, imgMeta.ID)
 	}
 
+	// RootFS.Layers is bottom-up; overlay mount syntax is top-down.
+	for i, j := 0, len(layers)-1; i < j; i, j = i+1, j-1 {
+		layers[i], layers[j] = layers[j], layers[i]
+	}
+
 	fakeContainer, err := newFakeContainer(layers, imgMeta, fanalImage.inspect.RootFS.Layers)
 	if err != nil {
 		return nil, err

--- a/pkg/util/trivy/crio.go
+++ b/pkg/util/trivy/crio.go
@@ -87,12 +87,12 @@ func (c *Collector) ScanCRIOImageFromOverlayFS(ctx context.Context, imgMeta *wor
 		diffIDs = append(diffIDs, "sha256:"+filepath.Base(filepath.Dir(dir)))
 	}
 
+	fc, err := newFakeContainer(lowerDirs, imgMeta, diffIDs)
+	if err != nil {
+		return nil, err
+	}
 	report, err := c.scanOverlayFS(ctx, lowerDirs, &fakeCRIOContainer{
-		fakeContainer: &fakeContainer{
-			imgMeta:    imgMeta,
-			layerPaths: lowerDirs,
-			layerIDs:   diffIDs,
-		},
+		fakeContainer: fc,
 	}, imgMeta, scanOptions)
 	if err != nil {
 		return nil, err

--- a/pkg/util/trivy/docker.go
+++ b/pkg/util/trivy/docker.go
@@ -96,9 +96,13 @@ func (c *Collector) ScanDockerImage(ctx context.Context, imgMeta *workloadmeta.C
 	}
 
 	if scanOptions.OverlayFsScan && fanalImage.inspect.GraphDriver.Name == "overlay2" {
+		// LowerDir is top-down without the topmost layer; UpperDir is the topmost.
 		var layers []string
 		if layerDirs, ok := fanalImage.inspect.GraphDriver.Data["LowerDir"]; ok {
-			layers = append(layers, strings.Split(layerDirs, ":")...)
+			parts := strings.Split(layerDirs, ":")
+			for i := len(parts) - 1; i >= 0; i-- {
+				layers = append(layers, parts[i])
+			}
 		}
 
 		if layerDirs, ok := fanalImage.inspect.GraphDriver.Data["UpperDir"]; ok {
@@ -111,13 +115,13 @@ func (c *Collector) ScanDockerImage(ctx context.Context, imgMeta *workloadmeta.C
 			}
 		}
 
+		fc, err := newFakeContainer(layers, imgMeta, fanalImage.inspect.RootFS.Layers)
+		if err != nil {
+			return nil, "overlayfs", err
+		}
 		fakeContainer := &fakeDockerContainer{
-			image: fanalImage,
-			fakeContainer: &fakeContainer{
-				layerIDs:   fanalImage.inspect.RootFS.Layers,
-				layerPaths: layers,
-				imgMeta:    imgMeta,
-			},
+			image:         fanalImage,
+			fakeContainer: fc,
 		}
 
 		report, err := c.scanOverlayFS(ctx, layers, fakeContainer, imgMeta, scanOptions)

--- a/pkg/util/trivy/overlayfs.go
+++ b/pkg/util/trivy/overlayfs.go
@@ -29,64 +29,63 @@ type fakeContainer struct {
 	layerIDs   []string
 	imgMeta    *workloadmeta.ContainerImageMetadata
 	layerPaths []string
+	layers     []ftypes.LayerPath
 }
 
+// layerIDs and layerPaths must both be in image-config order (bottom-up);
+// paths from overlay mount syntax must be reversed by the caller, else each
+// DiffID is paired with the wrong layer and trivy's DiffID-keyed blob cache
+// gets poisoned. Empty-layer history markers in imgMeta.Layers are filtered
+// to keep the i-th non-empty entry aligned with layerIDs[i].
 func newFakeContainer(layerPaths []string, imgMeta *workloadmeta.ContainerImageMetadata, layerIDs []string) (*fakeContainer, error) {
 	imageLayers := lo.Filter(imgMeta.Layers, func(layer workloadmeta.ContainerImageLayer, _ int) bool {
 		return layer.Digest != ""
 	})
-	if len(layerIDs) > len(layerPaths) || len(layerIDs) > len(imageLayers) {
-		return nil, fmt.Errorf("mismatch count for layer IDs and paths (%v, %v, %v)", layerIDs, layerPaths, imgMeta)
+	if len(layerIDs) != len(layerPaths) || len(layerIDs) != len(imageLayers) {
+		return nil, fmt.Errorf("mismatch count for layer IDs, paths and image layers (ids=%d, paths=%d, layers=%d)",
+			len(layerIDs), len(layerPaths), len(imageLayers))
 	}
 
 	log.Debugf("create fake container with paths=%v", layerPaths)
+
+	layers := make([]ftypes.LayerPath, len(layerIDs))
+	for i, id := range layerIDs {
+		diffID, _ := v1.NewHash(id)
+		layers[i] = ftypes.LayerPath{
+			DiffID: diffID.String(),
+			Path:   layerPaths[i],
+			Digest: imageLayers[i].Digest,
+		}
+	}
 
 	return &fakeContainer{
 		layerIDs:   layerIDs,
 		imgMeta:    imgMeta,
 		layerPaths: layerPaths,
+		layers:     layers,
 	}, nil
 }
 
 func (c *fakeContainer) LayerByDiffID(hash string) (ftypes.LayerPath, error) {
-	for i, layer := range c.layerIDs {
-		diffID, _ := v1.NewHash(layer)
-		if diffID.String() == hash {
-			return ftypes.LayerPath{
-				DiffID: diffID.String(),
-				Path:   c.layerPaths[i],
-				Digest: c.imgMeta.Layers[i].Digest,
-			}, nil
+	for _, layer := range c.layers {
+		if layer.DiffID == hash {
+			return layer, nil
 		}
 	}
 	return ftypes.LayerPath{}, errors.New("not found")
 }
 
 func (c *fakeContainer) LayerByDigest(hash string) (ftypes.LayerPath, error) {
-	for i, layer := range c.layerIDs {
-		diffID, _ := v1.NewHash(layer)
-		if hash == c.imgMeta.Layers[i].Digest {
-			return ftypes.LayerPath{
-				DiffID: diffID.String(),
-				Path:   c.layerPaths[i],
-				Digest: c.imgMeta.Layers[i].Digest,
-			}, nil
+	for _, layer := range c.layers {
+		if layer.Digest == hash {
+			return layer, nil
 		}
 	}
 	return ftypes.LayerPath{}, errors.New("not found")
 }
 
-func (c *fakeContainer) Layers() (layers []ftypes.LayerPath) {
-	for i, layer := range c.layerIDs {
-		diffID, _ := v1.NewHash(layer)
-		layers = append(layers, ftypes.LayerPath{
-			DiffID: diffID.String(),
-			Path:   c.layerPaths[i],
-			Digest: c.imgMeta.Layers[i].Digest,
-		})
-	}
-
-	return layers
+func (c *fakeContainer) Layers() []ftypes.LayerPath {
+	return c.layers
 }
 
 func (c *Collector) scanOverlayFS(ctx context.Context, layers []string, ctr ftypes.Container, imgMeta *workloadmeta.ContainerImageMetadata, scanOptions sbom.ScanOptions) (*Report, error) {

--- a/pkg/util/trivy/overlayfs_test.go
+++ b/pkg/util/trivy/overlayfs_test.go
@@ -15,119 +15,64 @@ import (
 )
 
 func TestFakeContainer(t *testing.T) {
-	tests := []struct {
-		name               string
-		layersPath         []string
-		imageMeta          *workloadmeta.ContainerImageMetadata
-		layerIDs           []string
-		requestedLayerDiff string
-		expectedLayerPath  string
-	}{
-		{
-			layersPath: []string{
-				"/host/root/var/lib/containerd/io.containerd.snapshotter.v1.nydus/snapshots/148/fs",
-				"/host/root/var/lib/containerd/io.containerd.snapshotter.v1.nydus/snapshots/147/fs",
-				"/host/root/var/lib/containerd/io.containerd.snapshotter.v1.nydus/snapshots/146/fs",
-				"/host/root/var/lib/containerd/io.containerd.snapshotter.v1.nydus/snapshots/145/fs",
-				"/host/root/var/lib/containerd/io.containerd.snapshotter.v1.nydus/snapshots/144/fs",
-				"/host/root/var/lib/containerd/io.containerd.snapshotter.v1.nydus/snapshots/143/fs",
-				"/host/root/var/lib/containerd/io.containerd.snapshotter.v1.nydus/snapshots/142/fs",
-				"/host/root/var/lib/containerd/io.containerd.snapshotter.v1.nydus/snapshots/141/fs",
-				"/host/root/var/lib/containerd/io.containerd.snapshotter.v1.nydus/snapshots/140/fs",
-				"/host/root/var/lib/containerd/io.containerd.snapshotter.v1.nydus/snapshots/139/fs",
-				"/host/root/var/lib/containerd/io.containerd.snapshotter.v1.nydus/snapshots/138/fs",
-				"/host/root/var/lib/containerd/io.containerd.snapshotter.v1.nydus/snapshots/137/fs",
-				"/host/root/var/lib/containerd/io.containerd.snapshotter.v1.nydus/snapshots/136/fs",
-				"/host/root/var/lib/containerd/io.containerd.snapshotter.v1.nydus/snapshots/135/fs",
-				"/host/root/var/lib/containerd/io.containerd.snapshotter.v1.nydus/snapshots/134/fs",
-			},
-			imageMeta: &workloadmeta.ContainerImageMetadata{
-				Layers: []workloadmeta.ContainerImageLayer{
-					{
-						Digest: "", // empty layer
-					},
-					{
-						Digest: "sha256:d543b8cad89e3428ac8852a13cb2dbfaf55b1e10fd95a9753e51faf393d60e81",
-					},
-					{
-						Digest: "sha256:7b1349c98b6929b220fd1ed89c7255c6a8a7557c448cf7fda8dcfbad37fa4549",
-					},
-					{
-						Digest: "sha256:1608fb7c693049b6edc16af0542d923cd8542f7039bfca161600e9142055dcfb",
-					},
-					{
-						Digest: "sha256:3c516036f954ffb308f505c5bbea2099110f84d3f7b76940e4eade80691194b7",
-					},
-					{
-						Digest: "sha256:a2ff3eeada006822f19570505fa99db3e6410addac86394fba4ba9304230cfeb",
-					},
-					{
-						Digest: "sha256:20bde7516cdbeccc4625f1691140d63ed8e3fc46a0f593163b48020de88b8c3e",
-					},
-					{
-						Digest: "sha256:b7d0da6041ab2b567cab384374652b82beddd560b7d59540463a7ce3e600274c",
-					},
-					{
-						Digest: "sha256:9b33b108c42d01575feac410e94f500e01cf2552df064a019a7b27184d8371ff",
-					},
-					{
-						Digest: "sha256:24586912362b7671f6b5e8e1a78194f340653f1df0376cd415e09832b2be40fb",
-					},
-					{
-						Digest: "sha256:384eaa6554ab5ccf7d8462698e5b86b98014aa1c8c8a7d8457f8854148941aad",
-					},
-					{
-						Digest: "sha256:1a651b5627b77ee65c117e801b759506cc6f4c907a0784aa0e0280e001386df8",
-					},
-					{
-						Digest: "sha256:0c11dc029b3c6cd8b02788f49f0d0a9bbc353cebb900869fd401e74f2e0ac8fd",
-					},
-					{
-						Digest: "sha256:f8a6696ef6df5fb297d4f1cd3ef877c836a3e269b566b415f47cf3cdf5b14c97",
-					},
-					{
-						Digest: "sha256:7c6bc12b66c3f9059ff7c6665f75916c2533e829476ff0ec351850f9d3f32233",
-					},
-					{
-						Digest: "sha256:873b790faaaaa245c52fba066b70c5a7b3d427d2068d72756738c7741b4b7031",
-					},
-				},
-			},
-			layerIDs: []string{
-				"sha256:d543b8cad89e3428ac8852a13cb2dbfaf55b1e10fd95a9753e51faf393d60e81",
-				"sha256:7b1349c98b6929b220fd1ed89c7255c6a8a7557c448cf7fda8dcfbad37fa4549",
-				"sha256:1608fb7c693049b6edc16af0542d923cd8542f7039bfca161600e9142055dcfb",
-				"sha256:3c516036f954ffb308f505c5bbea2099110f84d3f7b76940e4eade80691194b7",
-				"sha256:a2ff3eeada006822f19570505fa99db3e6410addac86394fba4ba9304230cfeb",
-				"sha256:20bde7516cdbeccc4625f1691140d63ed8e3fc46a0f593163b48020de88b8c3e",
-				"sha256:b7d0da6041ab2b567cab384374652b82beddd560b7d59540463a7ce3e600274c",
-				"sha256:9b33b108c42d01575feac410e94f500e01cf2552df064a019a7b27184d8371ff",
-				"sha256:24586912362b7671f6b5e8e1a78194f340653f1df0376cd415e09832b2be40fb",
-				"sha256:384eaa6554ab5ccf7d8462698e5b86b98014aa1c8c8a7d8457f8854148941aad",
-				"sha256:1a651b5627b77ee65c117e801b759506cc6f4c907a0784aa0e0280e001386df8",
-				"sha256:0c11dc029b3c6cd8b02788f49f0d0a9bbc353cebb900869fd401e74f2e0ac8fd",
-				"sha256:f8a6696ef6df5fb297d4f1cd3ef877c836a3e269b566b415f47cf3cdf5b14c97",
-				"sha256:7c6bc12b66c3f9059ff7c6665f75916c2533e829476ff0ec351850f9d3f32233",
-				"sha256:873b790faaaaa245c52fba066b70c5a7b3d427d2068d72756738c7741b4b7031",
-			},
-			requestedLayerDiff: "sha256:873b790faaaaa245c52fba066b70c5a7b3d427d2068d72756738c7741b4b7031",
-			expectedLayerPath:  "/host/root/var/lib/containerd/io.containerd.snapshotter.v1.nydus/snapshots/134/fs",
+	const snapshotsBase = "/host/root/var/lib/containerd/io.containerd.snapshotter.v1.nydus/snapshots"
+	layerIDs := []string{
+		"sha256:d543b8cad89e3428ac8852a13cb2dbfaf55b1e10fd95a9753e51faf393d60e81",
+		"sha256:7b1349c98b6929b220fd1ed89c7255c6a8a7557c448cf7fda8dcfbad37fa4549",
+		"sha256:1608fb7c693049b6edc16af0542d923cd8542f7039bfca161600e9142055dcfb",
+		"sha256:3c516036f954ffb308f505c5bbea2099110f84d3f7b76940e4eade80691194b7",
+		"sha256:a2ff3eeada006822f19570505fa99db3e6410addac86394fba4ba9304230cfeb",
+		"sha256:20bde7516cdbeccc4625f1691140d63ed8e3fc46a0f593163b48020de88b8c3e",
+		"sha256:b7d0da6041ab2b567cab384374652b82beddd560b7d59540463a7ce3e600274c",
+		"sha256:9b33b108c42d01575feac410e94f500e01cf2552df064a019a7b27184d8371ff",
+		"sha256:24586912362b7671f6b5e8e1a78194f340653f1df0376cd415e09832b2be40fb",
+		"sha256:384eaa6554ab5ccf7d8462698e5b86b98014aa1c8c8a7d8457f8854148941aad",
+		"sha256:1a651b5627b77ee65c117e801b759506cc6f4c907a0784aa0e0280e001386df8",
+		"sha256:0c11dc029b3c6cd8b02788f49f0d0a9bbc353cebb900869fd401e74f2e0ac8fd",
+		"sha256:f8a6696ef6df5fb297d4f1cd3ef877c836a3e269b566b415f47cf3cdf5b14c97",
+		"sha256:7c6bc12b66c3f9059ff7c6665f75916c2533e829476ff0ec351850f9d3f32233",
+		"sha256:873b790faaaaa245c52fba066b70c5a7b3d427d2068d72756738c7741b4b7031",
+	}
+	// Snapshot IDs grow with layer creation; smallest at the bottom.
+	layersPath := []string{
+		snapshotsBase + "/134/fs",
+		snapshotsBase + "/135/fs",
+		snapshotsBase + "/136/fs",
+		snapshotsBase + "/137/fs",
+		snapshotsBase + "/138/fs",
+		snapshotsBase + "/139/fs",
+		snapshotsBase + "/140/fs",
+		snapshotsBase + "/141/fs",
+		snapshotsBase + "/142/fs",
+		snapshotsBase + "/143/fs",
+		snapshotsBase + "/144/fs",
+		snapshotsBase + "/145/fs",
+		snapshotsBase + "/146/fs",
+		snapshotsBase + "/147/fs",
+		snapshotsBase + "/148/fs",
+	}
+	// One empty-layer history marker exercises the filter.
+	imageMeta := &workloadmeta.ContainerImageMetadata{
+		Layers: []workloadmeta.ContainerImageLayer{
+			{Digest: ""},
 		},
 	}
+	for _, id := range layerIDs {
+		imageMeta.Layers = append(imageMeta.Layers, workloadmeta.ContainerImageLayer{Digest: id})
+	}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			fakeContainer, err := newFakeContainer(test.layersPath, test.imageMeta, test.layerIDs)
-			if err != nil {
-				t.Error(err)
-			}
+	c, err := newFakeContainer(layersPath, imageMeta, layerIDs)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-			layerPath, err := fakeContainer.LayerByDiffID(test.requestedLayerDiff)
-			if err != nil {
-				t.Error(err)
-			}
-
-			assert.Equal(t, layerPath.Path, test.expectedLayerPath)
-		})
+	for i, id := range layerIDs {
+		got, err := c.LayerByDiffID(id)
+		if err != nil {
+			t.Errorf("LayerByDiffID(%s): %v", id, err)
+			continue
+		}
+		assert.Equal(t, layersPath[i], got.Path, "DiffID %s", id)
+		assert.Equal(t, id, got.Digest, "DiffID %s digest", id)
 	}
 }


### PR DESCRIPTION
### What does this PR do?

newFakeContainer paired layerIDs[i] with layerPaths[i] across opposite orderings: RootFS.Layers is image-config order (bottom-up), but extractLayersFromOverlayFSMounts and Docker's LowerDir return overlay mount syntax (top-down).

Trivy walked the wrong path for each DiffID and cached the result keyed solely by DiffID, so the canonical empty-layer DiffID 5f70bf18a086... leaked packages from one image to unrelated images on the same host.

Reverse the path list in the containerd and docker callers, filter empty-layer history markers out of imgMeta.Layers before pairing, and store a pre-paired []ftypes.LayerPath in fakeContainer. CRI-O already provides aligned inputs.

### Motivation

### Describe how you validated your changes

### Additional Notes
