### PR TITLE
spec json aggregator chunk boundary + finish prop test coverage

### DIFF
--- a/pkg/logs/internal/decoder/preprocessor/json_aggregator.allium
+++ b/pkg/logs/internal/decoder/preprocessor/json_aggregator.allium
@@ -425,3 +425,27 @@ surface JSONAggregation {
 -- (IncrementalJSONValidator.Write).
 -- Anchored in: TestJSONAggregator_TopLevelArraySplitNotAggregated
 -- (pkg/logs/internal/decoder/preprocessor/json_aggregator_test.go).
+
+-- Behavioural limitation: MidTokenSplitNotAggregated
+--
+-- The aggregator's input contract assumes chunk boundaries fall
+-- between JSON tokens. A chunk boundary that lands mid-token
+-- (mid-string, mid-number, mid-keyword) cannot be reliably
+-- resumed by the IncrementalJSONValidator: the underlying
+-- json.Decoder does not support resuming Token() reads after
+-- ErrUnexpectedEOF in the middle of a token, so the validator
+-- returns Invalid on the next Write that completes the token.
+-- The aggregator then takes the FlushOnInvalid path: every
+-- buffered message and the incoming message are emitted
+-- unmodified in arrival order; no aggregation occurs and no
+-- aggregated-JSON tag is added.
+--
+-- This contract is satisfied by the agent's line-based log
+-- framing, which splits at newline boundaries; pretty-printed
+-- JSON output emits newlines between tokens, never mid-token.
+-- Mid-token chunk boundaries are degenerate cases that do not
+-- occur in normal production input. The graceful FlushOnInvalid
+-- fallback ensures no data loss in the degenerate case.
+--
+-- Anchored in: TestJSONAggregator_MidTokenSplitFallsBackToFlushOnInvalid
+-- (pkg/logs/internal/decoder/preprocessor/json_aggregator_test.go).

--- a/pkg/logs/internal/decoder/preprocessor/json_aggregator_proptest_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/json_aggregator_proptest_test.go
@@ -9,10 +9,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 
 	"pgregory.net/rapid"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
 )
 
 // Property tests for the JSONAggregation surface and Aggregation entity
