### PR TITLE
[CONTP-1600] feat: autodiscovery handler for datadoginstrumentation

### DIFF
--- a/pkg/clusteragent/instrumentation/handlers/BUILD.bazel
+++ b/pkg/clusteragent/instrumentation/handlers/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "handlers",
@@ -9,9 +9,31 @@ go_library(
     importpath = "github.com/DataDog/datadog-agent/pkg/clusteragent/instrumentation/handlers",
     visibility = ["//visibility:public"],
     deps = [
+        "//comp/core/autodiscovery/integration",
+        "//comp/core/workloadfilter/def",
         "//pkg/clusteragent/instrumentation",
         "@com_github_datadog_datadog_operator_api//datadoghq/v1alpha1",
         "@io_k8s_api//autoscaling/v2:autoscaling",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_apimachinery//pkg/runtime",
+    ],
+)
+
+go_test(
+    name = "handlers_test",
+    srcs = ["autodiscovery_test.go"],
+    embed = [":handlers"],
+    gotags = [
+        "kubeapiserver",
+        "test",
+    ],
+    deps = [
+        "//pkg/clusteragent/instrumentation",
+        "@com_github_datadog_datadog_operator_api//datadoghq/v1alpha1",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@io_k8s_api//autoscaling/v2:autoscaling",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_apimachinery//pkg/runtime",
     ],
 )

--- a/pkg/clusteragent/instrumentation/handlers/autodiscovery.go
+++ b/pkg/clusteragent/instrumentation/handlers/autodiscovery.go
@@ -27,9 +27,9 @@ import (
 const (
 	checksReadyConditionType = "ChecksReady"
 
-	// AutodiscoveryProvider is the integration.Config Provider value used for configs
+	// autodiscoveryProvider is the integration.Config Provider value used for configs
 	// translated from a DatadogInstrumentation CR by the Autodiscovery handler.
-	AutodiscoveryProvider = "datadoginstrumentation"
+	autodiscoveryProvider = "datadoginstrumentation"
 )
 
 // AutodiscoveryHandler translates DatadogInstrumentation check sections into
@@ -57,9 +57,9 @@ func (h *AutodiscoveryHandler) HasSection(cr *datadoghq.DatadogInstrumentation) 
 }
 
 // SupportsTarget returns whether Autodiscovery check delivery supports the target kind.
