### PR TITLE
fix(battery): skip macOS battery check on devices without batteries

### DIFF
--- a/pkg/collector/corechecks/system/battery/battery_darwin.go
+++ b/pkg/collector/corechecks/system/battery/battery_darwin.go
@@ -34,8 +34,7 @@ func optionalBool(o C.OptionalBool) option.Option[bool] {
 }
 
 func hasBatteryAvailable() (bool, error) {
-	cInfo := C.getBatteryInfo()
-	return bool(cInfo.found), nil
+	return bool(C.hasInternalBattery()), nil
 }
 
 // getBatteryInfo retrieves battery information from IOKit

--- a/pkg/collector/corechecks/system/battery/battery_darwin.h
+++ b/pkg/collector/corechecks/system/battery/battery_darwin.h
@@ -14,7 +14,6 @@ typedef struct {
 } OptionalBool;
 
 typedef struct {
-    bool found;
     OptionalInt cycleCount;
     OptionalInt designCapacity;
     OptionalInt appleRawMaxCapacity;
@@ -25,6 +24,7 @@ typedef struct {
     OptionalBool externalConnected;
 } BatteryInfo;
 
+bool hasInternalBattery(void);
 BatteryInfo getBatteryInfo(void);
 
 #endif

--- a/pkg/collector/corechecks/system/battery/battery_darwin.m
+++ b/pkg/collector/corechecks/system/battery/battery_darwin.m
@@ -1,6 +1,8 @@
 #import <Foundation/Foundation.h>
 #import <IOKit/IOKitLib.h>
 #import <IOKit/IOKitKeys.h>
+#import <IOKit/ps/IOPowerSources.h>
+#import <IOKit/ps/IOPSKeys.h>
 #import "battery_darwin.h"
 
 // kIOMainPortDefault was introduced in macOS 12.0, use kIOMasterPortDefault for older versions
@@ -9,6 +11,39 @@
 #else
 #define IOKIT_MAIN_PORT kIOMasterPortDefault
 #endif
+
+// hasInternalBattery reports whether macOS sees a real internal battery via the
+// PowerSources API. This avoids false positives on Mac minis, where an
+// AppleSmartBattery IOKit stub may be present even though no battery exists.
+bool hasInternalBattery(void) {
+    CFTypeRef blob = IOPSCopyPowerSourcesInfo();
+    if (blob == NULL) {
+        return false;
+    }
+    CFArrayRef list = IOPSCopyPowerSourcesList(blob);
+    if (list == NULL) {
+        CFRelease(blob);
+        return false;
+    }
+    bool found = false;
+    CFIndex count = CFArrayGetCount(list);
+    for (CFIndex i = 0; i < count; i++) {
+        CFTypeRef ps = CFArrayGetValueAtIndex(list, i);
+        CFDictionaryRef desc = IOPSGetPowerSourceDescription(blob, ps);
+        if (desc == NULL) {
+            continue;
+        }
+        CFStringRef type = CFDictionaryGetValue(desc, CFSTR(kIOPSTypeKey));
+        if (type != NULL &&
+            CFStringCompare(type, CFSTR(kIOPSInternalBatteryType), 0) == kCFCompareEqualTo) {
+            found = true;
+            break;
+        }
+    }
+    CFRelease(list);
+    CFRelease(blob);
+    return found;
+}
 
 static NSDictionary *getSmartBatteryProperties(void) {
     CFMutableDictionaryRef matching = IOServiceMatching("AppleSmartBattery");
@@ -39,8 +74,6 @@ BatteryInfo getBatteryInfo(void) {
         if (!props) {
             return info;
         }
-
-        info.found = true;
 
         if (props[@"DesignCapacity"] != nil) {
             info.designCapacity = (OptionalInt){true, [props[@"DesignCapacity"] intValue]};

--- a/pkg/collector/corechecks/system/battery/battery_darwin_testhelpers.go
+++ b/pkg/collector/corechecks/system/battery/battery_darwin_testhelpers.go
@@ -15,7 +15,6 @@ import "C"
 // testCBatteryInfo is a test fixture with all fields populated
 // Had to move this here because cgo is not supported in test files
 var testCBatteryInfo = C.BatteryInfo{
-	found:               true,
 	cycleCount:          C.OptionalInt{hasValue: true, value: 500},
 	designCapacity:      C.OptionalInt{hasValue: true, value: 5000},  // 5000 mAh
 	appleRawMaxCapacity: C.OptionalInt{hasValue: true, value: 4500},  // 4500 mAh (90% health)

--- a/releasenotes/notes/fix-mac-mini-battery-check-756aa44ffc56defd.yaml
+++ b/releasenotes/notes/fix-mac-mini-battery-check-756aa44ffc56defd.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix the macOS battery check detecting battery on Mac minis.


### PR DESCRIPTION
### What does this PR do?

Switches macOS battery presence detection from `IOServiceMatching(\"AppleSmartBattery\")` to `IOPSCopyPowerSourcesList` (`IOKit/ps/IOPowerSources.h`). Property reads continue to use the existing `AppleSmartBattery` IOKit lookup once a battery is confirmed.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-2696

On Mac minis (no physical battery), an `AppleSmartBattery` IOKit entry exists as a stub with mostly empty/zero properties. The old detection treated that as a battery being present, so the check ran and emitted bogus metrics:

- `system.battery.cycle_count = 0`
- `system.battery.current_charge_pct = 0`
- `system.battery.maximum_capacity_pct = null`
- `system.battery.charge_rate = null`

`IOPSCopyPowerSourcesList` (the API behind `pmset -g batt` and Activity Monitor) only returns real power sources. Filtering by `Type == kIOPSInternalBatteryType` correctly distinguishes Mac minis (no source) from MacBooks (one internal battery) on both Intel and Apple Silicon.

The check now correctly returns `check.ErrSkipCheckInstance` from `Configure` on Mac minis, so no `system.battery.*` metrics are emitted.

### Describe how you validated your changes

- [x] Existing unit tests pass: `dda inv test --targets=./pkg/collector/corechecks/system/battery` (17/17). Tests mock at the Go level, so they don't exercise the C path directly.
- [ ] Manual verification on a Mac mini: agent logs `No battery available, skipping check`, no `system.battery.*` metrics emitted. Sanity: `pmset -g batt` shows no internal battery.
- [ ] Manual verification on a MacBook: `system.battery.*` metrics emit with non-zero `cycle_count`, populated `current_charge_pct`, `maximum_capacity_pct`, and `charge_rate`. Sanity: `pmset -g batt` lists `InternalBattery-0`.

### Additional Notes

- No new framework links — `#cgo LDFLAGS: -framework IOKit` already covers IOPowerSources.
- The vestigial `found` field on `BatteryInfo` (only used as the old detection gate) was removed; the `testCBatteryInfo` fixture was updated accordingly.
- IOPowerSources has been a public macOS API since 10.2, so this works uniformly on Intel and Apple Silicon.