### PR TITLE
Fix remote stream snapshot compatibility

### DIFF
--- a/comp/core/tagger/impl-remote/BUILD.bazel
+++ b/comp/core/tagger/impl-remote/BUILD.bazel
@@ -61,6 +61,7 @@ go_test(
         "//comp/def",
         "//pkg/config/mock",
         "//pkg/config/model",
+        "//pkg/proto/pbgo/core",
         "//pkg/util/fxutil",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/comp/core/tagger/impl-remote/remote.go
+++ b/comp/core/tagger/impl-remote/remote.go
@@ -97,7 +97,10 @@ type remoteTagger struct {
 
 	telemetryTicker *time.Ticker
 	telemetryStore  *telemetry.Store
-	resyncEvents    []types.EntityEvent
+
+	resyncEvents                             []types.EntityEvent
+	initialSnapshotCompleteSupportChecked    bool
+	initialSnapshotCompleteSupportedByServer bool
 
 	checksCardinality    types.TagCardinality
 	dogstatsdCardinality types.TagCardinality
@@ -538,6 +541,8 @@ func (t *remoteTagger) run() {
 			t.ready = false
 			t.stream = nil
 			t.resyncEvents = nil
+			t.initialSnapshotCompleteSupportChecked = false
+			t.initialSnapshotCompleteSupportedByServer = false
 
 			t.log.Warnf("error received from remote tagger: %s", err)
 
@@ -559,6 +564,8 @@ func (t *remoteTagger) run() {
 		timer.Reset(0)
 
 		t.telemetryStore.Receives.Inc()
+
+		t.checkInitialSnapshotCompleteSupport()
 
 		err = t.processResponse(response)
 		if err != nil {
@@ -604,9 +611,11 @@ func (t *remoteTagger) processResponse(response *pb.StreamTagsResponse) error {
 
 	if !t.ready {
 		// Accumulate events across chunked snapshot messages until the
-		// server signals that the initial snapshot is complete.
+		// server signals that the initial snapshot is complete. Older servers
+		// do not advertise or send that signal, so treat their first response as
+		// the complete snapshot to preserve pre-49682 behavior.
 		t.resyncEvents = append(t.resyncEvents, events...)
-		if response.GetInitialSnapshotComplete() {
+		if response.GetInitialSnapshotComplete() || !t.initialSnapshotCompleteSupportedByServer {
 			replaceStoreContents = true
 			err := t.store.processEvents(t.resyncEvents, replaceStoreContents)
 			t.resyncEvents = nil
@@ -619,6 +628,26 @@ func (t *remoteTagger) processResponse(response *pb.StreamTagsResponse) error {
 	}
 
 	return t.store.processEvents(events, replaceStoreContents)
+}
+
+func (t *remoteTagger) checkInitialSnapshotCompleteSupport() {
+	if t.initialSnapshotCompleteSupportChecked || t.stream == nil {
+		return
+	}
+	t.initialSnapshotCompleteSupportChecked = true
+
+	headers, err := t.stream.Header()
+	if err != nil {
+		t.log.Debugf("unable to read remote tagger stream headers: %s", err)
+		return
+	}
+
+	for _, value := range headers.Get(grpcutil.InitialSnapshotCompleteHeader) {
+		if value == "true" {
+			t.initialSnapshotCompleteSupportedByServer = true
+			return
+		}
+	}
 }
 
 // startTaggerStream tries to establish a stream with the remote gRPC endpoint.

--- a/comp/core/tagger/impl-remote/remote_test.go
+++ b/comp/core/tagger/impl-remote/remote_test.go
@@ -23,11 +23,16 @@ import (
 	ipcmock "github.com/DataDog/datadog-agent/comp/core/ipc/mock"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
+	taggerTelemetry "github.com/DataDog/datadog-agent/comp/core/tagger/telemetry"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
+	coretelemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/def"
 	nooptelemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/impl/noops"
+	mocktelemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/mock"
 	compdef "github.com/DataDog/datadog-agent/comp/def"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	configmodel "github.com/DataDog/datadog-agent/pkg/config/model"
+	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 // TestNewComponent tests that the Remote Tagger can be instantiated and started.
@@ -171,4 +176,64 @@ func TestNewComponentWithOverride(t *testing.T) {
 		assert.GreaterOrEqual(t, elapsed, 10*time.Second, "Should wait at least 10s before failing")
 		assert.Less(t, elapsed, 15*time.Second, "Should not wait excessively long")
 	})
+}
+
+func TestProcessResponseLegacyServerMarksReadyAfterFirstUnmarkedSnapshot(t *testing.T) {
+	tagger := newTestRemoteTagger(t)
+
+	err := tagger.processResponse(newStreamTagsResponse("container-1", []string{"pod_name:one"}, false))
+	require.NoError(t, err)
+
+	assert.True(t, tagger.ready)
+	assert.Empty(t, tagger.resyncEvents)
+	entity := tagger.store.getEntity(types.NewEntityID(types.ContainerID, "container-1"))
+	require.NotNil(t, entity)
+	assert.Equal(t, []string{"pod_name:one"}, entity.LowCardinalityTags)
+}
+
+func TestProcessResponseSupportedChunkedSnapshotWaitsForCompletion(t *testing.T) {
+	tagger := newTestRemoteTagger(t)
+	tagger.initialSnapshotCompleteSupportedByServer = true
+
+	err := tagger.processResponse(newStreamTagsResponse("container-1", []string{"pod_name:one"}, false))
+	require.NoError(t, err)
+
+	assert.False(t, tagger.ready)
+	assert.Len(t, tagger.resyncEvents, 1)
+	assert.Nil(t, tagger.store.getEntity(types.NewEntityID(types.ContainerID, "container-1")))
+
+	err = tagger.processResponse(newStreamTagsResponse("container-2", []string{"pod_name:two"}, true))
+	require.NoError(t, err)
+
+	assert.True(t, tagger.ready)
+	assert.Empty(t, tagger.resyncEvents)
+	assert.NotNil(t, tagger.store.getEntity(types.NewEntityID(types.ContainerID, "container-1")))
+	assert.NotNil(t, tagger.store.getEntity(types.NewEntityID(types.ContainerID, "container-2")))
+}
+
+func newTestRemoteTagger(t testing.TB) *remoteTagger {
+	t.Helper()
+	tel := fxutil.Test[coretelemetry.Component](t, mocktelemetry.Module())
+	return &remoteTagger{
+		store: newTagStore(taggerTelemetry.NewStore(tel)),
+		log:   logmock.New(t),
+	}
+}
+
+func newStreamTagsResponse(id string, lowCardinalityTags []string, initialSnapshotComplete bool) *pb.StreamTagsResponse {
+	return &pb.StreamTagsResponse{
+		Events: []*pb.StreamTagsEvent{
+			{
+				Type: pb.EventType_ADDED,
+				Entity: &pb.Entity{
+					Id: &pb.EntityId{
+						Prefix: string(types.ContainerID),
+						Uid:    id,
+					},
+					LowCardinalityTags: lowCardinalityTags,
+				},
+			},
+		},
+		InitialSnapshotComplete: initialSnapshotComplete,
+	}
 }

--- a/comp/core/tagger/server/server.go
+++ b/comp/core/tagger/server/server.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
 	"github.com/google/uuid"
@@ -56,6 +57,9 @@ func (s *Server) TaggerStreamEntities(in *pb.StreamTagsRequest, out pb.AgentSecu
 	cardinality, err := proto.Pb2TaggerCardinality(in.GetCardinality())
 	if err != nil {
 		return err
+	}
+	if err := out.SetHeader(metadata.Pairs(grpc.InitialSnapshotCompleteHeader, "true")); err != nil {
+		log.Debugf("unable to set tagger stream initial snapshot capability header: %s", err)
 	}
 
 	ticker := time.NewTicker(streamKeepAliveInterval)

--- a/comp/core/workloadmeta/collectors/internal/remote/generic.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/generic.go
@@ -50,6 +50,10 @@ type Stream interface {
 	Recv() (interface{}, error)
 }
 
+type headerProvider interface {
+	Header() (metadata.MD, error)
+}
+
 // StreamHandler is an interface that defines a gRPC stream handler.
 type StreamHandler interface {
 	// Port returns the targeted port
@@ -78,9 +82,11 @@ type GenericCollector struct {
 	Catalog       workloadmeta.AgentType
 	StreamHandler StreamHandler
 
-	store        workloadmeta.Component
-	resyncNeeded bool
-	resyncEvents []workloadmeta.CollectorEvent
+	store                                    workloadmeta.Component
+	resyncNeeded                             bool
+	resyncEvents                             []workloadmeta.CollectorEvent
+	initialSnapshotCompleteSupportChecked    bool
+	initialSnapshotCompleteSupportedByServer bool
 
 	client GrpcClient
 	stream Stream
@@ -230,6 +236,8 @@ func (c *GenericCollector) Run() {
 			c.stream = nil
 			c.resyncNeeded = true
 			c.resyncEvents = nil
+			c.initialSnapshotCompleteSupportChecked = false
+			c.initialSnapshotCompleteSupportedByServer = false
 
 			if err != io.EOF {
 				telemetry.RemoteClientErrors.Inc(c.CollectorID)
@@ -239,6 +247,8 @@ func (c *GenericCollector) Run() {
 			continue
 		}
 
+		c.checkInitialSnapshotCompleteSupport()
+
 		collectorEvents, err := c.StreamHandler.HandleResponse(c.store, response)
 		if err != nil {
 			log.Warnf("error processing event received from remote workloadmeta: %s", err)
@@ -247,13 +257,38 @@ func (c *GenericCollector) Run() {
 
 		if c.resyncNeeded {
 			c.resyncEvents = append(c.resyncEvents, collectorEvents...)
-			if c.StreamHandler.IsResyncComplete(response) {
+			if c.StreamHandler.IsResyncComplete(response) || !c.initialSnapshotCompleteSupportedByServer {
 				c.StreamHandler.HandleResync(c.store, c.resyncEvents)
 				c.resyncEvents = nil
 				c.resyncNeeded = false
 			}
 		} else {
 			c.store.Notify(collectorEvents)
+		}
+	}
+}
+
+func (c *GenericCollector) checkInitialSnapshotCompleteSupport() {
+	if c.initialSnapshotCompleteSupportChecked || c.stream == nil {
+		return
+	}
+	c.initialSnapshotCompleteSupportChecked = true
+
+	stream, ok := c.stream.(headerProvider)
+	if !ok {
+		return
+	}
+
+	headers, err := stream.Header()
+	if err != nil {
+		log.Debugf("unable to read remote workloadmeta stream headers: %s", err)
+		return
+	}
+
+	for _, value := range headers.Get(grpcutil.InitialSnapshotCompleteHeader) {
+		if value == "true" {
+			c.initialSnapshotCompleteSupportedByServer = true
+			return
 		}
 	}
 }

--- a/comp/core/workloadmeta/collectors/internal/remote/workloadmeta/workloadmeta.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/workloadmeta/workloadmeta.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/grpclog"
+	"google.golang.org/grpc/metadata"
 
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/remote"
@@ -90,6 +91,10 @@ type stream struct {
 
 func (s *stream) Recv() (interface{}, error) {
 	return s.cl.Recv()
+}
+
+func (s *stream) Header() (metadata.MD, error) {
+	return s.cl.Header()
 }
 
 type streamHandler struct {

--- a/comp/core/workloadmeta/server/server.go
+++ b/comp/core/workloadmeta/server/server.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"time"
 
+	"google.golang.org/grpc/metadata"
 	goproto "google.golang.org/protobuf/proto"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
@@ -53,6 +54,9 @@ func (s *Server) StreamEntities(in *pb.WorkloadmetaStreamRequest, out pb.AgentSe
 	filter, err := proto.WorkloadmetaFilterFromProtoFilter(in.GetFilter())
 	if err != nil {
 		return err
+	}
+	if err := out.SetHeader(metadata.Pairs(grpcutil.InitialSnapshotCompleteHeader, "true")); err != nil {
+		log.Debugf("unable to set workloadmeta stream initial snapshot capability header: %s", err)
 	}
 
 	workloadmetaEventsChannel := s.wmeta.Subscribe("stream-client", workloadmeta.NormalPriority, filter)

--- a/pkg/util/grpc/chunks.go
+++ b/pkg/util/grpc/chunks.go
@@ -5,6 +5,12 @@
 
 package grpc
 
+const (
+	// InitialSnapshotCompleteHeader is sent by streaming servers that mark the
+	// final chunk of the initial snapshot with InitialSnapshotComplete.
+	InitialSnapshotCompleteHeader = "dd-initial-snapshot-complete-supported"
+)
+
 // CountChunks returns the number of chunks that ProcessChunksInPlace would
 // produce for the given slice and size limit.
 func CountChunks[T any](slice []T, maxChunkSize int, computeSize func(T) int) int {


### PR DESCRIPTION
## What

This makes the remote tagger and remote workloadmeta stream snapshot completion protocol backward compatible with older servers.

New servers now advertise support for `InitialSnapshotComplete` via gRPC metadata. Clients only wait for the completion bit when that support is advertised. If the server does not advertise the protocol, the client falls back to the pre-49682 behavior and treats the first snapshot response as complete.

## Why

PR #49682 added `InitialSnapshotComplete` so clients could accumulate chunked initial snapshots and apply them atomically. That works when both sides include the change, but a new client connected to an older core Agent server waits forever because the old server never sends the completion bit.

That leaves the remote tagger unready and its local store empty in mixed-version deployments, for example a post-49682 host-profiler talking to a pre-49682 Agent core.

## Impact

The intended chunked-snapshot behavior is preserved for new server/new client pairs. Mixed new-client/old-server pairs recover the previous single-response behavior instead of blocking readiness forever.

The same compatibility check is applied to the remote workloadmeta stream because PR #49682 introduced the same completion signal there.

## Validation

Ran targeted checks locally before publishing:

- `dda inv test --targets=./comp/core/tagger/impl-remote`
- `dda inv test --targets=./comp/core/workloadmeta/collectors/internal/remote/...,./comp/core/workloadmeta/server`
- `dda inv test --targets=./comp/core/tagger/server,./pkg/util/grpc`
- `git diff --check`

Pre-push hooks were intentionally skipped with `git push --no-verify` per request.