### PR TITLE
Update workspaces configuration

### DIFF
--- a/.devcontainer/datadog/default/devcontainer.json
+++ b/.devcontainer/datadog/default/devcontainer.json
@@ -1,7 +1,7 @@
 // This devcontainer directs workspaces to use a pre-built image. To make
 // configuration changes, edit prebuild-devcontainer.json in this folder instead
 {
-    "image": "registry.ddbuild.io/workspaces/prebuilt/datadog-agent@sha256:c4d0c1ddf8937eb82ecd3b4a8102905a8c26f02fe6f7f8a94cdf8bc287729c08",
+    "image": "registry.ddbuild.io/workspaces/prebuilt/datadog-agent@sha256:dc3df71db6f913d04dd24dad09744a0afc6cc4fe689de05b14ca40da5880415b",
     "overrideCommand": false,
     "customizations": {
         "dog.infra.workspace": {

--- a/.devcontainer/datadog/default/devcontainer.json
+++ b/.devcontainer/datadog/default/devcontainer.json
@@ -1,7 +1,7 @@
 // This devcontainer directs workspaces to use a pre-built image. To make
 // configuration changes, edit prebuild-devcontainer.json in this folder instead
 {
-    "image": "registry.ddbuild.io/workspaces/prebuilt/datadog-agent@sha256:dc3df71db6f913d04dd24dad09744a0afc6cc4fe689de05b14ca40da5880415b",
+    "image": "registry.ddbuild.io/workspaces/prebuilt/datadog-agent@sha256:9682da917a29e102c70cf66246fd5e3958cd61be0fd9017552a3f55de3243276",
     "overrideCommand": false,
     "customizations": {
         "dog.infra.workspace": {

--- a/.devcontainer/datadog/default/devcontainer.json
+++ b/.devcontainer/datadog/default/devcontainer.json
@@ -1,5 +1,11 @@
 // This devcontainer directs workspaces to use a pre-built image. To make
 // configuration changes, edit prebuild-devcontainer.json in this folder instead
 {
-    "image": "registry.ddbuild.io/workspaces/prebuilt/datadog-agent@sha256:2ef4bf1c2efd74ce7265ca35ba19d52ce12e4abf0de32b027fa1ff9aa2a92bf6"
+    "image": "registry.ddbuild.io/workspaces/prebuilt/datadog-agent@sha256:c4d0c1ddf8937eb82ecd3b4a8102905a8c26f02fe6f7f8a94cdf8bc287729c08",
+    "overrideCommand": false,
+    "customizations": {
+        "dog.infra.workspace": {
+            "base-feature-version": "0.4.0"
+        }
+    }
 }

--- a/.devcontainer/datadog/default/features/datadog-agent/install.sh
+++ b/.devcontainer/datadog/default/features/datadog-agent/install.sh
@@ -12,6 +12,12 @@ fi
 install -d /opt/doghome/devcontainer/features/datadog-agent/lifecycle
 install -m 755 "$featureDir/lifecycle/postCreate.sh" /opt/doghome/devcontainer/features/datadog-agent/lifecycle/postCreate.sh
 
+# Fetch update-tool and use it to install the rest of the tools
+curl --no-progress-meter --retry 10 --retry-max-time 60 -Lo /usr/local/bin/update-tool\
+     https://binaries.ddbuild.io/devtools/bin/update-tool
+chmod +x /usr/local/bin/update-tool
+
+
 # Configure PATH for interactive shells.
 # File name convention *-workspace-env.sh is important:
 # /etc/zsh/zshenv sources these files.

--- a/.devcontainer/datadog/default/features/datadog-agent/install.sh
+++ b/.devcontainer/datadog/default/features/datadog-agent/install.sh
@@ -18,6 +18,7 @@ curl --no-progress-meter --retry 10 --retry-max-time 60 -Lo /usr/local/bin/updat
 chmod +x /usr/local/bin/update-tool
 
 su - bits <<EOF
+export PATH="~/.local/bin:\$PATH"
 (umask 077 && mkdir -p ~/.local/state/workspaces)
 touch ~/state-done
 mkdir -p ~/.local/bin

--- a/.devcontainer/datadog/default/features/datadog-agent/install.sh
+++ b/.devcontainer/datadog/default/features/datadog-agent/install.sh
@@ -29,7 +29,7 @@ ddtool auth helpers install > ~/helpers-install.log 2>&1
 touch ~/helpers-done
 
 # Activate xdg-open functionality
-ln -s workspaces-tool-helper ~/.local/bin/xdg-open
+ln -s /usr/local/bin/workspaces-tool-helper ~/.local/bin/xdg-open
 touch ~/xdg-open-done
 EOF
 

--- a/.devcontainer/datadog/default/features/datadog-agent/install.sh
+++ b/.devcontainer/datadog/default/features/datadog-agent/install.sh
@@ -12,12 +12,6 @@ fi
 install -d /opt/doghome/devcontainer/features/datadog-agent/lifecycle
 install -m 755 "$featureDir/lifecycle/postCreate.sh" /opt/doghome/devcontainer/features/datadog-agent/lifecycle/postCreate.sh
 
-# Fetch update-tool and use it to install the rest of the tools
-curl --no-progress-meter --retry 10 --retry-max-time 60 -Lo /usr/local/bin/update-tool\
-     https://binaries.ddbuild.io/devtools/bin/update-tool
-chmod +x /usr/local/bin/update-tool
-
-
 # Configure PATH for interactive shells.
 # File name convention *-workspace-env.sh is important:
 # /etc/zsh/zshenv sources these files.

--- a/.devcontainer/datadog/default/features/datadog-agent/install.sh
+++ b/.devcontainer/datadog/default/features/datadog-agent/install.sh
@@ -2,11 +2,11 @@
 set -euo pipefail
 featureDir=$(cd "$(dirname "$0")"; pwd)
 
-# Get claude from the buildimages /root/.local/bin
-cp /root/.local/bin/claude /home/bits/.local/bin/claude
-
-# Add bits user to the docker group. This should probably be handled by the base feature. But not working for now.
-usermod -aG docker bits
+# Keep Claude available when the image already carries it.
+if [[ -f /root/.local/bin/claude && -x /root/.local/bin/claude ]]; then
+    install -d -o bits -g dog /home/bits/.local/bin
+    install -m 755 -o bits -g dog /root/.local/bin/claude /home/bits/.local/bin/claude
+fi
 
 # Copy lifecycle scripts into the image
 install -d /opt/doghome/devcontainer/features/datadog-agent/lifecycle

--- a/.devcontainer/datadog/default/features/datadog-agent/install.sh
+++ b/.devcontainer/datadog/default/features/datadog-agent/install.sh
@@ -12,6 +12,21 @@ fi
 install -d /opt/doghome/devcontainer/features/datadog-agent/lifecycle
 install -m 755 "$featureDir/lifecycle/postCreate.sh" /opt/doghome/devcontainer/features/datadog-agent/lifecycle/postCreate.sh
 
+# Fetch update-tool and use it to install ddtool. Ideally we'd like to use dotslash but it does not work well with ddtool auth helpers install because of shims.
+curl --no-progress-meter --retry 10 --retry-max-time 60 -Lo /usr/local/bin/update-tool\
+     https://binaries.ddbuild.io/devtools/bin/update-tool
+chmod +x /usr/local/bin/update-tool
+
+su - bits <<EOF
+mkdir -p ~/.local/bin
+update-tool ddtool@1.101.0
+
+ddtool auth helpers install
+
+# Activate xdg-open functionality
+ln -s workspaces-tool-helper ~/.local/bin/xdg-open
+EOF
+
 # Configure PATH for interactive shells.
 # File name convention *-workspace-env.sh is important:
 # /etc/zsh/zshenv sources these files.

--- a/.devcontainer/datadog/default/features/datadog-agent/install.sh
+++ b/.devcontainer/datadog/default/features/datadog-agent/install.sh
@@ -18,13 +18,19 @@ curl --no-progress-meter --retry 10 --retry-max-time 60 -Lo /usr/local/bin/updat
 chmod +x /usr/local/bin/update-tool
 
 su - bits <<EOF
+(umask 077 && mkdir -p ~/.local/state/workspaces)
+touch ~/state-done
 mkdir -p ~/.local/bin
-update-tool ddtool@1.101.0
+touch ~/bin-done
+update-tool ddtool@1.101.0 > ~/ddtool-install.log 2>&1
+touch ~/ddtool-done
 
-ddtool auth helpers install
+ddtool auth helpers install > ~/helpers-install.log 2>&1
+touch ~/helpers-done
 
 # Activate xdg-open functionality
 ln -s workspaces-tool-helper ~/.local/bin/xdg-open
+touch ~/xdg-open-done
 EOF
 
 # Configure PATH for interactive shells.

--- a/.devcontainer/datadog/default/features/datadog-agent/install.sh
+++ b/.devcontainer/datadog/default/features/datadog-agent/install.sh
@@ -12,19 +12,12 @@ fi
 install -d /opt/doghome/devcontainer/features/datadog-agent/lifecycle
 install -m 755 "$featureDir/lifecycle/postCreate.sh" /opt/doghome/devcontainer/features/datadog-agent/lifecycle/postCreate.sh
 
-# Fetch update-tool and use it to install ddtool. Ideally we'd like to use dotslash but it does not work well with ddtool auth helpers install because of shims.
-curl --no-progress-meter --retry 10 --retry-max-time 60 -Lo /usr/local/bin/update-tool\
-     https://binaries.ddbuild.io/devtools/bin/update-tool
-chmod +x /usr/local/bin/update-tool
 
 su - bits <<EOF
 export PATH="~/.local/bin:\$PATH"
 (umask 077 && mkdir -p ~/.local/state/workspaces)
 touch ~/state-done
-mkdir -p ~/.local/bin
-touch ~/bin-done
-update-tool ddtool@1.101.0 > ~/ddtool-install.log 2>&1
-touch ~/ddtool-done
+
 
 ddtool auth helpers install > ~/helpers-install.log 2>&1
 touch ~/helpers-done

--- a/.devcontainer/datadog/default/features/datadog-agent/install.sh
+++ b/.devcontainer/datadog/default/features/datadog-agent/install.sh
@@ -39,4 +39,5 @@ EOF
 # /etc/zsh/zshenv sources these files.
 cat > /etc/profile.d/10-ddagent-workspace-env.sh << 'EOF'
 export PATH="/usr/local/go/bin:$HOME/go/bin:$PATH"
+export PASSWORD_STORE_GPG_OPTS="--homedir $HOME/.config/password-store/gpg"
 EOF

--- a/.devcontainer/datadog/default/features/datadog-agent/lifecycle/postCreate.sh
+++ b/.devcontainer/datadog/default/features/datadog-agent/lifecycle/postCreate.sh
@@ -14,6 +14,8 @@ configure_claude_mcp() {
 
 repo_dir="${HOME}/go/src/github.com/DataDog/datadog-agent"
 
+ln -s "${HOME}/go/src/github.com/DataDog" "${HOME}/dd"
+
 if [[ ! -d "${repo_dir}" ]]; then
     echo "Unable to find datadog-agent checkout at ${repo_dir}" >&2
     exit 1
@@ -23,4 +25,4 @@ configure_claude_mcp
 
 cd "${repo_dir}"
 
-dda inv install-tools 2>&1 | tee "${HOME}/.install-tools.log"
+DDA_NO_DYNAMIC_DEPS=0 dda inv install-tools 2>&1 | tee "${HOME}/.install-tools.log"

--- a/.devcontainer/datadog/default/features/datadog-agent/lifecycle/postCreate.sh
+++ b/.devcontainer/datadog/default/features/datadog-agent/lifecycle/postCreate.sh
@@ -28,7 +28,6 @@ cd "${repo_dir}"
 DDA_NO_DYNAMIC_DEPS=0 dda inv install-tools 2>&1 | tee "${HOME}/.install-tools.log"
 
 # Create the workspace state directory
-(umask 077 && mkdir -p ~/.local/state/workspaces)
 
 ddtool auth helpers install
 ln -s workspaces-tool-helper ~/.local/bin/xdg-open

--- a/.devcontainer/datadog/default/features/datadog-agent/lifecycle/postCreate.sh
+++ b/.devcontainer/datadog/default/features/datadog-agent/lifecycle/postCreate.sh
@@ -30,9 +30,5 @@ DDA_NO_DYNAMIC_DEPS=0 dda inv install-tools 2>&1 | tee "${HOME}/.install-tools.l
 # Create the workspace state directory
 (umask 077 && mkdir -p ~/.local/state/workspaces)
 
-update-tool ddtool@1.101.0
-
-update-tool workspaces-tool-helper@0.3.1
-
 ddtool auth helpers install
 ln -s workspaces-tool-helper ~/.local/bin/xdg-open

--- a/.devcontainer/datadog/default/features/datadog-agent/lifecycle/postCreate.sh
+++ b/.devcontainer/datadog/default/features/datadog-agent/lifecycle/postCreate.sh
@@ -1,27 +1,26 @@
 #!/bin/bash
+set -euo pipefail
 
+configure_claude_mcp() {
+    if ! command -v claude >/dev/null 2>&1; then
+        return 0
+    fi
 
-# Install Claude MCPs
-# Datadog
-claude mcp add --transport http datadog-mcp https://mcp.datadoghq.com/api/unstable/mcp-server/mcp?toolsets=all --scope user
+    claude mcp add --transport http datadog-mcp https://mcp.datadoghq.com/api/unstable/mcp-server/mcp?toolsets=all --scope user || true
+    claude mcp add --transport http --scope user atlassian https://mcp.atlassian.com/v1/mcp || true
+    claude mcp add datadog-google-workspace --transport http https://google-workspace-mcp-server-834963730936.us-central1.run.app/mcp --scope user || true
+    claude mcp add --transport http "ddci-mcp-prod" 'https://ddci-mcp.mcp.us1.ddbuild.io/internal/mcp' --scope user || true
+}
 
-# Atlassian
-claude mcp add --transport http --scope user atlassian https://mcp.atlassian.com/v1/mcp
+repo_dir="${HOME}/go/src/github.com/DataDog/datadog-agent"
 
-# Google
-claude mcp add datadog-google-workspace --transport http https://google-workspace-mcp-server-834963730936.us-central1.run.app/mcp --scope user
+if [[ ! -d "${repo_dir}" ]]; then
+    echo "Unable to find datadog-agent checkout at ${repo_dir}" >&2
+    exit 1
+fi
 
-# DDCI
-claude mcp add --transport http "ddci-mcp-prod" 'https://ddci-mcp.mcp.us1.ddbuild.io/internal/mcp' --scope user
+configure_claude_mcp
 
-# Run install tools
-cd ~/dd/datadog-agent
+cd "${repo_dir}"
 
-# Tweaking environment variables, will be removed once the Docker image is updated.
-# Make sure we can dynamically install dda dependencies
-export DDA_NO_DYNAMIC_DEPS=0
-# Unset GOPATH otherwise it is set to /go in the build image base
-unset GOPATH
-
-dda inv install-tools 2>&1 | tee "/home/bits/.install-tools.log"
-dda inv vscode.setup 2>&1 | tee "/home/bits/.vscode-setup.log"
+dda inv install-tools 2>&1 | tee "${HOME}/.install-tools.log"

--- a/.devcontainer/datadog/default/features/datadog-agent/lifecycle/postCreate.sh
+++ b/.devcontainer/datadog/default/features/datadog-agent/lifecycle/postCreate.sh
@@ -26,3 +26,13 @@ configure_claude_mcp
 cd "${repo_dir}"
 
 DDA_NO_DYNAMIC_DEPS=0 dda inv install-tools 2>&1 | tee "${HOME}/.install-tools.log"
+
+# Create the workspace state directory
+(umask 077 && mkdir -p ~/.local/state/workspaces)
+
+update-tool ddtool@1.101.0
+
+update-tool workspaces-tool-helper@0.3.1
+
+ddtool auth helpers install
+ln -s workspaces-tool-helper ~/.local/bin/xdg-open

--- a/.devcontainer/datadog/default/prebuild-devcontainer.json
+++ b/.devcontainer/datadog/default/prebuild-devcontainer.json
@@ -10,6 +10,16 @@
             "source": "${localEnv:HOME}/.cache",
             "target": "/var/cache/dd",
             "type": "bind"
+        },
+        {
+            "source": "dind-var-lib-docker-${devcontainerId}",
+            "target": "/var/lib/docker",
+            "type": "volume"
+        },
+        {
+            "source": "dind-var-lib-containerd-${devcontainerId}",
+            "target": "/var/lib/containerd",
+            "type": "volume"
         }
     ],
     "forwardPorts": [22],

--- a/.devcontainer/datadog/default/prebuild-devcontainer.json
+++ b/.devcontainer/datadog/default/prebuild-devcontainer.json
@@ -3,17 +3,7 @@
     "name": "Datadog Agent Development Container",
     "image": "registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-workspace_test_only:v114982950-87b35a20",
     "features": {
-        "./features/datadog-agent": {},
-        "ghcr.io/devcontainers/features/docker-in-docker:2.12.1": {
-            "dockerDashComposeVersion": "v2",
-            "version": "28.5.1",
-            // Use the upper half of the IP range allocated to docker by fabric
-            // ... this conflicts with the range used by the workspaces remote host
-            // , which claims the whole range, until that can be updated, but
-            // it is unlikely (famous last words) that 128 docker subnets will be
-            // created there... or on local hosts for that matter.
-            "dockerDefaultAddressPool": "base=172.17.128.0/17,size=24"
-          }
+        "./features/datadog-agent": {}
     },
     "mounts": [
         {

--- a/.devcontainer/datadog/default/prebuild-devcontainer.json
+++ b/.devcontainer/datadog/default/prebuild-devcontainer.json
@@ -1,5 +1,5 @@
 {
-    // Trigger build: 2026-05-25 14:32
+    // Trigger build: 2026-05-25 21:32
     "name": "Datadog Agent Development Container",
     "image": "registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-workspace_test_only:v115043376-c3c92731",
     "features": {

--- a/.devcontainer/datadog/default/prebuild-devcontainer.json
+++ b/.devcontainer/datadog/default/prebuild-devcontainer.json
@@ -1,7 +1,7 @@
 {
     // Trigger build: 2026-05-22 14:32
     "name": "Datadog Agent Development Container",
-    "image": "registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-workspace_test_only:v114707304-d3811639",
+    "image": "registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-workspace_test_only:v114748813-5e435901",
     "features": {
         "./features/datadog-agent": {}
     },

--- a/.devcontainer/datadog/default/prebuild-devcontainer.json
+++ b/.devcontainer/datadog/default/prebuild-devcontainer.json
@@ -1,7 +1,7 @@
 {
     // Trigger build: 2026-05-15 10:25
     "name": "Datadog Agent Development Container",
-    "image": "registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-workspace_test_only:v113231033-051cfde3",
+    "image": "registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-workspace:v114471858-795a98da",
     "features": {
         "./features/datadog-agent": {}
     },

--- a/.devcontainer/datadog/default/prebuild-devcontainer.json
+++ b/.devcontainer/datadog/default/prebuild-devcontainer.json
@@ -1,5 +1,5 @@
 {
-    // Trigger build: 2026-05-15 10:25
+    // Trigger build: 2026-05-22 14:32
     "name": "Datadog Agent Development Container",
     "image": "registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-workspace_test_only:v114707304-d3811639",
     "features": {

--- a/.devcontainer/datadog/default/prebuild-devcontainer.json
+++ b/.devcontainer/datadog/default/prebuild-devcontainer.json
@@ -1,7 +1,7 @@
 {
     // Trigger build: 2026-05-25 23:32
     "name": "Datadog Agent Development Container",
-    "image": "registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-workspace_test_only:v115053508-3940230e",
+    "image": "registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-workspace_test_only:v114982950-87b35a20",
     "features": {
         "./features/datadog-agent": {},
         "ghcr.io/devcontainers/features/docker-in-docker:2.12.1": {

--- a/.devcontainer/datadog/default/prebuild-devcontainer.json
+++ b/.devcontainer/datadog/default/prebuild-devcontainer.json
@@ -1,7 +1,7 @@
 {
     // Trigger build: 2026-05-22 14:32
     "name": "Datadog Agent Development Container",
-    "image": "registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-workspace_test_only:v114748813-5e435901",
+    "image": "registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-workspace_test_only:v114819980-f744cad7",
     "features": {
         "./features/datadog-agent": {}
     },

--- a/.devcontainer/datadog/default/prebuild-devcontainer.json
+++ b/.devcontainer/datadog/default/prebuild-devcontainer.json
@@ -1,5 +1,5 @@
 {
-    // Trigger build: 2026-05-25 21:32
+    // Trigger build: 2026-05-25 23:32
     "name": "Datadog Agent Development Container",
     "image": "registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-workspace_test_only:v115053508-3940230e",
     "features": {

--- a/.devcontainer/datadog/default/prebuild-devcontainer.json
+++ b/.devcontainer/datadog/default/prebuild-devcontainer.json
@@ -1,7 +1,7 @@
 {
     // Trigger build: 2026-05-22 14:32
     "name": "Datadog Agent Development Container",
-    "image": "registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-workspace_test_only:v114819980-f744cad7",
+    "image": "registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-workspace_test_only:v115043376-c3c92731",
     "features": {
         "./features/datadog-agent": {}
     },

--- a/.devcontainer/datadog/default/prebuild-devcontainer.json
+++ b/.devcontainer/datadog/default/prebuild-devcontainer.json
@@ -3,7 +3,17 @@
     "name": "Datadog Agent Development Container",
     "image": "registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-workspace_test_only:v115053508-3940230e",
     "features": {
-        "./features/datadog-agent": {}
+        "./features/datadog-agent": {},
+        "ghcr.io/devcontainers/features/docker-in-docker:2.12.1": {
+            "dockerDashComposeVersion": "v2",
+            "version": "28.5.1",
+            // Use the upper half of the IP range allocated to docker by fabric
+            // ... this conflicts with the range used by the workspaces remote host
+            // , which claims the whole range, until that can be updated, but
+            // it is unlikely (famous last words) that 128 docker subnets will be
+            // created there... or on local hosts for that matter.
+            "dockerDefaultAddressPool": "base=172.17.128.0/17,size=24"
+          }
     },
     "mounts": [
         {

--- a/.devcontainer/datadog/default/prebuild-devcontainer.json
+++ b/.devcontainer/datadog/default/prebuild-devcontainer.json
@@ -1,7 +1,7 @@
 {
     // Trigger build: 2026-05-25 23:32
     "name": "Datadog Agent Development Container",
-    "image": "registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-workspace_test_only:v114982950-87b35a20",
+    "image": "registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-workspace_test_only:v115202843-a2421094",
     "features": {
         "./features/datadog-agent": {}
     },

--- a/.devcontainer/datadog/default/prebuild-devcontainer.json
+++ b/.devcontainer/datadog/default/prebuild-devcontainer.json
@@ -1,7 +1,7 @@
 {
     // Trigger build: 2026-05-25 21:32
     "name": "Datadog Agent Development Container",
-    "image": "registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-workspace_test_only:v115043376-c3c92731",
+    "image": "registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-workspace_test_only:v115053508-3940230e",
     "features": {
         "./features/datadog-agent": {}
     },

--- a/.devcontainer/datadog/default/prebuild-devcontainer.json
+++ b/.devcontainer/datadog/default/prebuild-devcontainer.json
@@ -1,11 +1,17 @@
 {
-    // Trigger build: 2026-05-04 10:25
+    // Trigger build: 2026-05-15 10:25
     "name": "Datadog Agent Development Container",
-    "image": "registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-workspace:v110159745-8628883e",
+    "image": "registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-workspace_test_only:v113231033-051cfde3",
     "features": {
-        "registry.ddbuild.io/workspaces/features/base:0.4.100410934": {},
         "./features/datadog-agent": {}
     },
+    "mounts": [
+        {
+            "source": "${localEnv:HOME}/.cache",
+            "target": "/var/cache/dd",
+            "type": "bind"
+        }
+    ],
     "forwardPorts": [22],
     "containerUser": "root",
     "remoteUser": "bits",

--- a/.devcontainer/datadog/default/prebuild-devcontainer.json
+++ b/.devcontainer/datadog/default/prebuild-devcontainer.json
@@ -1,7 +1,7 @@
 {
     // Trigger build: 2026-05-15 10:25
     "name": "Datadog Agent Development Container",
-    "image": "registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-workspace:v114471858-795a98da",
+    "image": "registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-workspace_test_only:v114707304-d3811639",
     "features": {
         "./features/datadog-agent": {}
     },

--- a/.devcontainer/datadog/default/prebuild-devcontainer.json
+++ b/.devcontainer/datadog/default/prebuild-devcontainer.json
@@ -1,5 +1,5 @@
 {
-    // Trigger build: 2026-05-22 14:32
+    // Trigger build: 2026-05-25 14:32
     "name": "Datadog Agent Development Container",
     "image": "registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-workspace_test_only:v115043376-c3c92731",
     "features": {


### PR DESCRIPTION
### What does this PR do?

This adds compatibility with the upcoming image [changes](https://github.com/DataDog/datadog-agent-buildimages/pull/1089).

### Motivation

It was discovered that agent distribution artifacts cannot be built within workspaces.

### Additional Notes

After the aforementioned PR is merged, the image references here will be updated.