### PR TITLE
dyninst/object: fix DiskFile reservation leak on GC

### DIFF
--- a/pkg/dyninst/object/disk_cache.go
+++ b/pkg/dyninst/object/disk_cache.go
@@ -394,10 +394,14 @@ func (c *cachedSectionData) Close() error {
 // DiskFile is a writable file that reserves space from the DiskCache. It
 // enforces a maximum size and can be converted to a memory map.
 type DiskFile struct {
-	c             *DiskCache
-	f             *os.File
-	name          string
-	reservedSpace uint64
+	c    *DiskCache
+	f    *os.File
+	name string
+	// reservedSpace is heap-allocated and shared with the cleanup closure
+	// registered via runtime.AddCleanup so that the closure can observe the
+	// current reservation at finalization time without keeping the DiskFile
+	// itself reachable.
+	reservedSpace *uint64
 	maxSpace      uint64
 	used          uint64
 	cleanup       runtime.Cleanup
@@ -440,20 +444,27 @@ func (c *DiskCache) NewFile(name string, maxSize, initialSize uint64) (_ *DiskFi
 		return nil, err
 	}
 	type spaceAndFile struct {
-		space uint64
+		// space points at the DiskFile's reservedSpace counter so the cleanup
+		// observes growth from Write at finalization time. The pointer must
+		// not be reachable from the DiskFile itself or finalization would
+		// never run; both the DiskFile and this cleanup arg point at the
+		// same heap-allocated counter.
+		space *uint64
 		file  *os.File
 	}
+	reserved := new(uint64)
+	*reserved = initialSize
 	df := &DiskFile{
 		c:             c,
 		f:             f,
 		name:          name,
-		reservedSpace: initialSize,
+		reservedSpace: reserved,
 		maxSpace:      maxSize,
 	}
 	df.cleanup = runtime.AddCleanup(df, func(s spaceAndFile) {
 		_ = s.file.Close()
-		c.releaseSpace(s.space)
-	}, spaceAndFile{space: initialSize, file: f})
+		c.releaseSpace(*s.space)
+	}, spaceAndFile{space: reserved, file: f})
 	return df, nil
 }
 
@@ -478,15 +489,15 @@ func (df *DiskFile) Write(p []byte) (int, error) {
 	}
 
 	// Ensure reservation is large enough for this write.
