### PR TITLE
[ABLD-387] `bazel`ify proto generation: `process`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -633,7 +633,6 @@ exports_files(glob(
 # gazelle:exclude pkg/proto/datadog/kubemetadata
 # gazelle:exclude pkg/proto/datadog/model
 # gazelle:exclude pkg/proto/datadog/privateactionrunner
-# gazelle:exclude pkg/proto/datadog/process
 # gazelle:exclude pkg/proto/datadog/remoteagent
 # gazelle:exclude pkg/proto/datadog/remoteconfig
 # gazelle:exclude pkg/proto/datadog/workloadfilter

--- a/bazel/rules/write_pb_go/_gazelle_extension.go
+++ b/bazel/rules/write_pb_go/_gazelle_extension.go
@@ -97,10 +97,10 @@ func goProtoLibraries(args language.GenerateArgs) map[string][]goProtoLibrary {
 		if err != nil {
 			continue
 		}
-		if protos, ok := protoLibrarySrcs[protoLabel.Name]; ok {
+		if protoInfos, ok := protoLibrarySrcs[protoLabel.Name]; ok {
 			result[importPath] = append(result[importPath], goProtoLibrary{
 				label:         label.New("", args.Rel, r.Name()),
-				generatedSrcs: generatedSrcs(r, protos),
+				generatedSrcs: generatedSrcs(r, protoInfos),
 			})
 		}
 	}
@@ -134,30 +134,31 @@ func generateResult(args language.GenerateArgs, goProtoLibraries map[string][]go
 	return language.GenerateResult{}
 }
 
-// protoLibrarySrcs indexes proto_library srcs by rule name; OtherGen takes precedence over
-// File.Rules so Gazelle-generated rules are preferred over potentially stale committed ones.
-func protoLibrarySrcs(args language.GenerateArgs) map[string][]string {
-	result := map[string][]string{}
+// protoLibrarySrcs indexes proto_library srcs by rule name.
+func protoLibrarySrcs(args language.GenerateArgs) map[string][]proto.FileInfo {
+	result := map[string][]proto.FileInfo{}
 	for _, r := range args.OtherGen {
-		if r.Kind() == "proto_library" {
-			result[r.Name()] = r.AttrStrings("srcs")
+		if r.Kind() != "proto_library" {
+			continue
 		}
-	}
-	if args.File != nil {
-		for _, r := range args.File.Rules {
-			if r.Kind() == "proto_library" {
-				if _, ok := result[r.Name()]; !ok {
-					result[r.Name()] = r.AttrStrings("srcs")
-				}
-			}
+		pkg, ok := r.PrivateAttr(proto.PackageKey).(proto.Package)
+		if !ok {
+			continue
 		}
+		var protoInfos []proto.FileInfo
+		for _, src := range r.AttrStrings("srcs") {
+			protoInfos = append(protoInfos, pkg.Files[src])
+		}
+		result[r.Name()] = protoInfos
 	}
 	return result
 }
 
 // generatedSrcs infers .pb.go filenames from the compiler labels: :go_proto -> .pb.go,
 // :go_{name}_* -> _{name}.pb.go; defaults to [.pb.go].
-func generatedSrcs(r *rule.Rule, protos []string) []string {
+// For serviceless protos, omit dummy _grpc.pb.go backfilled by rules_go
+// (https://github.com/bazel-contrib/rules_go/pull/1394) that would only pollute the source tree.
+func generatedSrcs(r *rule.Rule, protoInfos []proto.FileInfo) []string {
 	var suffixes []string
 	for _, compiler := range r.AttrStrings("compilers") {
 		m := compilerRe.FindStringSubmatch(compiler)
@@ -174,9 +175,10 @@ func generatedSrcs(r *rule.Rule, protos []string) []string {
 		suffixes = []string{".pb.go"}
 	}
 	var result []string
-	for _, proto := range protos {
-		if stem, ok := strings.CutSuffix(proto, ".proto"); ok {
-			for _, suffix := range suffixes {
+	for _, protoInfo := range protoInfos {
+		stem := strings.TrimSuffix(protoInfo.Name, ".proto")
+		for _, suffix := range suffixes {
+			if protoInfo.HasServices || suffix != "_grpc.pb.go" {
 				result = append(result, stem+suffix)
 			}
 		}

--- a/pkg/proto/datadog/process/BUILD.bazel
+++ b/pkg/proto/datadog/process/BUILD.bazel
@@ -1,0 +1,25 @@
+# gazelle:go_grpc_compilers @rules_go//proto:go_proto,//bazel/rules/go_proto_compiler:go_grpc_futureproof
+
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
+load("@rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "process_proto",
+    srcs = [
+        "process.proto",
+        "workloadmeta_process.proto",
+    ],
+    strip_import_prefix = "/pkg/proto",
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "process_go_proto",
+    compilers = [
+        "@rules_go//proto:go_proto",
+        "//bazel/rules/go_proto_compiler:go_grpc_futureproof",
+    ],
+    importpath = "pkg/proto/pbgo/process",
+    proto = ":process_proto",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/proto/pbgo/process/BUILD.bazel
+++ b/pkg/proto/pbgo/process/BUILD.bazel
@@ -1,4 +1,16 @@
 load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/write_pb_go:defs.bzl", "write_pb_go")
+
+write_pb_go(
+    name = "write_pb_go",
+    srcs = {
+        "//pkg/proto/datadog/process:process_go_proto": [
+            "process.pb.go",
+            "workloadmeta_process.pb.go",
+            "workloadmeta_process_grpc.pb.go",
+        ],
+    },
+)
 
 go_library(
     name = "process",

--- a/tasks/protobuf.py
+++ b/tasks/protobuf.py
@@ -14,7 +14,6 @@ PROTO_PKGS = {
     'remoteconfig': False,
     'api/v1': False,
     'trace': True,
-    'process': False,
     'workloadmeta': False,
     'kubemetadata': False,
     'privateactionrunner': False,
@@ -75,6 +74,7 @@ def generate(ctx, pre_commit=False):
         print(f"generating protobuf code from: {proto_root}")
         bazel(ctx, "run", "//pkg/proto/pbgo/dogstatsdhttp:write_pb_go")
         bazel(ctx, "run", "//pkg/proto/pbgo/languagedetection:write_pb_go")
+        bazel(ctx, "run", "//pkg/proto/pbgo/process:write_pb_go")
         bazel(ctx, "run", "//pkg/proto/pbgo/sbom:write_pb_go")
         bazel(ctx, "run", "//pkg/proto/pbgo/trace/idx:write_pb_go")
         for pkg, inject_tags in PROTO_PKGS.items():


### PR DESCRIPTION
### What does this PR do?
- bring `pkg/proto/datadog/process` under `gazelle` control:
  - drop the matching `gazelle:exclude` from the root `BUILD.bazel`,
  - `proto_library` + `go_proto_library` (with `gRPC` compiler) in `pkg/proto/datadog/process/BUILD.bazel`,
  - `write_pb_go` in `pkg/proto/pbgo/process/BUILD.bazel` keeps `process.pb.go`, `workloadmeta_process.pb.go` and `workloadmeta_process_grpc.pb.go` in sync,
- extend the `write_pb_go` Gazelle extension to **omit** `_grpc.pb.go` for **serviceless** protos: `rules_go` backfills any missing expected output with a dummy `+build ignore` stub (bazel-contrib/rules_go#1394), indeed ignored by `go build` but that would otherwise pollute the source tree,
- delegate `process` generation to the topmost `bazel` command in `tasks/protobuf.py` (kept for didactic purposes, at least).

### Motivation
Next step migrating proto generation from the `dda inv protobuf.generate` task to pure `bazel`, enabling CI to verify that committed `.pb.go` files stay in sync with their proto source, where `process` is the first migrated package mixing service-bearing and serviceless protos in one directory.

### Describe how you validated your changes
- `bazel run //:gazelle` is stable,
- `bazel test //pkg/proto/pbgo/process:write_pb_go_tests` passes,
- previously migrated `write_pb_go` tests still pass (`dogstatsdhttp`, `languagedetection`, `sbom`, `trace/idx`),
- `dda inv protobuf.generate` succeeds and is a no-op on `process`.