### PR TITLE
Drop unused `skip_assets` parameter from tasks/security-agent

### DIFF
--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -56,7 +56,6 @@ def build(
     rebuild=False,
     install_path=None,
     go_mod="readonly",
-    skip_assets=False,
     static=False,
     fips_mode=False,
 ):


### PR DESCRIPTION
### What does this PR do?
Drop the unused `skip_assets` parameter from `security-agent.build`.

### Motivation
`vulture` flags `skip_assets` as dead.
Unlike `agent.build` and `cluster-agent.build`, `security-agent.build` has no asset-copying step, so the parameter has no effect.

### Describe how you validated your changes
N/A: the only known caller (`omnibus/config/software/datadog-agent.rb`) does not pass it.

### Additional Notes
Discovered while working on migrating the Go proto generation to `bazel`.