### PR TITLE
fix(system-probe-lite): log full error chain to surface EPERM and other causes

### DIFF
--- a/pkg/discovery/module/rust/src/main.rs
+++ b/pkg/discovery/module/rust/src/main.rs
@@ -117,7 +117,7 @@ fn drop_capabilities() {
             warn!("Not all required capabilities were available; service discovery may be impaired")
         }
         Err(e) => {
-            warn!("Failed to restrict capabilities: {e}; continuing with inherited capabilities")
+            warn!("Failed to restrict capabilities: {e:#}; continuing with inherited capabilities")
         }
     }
 }
@@ -381,7 +381,7 @@ async fn run_system_probe_lite(socket_path: &str) -> Result<()> {
                             io,
                             service_fn(|req| async {
                                 Ok::<_, anyhow::Error>(handle_request(req).await.unwrap_or_else(|e| {
-                                    error!("Request handling failed: {e}");
+                                    error!("Request handling failed: {e:#}");
                                     // Return an internal server error response
                                     Response::builder()
                                         .status(StatusCode::INTERNAL_SERVER_ERROR)
@@ -403,7 +403,7 @@ async fn run_system_probe_lite(socket_path: &str) -> Result<()> {
                         )
                         .await
                     {
-                        error!("Error serving connection: {err}");
+                        error!("Error serving connection: {:#}", anyhow::Error::new(err));
                     }
                 });
             }


### PR DESCRIPTION
### What does this PR do?

In \`pkg/discovery/module/rust/src/main.rs\`, three \`error!\`/\`warn!\` call sites now use the \`{:#}\` alternate format (via \`anyhow\`) so the full error cause chain is included in the log line.

| Call site | Before | After |
|---|---|---|
| \`serve_connection\` failure | \`Error serving connection: error writing a body to connection\` | \`Error serving connection: error writing a body to connection: Operation not permitted (os error 1)\` |
| \`handle_request\` failure | \`Request handling failed: <top-level>\` | \`Request handling failed: <top-level>: <cause>\` |
| \`drop_capabilities\` failure | \`Failed to restrict capabilities: <top-level>; …\` | \`Failed to restrict capabilities: <top-level>: <cause>; …\` |

For \`hyper::Error\` (the connection error), wrapping in \`anyhow::Error::new(err)\` is required because \`hyper::Error\`'s own \`Display\` impl does not traverse \`.source()\`. For the two \`anyhow::Error\` sites the change is simply adding \`#\` to the format specifier.

### Motivation

While debugging [helm-charts#2634](https://github.com/DataDog/helm-charts/pull/2634), which added \`writev\`, \`shutdown\`, and \`chown\` to the system-probe seccomp allowlist for SPL, the only log produced was:

```
SYS-PROBE-LITE | ERROR | Error serving connection: error writing a body to connection
```

The underlying cause (\`Operation not permitted (os error 1)\`) was invisible, making \`strace\` necessary to identify the blocked syscall. With this fix the EPERM — or any other root cause — appears directly in the log.

### Describe how you validated your changes

- \`bazel build --config=lint //pkg/discovery/module/rust/...\` passes
- \`bazel test //pkg/discovery/module/rust/...\` — all 7 tests pass
- Manual test for the \`serve_connection\` path: ran SPL with an \`LD_PRELOAD\` shim that makes every \`writev(2)\` call return \`EPERM\`, then sent a GET request to the socket:
  - **Before:** \`Error serving connection: error writing a body to connection\`
  - **After:** \`Error serving connection: error writing a body to connection: Operation not permitted (os error 1)\`
- Manual test for the \`handle_request\` path: ran SPL with a temporary chained-error injection (\`anyhow!("inner").context("outer")\`) at the top of \`handle_request\`:
  - **Before:** \`Request handling failed: outer\`
  - **After:** \`Request handling failed: outer: inner\`