-	if neededTotal > df.reservedSpace {
-		needed := neededTotal - df.reservedSpace
-		increment := max(needed, 2*df.reservedSpace)
+	if neededTotal > *df.reservedSpace {
+		needed := neededTotal - *df.reservedSpace
+		increment := max(needed, 2*(*df.reservedSpace))
 		remaining := df.maxSpace - df.used
 		increment = min(increment, remaining)
 		if err := df.c.reserveSpace(increment); err != nil {
 			return 0, err
 		}
-		df.reservedSpace += increment
+		*df.reservedSpace += increment
 	}
 
 	n, err := df.f.Write(p)
@@ -511,9 +522,9 @@ func (df *DiskFile) Close() error {
 	df.closed = true
 	err := df.f.Close()
 	df.f = nil
-	if df.reservedSpace > 0 {
-		df.c.releaseSpace(df.reservedSpace)
-		df.reservedSpace = 0
+	if *df.reservedSpace > 0 {
+		df.c.releaseSpace(*df.reservedSpace)
+		*df.reservedSpace = 0
 	}
 	df.used = 0
 	return err
@@ -594,17 +605,17 @@ func (df *DiskFile) IntoMMap(flags int) (_ SectionData, retErr error) {
 	// Decompression never ran; but release() expects refCount to be set.
 	df.c.mu.Lock()
 	// Replace reservation with actual usage in totalBytes.
-	if df.reservedSpace > df.c.mu.totalBytes {
+	if *df.reservedSpace > df.c.mu.totalBytes {
 		// Should not happen, but guard against underflow.
 		log.Errorf(
 			"IntoMMap: invariant violation: reservedSpace > totalBytes: %s > %s (delta: %s)",
-			humanize.IBytes(df.reservedSpace),
+			humanize.IBytes(*df.reservedSpace),
 			humanize.IBytes(df.c.mu.totalBytes),
-			humanize.IBytes(df.reservedSpace-df.c.mu.totalBytes),
+			humanize.IBytes(*df.reservedSpace-df.c.mu.totalBytes),
 		)
 		df.c.mu.totalBytes = 0
 	} else {
-		df.c.mu.totalBytes -= df.reservedSpace
+		df.c.mu.totalBytes -= *df.reservedSpace
 	}
 	df.c.mu.totalBytes += df.used
 	entry.cacheMu.refCount = 1
@@ -613,7 +624,7 @@ func (df *DiskFile) IntoMMap(flags int) (_ SectionData, retErr error) {
 	df.c.mu.Unlock()
 
 	// Finalize DiskFile state.
-	df.reservedSpace = 0
+	*df.reservedSpace = 0
 	df.closed = true
 	df.cleanup.Stop()
 	runtime.KeepAlive(df)

--- a/pkg/dyninst/object/disk_cache_test.go
+++ b/pkg/dyninst/object/disk_cache_test.go
@@ -200,6 +200,45 @@ func validateCacheVsProcMaps(t *testing.T, entryInfos map[string]object.EntryInf
 		len(cacheProcMaps), len(matchedProcMaps))
 }
 
+// TestDiskFileGCReleasesGrownReservation is a regression test for a bug where
+// the runtime.AddCleanup closure registered by NewFile captured the initial
+// reservation by value, so a DiskFile that grew its reservation via Write and
+// was then garbage-collected without Close would leak the difference between
+// the high-water mark and the initial size from the cache's accounting.
+func TestDiskFileGCReleasesGrownReservation(t *testing.T) {
+	const mib = 1 << 20
+	cacheDir := t.TempDir()
+	cache, err := object.NewDiskCacheInternal(object.DiskCacheConfig{
+		DirPath:                  cacheDir,
+		RequiredDiskSpaceBytes:   1, // permissive
+		RequiredDiskSpacePercent: 0,
+		MaxTotalBytes:            16 * mib,
+	}, stubDisk{total: 1 << 30, available: 1 << 30})
+	require.NoError(t, err)
+
+	// Repeatedly create a DiskFile with initialSize=0, write past the
+	// initial reservation, drop the reference without Close, and force GC.
+	// If the cleanup releases only the captured initial size, totalBytes
+	// drifts up by 4 MiB per iteration and NewFile starts failing once the
+	// drift reaches MaxTotalBytes.
+	for i := 0; i < 8; i++ {
+		func() {
+			df, err := cache.NewFile("test", 4*mib, 0)
+			require.NoError(t, err)
+			_, err = df.Write(make([]byte, 4*mib))
+			require.NoError(t, err)
+			// Intentionally drop df without Close.
+			_ = df
+		}()
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			runtime.GC()
+			runtime.GC()
+			assert.Zero(c, cache.SpaceInUse(),
+				"iteration %d: cache should be empty after GC", i)
+		}, 10*time.Second, time.Millisecond)
+	}
+}
+
 // stubDisk is a controllable implementation of the object.Disk interface for
 // exercising disk-space limit logic.
 type stubDisk struct {


### PR DESCRIPTION
### What does this PR do?

Indirect DiskFile.reservedSpace through a heap-allocated *uint64 shared between the DiskFile and the cleanup closure. The closure dereferences the pointer at finalization time, observing the current reservation rather than the captured initial value. The pointed-to uint64 is independently reachable from both sides, so it does not keep the DiskFile reachable and finalization still runs.


### Motivation

DiskCache.NewFile registered a runtime.AddCleanup closure that captured the initial reservation size by value. If a DiskFile was GC-finalized after Write had grown its reservation, the cleanup released only the initial size and the cache's totalBytes counter drifted upward by the high-water mark minus the initial size. With initialSize=0 the entire reservation leaked. Repeated leaks could push totalBytes to MaxTotalBytes and cause NewFile to reject new files even though the cache held no live DiskFiles.



### Describe how you validated your changes

Add TestDiskFileGCReleasesGrownReservation: repeatedly creates a DiskFile with initialSize=0, writes past the initial reservation, drops the reference without Close, forces GC, and asserts SpaceInUse() == 0. The test fails against the unfixed code.

### Additional Notes

Note that this was not a known bug in the wild because the finalizer is there for defense in depth and we don't have any known paths where the file is not explicitly closed.