### PR TITLE
fix(e2e): skip stack destroy when Pulumi reports no previous deployment

### DIFF
--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -1248,6 +1248,10 @@ def _destroy_stack(ctx: Context, stack: str):
                     ),
                     1,
                 )
+            if "no previous deployment" in ret.stderr:
+                # Stack was created but never had a successful up; no resources to destroy.
+                print(f"Stack {stack} has no previous deployment, skipping destroy")
+                return
             # run with refresh on first destroy attempt failure
             ret = ctx.run(
                 f"pulumi destroy --stack {stack} -r --yes --remove --skip-preview",


### PR DESCRIPTION
### What does this PR do?

In `_destroy_stack()` (`tasks/new_e2e_tests.py`), handle the case where `pulumi destroy` exits with `"no previous deployment"` in stderr: print an informational message and return early, allowing `_clean_stacks` to continue to the next stack.

### Motivation

`inv new-e2e-tests.clean -s` iterates all local Pulumi stacks and calls `pulumi destroy` on each. Stacks that were initialised but never had a successful `pulumi up` (e.g. from a previously interrupted test run) contain no resources. Pulumi exits non-zero for these with `"no previous deployment"`, which previously fell through to the final `raise Exit(...)` and aborted the entire clean sweep before reaching the remaining stacks.

Since there is nothing to destroy, skipping to `_remove_stack` is the correct behaviour.

### Describe how you validated your changes

Manually ran `inv new-e2e-tests.clean -s` against a local Pulumi state that contained several empty stacks alongside stacks with real resources. The empty stacks are now skipped with a log line; stacks with resources are still destroyed normally.