### PR TITLE
Attribute `tasks/protobuf.py` to `agent-build`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -772,6 +772,7 @@
 /tasks/kernel_matrix_testing/           @DataDog/ebpf-platform
 /tasks/ebpf_verifier/                   @DataDog/ebpf-platform
 /tasks/trace_agent.py                   @DataDog/agent-apm
+/tasks/protobuf.py                      @DataDog/agent-build
 /tasks/quality_gates.py                 @DataDog/agent-build
 /tasks/static_quality_gates/            @DataDog/agent-build
 /tasks/files_inventory.py               @DataDog/agent-build


### PR DESCRIPTION
### What does this PR do?
Override the catch-all `/tasks/ @DataDog/agent-devx` for `/tasks/protobuf.py` with `@DataDog/agent-build`.

### Motivation
`@DataDog/agent-build` has been taking over `tasks/protobuf.py` in the frame of the ongoing `bazel` migration of `proto`/`.pb.go` generation.