-// Service is delivered through endpoint checks by ServiceAutodiscoveryHandler.
 func (h *AutodiscoveryHandler) SupportsTarget(ref autoscalingv2.CrossVersionObjectReference) bool {
 	switch ref.Kind {
+	// 'Service' kind isn't supported but will be in the future.
 	case "Deployment", "DaemonSet", "StatefulSet", "CronJob", "Job":
 		return true
 	default:
@@ -213,14 +213,14 @@ func translateCheck(cr *datadoghq.DatadogInstrumentation, check datadoghq.Datado
 		Instances:   instances,
 		LogsConfig:  logsConfig,
 		CELSelector: buildCELSelector(cr.Spec.TargetRef, cr.Namespace, check.ContainerImage),
-		Provider:    AutodiscoveryProvider,
-		Source:      fmt.Sprintf("%s:%s/%s", AutodiscoveryProvider, cr.Namespace, cr.Name),
+		Provider:    autodiscoveryProvider,
+		Source:      fmt.Sprintf("%s:%s/%s", autodiscoveryProvider, cr.Namespace, cr.Name),
 	}, nil
 }
 
 func rawExtensionToData(raw runtime.RawExtension) (integration.Data, error) {
 	if len(raw.Raw) > 0 {
-		return integration.Data(raw.Raw), nil
+		return raw.Raw, nil
 	}
 	if raw.Object == nil {
 		return nil, nil
@@ -229,7 +229,7 @@ func rawExtensionToData(raw runtime.RawExtension) (integration.Data, error) {
 	if err != nil {
 		return nil, err
 	}
-	return integration.Data(b), nil
+	return b, nil
 }
 
 func marshalLogs(logs []datadoghq.DatadogInstrumentationLogConfig) (integration.Data, error) {
@@ -240,7 +240,7 @@ func marshalLogs(logs []datadoghq.DatadogInstrumentationLogConfig) (integration.
 	if err != nil {
 		return nil, err
 	}
-	return integration.Data(b), nil
+	return b, nil
 }
 
 func buildCELSelector(ref autoscalingv2.CrossVersionObjectReference, namespace string, images []string) workloadfilter.Rules {

--- a/pkg/clusteragent/instrumentation/handlers/autodiscovery.go
+++ b/pkg/clusteragent/instrumentation/handlers/autodiscovery.go
@@ -108,7 +108,7 @@ func (h *AutodiscoveryHandler) Handle(_ context.Context, event instrumentation.E
 		}, nil
 	}
 
-	key := storeKey(cr.Namespace, cr.Name)
+	key := cr.Namespace + "/" + cr.Name
 
 	if event == instrumentation.EventDelete {
 		h.deleteConfigs(key)
@@ -120,14 +120,18 @@ func (h *AutodiscoveryHandler) Handle(_ context.Context, event instrumentation.E
 		}, nil
 	}
 
-	configs, err := translateChecks(cr)
-	if err != nil {
-		return instrumentation.HandlerStatus{
-			Type:    checksReadyConditionType,
-			Status:  metav1.ConditionFalse,
-			Reason:  "TranslationFailed",
-			Message: err.Error(),
-		}, nil
+	configs := make([]integration.Config, 0, len(cr.Spec.Config.Checks))
+	for _, check := range cr.Spec.Config.Checks {
+		cfg, err := translateCheck(cr, check)
+		if err != nil {
+			return instrumentation.HandlerStatus{
+				Type:    checksReadyConditionType,
+				Status:  metav1.ConditionFalse,
+				Reason:  "TranslationFailed",
+				Message: err.Error(),
+			}, nil
+		}
+		configs = append(configs, cfg)
 	}
 
 	h.setConfigs(key, configs)
@@ -168,22 +172,6 @@ func (h *AutodiscoveryHandler) deleteConfigs(key string) {
 	delete(h.configs, key)
 }
 
-func storeKey(namespace, name string) string {
-	return namespace + "/" + name
-}
-
-func translateChecks(cr *datadoghq.DatadogInstrumentation) ([]integration.Config, error) {
-	configs := make([]integration.Config, 0, len(cr.Spec.Config.Checks))
-	for i, check := range cr.Spec.Config.Checks {
-		cfg, err := translateCheck(cr, check)
-		if err != nil {
-			return nil, fmt.Errorf("spec.config.checks[%d]: %w", i, err)
-		}
-		configs = append(configs, cfg)
-	}
-	return configs, nil
-}
-
 func translateCheck(cr *datadoghq.DatadogInstrumentation, check datadoghq.DatadogInstrumentationCheckConfig) (integration.Config, error) {
 	initConfig, err := rawExtensionToData(check.InitConfig)
 	if err != nil {
@@ -208,13 +196,13 @@ func translateCheck(cr *datadoghq.DatadogInstrumentation, check datadoghq.Datado
 	}
 
 	return integration.Config{
-		Name:        check.Integration,
-		InitConfig:  initConfig,
-		Instances:   instances,
-		LogsConfig:  logsConfig,
-		CELSelector: buildCELSelector(cr.Spec.TargetRef, cr.Namespace, check.ContainerImage),
-		Provider:    autodiscoveryProvider,
-		Source:      fmt.Sprintf("%s:%s/%s", autodiscoveryProvider, cr.Namespace, cr.Name),
+		Name:          check.Integration,
+		ADIdentifiers: check.ContainerImage,
+		InitConfig:    initConfig,
+		Instances:     instances,
+		LogsConfig:    logsConfig,
+		CELSelector:   buildCELSelector(cr.Spec.TargetRef, cr.Namespace),
+		Source:        fmt.Sprintf("%s:%s/%s", autodiscoveryProvider, cr.Namespace, cr.Name),
 	}, nil
 }
 
@@ -243,18 +231,11 @@ func marshalLogs(logs []datadoghq.DatadogInstrumentationLogConfig) (integration.
 	return b, nil
 }
 
-func buildCELSelector(ref autoscalingv2.CrossVersionObjectReference, namespace string, images []string) workloadfilter.Rules {
+func buildCELSelector(ref autoscalingv2.CrossVersionObjectReference, namespace string) workloadfilter.Rules {
 	expr := fmt.Sprintf(
 		`container.pod.rootowner.kind == %q && container.pod.rootowner.name == %q && container.pod.namespace == %q`,
 		ref.Kind, ref.Name, namespace,
 	)
-	if len(images) > 0 {
-		quoted := make([]string, 0, len(images))
-		for _, img := range images {
-			quoted = append(quoted, fmt.Sprintf("%q", img))
-		}
-		expr = fmt.Sprintf("%s && container.image.name in [%s]", expr, strings.Join(quoted, ", "))
-	}
 	return workloadfilter.Rules{
 		Containers: []string{expr},
 	}

--- a/pkg/clusteragent/instrumentation/handlers/autodiscovery.go
+++ b/pkg/clusteragent/instrumentation/handlers/autodiscovery.go
@@ -83,12 +83,22 @@ func (h *AutodiscoveryHandler) Validate(cr *datadoghq.DatadogInstrumentation) []
 				HandlerName: h.Name(),
 			})
 		}
-		if len(check.Instances) == 0 {
+		if len(check.Instances) == 0 && len(check.Logs) == 0 {
 			errs = append(errs, instrumentation.ValidationError{
 				Type:        checksReadyConditionType,
 				Reason:      "InvalidInstances",
-				Message:     "at least one instance is required",
+				Message:     "at least one instance or log config is required",
 				Field:       fmt.Sprintf("spec.config.checks[%d].instances", i),
+				HandlerName: h.Name(),
+			})
+		}
+
+		if len(check.ContainerImage) == 0 {
+			errs = append(errs, instrumentation.ValidationError{
+				Type:        checksReadyConditionType,
+				Reason:      "InvalidContainerImage",
+				Message:     "at least one container image is required",
+				Field:       fmt.Sprintf("spec.config.checks[%d].containerImage", i),
 				HandlerName: h.Name(),
 			})
 		}

--- a/pkg/clusteragent/instrumentation/handlers/autodiscovery.go
+++ b/pkg/clusteragent/instrumentation/handlers/autodiscovery.go
@@ -9,23 +9,41 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
 
-	"github.com/DataDog/datadog-agent/pkg/clusteragent/instrumentation"
 	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/instrumentation"
 )
 
-const checksReadyConditionType = "ChecksReady"
+const (
+	checksReadyConditionType = "ChecksReady"
 
-// TODO: Implement check translation and delivery.
+	// AutodiscoveryProvider is the integration.Config Provider value used for configs
+	// translated from a DatadogInstrumentation CR by the Autodiscovery handler.
+	AutodiscoveryProvider = "datadoginstrumentation"
+)
 
-// AutodiscoveryHandler is the shell for DatadogInstrumentation check configuration handling.
-type AutodiscoveryHandler struct{}
+// AutodiscoveryHandler translates DatadogInstrumentation check sections into
+// integration.Config entries and stores them in memory for delivery to node agents.
+type AutodiscoveryHandler struct {
+	mu      sync.RWMutex
+	configs map[string][]integration.Config
+}
 
 // NewAutodiscoveryHandler returns the Autodiscovery DatadogInstrumentation handler.
 func NewAutodiscoveryHandler(_ Deps) *AutodiscoveryHandler {
-	return &AutodiscoveryHandler{}
+	return &AutodiscoveryHandler{
+		configs: make(map[string][]integration.Config),
+	}
 }
 
 // Name returns the unique handler name.
@@ -39,26 +57,205 @@ func (h *AutodiscoveryHandler) HasSection(cr *datadoghq.DatadogInstrumentation) 
 }
 
 // SupportsTarget returns whether Autodiscovery check delivery supports the target kind.
+// Service is delivered through endpoint checks by ServiceAutodiscoveryHandler.
 func (h *AutodiscoveryHandler) SupportsTarget(ref autoscalingv2.CrossVersionObjectReference) bool {
 	switch ref.Kind {
-	case "Deployment", "DaemonSet", "StatefulSet", "CronJob", "Job", "Service":
+	case "Deployment", "DaemonSet", "StatefulSet", "CronJob", "Job":
 		return true
 	default:
 		return false
 	}
 }
 
-// Validate performs no additional validation beyond CRD schema validation for now.
-func (h *AutodiscoveryHandler) Validate(_ *datadoghq.DatadogInstrumentation) []instrumentation.ValidationError {
-	return nil
+// Validate reports per-check validation errors against spec.config.checks.
+func (h *AutodiscoveryHandler) Validate(cr *datadoghq.DatadogInstrumentation) []instrumentation.ValidationError {
+	if cr == nil {
+		return nil
+	}
+	var errs []instrumentation.ValidationError
+	for i, check := range cr.Spec.Config.Checks {
+		if strings.TrimSpace(check.Integration) == "" {
+			errs = append(errs, instrumentation.ValidationError{
+				Type:        checksReadyConditionType,
+				Reason:      "InvalidIntegration",
+				Message:     "integration name must not be empty",
+				Field:       fmt.Sprintf("spec.config.checks[%d].integration", i),
+				HandlerName: h.Name(),
+			})
+		}
+		if len(check.Instances) == 0 {
+			errs = append(errs, instrumentation.ValidationError{
+				Type:        checksReadyConditionType,
+				Reason:      "InvalidInstances",
+				Message:     "at least one instance is required",
+				Field:       fmt.Sprintf("spec.config.checks[%d].instances", i),
+				HandlerName: h.Name(),
+			})
+		}
+	}
+	return errs
 }
 
-// Handle is intentionally non-functional until the Autodiscovery delivery implementation is added.
-func (h *AutodiscoveryHandler) Handle(_ context.Context, _ instrumentation.EventType, _ *datadoghq.DatadogInstrumentation) (instrumentation.HandlerStatus, error) {
+// Handle translates check configs into integration.Config entries on Create/Update,
+// removes them on Delete, and reports a ChecksReady status.
+func (h *AutodiscoveryHandler) Handle(_ context.Context, event instrumentation.EventType, cr *datadoghq.DatadogInstrumentation) (instrumentation.HandlerStatus, error) {
+	if cr == nil {
+		return instrumentation.HandlerStatus{
+			Type:    checksReadyConditionType,
+			Status:  metav1.ConditionUnknown,
+			Reason:  "MissingResource",
+			Message: "DatadogInstrumentation resource is nil",
+		}, nil
+	}
+
+	key := storeKey(cr.Namespace, cr.Name)
+
+	if event == instrumentation.EventDelete {
+		h.deleteConfigs(key)
+		return instrumentation.HandlerStatus{
+			Type:    checksReadyConditionType,
+			Status:  metav1.ConditionTrue,
+			Reason:  "Deleted",
+			Message: fmt.Sprintf("checks removed for %s/%s", cr.Spec.TargetRef.Kind, cr.Spec.TargetRef.Name),
+		}, nil
+	}
+
+	configs, err := translateChecks(cr)
+	if err != nil {
+		return instrumentation.HandlerStatus{
+			Type:    checksReadyConditionType,
+			Status:  metav1.ConditionFalse,
+			Reason:  "TranslationFailed",
+			Message: err.Error(),
+		}, nil
+	}
+
+	h.setConfigs(key, configs)
+
 	return instrumentation.HandlerStatus{
 		Type:    checksReadyConditionType,
-		Status:  metav1.ConditionUnknown,
-		Reason:  "HandlerNotImplemented",
-		Message: "Autodiscovery DatadogInstrumentation handling is not implemented yet.",
+		Status:  metav1.ConditionTrue,
+		Reason:  "Configured",
+		Message: fmt.Sprintf("%d check(s) configured for %s/%s", len(configs), cr.Spec.TargetRef.Kind, cr.Spec.TargetRef.Name),
 	}, nil
+}
+
+// ListConfigs returns a snapshot of all stored integration.Config entries
+// across all DatadogInstrumentation CRs handled by this instance.
+func (h *AutodiscoveryHandler) ListConfigs() []integration.Config {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	out := make([]integration.Config, 0)
+	for _, cfgs := range h.configs {
+		out = append(out, cfgs...)
+	}
+	return out
+}
+
+func (h *AutodiscoveryHandler) setConfigs(key string, configs []integration.Config) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if len(configs) == 0 {
+		delete(h.configs, key)
+		return
+	}
+	h.configs[key] = configs
+}
+
+func (h *AutodiscoveryHandler) deleteConfigs(key string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	delete(h.configs, key)
+}
+
+func storeKey(namespace, name string) string {
+	return namespace + "/" + name
+}
+
+func translateChecks(cr *datadoghq.DatadogInstrumentation) ([]integration.Config, error) {
+	configs := make([]integration.Config, 0, len(cr.Spec.Config.Checks))
+	for i, check := range cr.Spec.Config.Checks {
+		cfg, err := translateCheck(cr, check)
+		if err != nil {
+			return nil, fmt.Errorf("spec.config.checks[%d]: %w", i, err)
+		}
+		configs = append(configs, cfg)
+	}
+	return configs, nil
+}
+
+func translateCheck(cr *datadoghq.DatadogInstrumentation, check datadoghq.DatadogInstrumentationCheckConfig) (integration.Config, error) {
+	initConfig, err := rawExtensionToData(check.InitConfig)
+	if err != nil {
+		return integration.Config{}, fmt.Errorf("init_config: %w", err)
+	}
+	if len(initConfig) == 0 {
+		initConfig = integration.Data("{}")
+	}
+
+	instances := make([]integration.Data, 0, len(check.Instances))
+	for j, raw := range check.Instances {
+		data, err := rawExtensionToData(raw)
+		if err != nil {
+			return integration.Config{}, fmt.Errorf("instances[%d]: %w", j, err)
+		}
+		instances = append(instances, data)
+	}
+
+	logsConfig, err := marshalLogs(check.Logs)
+	if err != nil {
+		return integration.Config{}, fmt.Errorf("logs: %w", err)
+	}
+
+	return integration.Config{
+		Name:        check.Integration,
+		InitConfig:  initConfig,
+		Instances:   instances,
+		LogsConfig:  logsConfig,
+		CELSelector: buildCELSelector(cr.Spec.TargetRef, cr.Namespace, check.ContainerImage),
+		Provider:    AutodiscoveryProvider,
+		Source:      fmt.Sprintf("%s:%s/%s", AutodiscoveryProvider, cr.Namespace, cr.Name),
+	}, nil
+}
+
+func rawExtensionToData(raw runtime.RawExtension) (integration.Data, error) {
+	if len(raw.Raw) > 0 {
+		return integration.Data(raw.Raw), nil
+	}
+	if raw.Object == nil {
+		return nil, nil
+	}
+	b, err := json.Marshal(raw.Object)
+	if err != nil {
+		return nil, err
+	}
+	return integration.Data(b), nil
+}
+
+func marshalLogs(logs []datadoghq.DatadogInstrumentationLogConfig) (integration.Data, error) {
+	if len(logs) == 0 {
+		return nil, nil
+	}
+	b, err := json.Marshal(logs)
+	if err != nil {
+		return nil, err
+	}
+	return integration.Data(b), nil
+}
+
+func buildCELSelector(ref autoscalingv2.CrossVersionObjectReference, namespace string, images []string) workloadfilter.Rules {
+	expr := fmt.Sprintf(
+		`container.pod.rootowner.kind == %q && container.pod.rootowner.name == %q && container.pod.namespace == %q`,
+		ref.Kind, ref.Name, namespace,
+	)
+	if len(images) > 0 {
+		quoted := make([]string, 0, len(images))
+		for _, img := range images {
+			quoted = append(quoted, fmt.Sprintf("%q", img))
+		}
+		expr = fmt.Sprintf("%s && container.image.name in [%s]", expr, strings.Join(quoted, ", "))
+	}
+	return workloadfilter.Rules{
+		Containers: []string{expr},
+	}
 }

--- a/pkg/clusteragent/instrumentation/handlers/autodiscovery_test.go
+++ b/pkg/clusteragent/instrumentation/handlers/autodiscovery_test.go
@@ -1,0 +1,441 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/instrumentation"
+)
+
+func newHandler() *AutodiscoveryHandler {
+	return NewAutodiscoveryHandler(Deps{})
+}
+
+func newCR(name, namespace string, targetKind, targetName string, checks []datadoghq.DatadogInstrumentationCheckConfig) *datadoghq.DatadogInstrumentation {
+	return &datadoghq.DatadogInstrumentation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: datadoghq.DatadogInstrumentationSpec{
+			TargetRef: autoscalingv2.CrossVersionObjectReference{
+				Kind: targetKind,
+				Name: targetName,
+			},
+			Config: datadoghq.DatadogInstrumentationConfig{
+				Checks: checks,
+			},
+		},
+	}
+}
+
+func rawJSON(t *testing.T, v interface{}) runtime.RawExtension {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return runtime.RawExtension{Raw: b}
+}
+
+func TestName(t *testing.T) {
+	h := newHandler()
+	assert.Equal(t, "autodiscovery", h.Name())
+}
+
+func TestHasSection(t *testing.T) {
+	tests := []struct {
+		name     string
+		cr       *datadoghq.DatadogInstrumentation
+		expected bool
+	}{
+		{
+			name:     "nil CR",
+			cr:       nil,
+			expected: false,
+		},
+		{
+			name:     "no checks",
+			cr:       newCR("test", "default", "Deployment", "app", nil),
+			expected: false,
+		},
+		{
+			name: "with checks",
+			cr: newCR("test", "default", "Deployment", "app", []datadoghq.DatadogInstrumentationCheckConfig{
+				{Integration: "redisdb"},
+			}),
+			expected: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newHandler()
+			assert.Equal(t, tt.expected, h.HasSection(tt.cr))
+		})
+	}
+}
+
+func TestSupportsTarget(t *testing.T) {
+	tests := []struct {
+		kind     string
+		expected bool
+	}{
+		{"Deployment", true},
+		{"DaemonSet", true},
+		{"StatefulSet", true},
+		{"CronJob", true},
+		{"Job", true},
+		{"Service", false},
+		{"ReplicaSet", false},
+		{"Pod", false},
+		{"", false},
+	}
+	h := newHandler()
+	for _, tt := range tests {
+		t.Run(tt.kind, func(t *testing.T) {
+			ref := autoscalingv2.CrossVersionObjectReference{Kind: tt.kind, Name: "test"}
+			assert.Equal(t, tt.expected, h.SupportsTarget(ref))
+		})
+	}
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		cr          *datadoghq.DatadogInstrumentation
+		expectCount int
+		expectField string
+	}{
+		{
+			name:        "nil CR returns nil",
+			cr:          nil,
+			expectCount: 0,
+		},
+		{
+			name: "valid check",
+			cr: newCR("test", "default", "Deployment", "app", []datadoghq.DatadogInstrumentationCheckConfig{
+				{
+					Integration: "redisdb",
+					Instances:   []runtime.RawExtension{rawJSON(t, map[string]string{"host": "localhost"})},
+				},
+			}),
+			expectCount: 0,
+		},
+		{
+			name: "empty integration name",
+			cr: newCR("test", "default", "Deployment", "app", []datadoghq.DatadogInstrumentationCheckConfig{
+				{
+					Integration: "",
+					Instances:   []runtime.RawExtension{rawJSON(t, map[string]string{"host": "localhost"})},
+				},
+			}),
+			expectCount: 1,
+			expectField: "spec.config.checks[0].integration",
+		},
+		{
+			name: "whitespace-only integration name",
+			cr: newCR("test", "default", "Deployment", "app", []datadoghq.DatadogInstrumentationCheckConfig{
+				{
+					Integration: "   ",
+					Instances:   []runtime.RawExtension{rawJSON(t, map[string]string{"host": "localhost"})},
+				},
+			}),
+			expectCount: 1,
+			expectField: "spec.config.checks[0].integration",
+		},
+		{
+			name: "no instances",
+			cr: newCR("test", "default", "Deployment", "app", []datadoghq.DatadogInstrumentationCheckConfig{
+				{
+					Integration: "redisdb",
+					Instances:   nil,
+				},
+			}),
+			expectCount: 1,
+			expectField: "spec.config.checks[0].instances",
+		},
+		{
+			name: "empty integration and no instances",
+			cr: newCR("test", "default", "Deployment", "app", []datadoghq.DatadogInstrumentationCheckConfig{
+				{Integration: "", Instances: nil},
+			}),
+			expectCount: 2,
+		},
+		{
+			name: "multiple checks with mixed errors",
+			cr: newCR("test", "default", "Deployment", "app", []datadoghq.DatadogInstrumentationCheckConfig{
+				{
+					Integration: "redisdb",
+					Instances:   []runtime.RawExtension{rawJSON(t, map[string]string{"host": "localhost"})},
+				},
+				{
+					Integration: "",
+					Instances:   []runtime.RawExtension{rawJSON(t, map[string]string{"host": "localhost"})},
+				},
+			}),
+			expectCount: 1,
+			expectField: "spec.config.checks[1].integration",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newHandler()
+			errs := h.Validate(tt.cr)
+			assert.Len(t, errs, tt.expectCount)
+			if tt.expectField != "" && len(errs) > 0 {
+				assert.Equal(t, tt.expectField, errs[0].Field)
+			}
+			for _, e := range errs {
+				assert.Equal(t, checksReadyConditionType, e.Type)
+				assert.Equal(t, "autodiscovery", e.HandlerName)
+			}
+		})
+	}
+}
+
+func TestHandle_NilCR(t *testing.T) {
+	h := newHandler()
+	status, err := h.Handle(context.Background(), instrumentation.EventCreate, nil)
+	require.NoError(t, err)
+	assert.Equal(t, metav1.ConditionUnknown, status.Status)
+	assert.Equal(t, "MissingResource", status.Reason)
+}
+
+func TestHandle_Delete(t *testing.T) {
+	h := newHandler()
+	cr := newCR("test", "default", "Deployment", "my-app", []datadoghq.DatadogInstrumentationCheckConfig{
+		{
+			Integration: "redisdb",
+			Instances:   []runtime.RawExtension{rawJSON(t, map[string]string{"host": "localhost"})},
+		},
+	})
+
+	// First create configs
+	_, err := h.Handle(context.Background(), instrumentation.EventCreate, cr)
+	require.NoError(t, err)
+	assert.Len(t, h.ListConfigs(), 1)
+
+	// Then delete
+	status, err := h.Handle(context.Background(), instrumentation.EventDelete, cr)
+	require.NoError(t, err)
+	assert.Equal(t, metav1.ConditionTrue, status.Status)
+	assert.Equal(t, "Deleted", status.Reason)
+	assert.Empty(t, h.ListConfigs())
+}
+
+func TestHandle_CreateAndUpdate(t *testing.T) {
+	h := newHandler()
+	cr := newCR("test", "default", "Deployment", "my-app", []datadoghq.DatadogInstrumentationCheckConfig{
+		{
+			Integration: "redisdb",
+			Instances:   []runtime.RawExtension{rawJSON(t, map[string]string{"host": "localhost"})},
+		},
+	})
+
+	// Create
+	status, err := h.Handle(context.Background(), instrumentation.EventCreate, cr)
+	require.NoError(t, err)
+	assert.Equal(t, metav1.ConditionTrue, status.Status)
+	assert.Equal(t, "Configured", status.Reason)
+	assert.Contains(t, status.Message, "1 check(s) configured")
+
+	configs := h.ListConfigs()
+	require.Len(t, configs, 1)
+	assert.Equal(t, "redisdb", configs[0].Name)
+	assert.Equal(t, autodiscoveryProvider, configs[0].Provider)
+	assert.Equal(t, "datadoginstrumentation:default/test", configs[0].Source)
+
+	// Update with two checks
+	cr.Spec.Config.Checks = append(cr.Spec.Config.Checks, datadoghq.DatadogInstrumentationCheckConfig{
+		Integration: "nginx",
+		Instances:   []runtime.RawExtension{rawJSON(t, map[string]string{"url": "http://localhost"})},
+	})
+	status, err = h.Handle(context.Background(), instrumentation.EventUpdate, cr)
+	require.NoError(t, err)
+	assert.Equal(t, metav1.ConditionTrue, status.Status)
+	assert.Contains(t, status.Message, "2 check(s) configured")
+	assert.Len(t, h.ListConfigs(), 2)
+}
+
+func TestHandle_MultipleCRs(t *testing.T) {
+	h := newHandler()
+	cr1 := newCR("redis-check", "ns1", "Deployment", "redis", []datadoghq.DatadogInstrumentationCheckConfig{
+		{Integration: "redisdb", Instances: []runtime.RawExtension{rawJSON(t, map[string]string{"host": "redis"})}},
+	})
+	cr2 := newCR("nginx-check", "ns2", "DaemonSet", "nginx", []datadoghq.DatadogInstrumentationCheckConfig{
+		{Integration: "nginx", Instances: []runtime.RawExtension{rawJSON(t, map[string]string{"url": "http://nginx"})}},
+	})
+
+	_, err := h.Handle(context.Background(), instrumentation.EventCreate, cr1)
+	require.NoError(t, err)
+	_, err = h.Handle(context.Background(), instrumentation.EventCreate, cr2)
+	require.NoError(t, err)
+	assert.Len(t, h.ListConfigs(), 2)
+
+	// Delete first CR; second should remain
+	_, err = h.Handle(context.Background(), instrumentation.EventDelete, cr1)
+	require.NoError(t, err)
+	configs := h.ListConfigs()
+	require.Len(t, configs, 1)
+	assert.Equal(t, "nginx", configs[0].Name)
+}
+
+func TestTranslateCheck(t *testing.T) {
+	port := int32(10514)
+	tests := []struct {
+		name             string
+		check            datadoghq.DatadogInstrumentationCheckConfig
+		expectedInit     string
+		expectedInstLen  int
+		instanceContains []string
+		logsNil          bool
+		logsContains     string
+	}{
+		{
+			name: "empty init config defaults to {}",
+			check: datadoghq.DatadogInstrumentationCheckConfig{
+				Integration: "http_check",
+				Instances:   []runtime.RawExtension{{Raw: []byte(`{"url":"http://localhost"}`)}},
+			},
+			expectedInit:    "{}",
+			expectedInstLen: 1,
+			logsNil:         true,
+		},
+		{
+			name: "provided init config is preserved",
+			check: datadoghq.DatadogInstrumentationCheckConfig{
+				Integration: "http_check",
+				InitConfig:  runtime.RawExtension{Raw: []byte(`{"service":"myservice"}`)},
+				Instances:   []runtime.RawExtension{{Raw: []byte(`{"url":"http://localhost"}`)}},
+			},
+			expectedInit:    `{"service":"myservice"}`,
+			expectedInstLen: 1,
+			logsNil:         true,
+		},
+		{
+			name: "multiple instances are translated",
+			check: datadoghq.DatadogInstrumentationCheckConfig{
+				Integration: "http_check",
+				Instances: []runtime.RawExtension{
+					{Raw: []byte(`{"url":"http://host1"}`)},
+					{Raw: []byte(`{"url":"http://host2"}`)},
+				},
+			},
+			expectedInit:     "{}",
+			expectedInstLen:  2,
+			instanceContains: []string{"host1", "host2"},
+			logsNil:          true,
+		},
+		{
+			name: "logs config is translated",
+			check: datadoghq.DatadogInstrumentationCheckConfig{
+				Integration: "custom",
+				Instances:   []runtime.RawExtension{{Raw: []byte(`{"key":"val"}`)}},
+				Logs:        []datadoghq.DatadogInstrumentationLogConfig{{Type: "tcp", Port: &port}},
+			},
+			expectedInit:    "{}",
+			expectedInstLen: 1,
+			logsContains:    `"type":"tcp"`,
+		},
+		{
+			name: "no logs returns nil logs config",
+			check: datadoghq.DatadogInstrumentationCheckConfig{
+				Integration: "redisdb",
+				Instances:   []runtime.RawExtension{{Raw: []byte(`{"host":"localhost"}`)}},
+			},
+			expectedInit:    "{}",
+			expectedInstLen: 1,
+			logsNil:         true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cr := newCR("test", "default", "Deployment", "app", []datadoghq.DatadogInstrumentationCheckConfig{tt.check})
+			h := newHandler()
+			_, err := h.Handle(context.Background(), instrumentation.EventCreate, cr)
+			require.NoError(t, err)
+
+			configs := h.ListConfigs()
+			require.Len(t, configs, 1)
+			assert.Equal(t, tt.expectedInit, string(configs[0].InitConfig))
+			require.Len(t, configs[0].Instances, tt.expectedInstLen)
+			for i, substr := range tt.instanceContains {
+				assert.Contains(t, string(configs[0].Instances[i]), substr)
+			}
+			if tt.logsNil {
+				assert.Nil(t, configs[0].LogsConfig)
+			} else {
+				assert.Contains(t, string(configs[0].LogsConfig), tt.logsContains)
+			}
+		})
+	}
+}
+
+func TestBuildCELSelector(t *testing.T) {
+	tests := []struct {
+		name      string
+		kind      string
+		target    string
+		namespace string
+		images    []string
+		contains  []string
+	}{
+		{
+			name:      "basic selector without images",
+			kind:      "Deployment",
+			target:    "my-app",
+			namespace: "default",
+			contains: []string{
+				`container.pod.rootowner.kind == "Deployment"`,
+				`container.pod.rootowner.name == "my-app"`,
+				`container.pod.namespace == "default"`,
+			},
+		},
+		{
+			name:      "selector with single image",
+			kind:      "StatefulSet",
+			target:    "redis",
+			namespace: "data",
+			images:    []string{"redis"},
+			contains: []string{
+				`container.pod.rootowner.kind == "StatefulSet"`,
+				`container.image.name in ["redis"]`,
+			},
+		},
+		{
+			name:      "selector with multiple images",
+			kind:      "Deployment",
+			target:    "multi",
+			namespace: "default",
+			images:    []string{"nginx", "redis"},
+			contains: []string{
+				`container.pod.rootowner.kind == "Deployment"`,
+				`container.pod.rootowner.name == "multi"`,
+				`container.image.name in ["nginx", "redis"]`,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ref := autoscalingv2.CrossVersionObjectReference{Kind: tt.kind, Name: tt.target}
+			rules := buildCELSelector(ref, tt.namespace, tt.images)
+			require.Len(t, rules.Containers, 1)
+			for _, substr := range tt.contains {
+				assert.Contains(t, rules.Containers[0], substr)
+			}
+		})
+	}
+}

