### PR TITLE
[CONS-8164] Add IPv6 e2e test for kind container integrations

### DIFF
--- a/.gitlab/test/e2e/e2e.yml
+++ b/.gitlab/test/e2e/e2e.yml
@@ -267,7 +267,7 @@ new-e2e-containers:
       - EXTRA_PARAMS: "--run TestKindSuite -c ddinfra:kubernetesVersion=1.29"
       - EXTRA_PARAMS: "--run TestKindSuite -c ddinfra:osDescriptor=ubuntu:20-04"
       - EXTRA_PARAMS: "--run TestKindSuite -c ddinfra:osDescriptor=ubuntu:22-04"
-      - EXTRA_PARAMS: "--run TestKindIPv6Suite -c ddinfra:kubernetesVersion=1.29"
+      - EXTRA_PARAMS: "--run TestKindIPv6Suite -c ddinfra:kubernetesVersion=1.34"
       - EXTRA_PARAMS: --run TestDockerSuite
       - EXTRA_PARAMS: --run "TestK8S(CEL|Legacy)FilteringSuite"
       - EXTRA_PARAMS: --skip "Test(Kind(IPv6)?|EKS|OpenShiftVM|ECS|Docker|K8SCELFiltering|K8SLegacyFiltering)Suite"

--- a/.gitlab/test/e2e/e2e.yml
+++ b/.gitlab/test/e2e/e2e.yml
@@ -267,9 +267,10 @@ new-e2e-containers:
       - EXTRA_PARAMS: "--run TestKindSuite -c ddinfra:kubernetesVersion=1.29"
       - EXTRA_PARAMS: "--run TestKindSuite -c ddinfra:osDescriptor=ubuntu:20-04"
       - EXTRA_PARAMS: "--run TestKindSuite -c ddinfra:osDescriptor=ubuntu:22-04"
+      - EXTRA_PARAMS: "--run TestKindIPv6Suite -c ddinfra:kubernetesVersion=1.29"
       - EXTRA_PARAMS: --run TestDockerSuite
       - EXTRA_PARAMS: --run "TestK8S(CEL|Legacy)FilteringSuite"
-      - EXTRA_PARAMS: --skip "Test(Kind|EKS|OpenShiftVM|ECS|Docker|K8SCELFiltering|K8SLegacyFiltering)Suite"
+      - EXTRA_PARAMS: --skip "Test(Kind(IPv6)?|EKS|OpenShiftVM|ECS|Docker|K8SCELFiltering|K8SLegacyFiltering)Suite"
 
 new-e2e-containers-k8s-latest:
   extends:

