### PR TITLE
[ABLD-387] `bazel`ify proto generation: `core` (but `remoteagent`)

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -629,13 +629,7 @@ exports_files(glob(
 # gazelle:exclude pkg/process/util/status
 # gazelle:exclude pkg/procmgr
 # gazelle:exclude pkg/proto/datadog/api
-# gazelle:exclude pkg/proto/datadog/autodiscovery
-# gazelle:exclude pkg/proto/datadog/kubemetadata
-# gazelle:exclude pkg/proto/datadog/model
 # gazelle:exclude pkg/proto/datadog/remoteagent
-# gazelle:exclude pkg/proto/datadog/remoteconfig
-# gazelle:exclude pkg/proto/datadog/workloadfilter
-# gazelle:exclude pkg/proto/datadog/workloadmeta
 # gazelle:exclude pkg/proto/protodep
 # gazelle:exclude pkg/remoteflags
 # gazelle:exclude pkg/sbom/collectors/docker

--- a/pkg/proto/BUILD.bazel
+++ b/pkg/proto/BUILD.bazel
@@ -1,5 +1,3 @@
-# gazelle:proto_strip_import_prefix /pkg/proto
-
 load("@rules_go//go:def.bzl", "go_library")
 
 go_library(

--- a/pkg/proto/datadog/BUILD.bazel
+++ b/pkg/proto/datadog/BUILD.bazel
@@ -1,1 +1,3 @@
+# gazelle:go_grpc_compilers @rules_go//proto:go_proto,//bazel/rules/go_proto_compiler:go_grpc_futureproof
 # gazelle:proto package
+# gazelle:proto_strip_import_prefix /pkg/proto

--- a/pkg/proto/datadog/autodiscovery/BUILD.bazel
+++ b/pkg/proto/datadog/autodiscovery/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
+load("@rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "autodiscovery_proto",
+    srcs = ["autodiscovery.proto"],
+    strip_import_prefix = "/pkg/proto",
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "autodiscovery_go_proto",
+    importpath = "pkg/proto/pbgo/core",
+    proto = ":autodiscovery_proto",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/proto/datadog/kubemetadata/BUILD.bazel
+++ b/pkg/proto/datadog/kubemetadata/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
+load("@rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "kubemetadata_proto",
+    srcs = ["kubemetadata.proto"],
+    strip_import_prefix = "/pkg/proto",
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "kubemetadata_go_proto",
+    importpath = "pkg/proto/pbgo/core",
+    proto = ":kubemetadata_proto",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/proto/datadog/model/v1/BUILD.bazel
+++ b/pkg/proto/datadog/model/v1/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
+load("@rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "v1_proto",
+    srcs = ["model.proto"],
+    strip_import_prefix = "/pkg/proto",
+    visibility = ["//visibility:public"],
+    deps = ["@protobuf//:struct_proto"],
+)
+
+go_proto_library(
+    name = "v1_go_proto",
+    importpath = "pkg/proto/pbgo/core",
+    proto = ":v1_proto",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/proto/datadog/remoteconfig/BUILD.bazel
+++ b/pkg/proto/datadog/remoteconfig/BUILD.bazel
@@ -2,22 +2,22 @@ load("@protobuf//bazel:proto_library.bzl", "proto_library")
 load("@rules_go//proto:def.bzl", "go_proto_library")
 
 proto_library(
-    name = "process_proto",
+    name = "config_proto",
     srcs = [
-        "process.proto",
-        "workloadmeta_process.proto",
+        "echo.proto",
+        "remoteconfig.proto",
     ],
     strip_import_prefix = "/pkg/proto",
     visibility = ["//visibility:public"],
 )
 
 go_proto_library(
-    name = "process_go_proto",
+    name = "config_go_proto",
     compilers = [
         "@rules_go//proto:go_proto",
         "//bazel/rules/go_proto_compiler:go_grpc_futureproof",
     ],
-    importpath = "pkg/proto/pbgo/process",
-    proto = ":process_proto",
+    importpath = "pkg/proto/pbgo/core",
+    proto = ":config_proto",
     visibility = ["//visibility:public"],
 )

--- a/pkg/proto/datadog/sbom/BUILD.bazel
+++ b/pkg/proto/datadog/sbom/BUILD.bazel
@@ -1,5 +1,3 @@
-# gazelle:go_grpc_compilers @rules_go//proto:go_proto,//bazel/rules/go_proto_compiler:go_grpc_futureproof
-
 load("@protobuf//bazel:proto_library.bzl", "proto_library")
 load("@rules_go//proto:def.bzl", "go_proto_library")
 

--- a/pkg/proto/datadog/workloadfilter/BUILD.bazel
+++ b/pkg/proto/datadog/workloadfilter/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
+load("@rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "workloadfilter_proto",
+    srcs = ["workloadfilter.proto"],
+    strip_import_prefix = "/pkg/proto",
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "workloadfilter_go_proto",
+    importpath = "pkg/proto/pbgo/core",
+    proto = ":workloadfilter_proto",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/proto/datadog/workloadmeta/BUILD.bazel
+++ b/pkg/proto/datadog/workloadmeta/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
+load("@rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "workloadmeta_proto",
+    srcs = ["workloadmeta.proto"],
+    strip_import_prefix = "/pkg/proto",
+    visibility = ["//visibility:public"],
+    deps = ["@protobuf//:timestamp_proto"],
+)
+
+go_proto_library(
+    name = "workloadmeta_go_proto",
+    importpath = "pkg/proto/pbgo/core",
+    proto = ":workloadmeta_proto",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/proto/pbgo/core/BUILD.bazel
+++ b/pkg/proto/pbgo/core/BUILD.bazel
@@ -1,4 +1,31 @@
 load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("//bazel/rules/write_pb_go:defs.bzl", "write_pb_go")
+
+write_pb_go(
+    name = "write_pb_go",
+    srcs = {
+        "//pkg/proto/datadog/autodiscovery:autodiscovery_go_proto": [
+            "autodiscovery.pb.go",
+        ],
+        "//pkg/proto/datadog/kubemetadata:kubemetadata_go_proto": [
+            "kubemetadata.pb.go",
+        ],
+        "//pkg/proto/datadog/model/v1:v1_go_proto": [
+            "model.pb.go",
+        ],
+        "//pkg/proto/datadog/remoteconfig:config_go_proto": [
+            "echo.pb.go",
+            "echo_grpc.pb.go",
+            "remoteconfig.pb.go",
+        ],
+        "//pkg/proto/datadog/workloadfilter:workloadfilter_go_proto": [
+            "workloadfilter.pb.go",
+        ],
+        "//pkg/proto/datadog/workloadmeta:workloadmeta_go_proto": [
+            "workloadmeta.pb.go",
+        ],
+    },
+)
 
 go_library(
     name = "core",

--- a/tasks/protobuf.py
+++ b/tasks/protobuf.py
@@ -10,15 +10,9 @@ from tasks.libs.common.color import Color, color_message
 from tasks.libs.common.git import get_unstaged_files, get_untracked_files
 
 PROTO_PKGS = {
-    'model/v1': False,
-    'remoteconfig': False,
     'api/v1': False,
     'trace': True,
-    'workloadmeta': False,
-    'kubemetadata': False,
     'remoteagent': False,
-    'autodiscovery': False,
-    'workloadfilter': False,
 }
 
 # maybe put this in a separate function
@@ -63,6 +57,7 @@ def generate(ctx, pre_commit=False):
     with ctx.cd(repo_root):
         # protobuf defs
         print(f"generating protobuf code from: {proto_root}")
+        bazel(ctx, "run", "//pkg/proto/pbgo/core:write_pb_go")
         bazel(ctx, "run", "//pkg/proto/pbgo/dogstatsdhttp:write_pb_go")
         bazel(ctx, "run", "//pkg/proto/pbgo/languagedetection:write_pb_go")
         bazel(ctx, "run", "//pkg/proto/pbgo/privateactionrunner/actionsclient:write_pb_go")


### PR DESCRIPTION
### What does this PR do?
- bring `pkg/proto/datadog/{autodiscovery,kubemetadata,model/v1,remoteconfig,workloadfilter,workloadmeta}` under `gazelle` control:
  - drop the matching `gazelle:exclude` lines from the root `BUILD.bazel`,
  - `proto_library` + `go_proto_library` (`importpath = "pkg/proto/pbgo/core"`) per package in the corresponding `pkg/proto/datadog/<pkg>/BUILD.bazel`,
  - `write_pb_go` in `pkg/proto/pbgo/core/BUILD.bazel` keeps `autodiscovery.pb.go`, `kubemetadata.pb.go`, `model.pb.go`, `echo.pb.go`, `echo_grpc.pb.go`, `remoteconfig.pb.go`, `workloadfilter.pb.go` and `workloadmeta.pb.go` in sync,
- delegate `pbgo/core` generation to the topmost `bazel` command in `tasks/protobuf.py` (kept for didactic purposes, at least).

### Motivation
Next step migrating proto generation from the `dda inv protobuf.generate` task to pure `bazel`, enabling CI to verify that committed `.pb.go` files stay in sync with their proto source.

First migration into the `pbgo/core` fan-in destination (**multiple source dirs to one Go package** topology enabled by #50440), except `remoteagent` which has a wrinkle: its 4 .proto files declare 4 distinct proto packages in the same directory.

### Describe how you validated your changes
- `bazel run //:gazelle` is stable,
- `bazel test //pkg/proto/pbgo/core:write_pb_go_tests` passes (**6 sub-tests**),
- `bazel build //pkg/proto/pbgo/core:core` succeeds,
- `dda inv protobuf.generate` succeeds and is a no-op on the migrated packages.