### PR TITLE
[kubeactions] increase payload size to fit larger resources

### DIFF
--- a/pkg/clusteragent/kubeactions/executors/get_resource.go
+++ b/pkg/clusteragent/kubeactions/executors/get_resource.go
@@ -19,13 +19,14 @@ import (
 
 	"sigs.k8s.io/yaml"
 
-	"github.com/DataDog/datadog-agent/pkg/util/log"
-
 	kubeactions "github.com/DataDog/agent-payload/v5/kubeactions"
 )
 
 const (
-	maxResourceOutputSize = 4 * 1024 // 4KB
+	// maxResourceOutputSize is the maximum size of the resource output in bytes
+	// it is set to 1.5MB to avoid filling the database with large resources
+	// largest expected resource is a 1MB for configMap, so 1.5MB is a safe margin
+	maxResourceOutputSize int = 1.5 * 1024 * 1024 // 1.5MB
 )
 
 type GetResourceExecutor struct {
@@ -117,15 +118,17 @@ func (e *GetResourceExecutor) Execute(ctx context.Context, action *kubeactions.K
 
 	output = bytes.TrimSpace(output)
 	if len(output) > maxResourceOutputSize {
-		log.Warnf("output for resource %s/%s of type %s is too large (%d bytes), truncating to %d bytes", namespace, name, kind, len(output), maxResourceOutputSize)
-		output = output[:maxResourceOutputSize]
+		return ExecutionResult{
+			Status:  StatusFailed,
+			Message: fmt.Sprintf("resource is too large (%d bytes), maximum size is %d bytes", len(output), maxResourceOutputSize),
+		}
 	}
 
 	return ExecutionResult{
 		Status:  StatusSuccess,
 		Message: fmt.Sprintf("get resource %s/%s success", kind, name),
 		Payloads: map[string][]byte{
-			"resource": []byte(output),
+			namespace + "/" + name: output,
 		},
 	}
 }

--- a/pkg/clusteragent/kubeactions/validator.go
+++ b/pkg/clusteragent/kubeactions/validator.go
@@ -9,6 +9,7 @@ package kubeactions
 
 import (
 	"fmt"
+	"strings"
 
 	kubeactions "github.com/DataDog/agent-payload/v5/kubeactions"
 )
@@ -139,6 +140,20 @@ func (v *ActionValidator) ValidateAction(action *kubeactions.KubeAction) error {
 				Message: "resource.kind must be 'Deployment' for rollback_deployment action",
 			}
 		}
+	case ActionTypeGetResource:
+		if action.Resource.ApiVersion == "" {
+			return &ValidationError{
+				Action:  action,
+				Message: "resource.api_version must be set for get_resource action",
+			}
+		}
+
+		if isProtectedKind(action.Resource.Kind) {
+			return &ValidationError{
+				Action:  action,
+				Message: "actions are not allowed to get protected kind " + action.Resource.Kind,
+			}
+		}
 	}
 
 	// Block actions on protected system namespaces
@@ -162,6 +177,18 @@ var protectedNamespaces = map[string]struct{}{
 // isProtectedNamespace returns true if the namespace is a protected system namespace
 func isProtectedNamespace(namespace string) bool {
 	_, ok := protectedNamespaces[namespace]
+	return ok
+}
+
+var protectedKind = map[string]struct{}{
+	"pods":            {},
+	"secrets":         {},
+	"serviceaccounts": {},
+}
+
+// isProtectedResource returns true if the requested kind is a protected resource kind
+func isProtectedKind(kind string) bool {
+	_, ok := protectedKind[strings.ToLower(kind)]
 	return ok
 }
 


### PR DESCRIPTION
[kubeactions] increase payload size to prevent truncated JSON

When getting a resource 4KB is quite small, increase it fit at least the
largest allowed configMap (1.0MB) + a margin for safety (0.5MB).

Add validation for the action get resource to ensure we have a kind and
api version set.

Add validation to prevent request to ask for a `Secret` or
`ServiceAccount` or `Pod`. These are already denied from the backend checks but
this is a second safeguard just in case.

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes

CONTINT-5273