### PR TITLE
fix(third_party/expansion): TestMapReference key mismatch

### DIFF
--- a/internal/third_party/golang/expansion/expand_test.go
+++ b/internal/third_party/golang/expansion/expand_test.go
@@ -55,7 +55,7 @@ func TestMapReference(t *testing.T) {
 			Value: "$(ZOO)-2",
 		},
 		{
-			Name:  "INCOMPLETE",
+			Name:  "FAIL",
 			Value: "$(ZOO)-2-$(DNE)",
 		},
 	}


### PR DESCRIPTION
### What does this PR do?

Fixes `TestMapReference` in `internal/third_party/golang/expansion`. The envs slice was iterating with `Name="INCOMPLETE"` while the expected and initial maps referenced `"FAIL"`, so `declaredEnv["FAIL"]` was never overwritten by `Expand()` and the test always failed under `go test`.

### Motivation

The mismatch was introduced in 49f84a7d0fc (March 2025) but hadn't surfaced because the root module's `test_targets` in `modules.yml` only cover `./pkg`, `./cmd` and `./comp` — `dda inv test` never visits `internal/third_party/...`. Running `bazel test //...` exposes the failure.

### Describe how you validated your changes

`go test ./internal/third_party/golang/expansion/...`

### Additional Notes
