### PR TITLE
[ABLD-387] Align `option go_package` and `generate-cws-proto` CLI flags

### DIFF
--- a/pkg/security/proto/api/api.pb.go
+++ b/pkg/security/proto/api/api.pb.go
@@ -3704,7 +3704,7 @@ const file_pkg_security_proto_api_api_proto_rawDesc = "" +
 	"\x13SaveSecurityProfile\x12\x1e.api.SecurityProfileSaveParams\x1a\x1f.api.SecurityProfileSaveMessage\"\x002\xac\x01\n" +
 	"\x10SecurityAgentAPI\x12B\n" +
 	"\tSendEvent\x12\x19.api.SecurityEventMessage\x1a\x16.google.protobuf.Empty\"\x00(\x01\x12T\n" +
-	"\x16SendActivityDumpStream\x12\x1e.api.ActivityDumpStreamMessage\x1a\x16.google.protobuf.Empty\"\x00(\x01B\x18Z\x16pkg/security/proto/apib\x06proto3"
+	"\x16SendActivityDumpStream\x12\x1e.api.ActivityDumpStreamMessage\x1a\x16.google.protobuf.Empty\"\x00(\x01B9Z7github.com/DataDog/datadog-agent/pkg/security/proto/apib\x06proto3"
 
 var (
 	file_pkg_security_proto_api_api_proto_rawDescOnce sync.Once

--- a/pkg/security/proto/api/api.proto
+++ b/pkg/security/proto/api/api.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/empty.proto";
-option go_package = "pkg/security/proto/api";
+option go_package = "github.com/DataDog/datadog-agent/pkg/security/proto/api";
 
 package api;
 

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -657,8 +657,9 @@ def generate_cws_proto(ctx):
     )
 
     # API
+    go_out = "paths=source_relative:."
     ctx.run(
-        f"{bt.protoc} {plugin_opts} -I. -Ipkg/proto/protodep --go_out=paths=source_relative:. --go-vtproto_out=. --go-vtproto_opt=features=marshal+unmarshal+size --go-grpc_out=paths=source_relative:. pkg/security/proto/api/api.proto"
+        f"{bt.protoc} {plugin_opts} -I. -Ipkg/proto/protodep --go_out={go_out} --go-vtproto_out={go_out} --go-vtproto_opt=features=marshal+unmarshal+size --go-grpc_out={go_out} pkg/security/proto/api/api.proto"
     )
     # no need to strip protoc version from headers: hermetic tools guarantee it's identical on all execution platforms
 


### PR DESCRIPTION
### What does this PR do?
- pass `paths=source_relative` to `protoc-gen-go-vtproto` in `tasks/security_agent.py`, matching the flag **already used** by `protoc-gen-go` and `protoc-gen-go-grpc` in the same `protoc` invocation
  (the shared `paths=source_relative:.` value is now factored out as `go_out` to make the parity explicit),
- set `option go_package` in `pkg/security/proto/api/api.proto` to the fully qualified Go import path
  (i.e., `github.com/DataDog/datadog-agent/pkg/security/proto/api`),
- regenerate `api.pb.go` accordingly.

### Motivation
1. fix the `protoc` CLI inconsistency: 2 of the 3 plugins (`protoc-gen-go`, `protoc-gen-go-grpc`) already received `paths=source_relative`, whereas `protoc-gen-go-vtproto` did not.
    The mismatch was **masked** because the previous relative `go_package` (`pkg/security/proto/api`) happened to coincide with the source directory under the default resolution (implicit `paths=import`).
    Otherwise, with `go_package` being fully qualified, the missing flag would write `_vtproto.pb.go` to a spurious `github.com/DataDog/...` tree at the repo root,
2. adhere to the upstream protobuf-go guidelines (https://protobuf.dev/reference/go/go-generated/#package) already partially observed in the repo:
    > We recommend declaring it within the `.proto` file so that the Go packages for `.proto` files can be centrally identified with the `.proto` files themselves and to simplify the set of flags passed when invoking `protoc`.
    
    The value takes the form of the full Go import path (`example.com/project/protos/fizz` in their example),
3. (trigger) **enable** tools relying on that convention: `gazelle` only embeds a `go_proto_library` into a same-directory `go_library` when their `importpath` attributes match exactly.

### Additional Notes
The small (27-byte) `FileDescriptor` growth buys unambiguous `github.com/DataDog/...` **provenance** in binaries, surfaced to SBOM scanners, gRPC reflection clients, and duplicate-registration diagnostics.