### PR TITLE
[ AGNTLOG-602 ] Syslog v5.1: TCP stream tailer and decoder

### DIFF
--- a/pkg/logs/internal/decoder/decoder.go
+++ b/pkg/logs/internal/decoder/decoder.go
@@ -121,7 +121,7 @@ func NewNoopDecoder() Decoder {
 
 // NewDecoderWithFraming initialize a decoder with given endline strategy.
 func NewDecoderWithFraming(source *sources.ReplaceableSource, parser parsers.Parser, framing framer.Framing, multiLinePattern *regexp.Regexp, tailerInfo *status.InfoRegistry) Decoder {
-	maxMessageSize := config.MaxMessageSizeBytes(pkgconfigsetup.Datadog())
+	maxMessageSize := source.Config().GetMaxMessageSizeBytes(pkgconfigsetup.Datadog())
 	inputChan := make(chan *message.Message)
 	outputChan := make(chan *message.Message)
 	detectedPattern := &DetectedPattern{}

--- a/pkg/logs/internal/decoder/stream_decoder.go
+++ b/pkg/logs/internal/decoder/stream_decoder.go
@@ -1,0 +1,55 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package decoder
+
+import (
+	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/framer"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/noop"
+	syslogparser "github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/syslog"
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
+	status "github.com/DataDog/datadog-agent/pkg/logs/status/utils"
+)
+
+// NewStreamDecoder builds a decoder for messages arriving over a
+// stream-oriented connection (TCP or Unix stream).
+//
+// It supports syslog format and unstructured format.
+//
+// For syslog format, it uses SyslogFraming (RFC 6587 octet counting / non-transparent framing)
+// paired with the same syslog parser used for file-based syslog. The parser
+// produces StateStructured messages; a NoopLineHandler is used to prevent
+// truncation logic from corrupting them.
+//
+// For unstructured format, it uses UTF-8 newline framing with a noop parser.
+func NewStreamDecoder(source *sources.ReplaceableSource, tailerInfo *status.InfoRegistry) Decoder {
+	format := source.Config().Format
+	switch format {
+	case config.SyslogFormat:
+		return newSyslogStreamDecoder(source, tailerInfo)
+	default:
+		return InitializeDecoder(source, noop.New(), tailerInfo)
+	}
+}
+
+func newSyslogStreamDecoder(source *sources.ReplaceableSource, tailerInfo *status.InfoRegistry) Decoder {
+	maxMessageSize := source.Config().GetMaxMessageSizeBytes(pkgconfigsetup.Datadog())
+	inputChan := make(chan *message.Message)
+	outputChan := make(chan *message.Message)
+	detectedPattern := &DetectedPattern{}
+
+	lineHandler := NewNoopLineHandler(outputChan)
+	lineParser := NewSingleLineParser(lineHandler, syslogparser.NewParser(source.Config().IsSIEMParsingEnabled()))
+	f := framer.NewFramer(lineParser.process, framer.SyslogFraming, maxMessageSize)
+
+	formatInfo := status.NewMappedInfo("Format")
+	formatInfo.SetMessage("Format", config.SyslogFormat)
+	tailerInfo.Register(formatInfo)
+
+	return New(inputChan, outputChan, f, lineParser, lineHandler, detectedPattern)
+}

--- a/pkg/logs/internal/parsers/syslog/parser.go
+++ b/pkg/logs/internal/parsers/syslog/parser.go
@@ -90,11 +90,6 @@ func (p *parser) Parse(msg *message.Message) (*message.Message, error) {
 	structured.ParsingExtra = msg.ParsingExtra
 	structured.ParsingExtra.Timestamp = parsed.Timestamp
 
-	if parsed.AppName != "" && parsed.AppName != nilvalue {
-		structured.ParsingExtra.SourceOverride = parsed.AppName
-		structured.ParsingExtra.ServiceOverride = parsed.AppName
-	}
-
 	return structured, err
 }
 

--- a/pkg/logs/internal/parsers/syslog/parser_test.go
+++ b/pkg/logs/internal/parsers/syslog/parser_test.go
@@ -42,61 +42,11 @@ func TestSyslogParser_NetworkFormat_RFC5424(t *testing.T) {
 	// Status from severity
 	assert.Equal(t, message.StatusNotice, result.Status)
 
-	// Appname stored as source/service override in ParsingExtra
-	assert.Equal(t, "evntslog", result.ParsingExtra.SourceOverride)
-	assert.Equal(t, "evntslog", result.ParsingExtra.ServiceOverride)
-
 	// RawDataLen preserved
 	assert.Equal(t, len(input.GetContent()), result.RawDataLen)
 
 	// Timestamp extracted
 	assert.Equal(t, "2003-10-11T22:14:15.003Z", result.ParsingExtra.Timestamp)
-}
-
-func TestSyslogParser_NetworkFormat_BSD(t *testing.T) {
-	parser := NewParser(true)
-
-	input := newTestMessage([]byte(`<34>Oct 11 22:14:15 mymachine su: 'su root' failed for lonvick on /dev/pts/8`))
-	result, err := parser.Parse(input)
-	require.NoError(t, err)
-
-	assert.Equal(t, message.StateStructured, result.State)
-	assert.Equal(t, message.StatusCritical, result.Status)
-
-	// Appname stored as source/service override in ParsingExtra
-	assert.Equal(t, "su", result.ParsingExtra.SourceOverride)
-	assert.Equal(t, "su", result.ParsingExtra.ServiceOverride)
-}
-
-func TestSyslogParser_BSDLineFormat(t *testing.T) {
-	parser := NewParser(true)
-
-	// BSD line without PRI: "Oct 11 22:14:15 mymachine su: message"
-	input := newTestMessage([]byte(`Oct 11 22:14:15 mymachine su: 'su root' failed for lonvick on /dev/pts/8`))
-	result, err := parser.Parse(input)
-	require.NoError(t, err)
-
-	assert.Equal(t, message.StateStructured, result.State)
-
-	// No PRI -> StatusInfo
-	assert.Equal(t, message.StatusInfo, result.Status)
-
-	// Appname stored as source/service override in ParsingExtra
-	assert.Equal(t, "su", result.ParsingExtra.SourceOverride)
-	assert.Equal(t, "su", result.ParsingExtra.ServiceOverride)
-}
-
-func TestSyslogParser_AppNameNILVALUE(t *testing.T) {
-	parser := NewParser(true)
-
-	input := newTestMessage([]byte(`<14>1 2003-10-11T22:14:15.003Z mymachine - - - - test message`))
-	result, err := parser.Parse(input)
-	require.NoError(t, err)
-	assert.Equal(t, message.StateStructured, result.State)
-
-	// NILVALUE appname should not set override
-	assert.Equal(t, "", result.ParsingExtra.SourceOverride)
-	assert.Equal(t, "", result.ParsingExtra.ServiceOverride)
 }
 
 func TestSyslogParser_Malformed(t *testing.T) {
@@ -175,10 +125,6 @@ func TestSyslogParser_NonSyslogText(t *testing.T) {
 			require.NoError(t, rerr)
 			assert.Contains(t, string(rendered), `"message"`)
 			assert.Contains(t, string(rendered), `"syslog"`)
-
-			// Syslog metadata is sparse — no source/service override.
-			assert.Empty(t, result.ParsingExtra.SourceOverride)
-			assert.Empty(t, result.ParsingExtra.ServiceOverride)
 		})
 	}
 }

