### PR TITLE
[ABLD-387] `bazel`ify proto generation: `sbom`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -539,7 +539,6 @@ exports_files(glob(
 # gazelle:exclude pkg/proto/datadog/process
 # gazelle:exclude pkg/proto/datadog/remoteagent
 # gazelle:exclude pkg/proto/datadog/remoteconfig
-# gazelle:exclude pkg/proto/datadog/sbom
 # gazelle:exclude pkg/proto/datadog/workloadfilter
 # gazelle:exclude pkg/proto/datadog/workloadmeta
 # gazelle:exclude pkg/proto/protodep

--- a/bazel/rules/go_proto_compiler/BUILD.bazel
+++ b/bazel/rules/go_proto_compiler/BUILD.bazel
@@ -1,5 +1,20 @@
 load("@rules_go//proto:compiler.bzl", "go_proto_compiler")
 
+# https://github.com/grpc/grpc-go/blob/master/cmd/protoc-gen-go-grpc/README.md#future-proofing-services
+go_proto_compiler(
+    name = "go_grpc_futureproof",
+    options = ["require_unimplemented_servers=true"],
+    plugin = "@org_golang_google_grpc_cmd_protoc_gen_go_grpc//:protoc-gen-go-grpc",
+    suffix = "_grpc.pb.go",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
+    ],
+)
+
+# https://github.com/planetscale/vtprotobuf#usage
 [
     go_proto_compiler(
         name = name,
@@ -10,7 +25,6 @@ load("@rules_go//proto:compiler.bzl", "go_proto_compiler")
         deps = ["@com_github_planetscale_vtprotobuf//protohelpers"],
     )
     for name, options in {
-        # https://github.com/planetscale/vtprotobuf#usage
         "go_vtproto_full": [],  # default: "If no features are given, all the codegen steps will be performed"
         "go_vtproto_serde": ["features=marshal+unmarshal+size"],  # SERialize/DEserialize: "Example from Vitess"
     }.items()

--- a/pkg/proto/datadog/sbom/BUILD.bazel
+++ b/pkg/proto/datadog/sbom/BUILD.bazel
@@ -1,0 +1,22 @@
+# gazelle:go_grpc_compilers @rules_go//proto:go_proto,//bazel/rules/go_proto_compiler:go_grpc_futureproof
+
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
+load("@rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "sbom_proto",
+    srcs = ["workloadmeta_sbom.proto"],
+    strip_import_prefix = "/pkg/proto",
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "sbom_go_proto",
+    compilers = [
+        "@rules_go//proto:go_proto",
+        "//bazel/rules/go_proto_compiler:go_grpc_futureproof",
+    ],
+    importpath = "pkg/proto/pbgo/sbom",
+    proto = ":sbom_proto",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/proto/pbgo/sbom/BUILD.bazel
+++ b/pkg/proto/pbgo/sbom/BUILD.bazel
@@ -1,4 +1,15 @@
 load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/write_pb_go:defs.bzl", "write_pb_go")
+
+write_pb_go(
+    name = "write_pb_go",
+    srcs = {
+        "//pkg/proto/datadog/sbom:sbom_go_proto": [
+            "workloadmeta_sbom.pb.go",
+            "workloadmeta_sbom_grpc.pb.go",
+        ],
+    },
+)
 
 go_library(
     name = "sbom",

--- a/tasks/protobuf.py
+++ b/tasks/protobuf.py
@@ -21,7 +21,6 @@ PROTO_PKGS = {
     'remoteagent': False,
     'autodiscovery': False,
     'workloadfilter': False,
-    'sbom': False,
 }
 
 CLI_EXTRAS = {
@@ -76,6 +75,7 @@ def generate(ctx, pre_commit=False):
         print(f"generating protobuf code from: {proto_root}")
         bazel(ctx, "run", "//pkg/proto/pbgo/dogstatsdhttp:write_pb_go")
         bazel(ctx, "run", "//pkg/proto/pbgo/languagedetection:write_pb_go")
+        bazel(ctx, "run", "//pkg/proto/pbgo/sbom:write_pb_go")
         bazel(ctx, "run", "//pkg/proto/pbgo/trace/idx:write_pb_go")
         for pkg, inject_tags in PROTO_PKGS.items():
             files = []


### PR DESCRIPTION
### What does this PR do?
- bring `pkg/proto/datadog/sbom` under `gazelle` control:
  - drop the matching `gazelle:exclude` from the root `BUILD.bazel`,
  - `proto_library` + `go_proto_library` (with `gRPC` compiler) in `pkg/proto/datadog/sbom/BUILD.bazel`,
  - `write_pb_go` in `pkg/proto/pbgo/sbom/BUILD.bazel` keeps `workloadmeta_sbom.pb.go` and `workloadmeta_sbom_grpc.pb.go` in sync,
- introduce a `go_grpc_futureproof` compiler in `bazel/rules/go_proto_compiler/BUILD.bazel`, mirroring `@rules_go//proto:go_grpc_v2` but with `require_unimplemented_servers=true`, preserving the shape of the committed `_grpc.pb.go` and the compile-time guarantee documented at https://github.com/grpc/grpc-go/blob/master/cmd/protoc-gen-go-grpc/README.md#future-proofing-services,
- delegate `sbom` generation to to the topmost `bazel` command in `bazel` in `tasks/protobuf.py` (kept for didactic purposes, at least).

### Motivation
Next step migrating proto generation from the `dda inv protobuf.generate` task to `bazel`, enabling CI to verify that committed `.pb.go` files stay in sync with their proto source, where `sbom` is the first addressed `gRPC` package.

### Describe how you validated your changes
- `bazel run //:gazelle` is stable,
- `bazel test //pkg/proto/pbgo/sbom:write_pb_go_tests` passes,
- `dda inv protobuf.generate` is a no-op on `sbom`.