### PR TITLE
fix(kubelet): avoid double-reporting when use_stats_summary_as_source is true

### DIFF
--- a/pkg/collector/corechecks/containers/kubelet/common/config.go
+++ b/pkg/collector/corechecks/containers/kubelet/common/config.go
@@ -9,6 +9,8 @@
 package common
 
 import (
+	"runtime"
+
 	"go.yaml.in/yaml/v2"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/types"
@@ -31,4 +33,15 @@ type KubeletConfig struct {
 // Parse parses the configuration.
 func (c *KubeletConfig) Parse(data []byte) error {
 	return yaml.Unmarshal(data, c)
+}
+
+// UseStatsSummary reports whether the /stats/summary endpoint should be the
+// source for metrics that are also emitted by /metrics/cadvisor. When the
+// option is unset, the default is true on Windows (where cAdvisor is not
+// available in modern kubelets) and false elsewhere.
+func (c *KubeletConfig) UseStatsSummary() bool {
+	if c.UseStatsSummaryAsSource != nil {
+		return *c.UseStatsSummaryAsSource
+	}
+	return runtime.GOOS == "windows"
 }

--- a/pkg/collector/corechecks/containers/kubelet/provider/cadvisor/provider.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/cadvisor/provider.go
@@ -60,6 +60,20 @@ var (
 	post116ContainerLabels = []string{"namespace", "name", "image", "id", "container", "pod"}
 
 	maxMemoryRss = math.Pow(2, 63)
+
+	// summaryOwnedMetricFamilies lists the cAdvisor metric families that are
+	// also produced by the /stats/summary endpoint. When the summary provider
+	// is configured as the source, these transformers are dropped from the
+	// cAdvisor provider to avoid double-reporting.
+	summaryOwnedMetricFamilies = []string{
+		"container_cpu_usage_seconds_total",
+		"container_memory_usage_bytes",
+		"container_memory_working_set_bytes",
+		"container_fs_usage_bytes",
+		"container_fs_limit_bytes",
+		"container_network_receive_bytes_total",
+		"container_network_transmit_bytes_total",
+	}
 )
 
 type uidFromLabelsFunc func(prom.Metric) string
@@ -125,6 +139,14 @@ func NewProvider(filterStore workloadfilter.Component, config *common.KubeletCon
 		"container_memory_swap":                            provider.containerMemorySwap,
 		"container_spec_memory_limit_bytes":                provider.containerSpecMemoryLimitBytes,
 		"container_spec_memory_swap_limit_bytes":           provider.containerSpecMemorySwapLimitBytes,
+	}
+
+	if config.UseStatsSummary() {
+		// The summary provider emits these metric families when it is configured
+		// as the source, so unregister them here to avoid double-reporting.
+		for _, name := range summaryOwnedMetricFamilies {
+			delete(transformers, name)
+		}
 	}
 
 	scraperConfig := &prometheus.ScraperConfig{

--- a/pkg/collector/corechecks/containers/kubelet/provider/cadvisor/provider_test.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/cadvisor/provider_test.go
@@ -8,6 +8,7 @@
 package cadvisor
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -83,7 +84,30 @@ var (
 		common.KubeletMetricsPrefix + "memory.rss",
 		common.KubeletMetricsPrefix + "memory.swap",
 	}
+
+	// expectedMetricsSummaryOverlap is the subset of expectedMetricsPrometheus
+	// that the summary provider also reports. When summary is the source these
+	// metrics are not emitted by the cAdvisor provider.
+	expectedMetricsSummaryOverlap = []string{
+		common.KubeletMetricsPrefix + "cpu.usage.total",
+		common.KubeletMetricsPrefix + "memory.usage",
+		common.KubeletMetricsPrefix + "memory.working_set",
+		common.KubeletMetricsPrefix + "filesystem.usage",
+		common.KubeletMetricsPrefix + "filesystem.usage_pct",
+		common.KubeletMetricsPrefix + "network.rx_bytes",
+		common.KubeletMetricsPrefix + "network.tx_bytes",
+	}
 )
+
+func expectedMetricsWithoutSummaryOverlap() []string {
+	filtered := make([]string, 0, len(expectedMetricsPrometheus))
+	for _, metric := range expectedMetricsPrometheus {
+		if !slices.Contains(expectedMetricsSummaryOverlap, metric) {
+			filtered = append(filtered, metric)
+		}
+	}
+	return filtered
+}
 
 type ProviderTestSuite struct {
 	suite.Suite
@@ -94,6 +118,10 @@ type ProviderTestSuite struct {
 }
 
 func (suite *ProviderTestSuite) SetupTest() {
+	suite.setupTestWithConfig(nil)
+}
+
+func (suite *ProviderTestSuite) setupTestWithConfig(mutate func(*common.KubeletConfig)) {
 	var err error
 
 	store := fxutil.Test[workloadmetamock.Mock](suite.T(), fx.Options(
@@ -131,6 +159,9 @@ func (suite *ProviderTestSuite) SetupTest() {
 			Namespace:            common.KubeletMetricsPrefix,
 		},
 	}
+	if mutate != nil {
+		mutate(config)
+	}
 	mockFilterStore := workloadfilterfxmock.SetupMockFilter(suite.T())
 
 	p, err := NewProvider(
@@ -149,22 +180,18 @@ func TestProviderTestSuite(t *testing.T) {
 }
 
 func (suite *ProviderTestSuite) TestExpectedMetricsShowUp() {
-	type want struct {
-		metrics []string
-		err     error
-	}
 	tests := []struct {
-		name     string
-		response commontesting.EndpointResponse
-		want     want
+		name          string
+		response      commontesting.EndpointResponse
+		configMutator func(*common.KubeletConfig)
+		wantMetrics   []string
+		wantErr       error
 	}{
 		{
 			name: "pre 1.16 metrics all show up",
 			response: commontesting.NewEndpointResponse(
 				"../../testdata/cadvisor_metrics_pre_1_16.txt", 200, nil),
-			want: want{
-				metrics: expectedMetricsPrometheus,
-			},
+			wantMetrics: expectedMetricsPrometheus,
 		},
 		{
 			// All the metrics reported by this provider require container or pod metadata in the store, and drop the
@@ -173,14 +200,22 @@ func (suite *ProviderTestSuite) TestExpectedMetricsShowUp() {
 			name: "no matching pod data no metrics show up",
 			response: commontesting.NewEndpointResponse(
 				"../../testdata/cadvisor_metrics_1_21.txt", 200, nil),
-			want: want{
-				metrics: []string{},
+			wantMetrics: []string{},
+		},
+		{
+			name: "summary as source disables overlapping metrics",
+			response: commontesting.NewEndpointResponse(
+				"../../testdata/cadvisor_metrics_pre_1_16.txt", 200, nil),
+			configMutator: func(c *common.KubeletConfig) {
+				enabled := true
+				c.UseStatsSummaryAsSource = &enabled
 			},
+			wantMetrics: expectedMetricsWithoutSummaryOverlap(),
 		},
 	}
 	for _, tt := range tests {
 		suite.T().Run(tt.name, func(t *testing.T) {
-			suite.SetupTest()
+			suite.setupTestWithConfig(tt.configMutator)
 			kubeletMock, err := commontesting.CreateKubeletMock(tt.response, endpoint)
 			if err != nil {
 				suite.T().Fatalf("error created kubelet mock: %v", err)
@@ -190,12 +225,12 @@ func (suite *ProviderTestSuite) TestExpectedMetricsShowUp() {
 			_ = suite.provider.Provide(kubeletMock, suite.mockSender)
 			suite.mockSender.ResetCalls()
 			err = suite.provider.Provide(kubeletMock, suite.mockSender)
-			if err != tt.want.err {
-				t.Errorf("Collect() error = %v, wantErr %v", err, tt.want.err)
+			if err != tt.wantErr {
+				t.Errorf("Collect() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 
-			commontesting.AssertMetricCallsMatch(t, tt.want.metrics, suite.mockSender)
+			commontesting.AssertMetricCallsMatch(t, tt.wantMetrics, suite.mockSender)
 		})
 	}
 }

--- a/pkg/collector/corechecks/containers/kubelet/provider/summary/provider.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/summary/provider.go
@@ -11,7 +11,6 @@ package summary
 import (
 	"context"
 	"regexp"
-	"runtime"
 	"strings"
 	"time"
 
@@ -77,14 +76,7 @@ func (p *Provider) Provide(kc kubelet.KubeUtilInterface, sender sender.Sender) e
 		return err
 	}
 
-	useStatsAsSource := false
-	if p.config.UseStatsSummaryAsSource == nil {
-		if runtime.GOOS == "windows" {
-			useStatsAsSource = true
-		}
-	} else {
-		useStatsAsSource = *p.config.UseStatsSummaryAsSource
-	}
+	useStatsAsSource := p.config.UseStatsSummary()
 
 	rateFilterList := p.defaultRateFilterList
 	if len(p.config.EnabledRates) > 0 {


### PR DESCRIPTION
### What does this PR do?

When `use_stats_summary_as_source` is enabled, the kubelet check now collects overlapping container metrics from the stats summary endpoint only. The cAdvisor provider stops registering Prometheus transformers for the same metric families (`container_cpu_usage_seconds_total`, memory, filesystem usage/limit, and pod network byte counters), so `kubernetes.cpu.usage.total`, `kubernetes.memory.*`, filesystem, and pod network metrics are no longer emitted twice.

The `nil` config case (default on Linux is summary off; on Windows summary on) is consolidated into a single `KubeletConfig.UseStatsSummary()` helper used by both the summary and cAdvisor providers.

### Motivation

Fixes double counting reported in [#50544](https://github.com/DataDog/datadog-agent/issues/50544): with `use_stats_summary_as_source: true`, `sum:` aggregations of `kubernetes.cpu.usage.total` and `kubernetes.memory.*` roughly doubled because both `/metrics/cadvisor` and `/stats/summary` were active for the same series.

### Describe how you validated your changes

- Unit tests: extended the cAdvisor provider table test to assert expected metrics when summary is the source (`expectedMetricsWithoutSummaryOverlap`).
- CI should run the kubelet-related packages; please run `dda inv test --targets=./pkg/collector/corechecks/containers/kubelet/...` locally if needed (not re-run here after push).

### Additional Notes

Closes #50544.