@@ -300,6 +304,195 @@ func TestAggregator_EmitAggregatedPreservesContent(t *testing.T) {
 		if actual != expected {
 			t.Fatalf("EmitAggregated byte preservation violated:\n  input    = %q\n  expected = %q\n  actual   = %q",
 				pretty, expected, actual)
+		}
+	})
+}
+
+// Shared helpers for TestAggregator_TagsOnlyOnAggregation and
+// TestAggregator_ArrivalOrderEmission.
+//
+// Each input message embeds a unique numeric ID (id_N) in its content
+// so that emissions can be linked back to the inputs that contributed
+// to them. The shapes are chosen to drive different rule paths without
+// ever splitting a JSON token mid-byte — the aggregator's chunk
+// boundary contract requires inputs to break at token boundaries (see
+// MidTokenSplitNotAggregated in json_aggregator.allium).
+
+type opShape int
+
+const (
+	shapeComplete opShape = iota // {"id_N":"v"} — drives FastPathEmit (or EmitAggregated when buffered)
+	shapeOpen                    // {"id_N":     — drives BufferIncomplete (open object, key + colon, awaits a value)
+	shapeClose                   // "v_id_N"}    — completes a buffered shapeOpen via EmitAggregated
+	shapeGarbage                 // not_json_id_N — drives FlushOnInvalid
+	shapeFlush                   // (no input)   — calls aggregator.Flush() — drives DrainOnFlush
+)
+
+func contentForShape(shape opShape, id int) string {
+	switch shape {
+	case shapeComplete:
+		return fmt.Sprintf(`{"id_%d":"v"}`, id)
+	case shapeOpen:
+		return fmt.Sprintf(`{"id_%d":`, id)
+	case shapeClose:
+		return fmt.Sprintf(`"v_id_%d"}`, id)
+	case shapeGarbage:
+		return fmt.Sprintf("not_json_id_%d", id)
+	}
+	return ""
+}
+
+var idMarkerRe = regexp.MustCompile(`id_(\d+)`)
+
+// extractInputIDs returns the ordered, deduplicated list of input IDs
+// found in an emission's content. Duplicates can arise if the same ID
+// appears more than once in a buffered fragment (it does not in the
+// shapes above), so deduplication is defensive.
+func extractInputIDs(content []byte) []int {
+	matches := idMarkerRe.FindAllSubmatch(content, -1)
+	seen := make(map[int]bool)
+	var ids []int
+	for _, m := range matches {
+		n, err := strconv.Atoi(string(m[1]))
+		if err != nil || seen[n] {
+			continue
+		}
+		seen[n] = true
+		ids = append(ids, n)
+	}
+	return ids
+}
+
+func hasAggregatedJSONTag(em *message.Message) bool {
+	for _, tag := range em.ParsingExtra.Tags {
+		if tag == message.AggregatedJSONTag {
+			return true
+		}
+	}
+	return false
+}
+
+// shapeGen draws a single op shape. Weighted toward Process ops over
+// Flush so sequences accumulate state worth observing.
+func shapeGen() *rapid.Generator[opShape] {
+	return rapid.SampledFrom([]opShape{
+		shapeComplete, shapeComplete,
+		shapeOpen, shapeOpen,
+		shapeClose,
+		shapeGarbage,
+		shapeFlush,
+	})
+}
+
+// TestAggregator_TagsOnlyOnAggregation anchors:
+//
+//	-- TagsOnlyOnAggregation: the aggregated JSON marker is added
+//	--   only by EmitAggregated and only when combined_count > 1
+//	--   and config.tag_complete_json is true. Single-fragment
+//	--   emissions and flushes never add the tag.
+//
+// (Behavioural-property comment in json_aggregator.allium.)
+//
+// The property: across an arbitrary sequence of Process and Flush
+// calls with both tag_complete_json values, every emission carries
+// the AggregatedJSONTag iff (a) the emission combines content from
+// more than one input message AND (b) tag_complete_json is true.
+//
+// Counting "more than one input message" by distinct input IDs in
+// the emission content is sound for these shapes: each shape embeds
+// exactly one id_N marker, FlushPath emissions carry exactly one
+// input each, and EmitAggregated emissions carry the markers of
+// every contributing input concatenated in arrival order.
+func TestAggregator_TagsOnlyOnAggregation(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		tagCompleteJSON := rapid.Bool().Draw(t, "tagCompleteJSON")
+		shapes := rapid.SliceOfN(shapeGen(), 1, 30).Draw(t, "shapes")
+
+		// Small max_content_size to make FlushOnSizeLimit reachable in
+		// the rotation alongside the other paths.
+		agg := NewJSONAggregator(tagCompleteJSON, 200)
+
+		nextID := 0
+		for i, shape := range shapes {
+			var emissions []*message.Message
+			if shape == shapeFlush {
+				emissions = agg.Flush()
+			} else {
+				emissions = agg.Process(newTestMessage(contentForShape(shape, nextID)))
+				nextID++
+			}
+
+			for j, em := range emissions {
+				ids := extractInputIDs(em.GetContent())
+				gotTag := hasAggregatedJSONTag(em)
+				wantTag := tagCompleteJSON && len(ids) > 1
+				if gotTag != wantTag {
+					t.Fatalf("TagsOnlyOnAggregation violated at op %d emission %d:\n"+
+						"  tagCompleteJSON=%v  distinctInputIDs=%d\n"+
+						"  expected tag=%v  got tag=%v\n"+
+						"  emission content=%q",
+						i, j, tagCompleteJSON, len(ids), wantTag, gotTag, em.GetContent())
+				}
+			}
+		}
+	})
+}
+
+// TestAggregator_ArrivalOrderEmission anchors:
+//
+//	-- ArrivalOrderEmission: where multiple buffered fragments are
+//	--   emitted (FlushOnSizeLimit, FlushOnInvalid, DrainOnFlush)
+//	--   they are emitted in arrival order, followed by the
+//	--   incoming message where applicable.
+//
+// (Behavioural-property comment in json_aggregator.allium.)
+//
+// The property: when a single Process or Flush call returns more than
+// one message (i.e., a flush path fired), those emitted messages'
+// input IDs appear in strictly increasing arrival order.
+//
+// Single-emission cases — FastPathEmit and EmitAggregated — are not
+// subject to this property as stated in the spec; the order of input
+// IDs within a single aggregated emission is a related but distinct
+// property and is not asserted here.
+func TestAggregator_ArrivalOrderEmission(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		shapes := rapid.SliceOfN(shapeGen(), 1, 30).Draw(t, "shapes")
+
+		// tag_complete_json=false to keep this test focused on ordering;
+		// tag presence is the sibling test's concern.
+		agg := NewJSONAggregator(false, 200)
+
+		nextID := 0
+		for i, shape := range shapes {
+			var emissions []*message.Message
+			if shape == shapeFlush {
+				emissions = agg.Flush()
+			} else {
+				emissions = agg.Process(newTestMessage(contentForShape(shape, nextID)))
+				nextID++
+			}
+
+			if len(emissions) <= 1 {
+				continue
+			}
+
+			prev := -1
+			for j, em := range emissions {
+				ids := extractInputIDs(em.GetContent())
+				if len(ids) != 1 {
+					t.Fatalf("flush-path emission must carry exactly one input ID, got %d at op %d emission %d (content=%q)",
+						len(ids), i, j, em.GetContent())
+				}
+				cur := ids[0]
+				if cur <= prev {
+					t.Fatalf("ArrivalOrderEmission violated at op %d:\n"+
+						"  emission %d carries id_%d, previous emission carried id_%d\n"+
+						"  IDs across emissions of one call must strictly increase",
+						i, j, cur, prev)
+				}
+				prev = cur
+			}
 		}
 	})
 }

--- a/pkg/logs/internal/decoder/preprocessor/json_aggregator_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/json_aggregator_test.go
@@ -410,6 +410,50 @@ func TestJSONAggregator_TopLevelArraySplitNotAggregated(t *testing.T) {
 	}
 }
 