--- a/pkg/logs/launchers/listener/tcp.go
+++ b/pkg/logs/launchers/listener/tcp.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"slices"
 	"strconv"
+
 	"sync"
 	"time"
 
@@ -36,7 +37,10 @@ const (
 	acceptDeadline = 1 * time.Second
 )
 
-// A TCPListener listens and accepts TCP connections and delegates the read operations to a tailer.
+// A TCPListener listens and accepts TCP connections and delegates the read
+// operations to a StreamTailer. The source's Format field controls whether
+// syslog or unstructured parsing is used.
+
 type TCPListener struct {
 	pipelineProvider pipeline.Provider
 	source           *sources.LogSource
@@ -48,7 +52,7 @@ type TCPListener struct {
 	denialInfo       *ipfilter.DenialInfo
 	listener         net.Listener
 	rawListener      *net.TCPListener
-	tailers          []*tailer.Tailer
+	tailers          []startstop.StartStoppable
 	mu               sync.Mutex
 	stopped          bool
 	connSem          chan struct{}
@@ -111,11 +115,12 @@ func NewTCPListener(pipelineProvider pipeline.Provider, source *sources.LogSourc
 		tlsCredentials:   tlsCreds,
 		ipFilter:         ipF,
 		denialInfo:       denialInfo,
-		tailers:          []*tailer.Tailer{},
+		tailers:          []startstop.StartStoppable{},
 		connSem:          make(chan struct{}, maxConns),
-		stop:             make(chan struct{}, 1),
-		ctx:              ctx,
-		cancel:           cancel,
+
+		stop:   make(chan struct{}, 1),
+		ctx:    ctx,
+		cancel: cancel,
 	}, nil
 }
 
@@ -149,13 +154,13 @@ func (l *TCPListener) Stop() {
 		l.listener.Close()
 	}
 	stopper := startstop.NewParallelStopper()
-	for _, tailer := range l.tailers {
-		stopper.Add(tailer)
+	for _, t := range l.tailers {
+		stopper.Add(t)
 	}
 	stopper.Stop()
 
 	// At this point all the tailers have been stopped - remove them all from the active tailer list
-	l.tailers = []*tailer.Tailer{}
+	l.tailers = []startstop.StartStoppable{}
 }
 
 // run accepts new TCP connections and create a dedicated tailer for each.
@@ -224,21 +229,6 @@ func (l *TCPListener) startListener() error {
 	return nil
 }
 
-// read reads data from connection, returns an error if it failed and stop the tailer.
-func (l *TCPListener) read(tailer *tailer.Tailer) ([]byte, string, error) {
-	if l.idleTimeout > 0 {
-		tailer.Conn.SetReadDeadline(time.Now().Add(l.idleTimeout)) //nolint:errcheck
-	}
-	frame := make([]byte, l.frameSize)
-	n, err := tailer.Conn.Read(frame)
-	if err != nil {
-		log.Debugf("Connection error on port %d from %s: %v", l.source.Config.Port, tailer.Conn.RemoteAddr(), err)
-		go l.stopTailer(tailer)
-		return nil, "", err
-	}
-	return frame[:n], tailer.Conn.RemoteAddr().String(), nil
-}
-
 // handleConnection performs the TLS handshake (if applicable) outside of any
 // mutex, then registers the tailer. This prevents a slow or malicious client
 // from blocking the accept loop.
@@ -261,24 +251,48 @@ func (l *TCPListener) handleConnection(conn net.Conn) {
 		<-l.connSem
 		return
 	}
-	t := tailer.NewTailer(l.source, conn, l.pipelineProvider.NextPipelineChan(), l.read)
+
+	outputChan, capacityMonitor := l.pipelineProvider.NextPipelineChanWithMonitor()
+	sourceHostAddr := extractIPFromAddr(conn.RemoteAddr().String())
+
+	t := tailer.NewStreamTailer(
+		l.source,
+		conn,
+		outputChan,
+		l.frameSize,
+		l.idleTimeout,
+		sourceHostAddr,
+		capacityMonitor,
+	)
+	t.SetOnDone(func() { l.removeTailer(t) })
 	l.tailers = append(l.tailers, t)
 	l.mu.Unlock()
 	t.Start()
 	l.source.Status.Success()
+
 }
 
