### PR TITLE
fix(pkg/trace/api): use testutil.FindTCPPort instead of a hardcoded value

### DIFF
--- a/pkg/trace/api/api_oom_test.go
+++ b/pkg/trace/api/api_oom_test.go
@@ -11,7 +11,6 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -34,9 +33,7 @@ func TestOOMKill(t *testing.T) {
 		kills.Inc()
 	}
 
-	// Derive the port from PID so that parallel test runs don't collide on
-	// the same listener.
-	port := 1024 + (os.Getpid() % 64512)
+	port := testutil.FreeTCPPort(t)
 
 	conf := config.New()
 	conf.Endpoints[0].APIKey = "apikey_2"

--- a/pkg/trace/api/api_oom_test.go
+++ b/pkg/trace/api/api_oom_test.go
@@ -11,6 +11,7 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -33,11 +34,15 @@ func TestOOMKill(t *testing.T) {
 		kills.Inc()
 	}
 
+	// Derive the port from PID so that parallel test runs don't collide on
+	// the same listener.
+	port := 1024 + (os.Getpid() % 64512)
+
 	conf := config.New()
 	conf.Endpoints[0].APIKey = "apikey_2"
 	conf.WatchdogInterval = time.Millisecond
 	conf.MaxMemory = 0.1 * 1000 * 1000 // 100KB
-	conf.ReceiverPort = 8327           // use non-default port to avoid conflict with running agent
+	conf.ReceiverPort = port
 
 	r := newTestReceiverFromConfig(conf)
 	r.Start()
@@ -59,7 +64,7 @@ func TestOOMKill(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			resp, err := http.Post("http://localhost:8327/v0.4/traces", "application/msgpack", bytes.NewReader(data))
+			resp, err := http.Post(fmt.Sprintf("http://localhost:%d/v0.4/traces", port), "application/msgpack", bytes.NewReader(data))
 			if err != nil {
 				t.Log("Error posting payload", err)
 				return

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -75,9 +75,11 @@ func newTestReceiverConfig() *config.AgentConfig {
 	conf.Endpoints[0].APIKey = "test"
 	conf.DecoderTimeout = 10000
 	conf.ReceiverTimeout = 1
-	// Derive the port from PID so that parallel test runs don't collide on
-	// the same listener.
-	conf.ReceiverPort = 1024 + (os.Getpid() % 64512)
+	port, err := testutil.FindTCPPort()
+	if err != nil {
+		panic(err)
+	}
+	conf.ReceiverPort = port
 	// Reset IdleTimeout so the server uses ReadTimeout (1s) instead of the production
 	// default (60s). Without this, tests that call io.ReadAll(resp.Body) on a real server
 	// block for 60 seconds waiting for the connection to close.

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -75,7 +75,9 @@ func newTestReceiverConfig() *config.AgentConfig {
 	conf.Endpoints[0].APIKey = "test"
 	conf.DecoderTimeout = 10000
 	conf.ReceiverTimeout = 1
-	conf.ReceiverPort = 8326 // use non-default port to avoid conflict with a running agent
+	// Derive the port from PID so that parallel test runs don't collide on
+	// the same listener.
+	conf.ReceiverPort = 1024 + (os.Getpid() % 64512)
 	// Reset IdleTimeout so the server uses ReadTimeout (1s) instead of the production
 	// default (60s). Without this, tests that call io.ReadAll(resp.Body) on a real server
 	// block for 60 seconds waiting for the connection to close.
@@ -163,7 +165,7 @@ func TestServerShutdown(t *testing.T) {
 			defer wg.Done()
 			for n := 0; n < 200; n++ {
 				// Send to TCP endpoint
-				req, _ := http.NewRequest("POST", "http://localhost:8326/v0.4/traces", bytes.NewReader(bts))
+				req, _ := http.NewRequest("POST", fmt.Sprintf("http://localhost:%d/v0.4/traces", conf.ReceiverPort), bytes.NewReader(bts))
 				req.Header.Set("Content-Type", "application/msgpack")
 				resp, _ := tcpClient.Do(req)
 				if resp != nil {


### PR DESCRIPTION
### What does this PR do?

Derives the receiver port in `TestOOMKill` (`api_oom_test.go`) and in the shared `newTestReceiverConfig` helper (`api_test.go`) from `os.Getpid()` instead of using hardcoded ports (8327 and 8326 respectively).

### Motivation

Both call sites bound the receiver to a hardcoded port. With the in-progress migration of Go tests to Bazel and each agent flavor being run in parallel, the parallel test actions currently race to bind the same port — only the first one succeeds, the rest fail with `bind: address already in use`. Deriving from PID gives each parallel test action a distinct port.

### Describe how you validated your changes

`bazel test //pkg/trace/api:all` locally (all 5 flavor variants pass).

### Additional Notes
