### PR TITLE
[FA] - Remove flake mark for apm inject tests

### DIFF
--- a/test/new-e2e/tests/installer/unix/package_apm_inject_test.go
+++ b/test/new-e2e/tests/installer/unix/package_apm_inject_test.go
@@ -33,6 +33,15 @@ func testApmInjectAgent(os e2eos.Descriptor, arch e2eos.Architecture, method Ins
 	}
 }
 
+func (s *packageApmInjectSuite) SetupTest() {
+	// Purge() uses Execute (not MustExecute), so failures are silent.
+	// A stale packages.db entry causes Install() to skip PostInstall hooks
+	// (which create /etc/ld.so.preload and /etc/docker/daemon.json).
+	s.Env().RemoteHost.Execute("sudo rm -f /opt/datadog-packages/packages.db")
+	s.Env().RemoteHost.Execute("sudo rm -f /etc/ld.so.preload")
+	s.Env().RemoteHost.Execute("sudo rm -f /etc/docker/daemon.json")
+}
+
 func (s *packageApmInjectSuite) TestInstall() {
 	s.host.InstallDocker()
 	s.RunInstallScript("DD_APM_INSTRUMENTATION_ENABLED=all", "DD_APM_INSTRUMENTATION_LIBRARIES=python")

--- a/test/new-e2e/tests/installer/unix/package_apm_inject_test.go
+++ b/test/new-e2e/tests/installer/unix/package_apm_inject_test.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	e2eos "github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
 	"github.com/stretchr/testify/assert"
 	"go.yaml.in/yaml/v3"
@@ -32,18 +31,6 @@ func testApmInjectAgent(os e2eos.Descriptor, arch e2eos.Architecture, method Ins
 	return &packageApmInjectSuite{
 		packageBaseSuite: newPackageSuite("apm-inject", os, arch, method),
 	}
-}
-
-func (s *packageApmInjectSuite) SetupTest() {
-	if s.os == e2eos.Debian12 || s.os == e2eos.Ubuntu2404 {
-		flake.Mark(s.T())
-	}
-	// Purge() uses Execute (not MustExecute), so failures are silent.
-	// A stale packages.db entry causes Install() to skip PostInstall hooks
-	// (which create /etc/ld.so.preload and /etc/docker/daemon.json).
-	s.Env().RemoteHost.Execute("sudo rm -f /opt/datadog-packages/packages.db")
-	s.Env().RemoteHost.Execute("sudo rm -f /etc/ld.so.preload")
-	s.Env().RemoteHost.Execute("sudo rm -f /etc/docker/daemon.json")
 }
 
 func (s *packageApmInjectSuite) TestInstall() {


### PR DESCRIPTION
Test failures fixed by https://github.com/DataDog/datadog-agent/pull/50400
