### PR TITLE
Replace deprecated h2c package with http.Server.Protocols

### DIFF
--- a/comp/api/grpcserver/helpers/BUILD.bazel
+++ b/comp/api/grpcserver/helpers/BUILD.bazel
@@ -7,7 +7,5 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/util/grpc/context",
-        "@org_golang_x_net//http2",
-        "@org_golang_x_net//http2/h2c",
     ],
 )

--- a/comp/api/grpcserver/helpers/grpc.go
+++ b/comp/api/grpcserver/helpers/grpc.go
@@ -14,9 +14,6 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
-
 	grpccontext "github.com/DataDog/datadog-agent/pkg/util/grpc/context"
 )
 
@@ -30,24 +27,26 @@ func NewMuxedGRPCServer(addr string, tlsConfig *tls.Config, grpcServer http.Hand
 		httpHandler = TimeoutHandlerFunc(httpHandler, timeout)
 	}
 
-	var handler http.Handler
-	// when HTTP/2 traffic that is not TLS being sent we need to create a new handler which
-	// is able to handle the pre fix magic sent
-	handler = h2c.NewHandler(handlerWithFallback(grpcServer, httpHandler), &http2.Server{})
-	if tlsConfig != nil {
-		tlsConfig.NextProtos = []string{"h2"}
-		handler = handlerWithFallback(grpcServer, httpHandler)
-	}
-
-	return &http.Server{
+	srv := &http.Server{
 		Addr:      addr,
-		Handler:   handler,
+		Handler:   handlerWithFallback(grpcServer, httpHandler),
 		TLSConfig: tlsConfig,
 		ConnContext: func(ctx context.Context, c net.Conn) context.Context {
 			// Store the connection in the context so requests can reference it if needed
 			return context.WithValue(ctx, grpccontext.ConnContextKey, c)
 		},
 	}
+
+	if tlsConfig != nil {
+		tlsConfig.NextProtos = []string{"h2"}
+	} else {
+		var p http.Protocols
+		p.SetHTTP1(true)
+		p.SetUnencryptedHTTP2(true)
+		srv.Protocols = &p
+	}
+
+	return srv
 }
 
 // TimeoutHandlerFunc returns an HTTP handler that times out after a duration.

--- a/comp/dogstatsd/http/impl/server.go
+++ b/comp/dogstatsd/http/impl/server.go
@@ -12,9 +12,6 @@ import (
 	"net"
 	"net/http"
 
-	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
-
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	hostname "github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
@@ -29,8 +26,7 @@ type server struct {
 	hostname hostname.Component
 	out      serializer
 
-	http  *http.Server
-	http2 *http2.Server
+	http *http.Server
 }
 
 type serializer interface {
@@ -60,12 +56,12 @@ func (s *server) start(ctx context.Context) error {
 	mux.Handle("POST /series", &seriesHandler{base})
 	mux.Handle("POST /sketches", &sketchesHandler{base})
 
-	s.http2 = &http2.Server{}
+	var p http.Protocols
+	p.SetHTTP1(true)
+	p.SetUnencryptedHTTP2(true)
 	s.http = &http.Server{
-		Handler: h2c.NewHandler(mux, s.http2),
-	}
-	if err := http2.ConfigureServer(s.http, s.http2); err != nil {
-		return fmt.Errorf("failed to configure http2 server: %w", err)
+		Handler:   mux,
+		Protocols: &p,
 	}
 
 	addr := s.config.GetString("dogstatsd_experimental_http.listen_address")


### PR DESCRIPTION
### What does this PR do?

Replaces the deprecated `golang.org/x/net/http2/h2c` package with Go's native `http.Server.Protocols` field (introduced in Go 1.24).

`staticcheck` now flags `h2c.NewHandler` and its package import as deprecated (SA1019), failing CI linting.

### Motivation

Fix the staticcheck SA1019 linter failures introduced when golangci-lint started reporting the `golang.org/x/net/http2/h2c` package as deprecated. The replacement (`http.Server.Protocols` with `SetUnencryptedHTTP2`) is natively supported since Go 1.24 and the repo is on Go 1.25.

### Describe how you validated your changes

The linter CI job that triggered this work is [job 1670388138](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1670388138).

### Additional Notes

Two sites changed:
- `comp/api/grpcserver/helpers/grpc.go` — muxed gRPC/HTTP server (non-TLS path)
- `comp/dogstatsd/http/impl/server.go` — experimental DogStatsD HTTP server