### PR TITLE
Move hostname function from pkg/util/kubernetes to own package

### DIFF
--- a/pkg/util/hostname/container.go
+++ b/pkg/util/hostname/container.go
@@ -15,7 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname/validate"
 	"github.com/DataDog/datadog-agent/pkg/util/kubelet"
-	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
+	k8shostname "github.com/DataDog/datadog-agent/pkg/util/kubernetes/hostname"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -24,7 +24,7 @@ var (
 	configIsContainerized  = env.IsContainerized
 	configIsFeaturePresent = env.IsFeaturePresent
 
-	kubernetesGetKubeAPIServerHostname = kubernetes.GetKubeAPIServerHostname
+	kubernetesGetKubeAPIServerHostname = k8shostname.GetKubeAPIServerHostname
 	dockerGetHostname                  = docker.GetHostname
 	kubeletGetHostname                 = kubelet.GetHostname
 )

--- a/pkg/util/hostname/container_test.go
+++ b/pkg/util/hostname/container_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config/env"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-agent/pkg/util/kubelet"
-	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
+	k8shostname "github.com/DataDog/datadog-agent/pkg/util/kubernetes/hostname"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -34,7 +34,7 @@ func TestFromContainer(t *testing.T) {
 	defer func() {
 		configIsContainerized = env.IsContainerized
 		configIsFeaturePresent = env.IsFeaturePresent
-		kubernetesGetKubeAPIServerHostname = kubernetes.GetKubeAPIServerHostname
+		kubernetesGetKubeAPIServerHostname = k8shostname.GetKubeAPIServerHostname
 		dockerGetHostname = docker.GetHostname
 		kubeletGetHostname = kubelet.GetHostname
 	}()
@@ -81,7 +81,7 @@ func TestFromContainerInvalidHostname(t *testing.T) {
 	defer func() {
 		configIsContainerized = env.IsContainerized
 		configIsFeaturePresent = env.IsFeaturePresent
-		kubernetesGetKubeAPIServerHostname = kubernetes.GetKubeAPIServerHostname
+		kubernetesGetKubeAPIServerHostname = k8shostname.GetKubeAPIServerHostname
 		dockerGetHostname = docker.GetHostname
 		kubeletGetHostname = kubelet.GetHostname
 	}()

--- a/pkg/util/kubernetes/hostname/doc.go
+++ b/pkg/util/kubernetes/hostname/doc.go
@@ -1,0 +1,7 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package hostname provides utilities for retrieving the Kubernetes hostname.
+package hostname

--- a/pkg/util/kubernetes/hostname/hostname.go
+++ b/pkg/util/kubernetes/hostname/hostname.go
@@ -5,7 +5,7 @@
 
 //go:build kubeapiserver && !kubelet
 
-package kubernetes
+package hostname
 
 import (
 	"context"

--- a/pkg/util/kubernetes/hostname/hostname_stub.go
+++ b/pkg/util/kubernetes/hostname/hostname_stub.go
@@ -5,7 +5,7 @@
 
 //go:build !kubeapiserver || kubelet
 
-package kubernetes
+package hostname
 
 import (
 	"context"


### PR DESCRIPTION
### What does this PR do?

### Motivation

This lets us break an import cycle at the package level (which is avoided in practice due to build constraints)

### Describe how you validated your changes

### Additional Notes
