### PR TITLE
Apply `testing/synctest` to 7 `rdnsquerier` tests

### DIFF
--- a/comp/rdnsquerier/impl/rdnsquerier_test.go
+++ b/comp/rdnsquerier/impl/rdnsquerier_test.go
@@ -221,15 +221,13 @@ func TestNormalOperationsCacheDisabled(t *testing.T) {
 	ts.validateExpected(t, expectedTelemetry)
 }
 
-// Test that the rate limiter limits the rate as expected.  Set rate limit to 1 per second, send a bunch of requests,
-// wait for N seconds, assert that no more that the expected number of requests succeed within that time period.
+// Test that the rate limiter limits the rate as expected.  Set rate limit to 1 per second, send N requests,
+// assert that all N complete and that N-1 seconds elapsed (1 per second after the initial burst of 1).
 func TestRateLimiter(t *testing.T) {
 	synctest.Test(t, syncTestRateLimiter)
 }
 
 func syncTestRateLimiter(t *testing.T) {
-	const numSeconds = 2
-
 	overrides := map[string]interface{}{
 		"network_devices.netflow.reverse_dns_enrichment_enabled": true,
 		"reverse_dns_enrichment.rate_limiter.limit_per_sec":      1,
@@ -237,6 +235,9 @@ func syncTestRateLimiter(t *testing.T) {
 	ts := testSetup(t, overrides, true, nil, 0)
 	defer ts.stop(t)
 
+	var wg sync.WaitGroup
+	wg.Add(20)
+	start := time.Now()
 	// IP addresses in private range
 	for i := range 20 {
 		err := ts.rdnsQuerier.GetHostnameAsync(
@@ -247,26 +248,22 @@ func syncTestRateLimiter(t *testing.T) {
 			func(hostname string, err error) {
 				assert.NoError(t, err)
 				assert.Equal(t, fmt.Sprintf("fakehostname-192.168.1.%d", i), hostname)
+				wg.Done()
 			},
 		)
 		assert.NoError(t, err)
 	}
-
-	time.Sleep(numSeconds * time.Second)
+	wg.Wait()
+	assert.Equal(t, 19*time.Second, time.Since(start))
 
 	expectedTelemetry := ts.makeExpectedTelemetry(map[string]float64{
 		"total":      20.0,
 		"private":    20.0,
 		"chan_added": 20.0,
 		"cache_miss": 20.0,
+		"successful": 20.0,
 	})
-	delete(expectedTelemetry, "successful")
 	ts.validateExpected(t, expectedTelemetry)
-
-	maximumTelemetry := map[string]float64{
-		"successful": float64(numSeconds + 3), // expect maximum of 1 per second, plus some buffer for test timing
-	}
-	ts.validateMaximum(t, maximumTelemetry)
 }
 
 // Test that the rate limiter throttles the limit down when the error threshold is reached, and throttles the limit back up

--- a/comp/rdnsquerier/impl/rdnsquerier_test.go
+++ b/comp/rdnsquerier/impl/rdnsquerier_test.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	rdnsquerierdef "github.com/DataDog/datadog-agent/comp/rdnsquerier/def"
@@ -37,7 +38,7 @@ func TestStartStop(t *testing.T) {
 	assert.NoError(t, ts.lc.Start(ts.ctx))
 	assert.Equal(t, true, internalRDNSQuerier.started)
 
-	assert.NoError(t, ts.lc.Stop(ts.ctx))
+	ts.stop(t)
 	assert.Equal(t, false, internalRDNSQuerier.started)
 }
 
@@ -223,6 +224,10 @@ func TestNormalOperationsCacheDisabled(t *testing.T) {
 // Test that the rate limiter limits the rate as expected.  Set rate limit to 1 per second, send a bunch of requests,
 // wait for N seconds, assert that no more that the expected number of requests succeed within that time period.
 func TestRateLimiter(t *testing.T) {
+	synctest.Test(t, syncTestRateLimiter)
+}
+
+func syncTestRateLimiter(t *testing.T) {
 	const numSeconds = 2
 
 	overrides := map[string]interface{}{
@@ -230,6 +235,7 @@ func TestRateLimiter(t *testing.T) {
 		"reverse_dns_enrichment.rate_limiter.limit_per_sec":      1,
 	}
 	ts := testSetup(t, overrides, true, nil, 0)
+	defer ts.stop(t)
 
 	// IP addresses in private range
 	for i := range 20 {
@@ -266,6 +272,10 @@ func TestRateLimiter(t *testing.T) {
 // Test that the rate limiter throttles the limit down when the error threshold is reached, and throttles the limit back up
 // after a recovery interval when queries are once again successful.
 func TestRateLimiterThrottled(t *testing.T) {
+	synctest.Test(t, syncTestRateLimiterThrottled)
+}
+
+func syncTestRateLimiterThrottled(t *testing.T) {
 	overrides := map[string]interface{}{
 		"network_devices.netflow.reverse_dns_enrichment_enabled":       true,
 		"reverse_dns_enrichment.workers":                               2,
@@ -289,6 +299,7 @@ func TestRateLimiterThrottled(t *testing.T) {
 		},
 		0,
 	)
+	defer ts.stop(t)
 
 	var wg sync.WaitGroup
 
@@ -514,11 +525,16 @@ func TestChannelFullRequestsDroppedWhenRateLimited(t *testing.T) {
 
 // Test that the cache prevents multiple outstanding requests for an IP address.
 func TestCacheHitInProgress(t *testing.T) {
+	synctest.Test(t, syncTestCacheHitInProgress)
+}
+
+func syncTestCacheHitInProgress(t *testing.T) {
 	overrides := map[string]interface{}{
 		"network_devices.netflow.reverse_dns_enrichment_enabled": true,
 		"reverse_dns_enrichment.rate_limiter.limit_per_sec":      1,
 	}
 	ts := testSetup(t, overrides, true, nil, 0)
+	defer ts.stop(t)
 
 	var wg sync.WaitGroup
 
@@ -830,12 +846,17 @@ func TestCacheMaxSize(t *testing.T) {
 
 // Test cache expiration
 func TestCacheExpiration(t *testing.T) {
+	synctest.Test(t, syncTestCacheExpiration)
+}
+
+func syncTestCacheExpiration(t *testing.T) {
 	overrides := map[string]interface{}{
 		"network_devices.netflow.reverse_dns_enrichment_enabled": true,
 		"reverse_dns_enrichment.cache.entry_ttl":                 time.Duration(100) * time.Millisecond,
 		"reverse_dns_enrichment.cache.clean_interval":            time.Duration(1) * time.Second,
 	}
 	ts := testSetup(t, overrides, true, nil, 0)
+	defer ts.stop(t)
 
 	var wg sync.WaitGroup
 
@@ -881,6 +902,10 @@ func TestCacheExpiration(t *testing.T) {
 
 // Test that the cache is persisted and that it is loaded and used when the agent starts.
 func TestCachePersist(t *testing.T) {
+	synctest.Test(t, syncTestCachePersist)
+}
+
+func syncTestCachePersist(t *testing.T) {
 	overrides := map[string]interface{}{
 		"network_devices.netflow.reverse_dns_enrichment_enabled": true,
 		"run_path": t.TempDir(),
@@ -932,7 +957,7 @@ func TestCachePersist(t *testing.T) {
 	ts.validateExpected(t, expectedTelemetry)
 
 	// stop the original test setup
-	assert.NoError(t, ts.lc.Stop(ts.ctx))
+	ts.stop(t)
 
 	// create new testsetup, validate that the IP address previously queried and cached is still cached
 	ts = testSetup(t, overrides, true, nil, 0)
@@ -962,7 +987,7 @@ func TestCachePersist(t *testing.T) {
 	ts.validateExpected(t, expectedTelemetry)
 
 	// stop the second test setup
-	assert.NoError(t, ts.lc.Stop(ts.ctx))
+	ts.stop(t)
 
 	// create new testsetup with shorter entryTTL, validate that the IP address previously
 	// cached has new shorter expiration time
@@ -997,6 +1022,9 @@ func TestCachePersist(t *testing.T) {
 		"cache_miss":        1.0,
 	})
 	ts.validateExpected(t, expectedTelemetry)
+
+	// stop the third test setup
+	ts.stop(t)
 }
 
 func TestGetHostname(t *testing.T) {
@@ -1093,6 +1121,10 @@ func TestGetHostnameTimeout(t *testing.T) {
 
 // Test that when the rate limit is exceeded and the channel fills requests are dropped.
 func TestGetHostnameChannelFullRequestsDroppedWhenRateLimited(t *testing.T) {
+	synctest.Test(t, syncTestGetHostnameChannelFullRequestsDroppedWhenRateLimited)
+}
+
+func syncTestGetHostnameChannelFullRequestsDroppedWhenRateLimited(t *testing.T) {
 	overrides := map[string]interface{}{
 		"network_devices.netflow.reverse_dns_enrichment_enabled": true,
 		"reverse_dns_enrichment.workers":                         1,
@@ -1101,6 +1133,7 @@ func TestGetHostnameChannelFullRequestsDroppedWhenRateLimited(t *testing.T) {
 		"reverse_dns_enrichment.rate_limiter.limit_per_sec":      1,
 	}
 	ts := testSetup(t, overrides, true, nil, 1*time.Second)
+	defer ts.stop(t)
 
 	// IP addresses in private range
 	var errCount atomic.Int32
@@ -1142,18 +1175,18 @@ func TestGetHostnames(t *testing.T) {
 		"network_devices.netflow.reverse_dns_enrichment_enabled": true,
 	}
 
-	defaultTs := testSetup(t, overrides, true, nil, 100*time.Millisecond)
+	defaultDelay := 100 * time.Millisecond
 
 	tests := []struct {
 		name     string
-		ts       *testState
+		delay    time.Duration
 		ipAddrs  []string
 		timeout  time.Duration
 		expected map[string]rdnsquerierdef.ReverseDNSResult
 	}{
 		{
 			name:    "valid IPs",
-			ts:      defaultTs,
+			delay:   defaultDelay,
 			ipAddrs: []string{"192.168.1.100", "192.168.1.101"},
 			timeout: 1 * time.Second,
 			expected: map[string]rdnsquerierdef.ReverseDNSResult{
@@ -1163,7 +1196,7 @@ func TestGetHostnames(t *testing.T) {
 		},
 		{
 			name:    "invalid IP, private IPs, and public IP",
-			ts:      defaultTs,
+			delay:   defaultDelay,
 			ipAddrs: []string{"invalid_ip", "192.168.1.102", "8.8.8.8", "192.168.1.100"},
 			timeout: 1 * time.Second,
 			expected: map[string]rdnsquerierdef.ReverseDNSResult{
@@ -1175,7 +1208,7 @@ func TestGetHostnames(t *testing.T) {
 		},
 		{
 			name:    "invalid IP, timeout for private and public IPs",
-			ts:      testSetup(t, overrides, true, nil, 10*time.Second),
+			delay:   10 * time.Second,
 			ipAddrs: []string{"192.168.1.105", "invalid", "8.8.8.8"},
 			timeout: 1 * time.Second,
 			expected: map[string]rdnsquerierdef.ReverseDNSResult{
@@ -1187,11 +1220,14 @@ func TestGetHostnames(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(tt.ts.ctx, tt.timeout)
+		syncTestGetHostnames := func(t *testing.T) {
+			ts := testSetup(t, overrides, true, nil, tt.delay)
+			defer ts.stop(t)
+
+			ctx, cancel := context.WithTimeout(ts.ctx, tt.timeout)
 			defer cancel()
 
-			internalRDNSQuerier := tt.ts.rdnsQuerier.(*rdnsQuerierImpl)
+			internalRDNSQuerier := ts.rdnsQuerier.(*rdnsQuerierImpl)
 			results := internalRDNSQuerier.GetHostnames(ctx, tt.ipAddrs)
 
 			for ip, expectedResult := range tt.expected {
@@ -1206,6 +1242,9 @@ func TestGetHostnames(t *testing.T) {
 					assert.NoError(t, result.Err)
 				}
 			}
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			synctest.Test(t, syncTestGetHostnames)
 		})
 	}
 }

--- a/comp/rdnsquerier/impl/rdnsquerier_test.go
+++ b/comp/rdnsquerier/impl/rdnsquerier_test.go
@@ -360,6 +360,7 @@ func syncTestRateLimiterThrottled(t *testing.T) {
 		"cache_retries_exceeded": 2.0,
 	})
 	ts.validateExpected(t, expectedTelemetry)
+	synctest.Wait() // gauge is set asynchronously by the adjuster goroutine
 	ts.validateExpectedGauge(t, "rate_limiter_limit", 1.0)
 
 	// The rate limiter is throttled now, but queries that are cache hits don't make it to the rate limiter so aren't throttled
@@ -462,6 +463,7 @@ func syncTestRateLimiterThrottled(t *testing.T) {
 		"cache_retries_exceeded": 2.0,
 	})
 	ts.validateExpected(t, expectedTelemetry)
+	synctest.Wait() // gauge is set asynchronously by the adjuster goroutine
 	ts.validateExpectedGauge(t, "rate_limiter_limit", 11.0)
 }
 

--- a/comp/rdnsquerier/impl/rdnsquerier_testutils.go
+++ b/comp/rdnsquerier/impl/rdnsquerier_testutils.go
@@ -70,9 +70,18 @@ type testState struct {
 	logComp       log.Component
 }
 
+func (ts *testState) stop(t *testing.T) {
+	assert.NoError(t, ts.lc.Stop(ts.ctx))
+}
+
 func testSetup(t *testing.T, overrides map[string]interface{}, start bool, fakeIPResults map[string]*fakeResults, delay time.Duration) *testState {
 	lc := compdef.NewTestLifecycle(t)
 
+	// Ensure run_path is sandboxed so cache.persist() on stop doesn't write to
+	// the system path (/opt/datadog-agent/run on POSIX systems).
+	if _, ok := overrides["run_path"]; !ok {
+		overrides["run_path"] = t.TempDir()
+	}
 	config := config.NewMockWithOverrides(t, overrides)
 
 	logComp := logmock.New(t)

--- a/comp/rdnsquerier/impl/rdnsquerier_testutils.go
+++ b/comp/rdnsquerier/impl/rdnsquerier_testutils.go
@@ -179,17 +179,6 @@ func (ts *testState) validateMinimum(t *testing.T, minimumTelemetry map[string]f
 	}
 }
 
-// validate that telemetry counter values are less than or equal to the expected maximum values
-func (ts *testState) validateMaximum(t *testing.T, maximumTelemetry map[string]float64) {
-	for name, expected := range maximumTelemetry {
-		ts.logComp.Debugf("Validating maximum telemetry counter %s", name)
-		metrics, err := ts.telemetryMock.GetCountMetric(moduleName, name)
-		assert.NoError(t, err)
-		assert.Len(t, metrics, 1)
-		assert.LessOrEqual(t, metrics[0].Value(), expected)
-	}
-}
-
 // validate that telemetry gauge value is equal to the expected value
 func (ts *testState) validateExpectedGauge(t *testing.T, name string, value float64) {
 	ts.logComp.Debugf("Validating expected telemetry gauge %s", name)


### PR DESCRIPTION
### What does this PR do?
Cuts the `//comp/rdnsquerier/impl:impl_test` wall clock from ~17.0s to ~1.6s (~91%) by wrapping wall-clock-bound tests in `synctest.Test`:
1. `TestRateLimiterThrottled` (7.35s -> 0.06s, ~123x)
2. `TestCacheExpiration` (2.13s -> 0.05s, ~43x)
3. `TestRateLimiter` (2.04s -> 0.05s, ~41x)
4. `TestGetHostnameChannelFullRequestsDroppedWhenRateLimited` (2.03s -> 0.04s, ~51x)
5. `TestGetHostnames` (1.23s -> 0.11s, ~11x)
6. `TestCacheHitInProgress` (1.03s -> 0.04s, ~26x)
7. `TestCachePersist` (0.24s -> 0.07s, ~3.4x)

For top-level tests, each body is extracted to a `syncTestXxx` function placed right below its `TestXxx` driver, mirroring the pattern used in #50276 and many predecessors.
For the table-driven `TestGetHostnames`, `syncTestGetHostnames` is bound as a closure inside the loop (capturing the iteration's case) and handed to `synctest.Test` from within `t.Run` (this ordering is required because `t.Run` called from inside a "bubble" panics).

Calling `lc.Stop()` from every converted test surfaces a dormant issue: `cache.stop()` runs `cache.persist()`, which attempts to write to the **production** `run_path` (`/opt/datadog-agent/run` on POSIX systems), harmless on Linux CI executors (the directory is missing + runners are still ephemeral) but writable on the macOS arm64 CI executors, where one test's persisted cache entries would silently load as cache hits in the next tests and break their assertions ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1668173207#L1370)).
=> `testSetup` now sandboxes `run_path` to `t.TempDir()` by default, leaving explicit overrides (`TestCachePersist`) intact.

Also, thanks to https://github.com/DataDog/datadog-agent/pull/50525#discussion_r3207755312 and https://github.com/DataDog/datadog-agent/pull/50525#discussion_r3208266129, it turns out we can rely on `synctest`'s deterministic clock to fix potential **race conditions**:
- `TestRateLimiter`: under the previous "≤ 5 succeeded in 2 s" assertion the deferred `ts.stop(t)` left ~17 pending queries whose user callbacks could be invoked with `context canceled` (the cache retry loop only avoids this through `select` randomness, fragile).
  => asserting on virtual elapsed time drains the queue first, closing the path entirely.
- `TestRateLimiterThrottled`: `markFailure`/`markSuccess` are sent on a channel _after_ the user callback fires `wg.Done()`, and the adjuster goroutine that drains those channels and updates `rate_limiter_limit` runs asynchronously, so `wg.Wait()` only catches the callback returning and the gauge can still be stale when the test reads it.
  => added `synctest.Wait()` that blocks until every other "bubble" goroutine is durably blocked, guaranteeing the adjuster has consumed its channel and the gauge reflects the latest state.

### Motivation
The 7 tests blocked on `time.Sleep` calls (cache TTL ticks, rate limiter recovery interval, fake resolver delays up to 10s) and on `golang.org/x/time/rate.Limiter` internal `time.NewTimer` waits.
The `synctest` "bubble" advances the fake clock instantly once all goroutines are durably blocked, with no production code changes.

`TestRateLimiterThrottled` carries real-time duration assertions (`assert.GreaterOrEqual(duration, 5*time.Second)`, `assert.LessOrEqual(duration, 2*time.Second)`) that nonetheless hold under virtual time: `time.Since` and `golang.org/x/time/rate.Limiter` share the same fake clock, so the relationships they encode are preserved.

### Describe how you validated your changes
Per-test averages above are computed from 10 samples each, measured back-to-back on the same machine on `main` and on this branch with:
```
go test -tags test -v -count 10 \
    -run 'TestRateLimiterThrottled$|TestCacheExpiration$|TestRateLimiter$|TestGetHostnameChannelFullRequestsDroppedWhenRateLimited$|TestGetHostnames$|TestCacheHitInProgress$|TestCachePersist$' \
    ./comp/rdnsquerier/impl/
```

Bazel target averages from 10 sequential runs of:
```
bazel test --nocache_test_results //comp/rdnsquerier/impl:impl_test
```
- main: 16.97s avg (range 16.8-17.2s)
- this branch: 1.60s avg (range 1.4-2.2s)

### Additional Notes
The remaining wall-clock budget is dominated by `TestConfig` (~0.45s), which is config-parsing fixture overhead and not amenable to `synctest`. Other top-level tests are all sub-0.15s.

💡 Worth a read: https://go.dev/blog/synctest