### PR TITLE
bazel: patch configtls to include curves_fips.go in srcs

### DIFF
--- a/deps/go.MODULE.bazel
+++ b/deps/go.MODULE.bazel
@@ -49,6 +49,10 @@ go_deps.gazelle_override(
     build_extra_args = ["-build_tags=grpcnotrace"],
     path = "google.golang.org/grpc",
 )
+go_deps.gazelle_override(
+    build_extra_args = ["-build_tags=requirefips"],
+    path = "go.opentelemetry.io/collector/config/configtls",
+)
 use_repo(
     go_deps,
     "cat_dario_mergo",


### PR DESCRIPTION
### What does this PR do?

Patch configtls' generated BUILD.bazel to append `curves_fips.go` to the `go_library` srcs.

### Motivation

Gazelle's `go_deps` extension analyzes external Go modules without our custom build tags. 

For `configtls`, that means it only sees `curves_nofips.go` (the `!requirefips` variant) and drops `curves_fips.go` from the generated `srcs`. 

At compile time the `fips` flavor propagates `requirefips` into the build configuration, which excludes `curves_nofips.go` via its `//go:build` constraint — and since `curves_fips.go` is absent from `srcs` entirely, `tlsCurveTypes` ends up undefined and the fips build fails wherever `configtls` is reachable (e.g. via `serializerexporter`).

### Describe how you validated your changes

Local builds & CI.

### Additional Notes
