### PR TITLE
[config] Enable kubernetes metadata streaming by default

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -3772,6 +3772,14 @@ api_key:
 #
 # kubernetes_metadata_tag_update_freq: 60
 
+## @param kubernetes_metadata_streaming - boolean - optional - default: true
+## @env DD_KUBERNETES_METADATA_STREAMING - boolean - optional - default: true
+## Stream Kubernetes metadata from the Cluster Agent instead of polling it every
+## `kubernetes_metadata_tag_update_freq` seconds. This propagates the associated
+## tags with less delay.
+#
+# kubernetes_metadata_streaming: true
+
 ## @param kubernetes_apiserver_client_timeout - integer - optional - default: 10
 ## @env DD_KUBERNETES_APISERVER_CLIENT_TIMEOUT - integer - optional - default: 10
 ## Set the timeout for the Agent when connecting to the Kubernetes API server.

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -2025,7 +2025,7 @@ func kubernetes(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("kubernetes_collect_metadata_tags", true)
 	config.BindEnvAndSetDefault("kubernetes_use_endpoint_slices", false)
 	config.BindEnvAndSetDefault("kubernetes_metadata_tag_update_freq", 60) // Polling frequency of the Agent to the DCA in seconds (gets the local cache if the DCA is disabled)
-	config.BindEnvAndSetDefault("kubernetes_metadata_streaming", false)    // Not exposed yet
+	config.BindEnvAndSetDefault("kubernetes_metadata_streaming", true)
 	config.BindEnvAndSetDefault("kubernetes_apiserver_client_timeout", 10)
 	config.BindEnvAndSetDefault("kubernetes_apiserver_informer_client_timeout", 0)
 	config.BindEnvAndSetDefault("kubernetes_map_services_on_ip", false) // temporary opt-out of the new mapping logic

--- a/releasenotes/notes/config-kubernetes-metadata-streaming-b04c9d47c7e6193d.yaml
+++ b/releasenotes/notes/config-kubernetes-metadata-streaming-b04c9d47c7e6193d.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The Agent now streams Kubernetes metadata from the Cluster Agent by default,
+    instead of polling for it periodically. This propagates tags derived from
+    Kubernetes metadata (like ``kube_service``) with less delay. This behavior
+    is controlled by the ``kubernetes_metadata_streaming`` setting.


### PR DESCRIPTION
### What does this PR do?

This PR enables `kubernetes_metadata_streaming` by default.

This option was first introduced in PR https://github.com/DataDog/datadog-agent/pull/47025. There have also been improvements in other PRs.

When this option is enabled, the core agent (via the kubemetadata workloadmeta collector) fetches kubernetes metadata (kubernetes services, namespace labels/annotations) from the Cluster Agent using the streaming endpoint instead of polling periodically. This propagates tags derived from Kubernetes metadata (like `kube_service`) with less delay. 

### Describe how you validated your changes

I enabled the option in internal clusters to verify everything works as expected.
Also, in a local kind cluster, I deployed with debug logs and checked for this log line: `kube metadata streaming active`. I also verified that `agent tagger-list` contains the expected `kube_service` tags.
