### PR TITLE
fix panic in SBOM resolver

### DIFF
--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -379,9 +379,9 @@ func (r *Resolver) triggerForwarding(sbom *SBOM) {
 					imageSBOM, err := r.getContainerSBOM(sbom.ContainerID)
 					if err != nil || imageSBOM == nil {
 						seclog.Debugf("Failed to get image SBOM for container '%s': %v", sbom.ContainerID, err)
+					} else {
+						sbom.status = imageSBOM.Status
 					}
-
-					sbom.status = imageSBOM.Status
 				}
 
 				if sbom.status == workloadmeta.Pending || sbom.status == "" {


### PR DESCRIPTION
### What does this PR do?

Fixes panic due to nil `imageSBOM` variable

### Motivation

panics on nightly clusters introduced in #50226:
```
runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x50 pc=0x1bf93ff]
goroutine 1132 [running]:
github.com/DataDog/datadog-agent/pkg/security/resolvers/sbom.(*Resolver).triggerForwarding.func1()
	github.com/DataDog/datadog-agent/pkg/security/resolvers/sbom/resolver.go:384 +0x17f
github.com/skydive-project/go-debouncer.(*Debouncer).debounce(0xc003347780)
	github.com/skydive-project/go-debouncer@v1.0.1/debouncer.go:43 +0x8e
created by github.com/skydive-project/go-debouncer.(*Debouncer).Start in goroutine 1138
	github.com/skydive-project/go-debouncer@v1.0.1/debouncer.go:64 +0x4f
```

### Describe how you validated your changes

### Additional Notes
