### PR TITLE
test/new-e2e/tests/autoscaling/spot: eliminate pod startup delays for test pods

### DIFF
--- a/test/new-e2e/tests/autoscaling/spot/deployment_test.go
+++ b/test/new-e2e/tests/autoscaling/spot/deployment_test.go
@@ -295,7 +295,7 @@ func (s *spotSchedulingSuite) createDeployment(name string, replicas int32, conf
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{
 						Name:  "app",
-						Image: "registry.k8s.io/pause",
+						Image: "registry.k8s.io/pause:3.10.1",
 					}},
 				},
 			},

--- a/test/new-e2e/tests/autoscaling/spot/statefulset_test.go
+++ b/test/new-e2e/tests/autoscaling/spot/statefulset_test.go
@@ -282,7 +282,7 @@ func (s *spotSchedulingSuite) createStatefulSet(name string, replicas int32, con
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{
 						Name:  "app",
-						Image: "registry.k8s.io/pause",
+						Image: "registry.k8s.io/pause:3.10.1",
 					}},
 				},
 			},

--- a/test/new-e2e/tests/autoscaling/spot/suite_test.go
+++ b/test/new-e2e/tests/autoscaling/spot/suite_test.go
@@ -88,13 +88,18 @@ clusterAgent:
       value: "%v"
     - name: DD_AUTOSCALING_CLUSTER_SPOT_REBALANCE_STABILIZATION_PERIOD
       value: "%v"
-# node-agent DaemonSet not needed; only the cluster-agent runs the spot scheduler
+  podAnnotations:
+    ad.datadoghq.com/cluster-agent.logs: '[{"source":"cluster-agent","service":"datadog-cluster-agent"}]'
+# node-agent DaemonSet collects cluster-agent logs via the annotation above
 agents:
-  enabled: false
+  enabled: true
 # cluster check runners not needed for spot scheduling
 clusterChecksRunner:
   enabled: false
 datadog:
+  logs:
+    enabled: true
+    containerCollectAll: false
   kubeStateMetricsCore:
     # the framework sets this to true by default, which unconditionally enables the
     # cluster checks runner deployment regardless of clusterChecksRunner.enabled
@@ -214,28 +219,35 @@ func (s *spotSchedulingSuite) eventually(fn func(c *assert.CollectT)) {
 	s.EventuallyWithT(fn, 1*time.Minute, 5*time.Second)
 }
 
-// expectRunningSpot asserts that exactly count pods are Running on the spot node with spot-assigned label.
-func (s *spotSchedulingSuite) expectRunningSpot(c *assert.CollectT, pods []corev1.Pod, count int) {
-	actual := 0
+// groupPods groups pods first by node name, then by phase.
+// Unscheduled pods (no node assigned) are grouped under "<unscheduled>".
+func groupPods(pods []corev1.Pod) map[string]map[corev1.PodPhase][]string {
+	g := make(map[string]map[corev1.PodPhase][]string)
 	for _, p := range pods {
-		if p.Status.Phase == corev1.PodRunning && p.Spec.NodeName == s.spotNode {
-			require.Contains(c, p.Labels, spotAssignedLabel, "pod %s on spot node should have spot-assigned label", p.Name)
-			actual++
+		node := p.Spec.NodeName
+		if node == "" {
+			node = "<unscheduled>"
 		}
+		if g[node] == nil {
+			g[node] = make(map[corev1.PodPhase][]string)
+		}
+		g[node][p.Status.Phase] = append(g[node][p.Status.Phase], p.Name)
 	}
-	require.Equal(c, count, actual, "expected %d running spot pods", count)
+	return g
 }
 
-// expectRunningOnDemand asserts that exactly count pods are Running on the on-demand node without spot-assigned label.
+// expectRunningSpot asserts that exactly count pods are Running on the spot node.
+func (s *spotSchedulingSuite) expectRunningSpot(c *assert.CollectT, pods []corev1.Pod, count int) {
+	g := groupPods(pods)
+	require.Equal(c, count, len(g[s.spotNode][corev1.PodRunning]),
+		"expected %d running spot pods; pod breakdown: %v", count, g)
+}
+
+// expectRunningOnDemand asserts that exactly count pods are Running on the on-demand node.
 func (s *spotSchedulingSuite) expectRunningOnDemand(c *assert.CollectT, pods []corev1.Pod, count int) {
-	actual := 0
-	for _, p := range pods {
-		if p.Status.Phase == corev1.PodRunning && p.Spec.NodeName == s.onDemandNode {
-			require.NotContains(c, p.Labels, spotAssignedLabel, "pod %s on on-demand node should not have spot-assigned label", p.Name)
-			actual++
-		}
-	}
-	require.Equal(c, count, actual, "expected %d running on-demand pods", count)
+	g := groupPods(pods)
+	require.Equal(c, count, len(g[s.onDemandNode][corev1.PodRunning]),
+		"expected %d running on-demand pods; pod breakdown: %v", count, g)
 }
 
 // identifyNodes finds the spot and on-demand worker nodes by autoscaling.datadoghq.com/capacity-type label.


### PR DESCRIPTION
What does this PR do
--------------------

Pin the test pod image to registry.k8s.io/pause:3.10.1 in both
createDeployment and createStatefulSet helpers.

Enable the node-agent DaemonSet with log collection scoped to the
cluster-agent container only, so that spot scheduler debug logs are
forwarded to Datadog for future failure investigations.

Improve expectRunningSpot and expectRunningOnDemand assertion helpers.
Add a groupPods helper that groups pods by node name and phase. Use it
in the assertion helpers to produce a breakdown of pod counts per phase
per node when assertions fail — so that actual=0 spot pods shows
exactly how many pods are in Pending, Failed, etc. on each node.

Motivation
----------

CI log analysis identified a source of pod startup delays on spot worker
nodes that caused pods to remain in Pending/ContainerCreating beyond
scheduleTimeout (30 s), repeatedly re-triggering the on-demand fallback
and producing actual=0 spot pods after the rebalancing window expired.

Without a version tag, registry.k8s.io/pause resolves to :latest and
Kubernetes applies imagePullPolicy: Always, performing a live manifest
HEAD request to registry.k8s.io on every pod startup. CI traces showed
this request timing out for 29-30 s on the spot worker node (11 hard
ErrImagePull failures and ~5000 live round-trips in the past week across
all spot scheduling clusters). Pinning to 3.10.1 sets the effective
policy to IfNotPresent; the image is bundled in kindest/node:v1.34.0 so
no network call is needed.

The node-agent was previously disabled as the spot scheduler only needs
the cluster-agent. However, without the node-agent there is no log
collection, making it impossible to inspect cluster-agent DEBUG logs
(already enabled via DD_LOG_LEVEL=DEBUG) when investigating failures.
Enabling the node-agent with containerCollectAll: false and a single
autodiscovery annotation on the cluster-agent pod collects only the
cluster-agent container logs with minimal overhead.

Describe how you validated your changes
---

Traced CI failures via Datadog logs from spot scheduling test clusters.

Updates https://datadoghq.atlassian.net/browse/CASCL-1222