-// stopTailer stops the tailer.
-func (l *TCPListener) stopTailer(tailer *tailer.Tailer) {
+// removeTailer removes a finished tailer from the active list.
+// Called by the tailer's onDone callback when readLoop exits.
+func (l *TCPListener) removeTailer(t startstop.StartStoppable) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	for i, t := range l.tailers {
-		if t == tailer {
-			// Only stop the tailer if it has not already been stopped
-			tailer.Stop()
+	for i, active := range l.tailers {
+		if active == t {
 			l.tailers = slices.Delete(l.tailers, i, i+1)
 			<-l.connSem
 			break
 		}
 	}
+}
+
+// extractIPFromAddr strips the port from an address string.
+// Handles IPv4 ("1.2.3.4:5678" -> "1.2.3.4"), IPv6 ("[::1]:5678" -> "::1"),
+// and bare addresses without a port.
+func extractIPFromAddr(addr string) string {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return addr
+	}
+	return host
 }

--- a/pkg/logs/message/message.go
+++ b/pkg/logs/message/message.go
@@ -288,14 +288,6 @@ type ParsingExtra struct {
 	IsMultiLine bool
 	IsMRFAllow  bool
 	Tags        []string
-	// SourceOverride, if non-empty, is applied to the message origin's source
-	// by the tailer after origin creation. Used by parsers (e.g. syslog) that
-	// run before the origin exists.
-	SourceOverride string
-	// ServiceOverride, if non-empty, is applied to the message origin's service
-	// by the tailer after origin creation. Used by parsers (e.g. syslog) that
-	// run before the origin exists.
-	ServiceOverride string
 }
 
 // ServerlessExtra ships extra information from logs processing in serverless envs.

--- a/pkg/logs/status/builder.go
+++ b/pkg/logs/status/builder.go
@@ -166,7 +166,21 @@ func (b *Builder) toDictionary(c *config.LogsConfig) map[string]interface{} {
 	dictionary["Service"] = c.Service
 	dictionary["Source"] = c.Source
 	switch c.Type {
-	case config.TCPType, config.UDPType:
+	case config.TCPType:
+		dictionary["Port"] = c.Port
+		if c.TLS != nil {
+			dictionary["TLS"] = "true"
+		}
+		if c.Format != "" {
+			dictionary["Format"] = c.Format
+		}
+		if len(c.AllowedIPs) > 0 {
+			dictionary["AllowedIPs"] = strings.Join(c.AllowedIPs, ", ")
+		}
+		if len(c.DeniedIPs) > 0 {
+			dictionary["DeniedIPs"] = strings.Join(c.DeniedIPs, ", ")
+		}
+	case config.UDPType:
 		dictionary["Port"] = c.Port
 	case config.FileType:
 		dictionary["Path"] = c.Path

--- a/pkg/logs/tailers/socket/stream_tailer.go
+++ b/pkg/logs/tailers/socket/stream_tailer.go
@@ -1,0 +1,160 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package socket provides socket-based log tailers
+package socket
+
+import (
+	"io"
+	"net"
+	"time"
+
+	"github.com/DataDog/datadog-agent/comp/logs-library/metrics"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/decoder"
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
+	status "github.com/DataDog/datadog-agent/pkg/logs/status/utils"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// StreamTailer reads data from a stream-oriented connection (TCP or Unix
+// stream) and sends log messages to the pipeline.
+//
+// The source's Format field controls how the byte stream is framed and parsed:
+//   - "" (default): UTF-8 newline framing with a noop parser (unstructured)
+//   - "syslog": RFC 6587 syslog framing (octet counting / non-transparent)
+//     with a syslog parser producing StateStructured messages
+type StreamTailer struct {
+	source          *sources.LogSource
+	Conn            net.Conn
+	outputChan      chan *message.Message
+	frameSize       int
+	idleTimeout     time.Duration
+	sourceHostAddr  string
+	decoder         decoder.Decoder
+	capacityMonitor *metrics.CapacityMonitor
+	stop            chan struct{}
+	done            chan struct{}
+	onDone          func() // called when readLoop exits (connection closed/error); used by listeners to prune dead tailers
+}
+
+// NewStreamTailer returns a new StreamTailer.
+//
+// Parameters:
+//   - source: the log source configuration (Format controls framing/parsing)
+//   - conn: the stream connection to read from
+//   - outputChan: channel for forwarding parsed messages to the pipeline
+//   - frameSize: buffer size for conn.Read()
+//   - idleTimeout: idle read timeout (0 means no timeout)
+//   - sourceHostAddr: pre-extracted remote IP for source_host tagging ("" to skip)
+func NewStreamTailer(source *sources.LogSource, conn net.Conn, outputChan chan *message.Message, frameSize int, idleTimeout time.Duration, sourceHostAddr string, capacityMonitor *metrics.CapacityMonitor) *StreamTailer {
+	replSource := sources.NewReplaceableSource(source)
+	tailerInfo := status.NewInfoRegistry()
+
+	dec := decoder.NewStreamDecoder(replSource, tailerInfo)
+
+	return &StreamTailer{
+		source:          source,
+		Conn:            conn,
+		outputChan:      outputChan,
+		frameSize:       frameSize,
+		idleTimeout:     idleTimeout,
+		sourceHostAddr:  sourceHostAddr,
+		decoder:         dec,
+		capacityMonitor: capacityMonitor,
+		stop:            make(chan struct{}, 1),
+		done:            make(chan struct{}, 1),
+	}
+}
+
+// Start begins reading and decoding data from the connection.
+func (t *StreamTailer) Start() {
+	t.source.Status.Success()
+	log.Infof("Start tailing stream from %s (format=%q)", t.Conn.RemoteAddr(), t.source.Config.Format)
+
+	go t.forwardMessages()
+	t.decoder.Start()
+	go t.readLoop()
+}
+
+// Stop stops the tailer and waits for the decoder to be flushed.
+func (t *StreamTailer) Stop() {
+	log.Infof("Stop tailing stream from %s", t.Conn.RemoteAddr())
+	t.stop <- struct{}{}
+	t.Conn.Close()
+	<-t.done
+}
+
+// SetOnDone registers a callback invoked when the readLoop exits
+// (connection closed, error, or EOF). Must be called before Start.
+func (t *StreamTailer) SetOnDone(fn func()) {
+	t.onDone = fn
+}
+
+// forwardMessages reads decoded messages from the decoder output and
+// forwards them to the pipeline output channel with a properly configured
+// origin.
+func (t *StreamTailer) forwardMessages() {
+	defer func() {
+		close(t.done)
+	}()
+
+	for output := range t.decoder.OutputChan() {
+		if output.HasContent() {
+			origin := message.NewOrigin(t.source)
+			origin.SetTags(output.ParsingExtra.Tags)
+
+			output.Origin = origin
+			t.outputChan <- output
+			t.capacityMonitor.AddIngress(output)
+		}
+	}
+}
+
+// readLoop reads raw bytes from the connection and feeds them to the
+// decoder. Idle timeout and source_host tagging are handled here.
+func (t *StreamTailer) readLoop() {
+	defer func() {
+		if t.onDone != nil {
+			go t.onDone()
+		}
+		t.Conn.Close()
+		t.decoder.Stop()
+	}()
+
+	buf := make([]byte, t.frameSize)
+	for {
+		select {
+		case <-t.stop:
+			return
+		default:
+			if t.idleTimeout > 0 {
+				t.Conn.SetReadDeadline(time.Now().Add(t.idleTimeout)) //nolint:errcheck
+			}
+
+			n, err := t.Conn.Read(buf)
+			if err != nil {
+				if err == io.EOF {
+					return
+				}
+				log.Warnf("Couldn't read message from connection %s: %v", t.Conn.RemoteAddr(), err)
+				return
+			}
+
+			data := make([]byte, n)
+			copy(data, buf[:n])
+
+			t.source.RecordBytes(int64(n))
+			msg := decoder.NewInput(data)
+
+			if t.sourceHostAddr != "" && pkgconfigsetup.Datadog().GetBool("logs_config.use_sourcehost_tag") {
+				msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, "source_host:"+t.sourceHostAddr)
+			}
+
+			t.decoder.InputChan() <- msg
+		}
+	}
+}

--- a/pkg/logs/tailers/socket/stream_tailer_test.go
+++ b/pkg/logs/tailers/socket/stream_tailer_test.go
@@ -1,0 +1,253 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package socket
+
+import (
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const testFrameSize = 4096
+
+func recvMsg(t *testing.T, ch <-chan *message.Message) *message.Message {
+	t.Helper()
+	select {
+	case msg := <-ch:
+		return msg
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for message")
+		return nil
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unstructured format tests
+// ---------------------------------------------------------------------------
+
+func TestStreamTailer_Unstructured_BasicMessages(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close()
+
+	source := sources.NewLogSource("test", &config.LogsConfig{})
+	outputChan := make(chan *message.Message, 10)
+
+	tailer := NewStreamTailer(source, serverConn, outputChan, testFrameSize, 0, "", nil)
+	tailer.Start()
+
+	clientConn.Write([]byte("foo\n"))
+	msg := recvMsg(t, outputChan)
+	assert.Equal(t, "foo", string(msg.GetContent()))
+
+	clientConn.Write([]byte("bar\nboo\n"))
+	msg = recvMsg(t, outputChan)
+	assert.Equal(t, "bar", string(msg.GetContent()))
+	msg = recvMsg(t, outputChan)
+	assert.Equal(t, "boo", string(msg.GetContent()))
+
+	clientConn.Close()
+	tailer.Stop()
+}
+
+func TestStreamTailer_Unstructured_ConnectionCloseCleansUp(t *testing.T) {
+	t.Helper()
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close()
+
+	source := sources.NewLogSource("test", &config.LogsConfig{})
+	outputChan := make(chan *message.Message, 10)
+
+	tailer := NewStreamTailer(source, serverConn, outputChan, testFrameSize, 0, "", nil)
+	tailer.Start()
+
+	// Close client side, tailer should stop gracefully.
+	clientConn.Close()
+
+	// Give the tailer a moment to observe EOF and shut down.
+	time.Sleep(100 * time.Millisecond)
+	tailer.Stop()
+}
+
+func TestStreamTailer_OnDoneCallbackFires(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close()
+
+	source := sources.NewLogSource("test", &config.LogsConfig{})
+	outputChan := make(chan *message.Message, 10)
+
+	tailer := NewStreamTailer(source, serverConn, outputChan, testFrameSize, 0, "", nil)
+
+	done := make(chan struct{})
+	tailer.SetOnDone(func() { close(done) })
+	tailer.Start()
+
+	clientConn.Close()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("onDone callback was not invoked after connection close")
+	}
+
+	tailer.Stop()
+}
+
+func TestStreamTailer_Unstructured_SourceHostTag(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close()
+
+	logsConfig := &config.LogsConfig{
+		Tags: []string{"test:tag"},
+	}
+	source := sources.NewLogSource("test-source", logsConfig)
+	outputChan := make(chan *message.Message, 10)
+
+	tailer := NewStreamTailer(source, serverConn, outputChan, testFrameSize, 0, "192.168.1.100", nil)
+	tailer.Start()
+
+	clientConn.Write([]byte("foo\n"))
+	msg := recvMsg(t, outputChan)
+	assert.Contains(t, msg.Origin.Tags(), "source_host:192.168.1.100")
+
+	clientConn.Close()
+	tailer.Stop()
+}
+
+func TestStreamTailer_Unstructured_SourceHostTagFlagDisabled(t *testing.T) {
+	mockConfig := configmock.New(t)
+	mockConfig.BindEnvAndSetDefault("logs_config.use_sourcehost_tag", false)
+
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close()
+
+	logsConfig := &config.LogsConfig{
+		Tags: []string{"test:tag"},
+	}
+	source := sources.NewLogSource("test-source", logsConfig)
+	outputChan := make(chan *message.Message, 10)
+
+	// Even though sourceHostAddr is set, the tag should not appear when disabled.
+	tailer := NewStreamTailer(source, serverConn, outputChan, testFrameSize, 0, "192.168.1.100", nil)
+	tailer.Start()
+
+	clientConn.Write([]byte("foo\n"))
+	msg := recvMsg(t, outputChan)
+	assert.NotContains(t, msg.Origin.Tags(), "source_host:192.168.1.100",
+		"source_host tag should not be added when flag is disabled")
+
+	clientConn.Close()
+	tailer.Stop()
+}
+
+// ---------------------------------------------------------------------------
+// Syslog format tests (migrated from syslog_stream_tailer_test.go)
+// ---------------------------------------------------------------------------
+
+func TestStreamTailer_Syslog_NonTransparent(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close()
+
+	source := sources.NewLogSource("test-syslog", &config.LogsConfig{Format: config.SyslogFormat})
+	outputChan := make(chan *message.Message, 10)
+
+	tailer := NewStreamTailer(source, serverConn, outputChan, testFrameSize, 0, "", nil)
+	tailer.Start()
+
+	clientConn.Write([]byte("<14>1 2003-10-11T22:14:15.003Z myhost myapp - - - Hello world\n"))
+	clientConn.Write([]byte("<11>1 2003-10-11T22:14:16.003Z myhost otherapp - - - Error occurred\n"))
+
+	msg := recvMsg(t, outputChan)
+	assert.Equal(t, message.StateStructured, msg.State)
+	assert.Equal(t, "Hello world", string(msg.GetContent()))
+	assert.Equal(t, message.StatusInfo, msg.Status)
+
+	msg = recvMsg(t, outputChan)
+	assert.Equal(t, "Error occurred", string(msg.GetContent()))
+	assert.Equal(t, message.StatusError, msg.Status)
+
+	clientConn.Close()
+	tailer.Stop()
+}
+
+func TestStreamTailer_Syslog_OctetCounted(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close()
+
+	source := sources.NewLogSource("test-syslog", &config.LogsConfig{Format: config.SyslogFormat})
+	outputChan := make(chan *message.Message, 10)
+
+	tailer := NewStreamTailer(source, serverConn, outputChan, testFrameSize, 0, "", nil)
+	tailer.Start()
+
+	syslogMsg := "<14>1 2003-10-11T22:14:15.003Z h app - - - Hi"
+	frame := []byte(fmt.Sprintf("%d %s", len(syslogMsg), syslogMsg))
+	clientConn.Write(frame)
+
+	msg := recvMsg(t, outputChan)
+	assert.Equal(t, message.StateStructured, msg.State)
+	assert.Equal(t, "Hi", string(msg.GetContent()))
+
+	clientConn.Close()
+	tailer.Stop()
+}
+
+func TestStreamTailer_Syslog_NULFraming(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close()
+
+	source := sources.NewLogSource("test-syslog", &config.LogsConfig{Format: config.SyslogFormat})
+	outputChan := make(chan *message.Message, 10)
+
+	tailer := NewStreamTailer(source, serverConn, outputChan, testFrameSize, 0, "", nil)
+	tailer.Start()
+
+	clientConn.Write([]byte("<14>1 2003-10-11T22:14:15.003Z myhost myapp - - - NUL hello\x00"))
+	clientConn.Write([]byte("<11>1 2003-10-11T22:14:16.003Z myhost otherapp - - - NUL world\x00"))
+
+	msg := recvMsg(t, outputChan)
+	assert.Equal(t, message.StateStructured, msg.State)
+	assert.Equal(t, "NUL hello", string(msg.GetContent()))
+	assert.Equal(t, message.StatusInfo, msg.Status)
+
+	msg = recvMsg(t, outputChan)
+	assert.Equal(t, "NUL world", string(msg.GetContent()))
+	assert.Equal(t, message.StatusError, msg.Status)
+
+	clientConn.Close()
+	tailer.Stop()
+}
+
+func TestStreamTailer_Syslog_NoSourceServiceOverride(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close()
+
+	source := sources.NewLogSource("test-syslog", &config.LogsConfig{Format: config.SyslogFormat})
+	outputChan := make(chan *message.Message, 10)
+
+	tailer := NewStreamTailer(source, serverConn, outputChan, testFrameSize, 0, "", nil)
+	tailer.Start()
+
+	clientConn.Write([]byte("<14>1 2003-10-11T22:14:15.003Z myhost myapp - - - hello\n"))
+
+	msg := recvMsg(t, outputChan)
+	assert.Empty(t, msg.Origin.Source(), "syslog parser should not override source directly")
+	assert.Empty(t, msg.Origin.Service(), "syslog parser should not override service")
+
+	clientConn.Close()
+	tailer.Stop()
+}

--- a/pkg/logs/tailers/socket/syslog_bench_test.go
+++ b/pkg/logs/tailers/socket/syslog_bench_test.go
@@ -1,0 +1,144 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package socket
+
+import (
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	syslogparser "github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/syslog"
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
+)
+
+// ---------------------------------------------------------------------------
+// Test data: representative syslog messages at various sizes
+// ---------------------------------------------------------------------------
+
+var (
+	rfc5424Short   = []byte(`<14>1 2003-10-11T22:14:15.003Z host app - - - short`)
+	rfc5424Typical = []byte(`<165>1 2003-10-11T22:14:15.003Z mymachine.example.com evntslog - ID47 [exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"] An application event log entry`)
+	rfc5424Long    = []byte(`<14>1 2003-10-11T22:14:15.003Z longhost.example.com myservice 12345 REQ-001 [meta@1234 key="val"] ` + strings.Repeat("x", 1024))
+	bsdTypical     = []byte(`<34>Oct 11 22:14:15 mymachine su: 'su root' failed for lonvick on /dev/pts/8`)
+)
+
+// ---------------------------------------------------------------------------
+// Parse (syslog field extraction)
+// ---------------------------------------------------------------------------
+
+func BenchmarkParse(b *testing.B) {
+	for _, tc := range []struct {
+		name string
+		msg  []byte
+	}{
+		{"RFC5424_Short", rfc5424Short},
+		{"RFC5424_Typical", rfc5424Typical},
+		{"RFC5424_Long_1KB", rfc5424Long},
+		{"BSD", bsdTypical},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			b.SetBytes(int64(len(tc.msg)))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, _ = syslogparser.Parse(tc.msg)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Render
+// ---------------------------------------------------------------------------
+
+func BenchmarkRender(b *testing.B) {
+	for _, tc := range []struct {
+		name string
+		msg  []byte
+	}{
+		{"RFC5424_Short", rfc5424Short},
+		{"RFC5424_Typical", rfc5424Typical},
+		{"RFC5424_Long_1KB", rfc5424Long},
+		{"BSD", bsdTypical},
+	} {
+		parsed, _ := syslogparser.Parse(tc.msg)
+		sc := &message.BasicStructuredContent{
+			Data: map[string]interface{}{
+				"message": string(parsed.Msg),
+				"syslog":  syslogparser.BuildSyslogFields(&parsed),
+			},
+		}
+		source := sources.NewLogSource("bench", &config.LogsConfig{})
+		origin := message.NewOrigin(source)
+		msg := message.NewStructuredMessage(sc, origin, syslogparser.SeverityToStatus(parsed.Pri), time.Now().UnixNano())
+		b.Run(tc.name, func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, err := msg.Render()
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end with net.Pipe through StreamTailer (syslog format)
+// ---------------------------------------------------------------------------
+
+func BenchmarkStreamTailerSyslogEndToEnd(b *testing.B) {
+	for _, tc := range []struct {
+		name string
+		msg  []byte
+	}{
+		{"RFC5424_Typical", rfc5424Typical},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			serverConn, clientConn := net.Pipe()
+			defer serverConn.Close()
+
+			source := sources.NewLogSource("bench-syslog", &config.LogsConfig{Format: config.SyslogFormat})
+			outputChan := make(chan *message.Message, 256)
+
+			tailer := NewStreamTailer(source, serverConn, outputChan, 4096, 0, "", nil)
+			tailer.Start()
+
+			line := append(tc.msg, '\n')
+			b.SetBytes(int64(len(line)))
+			b.ResetTimer()
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				for i := 0; i < b.N; i++ {
+					_, err := clientConn.Write(line)
+					if err != nil {
+						return
+					}
+				}
+				clientConn.Close()
+			}()
+
+			received := 0
+			timeout := time.After(30 * time.Second)
+			for received < b.N {
+				select {
+				case <-outputChan:
+					received++
+				case <-timeout:
+					b.Fatalf("timeout after receiving %d/%d messages", received, b.N)
+				}
+			}
+			b.StopTimer()
+
+			<-done
+			tailer.Stop()
+		})
+	}
+}

--- a/pkg/logs/tailers/socket/syslog_builder_test.go
+++ b/pkg/logs/tailers/socket/syslog_builder_test.go
@@ -1,0 +1,169 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package socket
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	syslogparser "github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/syslog"
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+)
+
+func TestStructuredContent_Render_RFC5424(t *testing.T) {
+	parsed := syslogparser.SyslogMessage{
+		Pri:       165,
+		Version:   "1",
+		Timestamp: "2003-10-11T22:14:15.003Z",
+		Hostname:  "mymachine",
+		AppName:   "evntslog",
+		ProcID:    "-",
+		MsgID:     "ID47",
+		StructuredData: map[string]map[string]string{
+			"exampleSDID@32473": {"iut": "3"},
+		},
+		Msg: []byte("An application event log entry"),
+	}
+
+	sc := &message.BasicStructuredContent{
+		Data: map[string]interface{}{
+			"message": string(parsed.Msg),
+			"syslog":  syslogparser.BuildSyslogFields(&parsed),
+		},
+	}
+
+	rendered, err := sc.Render()
+	require.NoError(t, err)
+
+	var data map[string]interface{}
+	err = json.Unmarshal(rendered, &data)
+	require.NoError(t, err)
+
+	assert.Equal(t, "An application event log entry", data["message"])
+
+	syslogMap, ok := data["syslog"].(map[string]interface{})
+	require.True(t, ok)
+
+	assert.Equal(t, float64(5), syslogMap["severity"])
+	assert.Equal(t, float64(20), syslogMap["facility"])
+	assert.Equal(t, "1", syslogMap["version"])
+	assert.Equal(t, "2003-10-11T22:14:15.003Z", syslogMap["timestamp"])
+	assert.Equal(t, "mymachine", syslogMap["hostname"])
+	assert.Equal(t, "evntslog", syslogMap["appname"])
+	assert.Equal(t, "-", syslogMap["procid"])
+	assert.Equal(t, "ID47", syslogMap["msgid"])
+
+	sdRaw, ok := syslogMap["structured_data"].(map[string]interface{})
+	require.True(t, ok, "structured_data should be a map")
+	elemRaw, ok := sdRaw["exampleSDID@32473"].(map[string]interface{})
+	require.True(t, ok, "SD element should be a map")
+	assert.Equal(t, "3", elemRaw["iut"])
+}
+
+func TestStructuredContent_Render_BSD(t *testing.T) {
+	parsed := syslogparser.SyslogMessage{
+		Pri:       38,
+		Timestamp: "Oct 11 22:14:15",
+		Hostname:  "mymachine",
+		AppName:   "su",
+		ProcID:    "-",
+		MsgID:     "-",
+		Msg:       []byte("'su root' failed for lonvick on /dev/pts/8"),
+	}
+
+	sc := &message.BasicStructuredContent{
+		Data: map[string]interface{}{
+			"message": string(parsed.Msg),
+			"syslog":  syslogparser.BuildSyslogFields(&parsed),
+		},
+	}
+
+	rendered, err := sc.Render()
+	require.NoError(t, err)
+
+	var data map[string]interface{}
+	err = json.Unmarshal(rendered, &data)
+	require.NoError(t, err)
+
+	syslogMap := data["syslog"].(map[string]interface{})
+
+	_, hasVersion := syslogMap["version"]
+	assert.False(t, hasVersion, "BSD messages should not have version")
+	_, hasSD := syslogMap["structured_data"]
+	assert.False(t, hasSD, "BSD messages should not have structured_data")
+
+	assert.Equal(t, float64(6), syslogMap["severity"])
+	assert.Equal(t, float64(4), syslogMap["facility"])
+}
+
+func TestStructuredContent_Render_NoPri(t *testing.T) {
+	parsed := syslogparser.SyslogMessage{
+		Pri:       -1,
+		Timestamp: "Oct 11 22:14:15",
+		Hostname:  "mymachine",
+		AppName:   "syslogd",
+		ProcID:    "-",
+		MsgID:     "-",
+		Msg:       []byte("restart"),
+	}
+
+	sc := &message.BasicStructuredContent{
+		Data: map[string]interface{}{
+			"message": string(parsed.Msg),
+			"syslog":  syslogparser.BuildSyslogFields(&parsed),
+		},
+	}
+
+	rendered, err := sc.Render()
+	require.NoError(t, err)
+
+	var data map[string]interface{}
+	err = json.Unmarshal(rendered, &data)
+	require.NoError(t, err)
+
+	syslogMap := data["syslog"].(map[string]interface{})
+	_, hasSev := syslogMap["severity"]
+	assert.False(t, hasSev, "Pri=-1 should omit severity")
+	_, hasFac := syslogMap["facility"]
+	assert.False(t, hasFac, "Pri=-1 should omit facility")
+}
+
+func TestStructuredContent_NILVALUEPreserved(t *testing.T) {
+	parsed := syslogparser.SyslogMessage{
+		Pri:       14,
+		Version:   "1",
+		Timestamp: "-",
+		Hostname:  "-",
+		AppName:   "-",
+		ProcID:    "-",
+		MsgID:     "-",
+		Msg:       []byte("test"),
+	}
+
+	sc := &message.BasicStructuredContent{
+		Data: map[string]interface{}{
+			"message": string(parsed.Msg),
+			"syslog":  syslogparser.BuildSyslogFields(&parsed),
+		},
+	}
+
+	rendered, err := sc.Render()
+	require.NoError(t, err)
+
+	var data map[string]interface{}
+	err = json.Unmarshal(rendered, &data)
+	require.NoError(t, err)
+
+	syslogMap := data["syslog"].(map[string]interface{})
+	assert.Equal(t, "-", syslogMap["timestamp"])
+	assert.Equal(t, "-", syslogMap["hostname"])
+	assert.Equal(t, "-", syslogMap["appname"])
+	assert.Equal(t, "-", syslogMap["procid"])
+	assert.Equal(t, "-", syslogMap["msgid"])
+}


### PR DESCRIPTION
### What does this PR do?

**Part 5.1** of the syslog ingestion stack. Introduces a dedicated TCP stream tailer and syslog-aware stream decoder.

- **StreamTailer** (`pkg/logs/tailers/socket/stream_tailer.go`): A self-contained tailer for TCP and Unix stream syslog connections. Each accepted connection gets its own tailer that owns the read loop, decoder lifecycle, idle timeout, and `source_host` tagging.
- **Stream decoder** (`pkg/logs/internal/decoder/stream_decoder.go`): Wires the RFC 6587 framer (octet-counting and non-transparent framing) with the syslog parser for TCP connections.
- **TCP launcher** (`pkg/logs/launchers/listener/tcp.go`): Creates a `StreamTailer` per accepted connection instead of the old callback-based tailer. IPv6-compliant source IP extraction.
- **Status builder** (`pkg/logs/status/builder.go`): `agent status` now shows `TLS`, `Format`, `AllowedIPs`, and `DeniedIPs` for TCP listeners.
- **Parser cleanup**: Removed `SourceOverride` and `ServiceOverride` from `ParsingExtra` — syslog should not override source or service outside a mapped-source flow.

### Motivation

The old `Tailer` handled both TCP and UDP in a single callback-based design, making it hard to reason about connection lifecycle, format-specific decoding, and per-connection metadata. Splitting TCP into its own `StreamTailer` gives each connection a clear ownership model and lets the TCP path use the RFC 6587 framer, which requires stateful tracking across reads.

### Describe how you validated your changes

- `inv test --only-modified-packages` — tests pass across decoder, launcher, and socket tailer packages
- `inv linter.go --only-modified-packages` — 0 issues

### Additional Notes

Stacked on `ryan.hall/syslog-v5` (#49029). File-specific changes (syslog file decoder, structured message preservation) are in v5.3 (#50709).