### PR TITLE
[SBOM] Tolerate extra non-empty entries in imgMeta.Layers

### DIFF
--- a/pkg/util/trivy/overlayfs.go
+++ b/pkg/util/trivy/overlayfs.go
@@ -41,7 +41,11 @@ func newFakeContainer(layerPaths []string, imgMeta *workloadmeta.ContainerImageM
 	imageLayers := lo.Filter(imgMeta.Layers, func(layer workloadmeta.ContainerImageLayer, _ int) bool {
 		return layer.Digest != ""
 	})
-	if len(layerIDs) != len(layerPaths) || len(layerIDs) != len(imageLayers) {
+	// Path / DiffID alignment must be exact: these are what trivy looks up.
+	// imageLayers feeds the optional Digest annotation; tolerate the Docker
+	// fallback in layersFromDockerHistoryAndInspect that can emit more
+	// non-empty entries than RootFS.Layers.
+	if len(layerIDs) != len(layerPaths) || len(layerIDs) > len(imageLayers) {
 		return nil, fmt.Errorf("mismatch count for layer IDs, paths and image layers (ids=%d, paths=%d, layers=%d)",
 			len(layerIDs), len(layerPaths), len(imageLayers))
 	}


### PR DESCRIPTION
### What does this PR do?

newFakeContainer requires `len(layerIDs) == len(filtered imgMeta.Layers)`, but `layersFromDockerHistoryAndInspect` has a documented fallback that emits more non-empty `Digest` entries than `RootFS.Layers` when it cannot safely align history with the manifest. After #50486, `ScanDockerImage` returns an error from this path and skips overlayfs scanning entirely for otherwise scannable images, regressing on the prefix-aligned behavior the previous check (`>`) allowed.

Path and DiffID alignment must still be exact — trivy's per-layer lookups go through there — but `imageLayers` only feeds the optional `Digest` annotation on the resulting `LayerPath`. Loosen that check back to `len(layerIDs) > len(imageLayers)`.

Caught by Codex review on the backport PR #50510.

### Motivation

### Describe how you validated your changes

### Additional Notes