--- a/test/e2e-framework/components/datadog/agent/kubernetes_helm.go
+++ b/test/e2e-framework/components/datadog/agent/kubernetes_helm.go
@@ -930,15 +930,15 @@ func (values HelmValues) configureFakeintake(e config.Env, fakeintake *fakeintak
 			},
 			pulumi.StringMap{
 				"name":  pulumi.String("DD_CONTAINER_IMAGE_ADDITIONAL_ENDPOINTS"),
-				"value": pulumi.Sprintf(`[{"host": "%s", "use_ssl": %t}]`, fakeintake.Host, useSSL),
+				"value": pulumi.Sprintf(`[{"host": "%s", "port": %v, "use_ssl": %t}]`, fakeintake.Host, fakeintake.Port, useSSL),
 			},
 			pulumi.StringMap{
 				"name":  pulumi.String("DD_CONTAINER_LIFECYCLE_ADDITIONAL_ENDPOINTS"),
-				"value": pulumi.Sprintf(`[{"host": "%s", "use_ssl": %t}]`, fakeintake.Host, useSSL),
+				"value": pulumi.Sprintf(`[{"host": "%s", "port": %v, "use_ssl": %t}]`, fakeintake.Host, fakeintake.Port, useSSL),
 			},
 			pulumi.StringMap{
 				"name":  pulumi.String("DD_SBOM_ADDITIONAL_ENDPOINTS"),
-				"value": pulumi.Sprintf(`[{"host": "%s", "use_ssl": %t}]`, fakeintake.Host, useSSL),
+				"value": pulumi.Sprintf(`[{"host": "%s", "port": %v, "use_ssl": %t}]`, fakeintake.Host, fakeintake.Port, useSSL),
 			},
 		}
 	} else {

--- a/test/e2e-framework/components/datadog/agent/kubernetes_helm.go
+++ b/test/e2e-framework/components/datadog/agent/kubernetes_helm.go
@@ -910,19 +910,19 @@ func (values HelmValues) configureFakeintake(e config.Env, fakeintake *fakeintak
 			},
 			pulumi.StringMap{
 				"name":  pulumi.String("DD_ADDITIONAL_ENDPOINTS"),
-				"value": pulumi.Sprintf(`{"%s": ["FAKEAPIKEY"]}`, fakeintake.URL),
+				"value": pulumi.Sprintf(`{"%s": ["FAKEAPIKEY"]}`, fakeintake.AgentURL),
 			},
 			pulumi.StringMap{
 				"name":  pulumi.String("DD_PROCESS_ADDITIONAL_ENDPOINTS"),
-				"value": pulumi.Sprintf(`{"%s": ["FAKEAPIKEY"]}`, fakeintake.URL),
+				"value": pulumi.Sprintf(`{"%s": ["FAKEAPIKEY"]}`, fakeintake.AgentURL),
 			},
 			pulumi.StringMap{
 				"name":  pulumi.String("DD_ORCHESTRATOR_EXPLORER_ORCHESTRATOR_ADDITIONAL_ENDPOINTS"),
-				"value": pulumi.Sprintf(`{"%s": ["FAKEAPIKEY"]}`, fakeintake.URL),
+				"value": pulumi.Sprintf(`{"%s": ["FAKEAPIKEY"]}`, fakeintake.AgentURL),
 			},
 			pulumi.StringMap{
 				"name":  pulumi.String("DD_LOGS_CONFIG_ADDITIONAL_ENDPOINTS"),
-				"value": pulumi.Sprintf(`[{"host": "%s", "port": %v, "use_ssl": %t}]`, fakeintake.Host, fakeintake.Port, useSSL),
+				"value": pulumi.Sprintf(`[{"host": "%s", "port": %v, "use_ssl": %t}]`, fakeintake.AgentHost, fakeintake.Port, useSSL),
 			},
 			pulumi.StringMap{
 				"name":  pulumi.String("DD_LOGS_CONFIG_USE_HTTP"),
@@ -930,38 +930,38 @@ func (values HelmValues) configureFakeintake(e config.Env, fakeintake *fakeintak
 			},
 			pulumi.StringMap{
 				"name":  pulumi.String("DD_CONTAINER_IMAGE_ADDITIONAL_ENDPOINTS"),
-				"value": pulumi.Sprintf(`[{"host": "%s", "port": %v, "use_ssl": %t}]`, fakeintake.Host, fakeintake.Port, useSSL),
+				"value": pulumi.Sprintf(`[{"host": "%s", "port": %v, "use_ssl": %t}]`, fakeintake.AgentHost, fakeintake.Port, useSSL),
 			},
 			pulumi.StringMap{
 				"name":  pulumi.String("DD_CONTAINER_LIFECYCLE_ADDITIONAL_ENDPOINTS"),
-				"value": pulumi.Sprintf(`[{"host": "%s", "port": %v, "use_ssl": %t}]`, fakeintake.Host, fakeintake.Port, useSSL),
+				"value": pulumi.Sprintf(`[{"host": "%s", "port": %v, "use_ssl": %t}]`, fakeintake.AgentHost, fakeintake.Port, useSSL),
 			},
 			pulumi.StringMap{
 				"name":  pulumi.String("DD_SBOM_ADDITIONAL_ENDPOINTS"),
-				"value": pulumi.Sprintf(`[{"host": "%s", "port": %v, "use_ssl": %t}]`, fakeintake.Host, fakeintake.Port, useSSL),
+				"value": pulumi.Sprintf(`[{"host": "%s", "port": %v, "use_ssl": %t}]`, fakeintake.AgentHost, fakeintake.Port, useSSL),
 			},
 		}
 	} else {
 		endpointsEnvVar = pulumi.StringMapArray{
 			pulumi.StringMap{
 				"name":  pulumi.String("DD_DD_URL"),
-				"value": pulumi.Sprintf("%s", fakeintake.URL),
+				"value": pulumi.Sprintf("%s", fakeintake.AgentURL),
 			},
 			pulumi.StringMap{
 				"name":  pulumi.String("DD_PROCESS_CONFIG_PROCESS_DD_URL"),
-				"value": pulumi.Sprintf("%s", fakeintake.URL),
+				"value": pulumi.Sprintf("%s", fakeintake.AgentURL),
 			},
 			pulumi.StringMap{
 				"name":  pulumi.String("DD_APM_DD_URL"),
-				"value": pulumi.Sprintf("%s", fakeintake.URL),
+				"value": pulumi.Sprintf("%s", fakeintake.AgentURL),
 			},
 			pulumi.StringMap{
 				"name":  pulumi.String("DD_LOGS_CONFIG_LOGS_DD_URL"),
-				"value": pulumi.Sprintf("%s", fakeintake.URL),
+				"value": pulumi.Sprintf("%s", fakeintake.AgentURL),
 			},
 			pulumi.StringMap{
 				"name":  pulumi.String("DD_ORCHESTRATOR_EXPLORER_ORCHESTRATOR_DD_URL"),
-				"value": pulumi.Sprintf("%s", fakeintake.URL),
+				"value": pulumi.Sprintf("%s", fakeintake.AgentURL),
 			},
 			pulumi.StringMap{
 				"name":  pulumi.String("DD_SKIP_SSL_VALIDATION"),
@@ -1031,7 +1031,7 @@ func (values HelmValues) configureFakeintake(e config.Env, fakeintake *fakeintak
 			parEnvDict = pulumi.StringMap{}
 			par["envDict"] = parEnvDict
 		}
-		parEnvDict["DD_DD_URL"] = pulumi.Sprintf("%s", fakeintake.URL)
+		parEnvDict["DD_DD_URL"] = pulumi.Sprintf("%s", fakeintake.AgentURL)
 		parEnvDict["DD_INTERNAL_PAR_SKIP_TASK_VERIFICATION"] = pulumi.String("true")
 	}
 }
@@ -1049,7 +1049,7 @@ func (values HelmValues) ToYAMLPulumiAssetOutput() pulumi.AssetOutput {
 
 func buildOTelConfigWithFakeintake(otelConfig string, fakeintake *fakeintake.Fakeintake) pulumi.AssetOutput {
 
-	return fakeintake.URL.ApplyT(func(url string) (pulumi.Asset, error) {
+	return fakeintake.AgentURL.ApplyT(func(url string) (pulumi.Asset, error) {
 		defaultConfig := map[string]any{
 			"exporters": map[string]any{
 				"datadog": map[string]any{
@@ -1087,7 +1087,7 @@ datadog:
 }
 
 func buildOTelAgentGatewayConfigWithFakeintake(otelConfig string, fakeintake *fakeintake.Fakeintake) pulumi.AssetOutput {
-	return fakeintake.URL.ApplyT(func(url string) (pulumi.Asset, error) {
+	return fakeintake.AgentURL.ApplyT(func(url string) (pulumi.Asset, error) {
 		defaultConfig := map[string]any{
 			"exporters": map[string]any{
 				"datadog": map[string]any{

--- a/test/e2e-framework/components/datadog/fakeintake/component.go
+++ b/test/e2e-framework/components/datadog/fakeintake/component.go
@@ -18,6 +18,14 @@ type FakeintakeOutput struct { // nolint:revive, We want to keep the name as <Co
 	Scheme string `json:"scheme"`
 	Port   uint32 `json:"port"`
 	URL    string `json:"url"`
+
+	// AgentHost/AgentURL are the host and URL the in-cluster agent should
+	// use to reach the fakeintake. They differ from Host/URL only when the
+	// fakeintake exposes a NAT64-translated IPv6 endpoint for an IPv6-only
+	// cluster (see WithIPv6NAT64 on the aws fakeintake scenario); otherwise
+	// they equal Host/URL.
+	AgentHost string `json:"agent_host"`
+	AgentURL  string `json:"agent_url"`
 }
 
 type Fakeintake struct {
@@ -29,6 +37,11 @@ type Fakeintake struct {
 	Port   pulumi.IntOutput    `pulumi:"port"`   // Same for Port
 
 	URL pulumi.StringOutput `pulumi:"url"`
+
+	// AgentHost/AgentURL are the in-cluster agent's view of the fakeintake.
+	// See FakeintakeOutput.AgentHost for the contract.
+	AgentHost pulumi.StringOutput `pulumi:"agent_host"`
+	AgentURL  pulumi.StringOutput `pulumi:"agent_url"`
 }
 
 func (fi *Fakeintake) Export(ctx *pulumi.Context, out *FakeintakeOutput) error {

--- a/test/e2e-framework/components/datadog/fakeintake/docker.go
+++ b/test/e2e-framework/components/datadog/fakeintake/docker.go
@@ -41,6 +41,8 @@ func NewLocalDockerFakeintake(e config.Env, resourceName string) (*Fakeintake, e
 		comp.Port = pulumi.Int(hostPort).ToIntOutput()
 		comp.Scheme = pulumi.Sprintf("%s", "http")
 		comp.URL = pulumi.Sprintf("%s://%s:%d", comp.Scheme, comp.Host, comp.Port)
+		comp.AgentHost = comp.Host
+		comp.AgentURL = comp.URL
 
 		return nil
 	})

--- a/test/e2e-framework/components/kubernetes/cilium/kind.go
+++ b/test/e2e-framework/components/kubernetes/cilium/kind.go
@@ -19,7 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/remote"
 )
 
-func NewKindCluster(env config.Env, vm *remote.Host, name string, kubeVersion string, ciliumOpts []Option, opts ...pulumi.ResourceOption) (*kubernetes.Cluster, error) {
+func NewKindCluster(env config.Env, vm *remote.Host, name string, kubeVersion string, ipFamily string, ciliumOpts []Option, opts ...pulumi.ResourceOption) (*kubernetes.Cluster, error) {
 	params, err := NewParams(ciliumOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("could not create cilium params from opts: %w", err)
@@ -28,6 +28,7 @@ func NewKindCluster(env config.Env, vm *remote.Host, name string, kubeVersion st
 	kindClusterConfigFlags := kubernetes.KindConfigFlags{
 		KubeProxyReplacement: params.hasKubeProxyReplacement(),
 		WorkerNodes:          []kubernetes.KindWorkerNode{{}},
+		IPFamily:             ipFamily,
 	}
 
 	cluster, err := kubernetes.NewKindClusterWithConfig(env, vm, name, kubeVersion, kindClusterConfigFlags, opts...)

--- a/test/e2e-framework/components/kubernetes/kind-cluster.yaml
+++ b/test/e2e-framework/components/kubernetes/kind-cluster.yaml
@@ -49,6 +49,9 @@ containerdConfigPatches:
 networking:
   apiServerAddress: "0.0.0.0"
   apiServerPort: 8443
+{{- if .IPFamily }}
+  ipFamily: {{ .IPFamily }}
+{{- end }}
 {{- if .KubeProxyReplacement }}
   disableDefaultCNI: true
   kubeProxyMode: "none"

--- a/test/e2e-framework/components/kubernetes/kind_versions.go
+++ b/test/e2e-framework/components/kubernetes/kind_versions.go
@@ -30,6 +30,7 @@ type KindConfigFlags struct {
 	NewContainerdRegistryConfig bool             // whether to use the new containerd registry mirror config format (for containerd >= 2.2, used in kubernetes >= v1.32)
 	KubeProxyReplacement        bool             // whether to set kubeProxyMode to "none" in the kind config
 	WorkerNodes                 []KindWorkerNode // additional worker nodes beyond the control-plane
+	IPFamily                    string           // kind networking.ipFamily: "" (default ipv4), "ipv4", "ipv6", or "dual"
 }
 
 // KindWorkerNode describes a kind worker node.

--- a/test/e2e-framework/components/kubernetes/nat64/nat64.go
+++ b/test/e2e-framework/components/kubernetes/nat64/nat64.go
@@ -1,0 +1,32 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// Package nat64 deploys an aojea/nat64 DaemonSet into a Kubernetes cluster so
+// that IPv6-only pods can reach IPv4-only services through the well-known
+// NAT64 prefix 64:ff9b::/96. kindest/kindnetd, the CNI bundled with kind,
+// does not implement NAT64 itself, so an IPv6-only kind cluster needs this
+// daemon to make external IPv4 endpoints reachable.
+package nat64
+
+import (
+	_ "embed"
+
+	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
+	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/yaml"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+//go:embed nat64.yaml
+var manifest string
+
+// Deploy applies the pinned aojea/nat64 manifest to the cluster reachable via
+// kubeProvider. Returns the resulting ConfigGroup so callers can chain
+// dependsOn against it.
+func Deploy(ctx *pulumi.Context, name string, kubeProvider *kubernetes.Provider, opts ...pulumi.ResourceOption) (*yaml.ConfigGroup, error) {
+	opts = append(opts, pulumi.Provider(kubeProvider))
+	return yaml.NewConfigGroup(ctx, name, &yaml.ConfigGroupArgs{
+		YAML: []string{manifest},
+	}, opts...)
+}

--- a/test/e2e-framework/components/kubernetes/nat64/nat64.yaml
+++ b/test/e2e-framework/components/kubernetes/nat64/nat64.yaml
@@ -1,0 +1,84 @@
+---
+# Pinned copy of https://github.com/aojea/nat64/blob/main/install.yaml.
+# Provides a NAT64 gateway for the well-known prefix 64:ff9b::/96 so that
+# IPv6-only pods can reach IPv4-only services. Needed in kind clusters
+# because kindest/kindnetd (kind's default CNI) does not implement NAT64
+# (only the upstream aojea/kindnet does).
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: nat64
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: nat64
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nat64
+subjects:
+- kind: ServiceAccount
+  name: nat64
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nat64
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nat64
+  namespace: kube-system
+  labels:
+    tier: node
+    app: nat64
+    k8s-app: nat64
+spec:
+  selector:
+    matchLabels:
+      app: nat64
+  template:
+    metadata:
+      labels:
+        tier: node
+        app: nat64
+        k8s-app: nat64
+    spec:
+      hostNetwork: true
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      serviceAccountName: nat64
+      containers:
+      - name: nat64
+        image: aojea/nat64:v0.1.0
+        volumeMounts:
+        - name: xtables-lock
+          mountPath: /run/xtables.lock
+          readOnly: false
+        - name: lib-modules
+          mountPath: /lib/modules
+          readOnly: true
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "50Mi"
+          limits:
+            cpu: "100m"
+            memory: "50Mi"
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["NET_ADMIN"]
+      volumes:
+      - name: xtables-lock
+        hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
+      - name: lib-modules
+        hostPath:
+          path: /lib/modules

--- a/test/e2e-framework/scenarios/aws/fakeintake/fakeintake.go
+++ b/test/e2e-framework/scenarios/aws/fakeintake/fakeintake.go
@@ -155,17 +155,22 @@ func fargateSvcNoLB(e aws.Environment, namer namer.Namer, taskDef *awsxEcs.Farga
 		}
 		e.Ctx().Log.Info(fmt.Sprintf("fakeintake healthy at %s", ipAddress), nil)
 
-		exportedHost := ipAddress
+		clientURL := buildFakeIntakeURL("http", ipAddress, "", httpPort)
+		agentHost := ipAddress
+		agentURL := clientURL
 		if ipv6NAT64 {
-			exportedHost = "64:ff9b::" + ipAddress
+			agentHost = "64:ff9b::" + ipAddress
+			agentURL = buildFakeIntakeURL("http", agentHost, "", httpPort)
 		}
-		return []string{exportedHost, buildFakeIntakeURL("http", exportedHost, "", httpPort)}, nil
+		return []string{ipAddress, clientURL, agentHost, agentURL}, nil
 	}).(pulumi.StringArrayOutput)
 
 	fi.Scheme = pulumi.Sprintf("%s", "http")
 	fi.Port = pulumi.Int(httpPort).ToIntOutput()
 	fi.Host = output.Index(pulumi.Int(0))
 	fi.URL = output.Index(pulumi.Int(1))
+	fi.AgentHost = output.Index(pulumi.Int(2))
+	fi.AgentURL = output.Index(pulumi.Int(3))
 
 	return err
 }
@@ -226,6 +231,8 @@ func fargateSvcLB(e aws.Environment, namer namer.Namer, taskDef *awsxEcs.Fargate
 	fi.Port = pulumi.Int(httpsPort).ToIntOutput()
 	fi.Host = host
 	fi.URL = pulumi.Sprintf("%s://%s", fi.Scheme, host)
+	fi.AgentHost = fi.Host
+	fi.AgentURL = fi.URL
 	return nil
 }
 

--- a/test/e2e-framework/scenarios/aws/fakeintake/fakeintake.go
+++ b/test/e2e-framework/scenarios/aws/fakeintake/fakeintake.go
@@ -82,10 +82,14 @@ func NewECSFargateInstance(e aws.Environment, name string, option ...Option) (*f
 			}
 		}
 
+		if useLoadBalancer && params.IPv6NAT64 {
+			return fmt.Errorf("WithIPv6NAT64 is incompatible with the load-balanced fakeintake mode")
+		}
+
 		if useLoadBalancer {
 			err = fargateSvcLB(e, namer, taskDef, fi, opts...)
 		} else {
-			err = fargateSvcNoLB(e, namer, taskDef, fi, opts...)
+			err = fargateSvcNoLB(e, namer, taskDef, fi, params.IPv6NAT64, opts...)
 		}
 		if err != nil {
 			return err
@@ -95,9 +99,11 @@ func NewECSFargateInstance(e aws.Environment, name string, option ...Option) (*f
 	})
 }
 
-// fargateSvcNoLB deploys one fakeintake container to a dedicated Fargate cluster
-// Hardcoded on sandbox
-func fargateSvcNoLB(e aws.Environment, namer namer.Namer, taskDef *awsxEcs.FargateTaskDefinition, fi *fakeintake.Fakeintake, opts ...pulumi.ResourceOption) error {
+// fargateSvcNoLB deploys one fakeintake container to a dedicated Fargate cluster.
+// Hardcoded on sandbox. When ipv6NAT64 is true, fi.Host/fi.URL advertise the
+// NAT64-translated IPv6 form (64:ff9b::<ipv4>) of the task's private IPv4; the
+// pulumi-side healthcheck still dials IPv4 directly from the host.
+func fargateSvcNoLB(e aws.Environment, namer namer.Namer, taskDef *awsxEcs.FargateTaskDefinition, fi *fakeintake.Fakeintake, ipv6NAT64 bool, opts ...pulumi.ResourceOption) error {
 	fargateService, err := ecs.FargateService(e, namer.ResourceName("srv"), e.ECSFargateFakeintakeClusterArn(), taskDef.TaskDefinition.Arn(), nil, opts...)
 	if err != nil {
 		return err
@@ -149,7 +155,11 @@ func fargateSvcNoLB(e aws.Environment, namer namer.Namer, taskDef *awsxEcs.Farga
 		}
 		e.Ctx().Log.Info(fmt.Sprintf("fakeintake healthy at %s", ipAddress), nil)
 
-		return []string{ipAddress, buildFakeIntakeURL("http", ipAddress, "", httpPort)}, nil
+		exportedHost := ipAddress
+		if ipv6NAT64 {
+			exportedHost = "64:ff9b::" + ipAddress
+		}
+		return []string{exportedHost, buildFakeIntakeURL("http", exportedHost, "", httpPort)}, nil
 	}).(pulumi.StringArrayOutput)
 
 	fi.Scheme = pulumi.Sprintf("%s", "http")

--- a/test/e2e-framework/scenarios/aws/fakeintake/params.go
+++ b/test/e2e-framework/scenarios/aws/fakeintake/params.go
@@ -14,6 +14,7 @@ type Params struct {
 	Memory              int
 	DDDevForwarding     bool
 	RetentionPeriod     string
+	IPv6NAT64           bool
 }
 
 type Option = func(*Params) error
@@ -81,6 +82,17 @@ func WithoutDDDevForwarding() Option {
 func WithRetentionPeriod(retentionPeriod string) Option {
 	return func(p *Params) error {
 		p.RetentionPeriod = retentionPeriod
+		return nil
+	}
+}
+
+// WithIPv6NAT64 makes the fakeintake export its endpoint as the NAT64-translated
+// IPv6 form (64:ff9b::<ipv4>, RFC 6052) of the Fargate task's private IPv4, so
+// IPv6-only callers can reach it through a NAT64 gateway. Incompatible with
+// WithLoadBalancer.
+func WithIPv6NAT64() Option {
+	return func(p *Params) error {
+		p.IPv6NAT64 = true
 		return nil
 	}
 }

--- a/test/e2e-framework/scenarios/aws/kindvm/run.go
+++ b/test/e2e-framework/scenarios/aws/kindvm/run.go
@@ -108,10 +108,10 @@ func RunWithEnv(ctx *pulumi.Context, awsEnv resAws.Environment, env outputs.Kube
 
 	var kindCluster *kubeComp.Cluster
 	if len(params.ciliumOptions) > 0 {
-		kindCluster, err = cilium.NewKindCluster(&awsEnv, host, params.Name, awsEnv.KubernetesVersion(), params.ciliumOptions, utils.PulumiDependsOn(installEcrCredsHelperCmd))
+		kindCluster, err = cilium.NewKindCluster(&awsEnv, host, params.Name, awsEnv.KubernetesVersion(), params.ipFamily, params.ciliumOptions, utils.PulumiDependsOn(installEcrCredsHelperCmd))
 	} else {
 		kindCluster, err = kubeComp.NewKindClusterWithConfig(&awsEnv, host, params.Name, awsEnv.KubernetesVersion(),
-			kubeComp.KindConfigFlags{WorkerNodes: params.workerNodes},
+			kubeComp.KindConfigFlags{WorkerNodes: params.workerNodes, IPFamily: params.ipFamily},
 			utils.PulumiDependsOn(installEcrCredsHelperCmd))
 	}
 

--- a/test/e2e-framework/scenarios/aws/kindvm/run.go
+++ b/test/e2e-framework/scenarios/aws/kindvm/run.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/kubernetes/argorollouts"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/kubernetes/cilium"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/kubernetes/nat64"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/kubernetes/vpa"
 	resAws "github.com/DataDog/datadog-agent/test/e2e-framework/resources/aws"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
@@ -135,6 +136,12 @@ func RunWithEnv(ctx *pulumi.Context, awsEnv resAws.Environment, env outputs.Kube
 	})
 	if err != nil {
 		return err
+	}
+
+	if params.deployNAT64 {
+		if _, err := nat64.Deploy(ctx, awsEnv.Namer.ResourceName("nat64"), kubeProvider); err != nil {
+			return err
+		}
 	}
 
 	vpaCrd, err := vpa.DeployCRD(&awsEnv, kubeProvider)

--- a/test/e2e-framework/scenarios/aws/kindvm/run_args.go
+++ b/test/e2e-framework/scenarios/aws/kindvm/run_args.go
@@ -48,6 +48,10 @@ type RunParams struct {
 	// workerNodes configures the kind cluster worker nodes with custom labels and taints.
 	// When empty the cluster uses the default single worker node.
 	workerNodes []kubecomp.KindWorkerNode
+
+	// ipFamily selects the kind cluster's IP family ("ipv4", "ipv6", "dual").
+	// Empty leaves it to the kind default (ipv4).
+	ipFamily string
 }
 
 type RunOption = func(*RunParams) error
@@ -210,4 +214,9 @@ func WithKindWorkerNodes(nodes ...kubecomp.KindWorkerNode) RunOption {
 		p.workerNodes = append(p.workerNodes, nodes...)
 		return nil
 	}
+}
+
+// WithIPFamily sets the kind cluster's IP family ("ipv4", "ipv6", "dual")
+func WithIPFamily(family string) RunOption {
+	return func(p *RunParams) error { p.ipFamily = family; return nil }
 }

--- a/test/e2e-framework/scenarios/aws/kindvm/run_args.go
+++ b/test/e2e-framework/scenarios/aws/kindvm/run_args.go
@@ -52,6 +52,10 @@ type RunParams struct {
 	// ipFamily selects the kind cluster's IP family ("ipv4", "ipv6", "dual").
 	// Empty leaves it to the kind default (ipv4).
 	ipFamily string
+
+	// deployNAT64 toggles deployment of the aojea/nat64 DaemonSet, which
+	// makes the 64:ff9b::/96 NAT64 prefix reachable from pods.
+	deployNAT64 bool
 }
 
 type RunOption = func(*RunParams) error
@@ -219,4 +223,12 @@ func WithKindWorkerNodes(nodes ...kubecomp.KindWorkerNode) RunOption {
 // WithIPFamily sets the kind cluster's IP family ("ipv4", "ipv6", "dual")
 func WithIPFamily(family string) RunOption {
 	return func(p *RunParams) error { p.ipFamily = family; return nil }
+}
+
+// WithIPv6NAT64Daemon deploys an aojea/nat64 DaemonSet on the cluster so
+// that IPv6-only pods can reach IPv4 destinations through the well-known
+// NAT64 prefix 64:ff9b::/96. Needed when ipFamily=ipv6 because kindest/kindnetd
+// (kind's default CNI) does not provide NAT64 itself.
+func WithIPv6NAT64Daemon() RunOption {
+	return func(p *RunParams) error { p.deployNAT64 = true; return nil }
 }

--- a/test/new-e2e/tests/containers/kindvm_ipv6_test.go
+++ b/test/new-e2e/tests/containers/kindvm_ipv6_test.go
@@ -54,10 +54,7 @@ clusterAgent:
 				scenkind.WithDeployDogstatsd(),
 				scenkind.WithDeployTestWorkload(),
 				scenkind.WithAgentOptions(
-					// Single-shipping (no dual): every payload goes to the
-					// fakeintake via the IPv6/NAT64 path. The dddev primary
-					// is IPv4-only and unreachable from these IPv6-only pods,
-					// so enabling dual-shipping would stall the forwarder.
+					kubernetesagentparams.WithDualShipping(),
 					kubernetesagentparams.WithHelmValues(helmValues),
 					kubernetesagentparams.WithHelmValues(containerHelmValues),
 					kubernetesagentparams.WithKubernetesUseEndpointSlices(),

--- a/test/new-e2e/tests/containers/kindvm_ipv6_test.go
+++ b/test/new-e2e/tests/containers/kindvm_ipv6_test.go
@@ -26,12 +26,10 @@ type kindIPv6Suite struct {
 	kindSuite
 }
 
-// TestKindIPv6Suite runs the kind container-integration assertions against a
-// dual-stack kind cluster. Pods get both IPv4 and IPv6 PodIPs, so the agent
-// can still reach the IPv4-only fakeintake ALB while intra-cluster IPv6 paths
-// (kubelet, services, peer pods) are exercised. Strict ipFamily=ipv6 is
-// blocked until the fakeintake exposes an IPv6-reachable endpoint. See
-// [CONS-8164].
+// TestKindIPv6Suite runs the kind container-integration assertions against an
+// IPv6-only kind cluster. Agent pods have no IPv4 stack, so the IPv4-only
+// fakeintake is reached through kindnet's NAT64 gateway via the well-known
+// 64:ff9b::/96 prefix. See [CONS-8164].
 func TestKindIPv6Suite(t *testing.T) {
 	helmValues := `
 datadog:
@@ -44,13 +42,14 @@ clusterAgent:
 		e2e.WithStackName("kind-ipv6"),
 		e2e.WithProvisioner(provkind.Provisioner(
 			provkind.WithRunOptions(
-				scenkind.WithIPFamily("dual"),
+				scenkind.WithIPFamily("ipv6"),
 				scenkind.WithVMOptions(
 					scenec2.WithInstanceType("t3.xlarge"),
 				),
 				scenkind.WithFakeintakeOptions(
 					fakeintake.WithMemory(2048),
 					fakeintake.WithRetentionPeriod("31m"),
+					fakeintake.WithIPv6NAT64(),
 				),
 				scenkind.WithDeployDogstatsd(),
 				scenkind.WithDeployTestWorkload(),
@@ -66,10 +65,11 @@ clusterAgent:
 	)
 }
 
-// Test0AgentPodHasIPv6 asserts each agent DaemonSet pod has at least one IPv6
-// PodIP, catching the case where the ipFamily plumbing silently falls back to
-// IPv4-only. The leading 0 orders it right after k8sSuite.Test00UpAndRunning.
-func (suite *kindIPv6Suite) Test0AgentPodHasIPv6() {
+// Test0AgentPodIsIPv6Only asserts each agent DaemonSet pod has only IPv6
+// PodIPs, catching the case where the ipFamily plumbing silently falls back
+// to dual-stack or IPv4. The leading 0 orders it right after
+// k8sSuite.Test00UpAndRunning.
+func (suite *kindIPv6Suite) Test0AgentPodIsIPv6Only() {
 	ctx := context.Background()
 
 	pods, err := suite.Env().KubernetesCluster.Client().CoreV1().Pods("datadog").List(ctx, metav1.ListOptions{
@@ -80,14 +80,10 @@ func (suite *kindIPv6Suite) Test0AgentPodHasIPv6() {
 
 	for _, pod := range pods.Items {
 		require.NotEmpty(suite.T(), pod.Status.PodIPs, "pod %s has no PodIPs", pod.Name)
-		hasIPv6 := false
 		for _, entry := range pod.Status.PodIPs {
 			ip := net.ParseIP(entry.IP)
 			require.NotNilf(suite.T(), ip, "pod %s PodIP %q is not a valid IP", pod.Name, entry.IP)
-			if ip.To4() == nil {
-				hasIPv6 = true
-			}
+			assert.Nilf(suite.T(), ip.To4(), "pod %s PodIP %q is IPv4 (expected IPv6-only); full PodIPs=%+v", pod.Name, entry.IP, pod.Status.PodIPs)
 		}
-		assert.Truef(suite.T(), hasIPv6, "pod %s has no IPv6 entry in PodIPs %+v", pod.Name, pod.Status.PodIPs)
 	}
 }

--- a/test/new-e2e/tests/containers/kindvm_ipv6_test.go
+++ b/test/new-e2e/tests/containers/kindvm_ipv6_test.go
@@ -54,7 +54,10 @@ clusterAgent:
 				scenkind.WithDeployDogstatsd(),
 				scenkind.WithDeployTestWorkload(),
 				scenkind.WithAgentOptions(
-					kubernetesagentparams.WithDualShipping(),
+					// Single-shipping (no dual): every payload goes to the
+					// fakeintake via the IPv6/NAT64 path. The dddev primary
+					// is IPv4-only and unreachable from these IPv6-only pods,
+					// so enabling dual-shipping would stall the forwarder.
 					kubernetesagentparams.WithHelmValues(helmValues),
 					kubernetesagentparams.WithHelmValues(containerHelmValues),
 					kubernetesagentparams.WithKubernetesUseEndpointSlices(),

--- a/test/new-e2e/tests/containers/kindvm_ipv6_test.go
+++ b/test/new-e2e/tests/containers/kindvm_ipv6_test.go
@@ -43,6 +43,7 @@ clusterAgent:
 		e2e.WithProvisioner(provkind.Provisioner(
 			provkind.WithRunOptions(
 				scenkind.WithIPFamily("ipv6"),
+				scenkind.WithIPv6NAT64Daemon(),
 				scenkind.WithVMOptions(
 					scenec2.WithInstanceType("t3.xlarge"),
 				),

--- a/test/new-e2e/tests/containers/kindvm_ipv6_test.go
+++ b/test/new-e2e/tests/containers/kindvm_ipv6_test.go
@@ -27,8 +27,11 @@ type kindIPv6Suite struct {
 }
 
 // TestKindIPv6Suite runs the kind container-integration assertions against a
-// cluster configured with networking.ipFamily=ipv6. External egress relies on
-// kindnet's NAT64 (64:ff9b::/96) and CoreDNS DNS64. See [CONS-8164].
+// dual-stack kind cluster. Pods get both IPv4 and IPv6 PodIPs, so the agent
+// can still reach the IPv4-only fakeintake ALB while intra-cluster IPv6 paths
+// (kubelet, services, peer pods) are exercised. Strict ipFamily=ipv6 is
+// blocked until the fakeintake exposes an IPv6-reachable endpoint. See
+// [CONS-8164].
 func TestKindIPv6Suite(t *testing.T) {
 	helmValues := `
 datadog:
@@ -41,7 +44,7 @@ clusterAgent:
 		e2e.WithStackName("kind-ipv6"),
 		e2e.WithProvisioner(provkind.Provisioner(
 			provkind.WithRunOptions(
-				scenkind.WithIPFamily("ipv6"),
+				scenkind.WithIPFamily("dual"),
 				scenkind.WithVMOptions(
 					scenec2.WithInstanceType("t3.xlarge"),
 				),
@@ -63,11 +66,10 @@ clusterAgent:
 	)
 }
 
-// Test0AgentPodIsIPv6 asserts the agent DaemonSet pods got IPv6 PodIPs, so
-// later IPv6-specific assertions don't pass for the wrong reason if the
-// ipFamily plumbing silently falls back to IPv4. The leading 0 orders this
-// test right after k8sSuite.Test00UpAndRunning.
-func (suite *kindIPv6Suite) Test0AgentPodIsIPv6() {
+// Test0AgentPodHasIPv6 asserts each agent DaemonSet pod has at least one IPv6
+// PodIP, catching the case where the ipFamily plumbing silently falls back to
+// IPv4-only. The leading 0 orders it right after k8sSuite.Test00UpAndRunning.
+func (suite *kindIPv6Suite) Test0AgentPodHasIPv6() {
 	ctx := context.Background()
 
 	pods, err := suite.Env().KubernetesCluster.Client().CoreV1().Pods("datadog").List(ctx, metav1.ListOptions{
@@ -77,9 +79,15 @@ func (suite *kindIPv6Suite) Test0AgentPodIsIPv6() {
 	require.NotEmpty(suite.T(), pods.Items, "no datadog agent pods found")
 
 	for _, pod := range pods.Items {
-		require.NotEmpty(suite.T(), pod.Status.PodIP, "pod %s has no PodIP", pod.Name)
-		ip := net.ParseIP(pod.Status.PodIP)
-		require.NotNil(suite.T(), ip, "pod %s PodIP %q is not a valid IP", pod.Name, pod.Status.PodIP)
-		assert.Nil(suite.T(), ip.To4(), "pod %s PodIP %q is IPv4, expected IPv6", pod.Name, pod.Status.PodIP)
+		require.NotEmpty(suite.T(), pod.Status.PodIPs, "pod %s has no PodIPs", pod.Name)
+		hasIPv6 := false
+		for _, entry := range pod.Status.PodIPs {
+			ip := net.ParseIP(entry.IP)
+			require.NotNilf(suite.T(), ip, "pod %s PodIP %q is not a valid IP", pod.Name, entry.IP)
+			if ip.To4() == nil {
+				hasIPv6 = true
+			}
+		}
+		assert.Truef(suite.T(), hasIPv6, "pod %s has no IPv6 entry in PodIPs %+v", pod.Name, pod.Status.PodIPs)
 	}
 }

--- a/test/new-e2e/tests/containers/kindvm_ipv6_test.go
+++ b/test/new-e2e/tests/containers/kindvm_ipv6_test.go
@@ -1,0 +1,85 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package containers
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/kubernetesagentparams"
+	scenec2 "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/fakeintake"
+	scenkind "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/kindvm"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	provkind "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/kubernetes/kindvm"
+)
+
+type kindIPv6Suite struct {
+	kindSuite
+}
+
+// TestKindIPv6Suite runs the kind container-integration assertions against a
+// cluster configured with networking.ipFamily=ipv6. External egress relies on
+// kindnet's NAT64 (64:ff9b::/96) and CoreDNS DNS64. See [CONS-8164].
+func TestKindIPv6Suite(t *testing.T) {
+	helmValues := `
+datadog:
+    logLevel: DEBUG
+clusterAgent:
+    envDict:
+        DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_BASE_BACKOFF: "10s"
+`
+	e2e.Run(t, &kindIPv6Suite{},
+		e2e.WithStackName("kind-ipv6"),
+		e2e.WithProvisioner(provkind.Provisioner(
+			provkind.WithRunOptions(
+				scenkind.WithIPFamily("ipv6"),
+				scenkind.WithVMOptions(
+					scenec2.WithInstanceType("t3.xlarge"),
+				),
+				scenkind.WithFakeintakeOptions(
+					fakeintake.WithMemory(2048),
+					fakeintake.WithRetentionPeriod("31m"),
+				),
+				scenkind.WithDeployDogstatsd(),
+				scenkind.WithDeployTestWorkload(),
+				scenkind.WithAgentOptions(
+					kubernetesagentparams.WithDualShipping(),
+					kubernetesagentparams.WithHelmValues(helmValues),
+					kubernetesagentparams.WithHelmValues(containerHelmValues),
+					kubernetesagentparams.WithKubernetesUseEndpointSlices(),
+				),
+				scenkind.WithDeployArgoRollout(),
+			),
+		)),
+	)
+}
+
+// Test0AgentPodIsIPv6 asserts the agent DaemonSet pods got IPv6 PodIPs, so
+// later IPv6-specific assertions don't pass for the wrong reason if the
+// ipFamily plumbing silently falls back to IPv4. The leading 0 orders this
+// test right after k8sSuite.Test00UpAndRunning.
+func (suite *kindIPv6Suite) Test0AgentPodIsIPv6() {
+	ctx := context.Background()
+
+	pods, err := suite.Env().KubernetesCluster.Client().CoreV1().Pods("datadog").List(ctx, metav1.ListOptions{
+		LabelSelector: "app=" + suite.Env().Agent.LinuxNodeAgent.LabelSelectors["app"],
+	})
+	require.NoError(suite.T(), err, "failed to list datadog agent pods")
+	require.NotEmpty(suite.T(), pods.Items, "no datadog agent pods found")
+
+	for _, pod := range pods.Items {
+		require.NotEmpty(suite.T(), pod.Status.PodIP, "pod %s has no PodIP", pod.Name)
+		ip := net.ParseIP(pod.Status.PodIP)
+		require.NotNil(suite.T(), ip, "pod %s PodIP %q is not a valid IP", pod.Name, pod.Status.PodIP)
+		assert.Nil(suite.T(), ip.To4(), "pod %s PodIP %q is IPv4, expected IPv6", pod.Name, pod.Status.PodIP)
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Adds optional `networking.ipFamily` support to the e2e-framework's kind-on-EC2 scenario, plus a new `TestKindIPv6Suite` that provisions a **dual-stack** kind cluster and exercises the existing `kindSuite` / `k8sSuite` assertions against it.

Framework delta:
- New `KindConfigFlags.IPFamily` (string: `""` | `"ipv4"` | `"ipv6"` | `"dual"`) templated into `kind-cluster.yaml`'s `networking:` block.
- New `RunParams.ipFamily` + `scenkind.WithIPFamily(family)` option in `scenarios/aws/kindvm`.
- `cilium.NewKindCluster` signature extended with an `ipFamily` parameter so the cilium path doesn't silently drop the option.

Test delta:
- New `test/new-e2e/tests/containers/kindvm_ipv6_test.go`:
  - `TestKindIPv6Suite` embeds `kindSuite`, sets `WithIPFamily("dual")`, runs under a separate `kind-ipv6` Pulumi stack.
  - One new method `Test0AgentPodHasIPv6` asserts at least one IPv6 entry in each agent DaemonSet pod's `PodIPs` — fails loudly if the framework ever silently falls back to IPv4-only.

### Motivation

Follow-up to the [CONS-8164] host:port formatting fixes. Over the last two weeks ~19 PRs landed agent-side fixes for naive `fmt.Sprintf("%s:%d", host, port)` patterns that break on IPv6 literals. There was **zero IPv6 end-to-end coverage** in the repo — a grep for `ipv6|Ipv6|IPv6|ipFamily|dualStack` under `test/new-e2e/` and `test/e2e-framework/` returned nothing. This suite exercises the intra-cluster IPv6 surface (kubelet API, cluster-agent gRPC remote tagger, leader-election Leases, in-cluster DogStatsD/Prometheus scrapes) so regressions surface in CI.

Kind-on-EC2 was chosen over EKS because EKS would require: (a) extending the agent-qa VPC's private subnets with IPv6 `/64`s + an egress-only IGW (Terraform-managed by `cloud-networks`), and (b) a brand-new EKS cluster spec (`kubernetesNetworkConfig.ipFamily` is immutable at creation). Kind has none of those constraints — the cluster's network lives entirely inside Docker on the EC2 host, so the VPC's IPv6 status is irrelevant.

### Why dual-stack instead of IPv6-only

The first revision of this PR shipped `ipFamily=ipv6` (strict IPv6-only). Codex flagged that the fakeintake (`fargateSvcNoLB`) exports a raw IPv4 literal as its endpoint, and kindnet's NAT64 + DNS64 cannot synthesize an AAAA for an IP literal — so IPv6-only pods would time out delivering payloads and the fakeintake-based assertions would silently fail.

Dual-stack keeps the IPv4 path to fakeintake usable while still exercising intra-cluster IPv6 paths. Strict IPv6-only can be re-enabled later once the fakeintake exposes an IPv6-reachable endpoint.

### Describe how you validated your changes

- `go build ./...` in `test/e2e-framework/` is clean.
- `go vet ./tests/containers/...` in `test/new-e2e/` is clean.
- `go test -list '^Test.*' ./tests/containers/...` shows `TestKindIPv6Suite` is enumerated.
- Pre-commit gates passed (Codex review, `pr-review-toolkit:code-reviewer`, `/simplify` skill) with cross-validation; Codex caught a real issue (cilium path missing the IPFamily) which was fixed before this PR opened, and a second pass flagged the fakeintake reachability that motivated the dual-stack switch.
- The actual e2e run on AWS will only happen on `main` per the standard kindvm gating. One known follow-up expected on the first run: some `k8sSuite` test methods may surface real product bugs (e.g. listeners bound to `0.0.0.0` instead of `::`). Those are findings, not test bugs — the purpose of this suite is exactly to surface them.

### Additional Notes

Strict IPv6-only and EKS-IPv6 are intentionally out of scope for this PR. They can be added once (a) the fakeintake gains an IPv6-reachable endpoint, and (b) the agent-qa VPC's private subnets gain IPv6 CIDRs respectively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CONS-8164]: https://datadoghq.atlassian.net/browse/CONS-8164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