--- a/pkg/clusteragent/instrumentation/handlers/autodiscovery_test.go
+++ b/pkg/clusteragent/instrumentation/handlers/autodiscovery_test.go
@@ -255,7 +255,6 @@ func TestHandle_CreateAndUpdate(t *testing.T) {
 	configs := h.ListConfigs()
 	require.Len(t, configs, 1)
 	assert.Equal(t, "redisdb", configs[0].Name)
-	assert.Equal(t, autodiscoveryProvider, configs[0].Provider)
 	assert.Equal(t, "datadoginstrumentation:default/test", configs[0].Source)
 
 	// Update with two checks
@@ -300,6 +299,7 @@ func TestTranslateCheck(t *testing.T) {
 		check            datadoghq.DatadogInstrumentationCheckConfig
 		expectedInit     string
 		expectedInstLen  int
+		expectedADIDs    []string
 		instanceContains []string
 		logsNil          bool
 		logsContains     string
@@ -307,28 +307,33 @@ func TestTranslateCheck(t *testing.T) {
 		{
 			name: "empty init config defaults to {}",
 			check: datadoghq.DatadogInstrumentationCheckConfig{
-				Integration: "http_check",
-				Instances:   []runtime.RawExtension{{Raw: []byte(`{"url":"http://localhost"}`)}},
+				Integration:    "http_check",
+				ContainerImage: []string{"container-image"},
+				Instances:      []runtime.RawExtension{{Raw: []byte(`{"url":"http://localhost"}`)}},
 			},
 			expectedInit:    "{}",
 			expectedInstLen: 1,
+			expectedADIDs:   []string{"container-image"},
 			logsNil:         true,
 		},
 		{
 			name: "provided init config is preserved",
 			check: datadoghq.DatadogInstrumentationCheckConfig{
-				Integration: "http_check",
-				InitConfig:  runtime.RawExtension{Raw: []byte(`{"service":"myservice"}`)},
-				Instances:   []runtime.RawExtension{{Raw: []byte(`{"url":"http://localhost"}`)}},
+				Integration:    "http_check",
+				ContainerImage: []string{"container-image"},
+				InitConfig:     runtime.RawExtension{Raw: []byte(`{"service":"myservice"}`)},
+				Instances:      []runtime.RawExtension{{Raw: []byte(`{"url":"http://localhost"}`)}},
 			},
 			expectedInit:    `{"service":"myservice"}`,
 			expectedInstLen: 1,
+			expectedADIDs:   []string{"container-image"},
 			logsNil:         true,
 		},
 		{
 			name: "multiple instances are translated",
 			check: datadoghq.DatadogInstrumentationCheckConfig{
-				Integration: "http_check",
+				Integration:    "http_check",
+				ContainerImage: []string{"container-image", "other-container"},
 				Instances: []runtime.RawExtension{
 					{Raw: []byte(`{"url":"http://host1"}`)},
 					{Raw: []byte(`{"url":"http://host2"}`)},
@@ -336,6 +341,7 @@ func TestTranslateCheck(t *testing.T) {
 			},
 			expectedInit:     "{}",
 			expectedInstLen:  2,
+			expectedADIDs:    []string{"container-image", "other-container"},
 			instanceContains: []string{"host1", "host2"},
 			logsNil:          true,
 		},
@@ -372,6 +378,11 @@ func TestTranslateCheck(t *testing.T) {
 			require.Len(t, configs, 1)
 			assert.Equal(t, tt.expectedInit, string(configs[0].InitConfig))
 			require.Len(t, configs[0].Instances, tt.expectedInstLen)
+
+			if tt.expectedADIDs != nil {
+				require.ElementsMatch(t, tt.expectedADIDs, configs[0].ADIdentifiers)
+			}
+
 			for i, substr := range tt.instanceContains {
 				assert.Contains(t, string(configs[0].Instances[i]), substr)
 			}
@@ -390,7 +401,6 @@ func TestBuildCELSelector(t *testing.T) {
 		kind      string
 		target    string
 		namespace string
-		images    []string
 		contains  []string
 	}{
 		{
@@ -409,10 +419,8 @@ func TestBuildCELSelector(t *testing.T) {
 			kind:      "StatefulSet",
 			target:    "redis",
 			namespace: "data",
-			images:    []string{"redis"},
 			contains: []string{
 				`container.pod.rootowner.kind == "StatefulSet"`,
-				`container.image.name in ["redis"]`,
 			},
 		},
 		{
@@ -420,18 +428,16 @@ func TestBuildCELSelector(t *testing.T) {
 			kind:      "Deployment",
 			target:    "multi",
 			namespace: "default",
-			images:    []string{"nginx", "redis"},
 			contains: []string{
 				`container.pod.rootowner.kind == "Deployment"`,
 				`container.pod.rootowner.name == "multi"`,
-				`container.image.name in ["nginx", "redis"]`,
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ref := autoscalingv2.CrossVersionObjectReference{Kind: tt.kind, Name: tt.target}
-			rules := buildCELSelector(ref, tt.namespace, tt.images)
+			rules := buildCELSelector(ref, tt.namespace)
 			require.Len(t, rules.Containers, 1)
 			for _, substr := range tt.contains {
 				assert.Contains(t, rules.Containers[0], substr)

--- a/pkg/clusteragent/instrumentation/handlers/autodiscovery_test.go
+++ b/pkg/clusteragent/instrumentation/handlers/autodiscovery_test.go
@@ -114,87 +114,115 @@ func TestSupportsTarget(t *testing.T) {
 
 func TestValidate(t *testing.T) {
 	tests := []struct {
-		name        string
-		cr          *datadoghq.DatadogInstrumentation
-		expectCount int
-		expectField string
+		name           string
+		cr             *datadoghq.DatadogInstrumentation
+		expectErrCount int
+		expectField    string
 	}{
 		{
-			name:        "nil CR returns nil",
-			cr:          nil,
-			expectCount: 0,
+			name:           "nil CR returns nil",
+			cr:             nil,
+			expectErrCount: 0,
 		},
 		{
 			name: "valid check",
 			cr: newCR("test", "default", "Deployment", "app", []datadoghq.DatadogInstrumentationCheckConfig{
 				{
-					Integration: "redisdb",
-					Instances:   []runtime.RawExtension{rawJSON(t, map[string]string{"host": "localhost"})},
+					Integration:    "redisdb",
+					ContainerImage: []string{"redis"},
+					Instances:      []runtime.RawExtension{rawJSON(t, map[string]string{"host": "localhost"})},
 				},
 			}),
-			expectCount: 0,
+			expectErrCount: 0,
 		},
 		{
 			name: "empty integration name",
 			cr: newCR("test", "default", "Deployment", "app", []datadoghq.DatadogInstrumentationCheckConfig{
 				{
-					Integration: "",
-					Instances:   []runtime.RawExtension{rawJSON(t, map[string]string{"host": "localhost"})},
+					Integration:    "",
+					ContainerImage: []string{"redis"},
+					Instances:      []runtime.RawExtension{rawJSON(t, map[string]string{"host": "localhost"})},
 				},
 			}),
-			expectCount: 1,
-			expectField: "spec.config.checks[0].integration",
+			expectErrCount: 1,
+			expectField:    "spec.config.checks[0].integration",
 		},
 		{
 			name: "whitespace-only integration name",
 			cr: newCR("test", "default", "Deployment", "app", []datadoghq.DatadogInstrumentationCheckConfig{
 				{
-					Integration: "   ",
-					Instances:   []runtime.RawExtension{rawJSON(t, map[string]string{"host": "localhost"})},
+					Integration:    "   ",
+					ContainerImage: []string{"redis"},
+					Instances:      []runtime.RawExtension{rawJSON(t, map[string]string{"host": "localhost"})},
 				},
 			}),
-			expectCount: 1,
-			expectField: "spec.config.checks[0].integration",
+			expectErrCount: 1,
+			expectField:    "spec.config.checks[0].integration",
 		},
 		{
-			name: "no instances",
+			name: "no instances or logs",
+			cr: newCR("test", "default", "Deployment", "app", []datadoghq.DatadogInstrumentationCheckConfig{
+				{
+					Integration:    "redisdb",
+					ContainerImage: []string{"redis"},
+					Instances:      nil,
+				},
+			}),
+			expectErrCount: 1,
+			expectField:    "spec.config.checks[0].instances",
+		},
+		{
+			name: "logs only is valid",
+			cr: newCR("test", "default", "Deployment", "app", []datadoghq.DatadogInstrumentationCheckConfig{
+				{
+					Integration:    "custom",
+					ContainerImage: []string{"app"},
+					Logs:           []datadoghq.DatadogInstrumentationLogConfig{{Type: "tcp"}},
+				},
+			}),
+			expectErrCount: 0,
+		},
+		{
+			name: "no container image",
 			cr: newCR("test", "default", "Deployment", "app", []datadoghq.DatadogInstrumentationCheckConfig{
 				{
 					Integration: "redisdb",
-					Instances:   nil,
+					Instances:   []runtime.RawExtension{rawJSON(t, map[string]string{"host": "localhost"})},
 				},
 			}),
-			expectCount: 1,
-			expectField: "spec.config.checks[0].instances",
+			expectErrCount: 1,
+			expectField:    "spec.config.checks[0].containerImage",
 		},
 		{
-			name: "empty integration and no instances",
+			name: "all validations fail",
 			cr: newCR("test", "default", "Deployment", "app", []datadoghq.DatadogInstrumentationCheckConfig{
 				{Integration: "", Instances: nil},
 			}),
-			expectCount: 2,
+			expectErrCount: 3,
 		},
 		{
 			name: "multiple checks with mixed errors",
 			cr: newCR("test", "default", "Deployment", "app", []datadoghq.DatadogInstrumentationCheckConfig{
 				{
-					Integration: "redisdb",
-					Instances:   []runtime.RawExtension{rawJSON(t, map[string]string{"host": "localhost"})},
+					Integration:    "redisdb",
+					ContainerImage: []string{"redis"},
+					Instances:      []runtime.RawExtension{rawJSON(t, map[string]string{"host": "localhost"})},
 				},
 				{
-					Integration: "",
-					Instances:   []runtime.RawExtension{rawJSON(t, map[string]string{"host": "localhost"})},
+					Integration:    "",
+					ContainerImage: []string{"app"},
+					Instances:      []runtime.RawExtension{rawJSON(t, map[string]string{"host": "localhost"})},
 				},
 			}),
-			expectCount: 1,
-			expectField: "spec.config.checks[1].integration",
+			expectErrCount: 1,
+			expectField:    "spec.config.checks[1].integration",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := newHandler()
 			errs := h.Validate(tt.cr)
-			assert.Len(t, errs, tt.expectCount)
+			assert.Len(t, errs, tt.expectErrCount)
 			if tt.expectField != "" && len(errs) > 0 {
 				assert.Equal(t, tt.expectField, errs[0].Field)
 			}


### PR DESCRIPTION
### What does this PR do?

Adds an autodiscovery handler for the `DatadogInstrumentation` CRD that translates check sections from the CR into `integration.Config` entries. Also adds a validating admission webhook for the CRD and refactors webhook resource declarations to use a structured `WebhookResourceRule` type.

- Translates `spec.config.checks` into autodiscovery configs with CEL-based workload selectors
- Stores configs in memory for delivery to node agents via `ListConfigs()`
- Adds a validating webhook that rejects invalid CRs (empty integration names, missing instances, unsupported targets, duplicate target refs)
- Passes `DatadogInstrumentation` lister to the webhook controller for duplicate validation
- Refactors webhook resource rules from `map` to structured type

### Motivation

[CONTP-1600](https://datadoghq.atlassian.net/browse/CONTP-1600)

### Describe how you validated your changes

- Added unit tests for `AutodiscoveryHandler` covering `HasSection`, `SupportsTarget`, `Validate`, `Handle` (create/update/delete/nil CR/multiple CRs), check translation (init config, instances, logs, CEL selectors), and helper functions

[CONTP-1600]: https://datadoghq.atlassian.net/browse/CONTP-1600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