### PR TITLE
[ABLD-387] `bazel`ify proto generation: `privateactionrunner`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -632,7 +632,6 @@ exports_files(glob(
 # gazelle:exclude pkg/proto/datadog/autodiscovery
 # gazelle:exclude pkg/proto/datadog/kubemetadata
 # gazelle:exclude pkg/proto/datadog/model
-# gazelle:exclude pkg/proto/datadog/privateactionrunner
 # gazelle:exclude pkg/proto/datadog/remoteagent
 # gazelle:exclude pkg/proto/datadog/remoteconfig
 # gazelle:exclude pkg/proto/datadog/workloadfilter
@@ -928,6 +927,9 @@ _GAZELLE_BUILD_TAGS = [
     "zstd",
 ]
 
+# gazelle:resolve go github.com/DataDog/datadog-agent/pkg/proto/pbgo/privateactionrunner/actionsclient //pkg/proto/pbgo/privateactionrunner/actionsclient
+# gazelle:resolve go github.com/DataDog/datadog-agent/pkg/proto/pbgo/privateactionrunner/errorcode //pkg/proto/pbgo/privateactionrunner/errorcode
+# gazelle:resolve go github.com/DataDog/datadog-agent/pkg/proto/pbgo/privateactionrunner/privateactions //pkg/proto/pbgo/privateactionrunner/privateactions
 # gazelle:resolve go github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace/idx //pkg/proto/pbgo/trace/idx
 gazelle(
     name = "gazelle",

--- a/pkg/proto/datadog/privateactionrunner/BUILD.bazel
+++ b/pkg/proto/datadog/privateactionrunner/BUILD.bazel
@@ -1,0 +1,50 @@
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
+load("@rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "actionsclient_proto",
+    srcs = ["actionsclient.proto"],
+    strip_import_prefix = "/pkg/proto",
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "errorcode_proto",
+    srcs = ["error_code.proto"],
+    strip_import_prefix = "/pkg/proto",
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "privateactions_proto",
+    srcs = ["private_actions.proto"],
+    strip_import_prefix = "/pkg/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":actionsclient_proto",
+        "@protobuf//:struct_proto",
+        "@protobuf//:timestamp_proto",
+    ],
+)
+
+go_proto_library(
+    name = "actionsclient_go_proto",
+    importpath = "github.com/DataDog/datadog-agent/pkg/proto/pbgo/privateactionrunner/actionsclient",
+    proto = ":actionsclient_proto",
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "errorcode_go_proto",
+    importpath = "github.com/DataDog/datadog-agent/pkg/proto/pbgo/privateactionrunner/errorcode",
+    proto = ":errorcode_proto",
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "privateactions_go_proto",
+    importpath = "github.com/DataDog/datadog-agent/pkg/proto/pbgo/privateactionrunner/privateactions",
+    proto = ":privateactions_proto",
+    visibility = ["//visibility:public"],
+    deps = [":actionsclient_go_proto"],
+)

--- a/pkg/proto/pbgo/privateactionrunner/actionsclient/BUILD.bazel
+++ b/pkg/proto/pbgo/privateactionrunner/actionsclient/BUILD.bazel
@@ -1,4 +1,14 @@
 load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/write_pb_go:defs.bzl", "write_pb_go")
+
+write_pb_go(
+    name = "write_pb_go",
+    srcs = {
+        "//pkg/proto/datadog/privateactionrunner:actionsclient_go_proto": [
+            "actionsclient.pb.go",
+        ],
+    },
+)
 
 go_library(
     name = "actionsclient",

--- a/pkg/proto/pbgo/privateactionrunner/errorcode/BUILD.bazel
+++ b/pkg/proto/pbgo/privateactionrunner/errorcode/BUILD.bazel
@@ -1,4 +1,14 @@
 load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/write_pb_go:defs.bzl", "write_pb_go")
+
+write_pb_go(
+    name = "write_pb_go",
+    srcs = {
+        "//pkg/proto/datadog/privateactionrunner:errorcode_go_proto": [
+            "error_code.pb.go",
+        ],
+    },
+)
 
 go_library(
     name = "errorcode",

--- a/pkg/proto/pbgo/privateactionrunner/privateactions/BUILD.bazel
+++ b/pkg/proto/pbgo/privateactionrunner/privateactions/BUILD.bazel
@@ -1,4 +1,14 @@
 load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/write_pb_go:defs.bzl", "write_pb_go")
+
+write_pb_go(
+    name = "write_pb_go",
+    srcs = {
+        "//pkg/proto/datadog/privateactionrunner:privateactions_go_proto": [
+            "private_actions.pb.go",
+        ],
+    },
+)
 
 go_library(
     name = "privateactions",

--- a/tasks/protobuf.py
+++ b/tasks/protobuf.py
@@ -16,18 +16,9 @@ PROTO_PKGS = {
     'trace': True,
     'workloadmeta': False,
     'kubemetadata': False,
-    'privateactionrunner': False,
     'remoteagent': False,
     'autodiscovery': False,
     'workloadfilter': False,
-}
-
-CLI_EXTRAS = {
-    'privateactionrunner': '--go_opt=module=github.com/DataDog/datadog-agent',
-}
-
-CLI_EXTRAS_GRPC = {
-    'privateactionrunner': '--go-grpc_opt=module=github.com/DataDog/datadog-agent',
 }
 
 # maybe put this in a separate function
@@ -74,6 +65,9 @@ def generate(ctx, pre_commit=False):
         print(f"generating protobuf code from: {proto_root}")
         bazel(ctx, "run", "//pkg/proto/pbgo/dogstatsdhttp:write_pb_go")
         bazel(ctx, "run", "//pkg/proto/pbgo/languagedetection:write_pb_go")
+        bazel(ctx, "run", "//pkg/proto/pbgo/privateactionrunner/actionsclient:write_pb_go")
+        bazel(ctx, "run", "//pkg/proto/pbgo/privateactionrunner/errorcode:write_pb_go")
+        bazel(ctx, "run", "//pkg/proto/pbgo/privateactionrunner/privateactions:write_pb_go")
         bazel(ctx, "run", "//pkg/proto/pbgo/process:write_pb_go")
         bazel(ctx, "run", "//pkg/proto/pbgo/sbom:write_pb_go")
         bazel(ctx, "run", "//pkg/proto/pbgo/trace/idx:write_pb_go")
@@ -89,22 +83,13 @@ def generate(ctx, pre_commit=False):
             # Generate Go code with protoc-gen-go and protoc-gen-go-grpc
             # Note: The new protoc-gen-go doesn't support plugins=grpc, so we use separate outputs
             # This generates *.pb.go (messages) and *_grpc.pb.go (gRPC stubs) in a single protoc call
-            cli_extras = ''
-            cli_extras_grpc = ''
-            if pkg in CLI_EXTRAS:
-                cli_extras = CLI_EXTRAS[pkg]
-            if pkg in CLI_EXTRAS_GRPC:
-                cli_extras_grpc = CLI_EXTRAS_GRPC[pkg]
             ctx.run(
-                f"{bt.protoc} {bt.protoc_plugin("protoc-gen-go")} {bt.protoc_plugin("protoc-gen-go-grpc")} -I{proto_root} -I{protodep_root} --go_out={repo_root} {cli_extras} --go-grpc_out={repo_root} {cli_extras_grpc} {targets}"
+                f"{bt.protoc} {bt.protoc_plugin("protoc-gen-go")} {bt.protoc_plugin("protoc-gen-go-grpc")} -I{proto_root} -I{protodep_root} --go_out={repo_root} --go-grpc_out={repo_root} {targets}"
             )
 
             if pkg in PKG_PLUGINS:
                 output_generator = PKG_PLUGINS[pkg]
-
-                if pkg in PKG_CLI_EXTRAS:
-                    cli_extras = PKG_CLI_EXTRAS[pkg]
-
+                cli_extras = PKG_CLI_EXTRAS.get(pkg, '')
                 ctx.run(
                     f"{bt.protoc} {bt.protoc_plugin("protoc-gen-go-vtproto")} -I{proto_root} -I{protodep_root} {output_generator}{repo_root} {cli_extras} {targets}"
                 )


### PR DESCRIPTION
### What does this PR do?
- bring `pkg/proto/datadog/privateactionrunner` under `gazelle` control:
  - drop the matching `gazelle:exclude` from the root `BUILD.bazel`,
  - `proto_library` + `go_proto_library` per `.proto` in `pkg/proto/datadog/privateactionrunner/BUILD.bazel`, with `actionsclient_go_proto` listed as a dep of `privateactions_go_proto` to mirror the inter-`.proto` import,
  - `write_pb_go` in each `pkg/proto/pbgo/privateactionrunner/<sub>/BUILD.bazel` keeps `actionsclient.pb.go`, `error_code.pb.go` and `private_actions.pb.go` in sync,
- add `gazelle:resolve` directives in the root `BUILD.bazel` to steer consumers towards the destination `go_library` rather than the `go_proto_library` with same `importpath`, since each `.proto` declares a fully-qualified `option go_package`,
- delegate `privateactionrunner` generation to the topmost `bazel` command in `tasks/protobuf.py` (kept for didactic purposes, at least), and drop the now-unused `--go_opt=module=...` and `--go-grpc_opt=module=...` flags.

### Motivation
Next step migrating proto generation from the
`dda inv protobuf.generate` task to pure `bazel`, enabling CI to verify that committed `.pb.go` files stay in sync with their proto source, where `privateactionrunner` is the first migrated package fanning out from **one** `.proto` directory into **several** Go subpackages.

### Describe how you validated your changes
- `bazel run //:gazelle` is stable,
- `bazel test //pkg/proto/pbgo/privateactionrunner/...:all` passes,
- consumer targets (`pkg/privateactionrunner/types`, `pkg/privateactionrunner/util`) still build,
- `dda inv protobuf.generate` succeeds and is a no-op on `privateactionrunner`.