### PR TITLE
[observer] Test metrics enabled

### DIFF
--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1675,6 +1675,8 @@ func dogstatsd(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("dogstatsd_origin_optout_enabled", true)
 	config.BindEnvAndSetDefault("dogstatsd_so_rcvbuf", 0)
 	config.BindEnvAndSetDefault("dogstatsd_metrics_stats_enable", false)
+	// TEST ONLY: enabled by default to measure overhead — do not merge
+	config.BindEnvAndSetDefault("anomaly_detection.metrics.enabled", true)
 	config.BindEnvAndSetDefault("dogstatsd_tags", []string{})
 	config.BindEnvAndSetDefault("dogstatsd_mapper_cache_size", 1000)
 	config.BindEnvAndSetDefault("dogstatsd_string_interner_size", 4096)


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — performance measurement branch

This branch enables `anomaly_detection.metrics.enabled` by **default** (`true`) on top of #50466 to measure the CPU and memory overhead of the observer metrics hot path when active.

The purpose is to give reviewers a CI pipeline to compare against `dogstatsd_metrics_stats_enable` and validate our claim that the per-sample overhead is acceptable.

## What changed

Single line in `pkg/config/setup/common_settings.go`:
```go
config.BindEnvAndSetDefault("anomaly_detection.metrics.enabled", true)
```

This wires the (currently no-op) observer handle into every `TimeSampler.sample()` call — adding one nil check + one virtual interface dispatch per sample.

## What to look at

- Benchmark jobs in CI
- Compare against a baseline run with `dogstatsd_metrics_stats_enable=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)