+// TestJSONAggregator_MidTokenSplitFallsBackToFlushOnInvalid anchors the
+// "MidTokenSplitNotAggregated" behavioural limitation captured at the
+// bottom of json_aggregator.allium: when an incoming chunk's boundary
+// with a previously buffered chunk falls mid-token, the
+// IncrementalJSONValidator cannot resume token reads cleanly, returns
+// Invalid, and the aggregator takes the FlushOnInvalid path.
+//
+// The test uses a fixed pretty-printed JSON object split mid-string at
+// the opening quote of the key — discovered via property test fuzzing
+// (see TestAggregator_EmitAggregatedPreservesContent docstring). The
+// contract is satisfied by line-based log framing in production; this
+// test demonstrates the graceful fallback for the degenerate case.
+//
+// If this test ever starts failing, the spec's MidTokenSplitNotAggregated
+// limitation note must be updated to match the new behaviour.
+func TestJSONAggregator_MidTokenSplitFallsBackToFlushOnInvalid(t *testing.T) {
+	aggregator := NewJSONAggregator(true, 1000)
+
+	// Valid pretty-printed JSON object: `{\n  "a": null\n}`. Splitting
+	// at byte 5 cuts the input mid-string, just past the opening quote
+	// of the key "a".
+	full := []byte("{\n  \"a\": null\n}")
+	chunk1 := full[:5]
+	chunk2 := full[5:]
+
+	emitted1 := aggregator.Process(newTestMessage(string(chunk1)))
+	assert.Empty(t, emitted1, "chunk1 alone is an incomplete prefix and should buffer")
+
+	emitted2 := aggregator.Process(newTestMessage(string(chunk2)))
+
+	// Per MidTokenSplitNotAggregated: the validator returns Invalid on
+	// the second write because the json.Decoder cannot resume reading
+	// the partially-consumed key string. The aggregator falls back to
+	// FlushOnInvalid: both buffered messages are emitted unmodified in
+	// arrival order, no compaction, no tag.
+	assert.Len(t, emitted2, 2, "mid-token split must fall back to FlushOnInvalid (2 unmodified messages, not 1 aggregated)")
+	assert.Equal(t, string(chunk1), string(emitted2[0].GetContent()), "first emission preserves chunk1 bytes")
+	assert.Equal(t, string(chunk2), string(emitted2[1].GetContent()), "second emission preserves chunk2 bytes")
+	assert.NotContains(t, emitted2[0].ParsingExtra.Tags, message.AggregatedJSONTag,
+		"FlushOnInvalid emissions must not carry the aggregated JSON tag")
+	assert.NotContains(t, emitted2[1].ParsingExtra.Tags, message.AggregatedJSONTag,
+		"FlushOnInvalid emissions must not carry the aggregated JSON tag")
+}
+
 func TestJSONAggregatorMultilineStillWorks(t *testing.T) {
 	aggregator := NewJSONAggregator(true, 1000)
 


### PR DESCRIPTION
  ## What does this PR do?
  Documents the aggregator's chunk-boundary contract in `json_aggregator.allium` as the behavioural limitation `MidTokenSplitNotAggregated` (with anchoring test), and adds rapid property tests for the two remaining named properties: `TagsOnlyOnAggregation` and
  `ArrivalOrderEmission`.

  ## Motivation
  Completes Layer 2 property test coverage for json_aggregator — every named property now has both anchoring and property test coverage. The chunk-boundary contract was discovered while writing PR3's rapid generator (mid-string splits trigger graceful FlushOnInvalid
  fallback) and was previously undocumented in the spec.

  <details>
  <summary>Property coverage snapshot: 14/14 (was 11/13; +1 new property added by this PR)</summary>

  - [x] `Determinism` (validator @invariant) — property
  - [x] `InvalidStable` (validator @invariant) — property
  - [x] `TopLevelArrayInvalid` (validator @invariant) — property (table-driven)
  - [x] `TristateExclusive` (validator @invariant) — property
  - [x] `BufferedSizeNonNegative` (state invariant) — property
  - [x] `EmptyImpliesZeroSize` (state invariant) — property
  - [x] `FragmentBackrefConsistent` (state invariant) — structurally trivial in Go
  - [x] `ContentBytePassthrough` (behavioural) — anchor + property, all paths
  - [x] `DeliveryOrPreservation` (behavioural) — anchor + property (implicit via byte-equality)
  - [x] `TagsOnlyOnAggregation` (behavioural) — anchor + property **(this PR)**
  - [x] `ArrivalOrderEmission` (behavioural) — anchor + property **(this PR)**
  - [x] `CompletenessOrPassthrough` (surface @guarantee) — anchor + property (implicit via byte-equality)
  - [x] `TopLevelArrayNotAggregated` (behavioural limitation) — anchor
  - [x] `MidTokenSplitNotAggregated` (behavioural limitation) — anchor **(new property added in this PR)**

  After this PR, every named property in `json_aggregator.allium` has the test coverage SPEC_PLAN deems sufficient.

  </details>