### PR TITLE
[anomalydetection] Add remaining component stubs

### DIFF
--- a/comp/anomalydetection/observer/def/go.mod
+++ b/comp/anomalydetection/observer/def/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually
 
 replace (
+	github.com/DataDog/datadog-agent/comp/anomalydetection/recorder/def => ../../../../comp/anomalydetection/recorder/def
 	github.com/DataDog/datadog-agent/comp/api/api/def => ../../../../comp/api/api/def
 	github.com/DataDog/datadog-agent/comp/core/agenttelemetry/def => ../../../../comp/core/agenttelemetry/def
 	github.com/DataDog/datadog-agent/comp/core/agenttelemetry/fx => ../../../../comp/core/agenttelemetry/fx

--- a/comp/anomalydetection/observer/def/types.go
+++ b/comp/anomalydetection/observer/def/types.go
@@ -10,6 +10,12 @@
 // passed to data pipelines without adding significant overhead.
 package observer
 
+import (
+	"sort"
+	"strconv"
+	"strings"
+)
+
 // Handle is the lightweight observation interface passed to other components.
 type Handle interface {
 	// ObserveMetric observes a DogStatsD metric sample.
@@ -47,4 +53,463 @@ type LogView interface {
 	GetHostname() string
 	// GetTimestampUnixMilli returns the log timestamp in Unix milliseconds.
 	GetTimestampUnixMilli() int64
+}
+
+// LogMetricsExtractor transforms observed logs into metrics.
+// Implementations should be fast since they run synchronously on every observed
+// log. Extractors may keep lightweight internal state when needed for pattern
+// tracking or context enrichment.
+type LogMetricsExtractor interface {
+	// Name returns the extractor name for debugging and logging.
+	Name() string
+	// ProcessLog examines a log and returns any derived metrics.
+	ProcessLog(log LogView) LogMetricsExtractorOutput
+}
+
+// LogObserver is an optional interface that Detectors can implement to
+// receive log observations. This allows detectors to incorporate log signals
+// without going through the metrics extraction path.
+type LogObserver interface {
+	Detector
+	ProcessLog(log LogView)
+}
+
+// MetricOutput is a timeseries value derived from log analysis.
+// The storage keeps full summaries (min/max/sum/count) so aggregation
+// is specified at read time, not write time.
+type MetricOutput struct {
+	Name       string
+	Value      float64
+	Tags       []string
+	ContextKey string
+}
+
+// LogMetricsExtractorOutput is what we obtain when we process a log with a log metrics extractor.
+type LogMetricsExtractorOutput struct {
+	Metrics   []MetricOutput
+	Telemetry []ObserverTelemetry
+	// EvictedContextKeys lists context keys that are no longer valid (e.g. after
+	// extractor garbage collection). The engine removes matching contextRefs entries.
+	EvictedContextKeys []string
+}
+
+// SeriesDescriptor is the fully resolved identity of a time series.
+// It carries namespace, metric name, tags, and aggregation — everything
+// needed to display, key, and compare series across correlators and API.
+type SeriesDescriptor struct {
+	// Namespace identifies the component that produced this metric
+	// (e.g. an extractor name like "log_metrics_extractor", or "dogstatsd").
+	Namespace string
+	// Name is the base metric name (e.g. "log.pattern.<hash>.count", "cpu.user").
+	Name string
+	// Tags are the series-level tags (e.g. ["host:web-1", "env:prod"]).
+	Tags []string
+	// Aggregate is the aggregation applied when reading the series.
+	Aggregate Aggregate
+}
+
+// String returns a human-readable representation (e.g. "cpu.user:avg").
+// Namespace and tags are not included — use DisplayName() for that.
+func (sd SeriesDescriptor) String() string {
+	if sd.Name == "" {
+		return ""
+	}
+	if sd.Aggregate == AggregateNone {
+		return sd.Name
+	}
+	return sd.Name + ":" + AggregateString(sd.Aggregate)
+}
+
+// DisplayName returns a display string with tags (e.g. "cpu.user:avg{host:web-1}").
+func (sd SeriesDescriptor) DisplayName() string {
+	base := sd.String()
+	if len(sd.Tags) == 0 {
+		return base
+	}
+	return base + "{" + strings.Join(sd.Tags, ",") + "}"
+}
+
+// Key returns a stable string suitable for use as a map key.
+// Format: "namespace|name:agg|tag1,tag2,..."
+func (sd SeriesDescriptor) Key() string {
+	aggStr := AggregateString(sd.Aggregate)
+	var tagStr string
+	if len(sd.Tags) > 0 {
+		sorted := make([]string, len(sd.Tags))
+		copy(sorted, sd.Tags)
+		sort.Strings(sorted)
+		tagStr = strings.Join(sorted, ",")
+	}
+	return sd.Namespace + "|" + sd.Name + ":" + aggStr + "|" + tagStr
+}
+
+// SeriesRef is a compact numeric handle for a stored time series.
+// Storage assigns a SeriesRef when a series key is first created;
+// the ref remains stable for the lifetime of the storage instance.
+type SeriesRef int
+
+// QueryHandle pairs a storage series ref with its aggregate, providing
+// enough information to produce the compact ID ("42:avg") that the API
+// uses as a join key across endpoints.
+type QueryHandle struct {
+	Ref       SeriesRef
+	Aggregate Aggregate
+}
+
+// CompactID returns the compact series identifier (e.g. "42:avg").
+func (q QueryHandle) CompactID() string {
+	return strconv.Itoa(int(q.Ref)) + ":" + AggregateString(q.Aggregate)
+}
+
+// AnomalyType distinguishes the source type of an anomaly.
+type AnomalyType string
+
+const (
+	// AnomalyTypeMetric is a metric-based anomaly detected by a detector.
+	AnomalyTypeMetric AnomalyType = "metric"
+	// AnomalyTypeLog is a log-based anomaly emitted directly by a log observer,
+	// bypassing the metrics extraction pipeline.
+	AnomalyTypeLog AnomalyType = "log"
+)
+
+// Anomaly is a detected anomaly event.
+// Anomalies represent a point in time where something anomalous was detected.
+type Anomaly struct {
+	// Type distinguishes log-based anomalies from metric-based ones.
+	// Defaults to AnomalyTypeMetric if not set.
+	Type AnomalyType
+	// Source is the fully resolved series identity (namespace, name, tags, aggregate).
+	Source SeriesDescriptor
+	// SourceRef is the storage handle for this anomaly's series, enabling
+	// direct compact ID lookups without string-key reconstruction. Nil for
+	// anomalies without a storage-backed series (e.g. log anomalies, RRCF).
+	SourceRef *QueryHandle
+	// DetectorName identifies which detector produced this anomaly.
+	DetectorName string
+	Title        string
+	Description  string
+	// Context carries optional enrichment about the originating signal, such as
+	// a synthesized pattern and example source data.
+	Context   *MetricContext
+	Timestamp int64    // when the anomaly was detected (unix seconds)
+	Score     *float64 // confidence/severity score (nil if not available)
+	// SamplingIntervalSec is the median interval between consecutive data points
+	// for the source series, in seconds. Set by scan detectors (ScanMW, ScanWelch)
+	// at detection time from the actual point buffer. Zero if unknown.
+	// Correlators use this to dynamically scale proximity windows so that
+	// slow-sampling series (e.g. 15s redis check) can join clusters formed
+	// by faster-sampling series (e.g. 10s trace stats).
+	SamplingIntervalSec int64
+	// DebugInfo contains detector-specific debug information explaining the detection.
+	DebugInfo *AnomalyDebugInfo
+}
+
+// AnomalyDebugInfo provides detailed information about why an anomaly was detected.
+type AnomalyDebugInfo struct {
+	// Baseline statistics
+	BaselineStart  int64   // timestamp of baseline period start
+	BaselineEnd    int64   // timestamp of baseline period end
+	BaselineMean   float64 // mean of baseline (for CUSUM)
+	BaselineMedian float64 // median of baseline
+	BaselineStddev float64 // stddev of baseline (for CUSUM)
+	BaselineMAD    float64 // MAD of baseline
+
+	// Detection parameters
+	Threshold      float64 // threshold that was crossed
+	SlackParam     float64 // k parameter (CUSUM only)
+	CurrentValue   float64 // value at detection time
+	DeviationSigma float64 // how many sigmas from baseline
+
+	// For CUSUM: the cumulative sum values leading up to detection
+	CUSUMValues []float64 // S[t] values (may be truncated to last N points)
+}
+
+// ReportOutput is the output model passed to reporters after each advance cycle.
+// It carries enough data for reporters to act without reaching back into engine internals.
+type ReportOutput struct {
+	// AdvancedToSec is the data time the engine advanced to.
+	AdvancedToSec int64
+	// NewAnomalies are anomalies detected in this advance cycle.
+	NewAnomalies []Anomaly
+	// ActiveCorrelations are the current correlation patterns across all correlators.
+	ActiveCorrelations []ActiveCorrelation
+}
+
+// Series is a time series with simple timestamp/value points.
+// This is the simplified view passed to SeriesDetector.
+type Series struct {
+	Namespace string
+	Name      string
+	Tags      []string
+	Points    []Point
+}
+
+// Point is a single timestamp/value pair.
+type Point struct {
+	Timestamp int64
+	Value     float64
+}
+
+// MetricKind distinguishes gauge (absolute level) from counter (increment) telemetry.
+// Gauge samples are exported with Set; counter samples with Add(value) on the backend counter.
+type MetricKind int
+
+const (
+	// MetricKindGauge is the default: the metric value is an absolute level.
+	MetricKindGauge MetricKind = iota
+	// MetricKindCounter indicates the value is a delta added to the named counter.
+	MetricKindCounter
+)
+
+// ObserverTelemetry describes a telemetry event emitted by the observer.
+type ObserverTelemetry struct {
+	DetectorName string
+	Metric       MetricView
+	Log          LogView
+	// Kind is telemetry metric kind; zero means gauge (backward compatible).
+	Kind MetricKind
+}
+
+// DetectionResult contains outputs from anomaly detection.
+type DetectionResult struct {
+	Anomalies []Anomaly
+	// Used to debug anomaly detectors
+	Telemetry []ObserverTelemetry
+}
+
+// SeriesDetector analyzes a time series for anomalies.
+// Implementations should be stateless and just do math on the points.
+type SeriesDetector interface {
+	// Name returns the analysis name for debugging.
+	Name() string
+	// Detect examines a series and returns any detected anomalies.
+	Detect(series Series) DetectionResult
+}
+
+// Correlator accumulates anomaly events and produces correlated patterns.
+// Correlators are stateful and cluster/filter/summarize anomaly streams.
+//
+// The lifecycle is: ProcessAnomaly to feed anomalies, Advance to trigger
+// time-based maintenance (eviction, window finalization), and
+// ActiveCorrelations to read current state.
+type Correlator interface {
+	// Name returns the correlator name for debugging.
+	Name() string
+	// ProcessAnomaly receives an anomaly event for accumulation.
+	ProcessAnomaly(a Anomaly)
+	// Advance performs time-based maintenance (eviction, window finalization)
+	// up to the given data time. Callers should invoke this after each
+	// detection cycle so correlators can manage their windows.
+	Advance(dataTime int64)
+	// ActiveCorrelations returns currently detected correlation patterns.
+	ActiveCorrelations() []ActiveCorrelation
+	// Reset clears all internal state for reanalysis.
+	Reset()
+}
+
+// Reporter receives reports and displays or delivers them.
+type Reporter interface {
+	// Name returns the reporter name for debugging.
+	Name() string
+	// Report delivers a report to its destination (stdout, file, webserver, etc).
+	Report(report ReportOutput)
+}
+
+// ActiveCorrelation represents a detected correlation pattern.
+type ActiveCorrelation struct {
+	Pattern string // pattern name, e.g. "kernel_bottleneck"
+	Title   string // display title, e.g. "Correlated: Kernel network bottleneck"
+	// Members are the fully resolved series descriptors participating in this correlation.
+	Members     []SeriesDescriptor
+	Anomalies   []Anomaly // the actual anomalies that triggered this correlation
+	FirstSeen   int64     // when pattern first matched (unix seconds, from data)
+	LastUpdated int64     // most recent contributing signal (unix seconds, from data)
+}
+
+// RawAnomalyState provides read access to raw anomalies before correlation processing.
+// Used by test bench reporters to display individual detector outputs.
+type RawAnomalyState interface {
+	// RawAnomalies returns all anomalies detected by detector implementations.
+	RawAnomalies() []Anomaly
+}
+
+// TelemetryNamespace is the storage namespace used for observer-internal debug
+// metrics (e.g. testbench UI charts). Detectors must not treat it as workload data.
+const TelemetryNamespace = "telemetry"
+
+// SeriesFilter specifies criteria for selecting series.
+type SeriesFilter struct {
+	Namespace   string            // exact match (empty = any)
+	NamePattern string            // prefix match (empty = any)
+	TagMatchers map[string]string // required tag key=value pairs
+	// ExcludeNamespaces skips series whose namespace is in this list. It is only
+	// applied when Namespace is empty (list-all mode). An explicit Namespace match
+	// ignores ExcludeNamespaces so callers can still list internal series when needed.
+	ExcludeNamespaces []string
+}
+
+// WorkloadSeriesFilter returns a filter for anomaly detectors: all namespaces
+// except TelemetryNamespace.
+func WorkloadSeriesFilter() SeriesFilter {
+	return SeriesFilter{ExcludeNamespaces: []string{TelemetryNamespace}}
+}
+
+// SeriesMeta describes a series discovered via ListSeries.
+// The Ref field is a stable numeric identifier for use in hot-path methods.
+type SeriesMeta struct {
+	Ref       SeriesRef
+	Namespace string
+	Name      string
+	Tags      []string
+}
+
+// Aggregate specifies which statistic to extract from summary stats.
+type Aggregate int
+
+const (
+	AggregateNone Aggregate = iota
+	AggregateAverage
+	AggregateSum
+	AggregateCount
+	AggregateMin
+	AggregateMax
+)
+
+// AggregateString returns a short string label for the aggregation type.
+func AggregateString(agg Aggregate) string {
+	switch agg {
+	case AggregateNone:
+		return "none"
+	case AggregateAverage:
+		return "avg"
+	case AggregateSum:
+		return "sum"
+	case AggregateCount:
+		return "count"
+	case AggregateMin:
+		return "min"
+	case AggregateMax:
+		return "max"
+	default:
+		return "unknown"
+	}
+}
+
+// ContextProvider resolves metric keys back to richer context about their
+// origin. Components that synthesize metrics from richer data (e.g. log
+// extractors that turn log patterns into count metrics) can implement this
+// interface so that downstream consumers (detectors, reporters) can produce
+// more descriptive anomaly reports.
+type ContextProvider interface {
+	// GetContextByKey returns contextual information for a previously emitted
+	// context key, if available.
+	GetContextByKey(key string) (MetricContext, bool)
+}
+
+// MetricContext describes the origin of a synthesized metric.
+type MetricContext struct {
+	// Pattern is the normalized pattern that generated this metric (e.g. a log signature).
+	Pattern string
+	// Example is a recent raw input that matched the pattern.
+	Example string
+	// Source identifies the originating component or data stream.
+	Source string
+	// SplitTags carries the tag-group key/value pairs (source, service, env, host) that
+	// scoped the sub-clusterer which produced this metric. Nil when no split tags apply.
+	SplitTags map[string]string
+}
+
+// StorageReader provides read access to time series data.
+// Detectors use this to pull whatever data they need.
+//
+// Use ListSeries to discover series and obtain their numeric handles.
+// All hot-path methods take a SeriesRef for O(1) lookups.
+//
+// Reading points: ForEachPoint and GetSeriesRange both read the same data;
+// they differ in allocation cost and ownership model.
+//
+//   - ForEachPoint reuses a pooled buffer internally — effectively zero
+//     allocation at steady state. The callback sees each point exactly once
+//     and must not retain the *Series pointer. Prefer this for streaming or
+//     incremental callers that process points one at a time.
+//
+//   - GetSeriesRange allocates a fresh []Point each call. The caller owns the
+//     returned data and may slice, index, or store it freely. Prefer this when
+//     the detector needs random access to the full window (e.g. baseline
+//     estimation, cross-series alignment).
+//
+// Use PointCountUpTo and WriteGeneration to cheaply detect new data before
+// reading points.
+type StorageReader interface {
+	// ListSeries returns metadata for all series matching the filter.
+	ListSeries(filter SeriesFilter) []SeriesMeta
+
+	// GetSeriesRange returns points within a time range (start, end].
+	// Start is exclusive, end is inclusive. Use start=0 to read from the beginning.
+	// Allocates a new []Point slice — see interface doc for when to prefer ForEachPoint.
+	GetSeriesRange(handle SeriesRef, start, end int64, agg Aggregate) *Series
+
+	// ForEachPoint calls fn for every point in the time range (start, end].
+	// The Series pointer and its contents are valid only for the duration of
+	// the callback. Uses a pooled buffer internally so steady-state calls
+	// do not allocate. Returns false if the series was not found.
+	ForEachPoint(handle SeriesRef, start, end int64, agg Aggregate, fn func(*Series, Point)) bool
+
+	// PointCount returns the number of raw data points for a series without
+	// loading or converting them. Returns 0 if the series is not found.
+	PointCount(handle SeriesRef) int
+
+	// PointCountUpTo returns the number of raw data points with timestamp <= endTime.
+	// Uses binary search for efficiency. Returns 0 if the series is not found.
+	PointCountUpTo(handle SeriesRef, endTime int64) int
+
+	// SumRange returns the sum of the specified aggregate over all points with
+	// timestamp in (start, end] without allocating any intermediate slices.
+	// Returns 0 if the series is not found or the range is empty.
+	// This is more efficient than ForEachPoint when only the aggregate total
+	// is needed (e.g. computing an average rate over a window).
+	SumRange(handle SeriesRef, start, end int64, agg Aggregate) float64
+
+	// WriteGeneration returns a per-series counter that increments on every
+	// write to that series, including same-bucket merges. Use this to detect
+	// updates to an existing series even when its point count does not change.
+	// Returns 0 if the series is not found.
+	WriteGeneration(handle SeriesRef) int64
+
+	// SeriesGeneration returns a global counter that increments only when the
+	// set of known series changes. Use this to cache ListSeries results and
+	// refresh them only when new series keys appear.
+	SeriesGeneration() uint64
+}
+
+// Detector is the flexible detection interface where detectors pull data from storage.
+// This supports multivariate detection across multiple series.
+type Detector interface {
+	Name() string
+
+	// Detect is called periodically by the scheduler.
+	// The detector queries storage for whatever data it needs.
+	// dataTime is the current data timestamp (for determinism - only read data <= dataTime).
+	Detect(storage StorageReader, dataTime int64) DetectionResult
+}
+
+// SeriesRemover is an optional interface that Detector implementations can
+// satisfy to receive notifications when storage drops series.
+//
+// Many detectors maintain per-series state (BOCPD posterior arrays, ScanMW
+// segment buffers, ScanWelch posterior, the seriesDetectorAdapter visible
+// point count map, etc.) keyed by SeriesRef. Storage frees the series
+// payload itself when extractors evict their LRU contexts and the engine
+// calls RemoveSeriesByKeys, but without this hook the detector-side maps
+// keep growing unbounded with the cumulative number of series ever
+// observed. The engine fans the freed refs out to every detector that
+// implements this interface immediately after RemoveSeriesByKeys returns
+// them, keeping detector state symmetric with storage state.
+//
+// Implementations should be cheap (a handful of map deletes) and tolerant
+// of refs they have never seen — adapters routinely receive refs for
+// series they were never asked to detect on (e.g. metric series on a
+// log-only detector).
+type SeriesRemover interface {
+	RemoveSeries(refs []SeriesRef)
 }

--- a/comp/anomalydetection/observer/impl/hfrunner/BUILD.bazel
+++ b/comp/anomalydetection/observer/impl/hfrunner/BUILD.bazel
@@ -1,0 +1,4 @@
+# gazelle:ignore
+# hfrunner imports corechecks/system/cpu, memory, disk, io, network, uptime, filehandles,
+# and corechecks/containers/generic — none of these are migrated to Bazel yet.
+# Migrate those packages first, then add a proper go_library rule here.

--- a/comp/anomalydetection/observer/impl/hfrunner/runner.go
+++ b/comp/anomalydetection/observer/impl/hfrunner/runner.go
@@ -1,0 +1,215 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package hfrunner
+
+import (
+	"sync"
+	"time"
+
+	observerdef "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
+
+	taggerdef "github.com/DataDog/datadog-agent/comp/core/tagger/def"
+	workloadfilterdef "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
+	workloadmetadef "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers/generic"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/net/network"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/system/cpu/cpu"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/system/cpu/load"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/system/disk/disk"
+	diskio "github.com/DataDog/datadog-agent/pkg/collector/corechecks/system/disk/io"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/system/filehandles"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/system/memory"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/system/uptime"
+)
+
+const (
+	// tickInterval is how often each check is run.
+	tickInterval = time.Second
+
+	// initialBackoff is the backoff after the first failure.
+	initialBackoff = 2 * time.Second
+
+	// maxBackoff caps the retry wait to avoid long silences.
+	maxBackoff = 60 * time.Second
+
+	// HFSource is the observer handle source name for HF system check metrics.
+	// Using a distinct name from "all-metrics" lets the observer suppress the
+	// lower-frequency 15s versions of these metrics when HF mode is active.
+	HFSource = "system-checks-hf"
+
+	// HFContainerSource is the observer handle source name for HF container metrics.
+	HFContainerSource = "container-checks-hf"
+)
+
+// checkEntry tracks a single check instance and its retry state.
+type checkEntry struct {
+	name    string
+	ch      check.Check
+	backoff time.Duration // current backoff duration; 0 = no active backoff
+	retryAt time.Time     // when to next attempt after a failure
+	logged  bool          // whether we've already logged the first failure
+}
+
+// Runner runs system checks at 1-second intervals and routes their output
+// directly into the observer pipeline. It is owned by the observer component
+// and has no interaction with the normal collector/aggregator/forwarder chain.
+type Runner struct {
+	entries  []*checkEntry
+	stopCh   chan struct{}
+	stopOnce sync.Once
+}
+
+// New creates a Runner, instantiates system checks, and configures them.
+// Checks that are unavailable on the current platform (e.g. battery on Linux
+// servers, Windows-only checks on Linux) are silently skipped.
+// Returns the runner; call Start() to begin collection.
+func New(handle observerdef.Handle) *Runner {
+	mgr := newObserverSenderManager(handle)
+
+	type factoryEntry struct {
+		name    string
+		factory option.Option[func() check.Check]
+	}
+
+	factories := []factoryEntry{
+		{"cpu", cpu.Factory()},
+		{"load", load.Factory()},
+		{"memory", memory.Factory()},
+		{"disk", disk.Factory()},
+		{"io", diskio.Factory()},
+		{"network", network.Factory()},
+		{"uptime", uptime.Factory()},
+		{"filehandles", filehandles.Factory()},
+	}
+
+	var entries []*checkEntry
+	for _, fe := range factories {
+		factory, ok := fe.factory.Get()
+		if !ok {
+			log.Debugf("[observer/hfrunner] %s check not available on this platform, skipping", fe.name)
+			continue
+		}
+
+		ch := factory()
+
+		err := ch.Configure(mgr, 0, integration.Data("{}"), integration.Data("{}"), "hf-runner", "hf-runner")
+		if err != nil {
+			log.Warnf("[observer/hfrunner] failed to configure %s check, skipping: %v", fe.name, err)
+			continue
+		}
+
+		entries = append(entries, &checkEntry{name: fe.name, ch: ch})
+	}
+
+	log.Infof("[observer/hfrunner] initialized %d system checks for high-frequency collection", len(entries))
+	return &Runner{entries: entries, stopCh: make(chan struct{})}
+}
+
+// ContainerDeps holds the components required to run the generic container check.
+// All three must be non-nil; NewContainer returns nil if any are missing.
+type ContainerDeps struct {
+	WMeta       workloadmetadef.Component
+	FilterStore workloadfilterdef.Component
+	Tagger      taggerdef.Component
+}
+
+// NewContainer creates a Runner that collects container metrics at 1-second intervals
+// via the generic container check. Returns nil if any dep in ContainerDeps is nil.
+func NewContainer(handle observerdef.Handle, deps ContainerDeps) *Runner {
+	if deps.WMeta == nil || deps.FilterStore == nil || deps.Tagger == nil {
+		log.Warn("[observer/hfrunner] container check deps incomplete, skipping container HF runner")
+		return nil
+	}
+
+	mgr := newObserverSenderManager(handle)
+
+	type factoryEntry struct {
+		name    string
+		factory option.Option[func() check.Check]
+	}
+
+	factories := []factoryEntry{
+		{"container", generic.Factory(deps.WMeta, deps.FilterStore, deps.Tagger)},
+	}
+
+	var entries []*checkEntry
+	for _, fe := range factories {
+		factory, ok := fe.factory.Get()
+		if !ok {
+			log.Debugf("[observer/hfrunner] %s check not available on this platform, skipping", fe.name)
+			continue
+		}
+		ch := factory()
+		err := ch.Configure(mgr, 0, integration.Data("{}"), integration.Data("{}"), "hf-container-runner", "hf-container-runner")
+		if err != nil {
+			log.Warnf("[observer/hfrunner] failed to configure %s check, skipping: %v", fe.name, err)
+			continue
+		}
+		entries = append(entries, &checkEntry{name: fe.name, ch: ch})
+	}
+
+	log.Infof("[observer/hfrunner] initialized %d container checks for high-frequency collection", len(entries))
+	return &Runner{entries: entries, stopCh: make(chan struct{})}
+}
+
+// Start begins the 1-second collection loop in a background goroutine.
+func (r *Runner) Start() {
+	go r.run()
+}
+
+// Stop signals the collection loop to exit. Safe to call multiple times.
+func (r *Runner) Stop() {
+	r.stopOnce.Do(func() { close(r.stopCh) })
+}
+
+func (r *Runner) run() {
+	ticker := time.NewTicker(tickInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-r.stopCh:
+			return
+		case now := <-ticker.C:
+			for _, e := range r.entries {
+				r.runCheck(e, now)
+			}
+		}
+	}
+}
+
+func (r *Runner) runCheck(e *checkEntry, now time.Time) {
+	if e.backoff > 0 && now.Before(e.retryAt) {
+		return
+	}
+
+	if err := e.ch.Run(); err != nil {
+		if !e.logged {
+			log.Warnf("[observer/hfrunner] %s check failed (will retry with backoff): %v", e.name, err)
+			e.logged = true
+		}
+		if e.backoff == 0 {
+			e.backoff = initialBackoff
+		} else {
+			e.backoff *= 2
+			if e.backoff > maxBackoff {
+				e.backoff = maxBackoff
+			}
+		}
+		e.retryAt = now.Add(e.backoff)
+		return
+	}
+
+	if e.backoff > 0 {
+		log.Infof("[observer/hfrunner] %s check recovered", e.name)
+	}
+	e.backoff = 0
+	e.logged = false
+}

--- a/comp/anomalydetection/observer/impl/hfrunner/sender.go
+++ b/comp/anomalydetection/observer/impl/hfrunner/sender.go
@@ -1,0 +1,172 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package hfrunner provides a high-frequency system check runner for the observer.
+// It runs system checks at 1-second intervals and routes their output directly
+// into the observer pipeline, bypassing the normal aggregator/forwarder chain.
+// Metrics collected here are never forwarded to Datadog intake.
+package hfrunner
+
+import (
+	"time"
+
+	observerdef "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
+	aggsender "github.com/DataDog/datadog-agent/pkg/aggregator/sender"
+	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
+	"github.com/DataDog/datadog-agent/pkg/collector/check/stats"
+	"github.com/DataDog/datadog-agent/pkg/metrics/event"
+	"github.com/DataDog/datadog-agent/pkg/metrics/servicecheck"
+	"github.com/DataDog/datadog-agent/pkg/serializer/types"
+)
+
+// observerSenderManager implements sender.SenderManager.
+// All senders it produces route metrics to the observer handle.
+type observerSenderManager struct {
+	handle observerdef.Handle
+}
+
+func newObserverSenderManager(handle observerdef.Handle) *observerSenderManager {
+	return &observerSenderManager{handle: handle}
+}
+
+func (m *observerSenderManager) GetSender(_id checkid.ID) (aggsender.Sender, error) {
+	return &observerSender{handle: m.handle}, nil
+}
+
+func (m *observerSenderManager) SetSender(_s aggsender.Sender, _id checkid.ID) error {
+	return nil
+}
+
+func (m *observerSenderManager) DestroySender(_id checkid.ID) {}
+
+func (m *observerSenderManager) GetDefaultSender() (aggsender.Sender, error) {
+	return &observerSender{handle: m.handle}, nil
+}
+
+// observerSender implements sender.Sender. Metric calls route to the observer
+// handle as MetricView observations. Everything else (events, service checks,
+// orchestrator metadata) is silently dropped — the observer doesn't use them.
+type observerSender struct {
+	handle observerdef.Handle
+}
+
+// inlineMetric is a lightweight MetricView that holds a single sample.
+// It is stack-allocated and passed synchronously to ObserveMetric, which
+// copies the data before returning, so no heap escape is required.
+type inlineMetric struct {
+	name      string
+	value     float64
+	tags      []string
+	timestamp int64
+}
+
+func (m *inlineMetric) GetName() string         { return m.name }
+func (m *inlineMetric) GetValue() float64       { return m.value }
+func (m *inlineMetric) GetRawTags() []string    { return m.tags }
+func (m *inlineMetric) GetTimestampUnix() int64 { return m.timestamp }
+func (m *inlineMetric) GetSampleRate() float64  { return 1.0 }
+
+func (s *observerSender) observe(name string, value float64, tags []string) {
+	m := &inlineMetric{
+		name:      name,
+		value:     value,
+		tags:      tags,
+		timestamp: time.Now().Unix(),
+	}
+	s.handle.ObserveMetric(m)
+}
+
+func (s *observerSender) Commit() {}
+
+func (s *observerSender) Gauge(metric string, value float64, _ string, tags []string) {
+	s.observe(metric, value, tags)
+}
+
+func (s *observerSender) GaugeNoIndex(metric string, value float64, _ string, tags []string) {
+	s.observe(metric, value, tags)
+}
+
+func (s *observerSender) Rate(metric string, value float64, _ string, tags []string) {
+	s.observe(metric, value, tags)
+}
+
+func (s *observerSender) Count(metric string, value float64, _ string, tags []string) {
+	s.observe(metric, value, tags)
+}
+
+func (s *observerSender) MonotonicCount(metric string, value float64, _ string, tags []string) {
+	s.observe(metric, value, tags)
+}
+
+func (s *observerSender) MonotonicCountWithFlushFirstValue(metric string, value float64, _ string, tags []string, _ bool) {
+	s.observe(metric, value, tags)
+}
+
+func (s *observerSender) Counter(metric string, value float64, _ string, tags []string) {
+	s.observe(metric, value, tags)
+}
+
+func (s *observerSender) Histogram(metric string, value float64, _ string, tags []string) {
+	s.observe(metric, value, tags)
+}
+
+func (s *observerSender) Historate(metric string, value float64, _ string, tags []string) {
+	s.observe(metric, value, tags)
+}
+
+func (s *observerSender) Distribution(metric string, value float64, _ string, tags []string) {
+	s.observe(metric, value, tags)
+}
+
+func (s *observerSender) GaugeWithTimestamp(metric string, value float64, _ string, tags []string, timestamp float64) error {
+	m := &inlineMetric{
+		name:      metric,
+		value:     value,
+		tags:      tags,
+		timestamp: int64(timestamp),
+	}
+	s.handle.ObserveMetric(m)
+	return nil
+}
+
+func (s *observerSender) CountWithTimestamp(metric string, value float64, _ string, tags []string, timestamp float64) error {
+	m := &inlineMetric{
+		name:      metric,
+		value:     value,
+		tags:      tags,
+		timestamp: int64(timestamp),
+	}
+	s.handle.ObserveMetric(m)
+	return nil
+}
+
+// The following methods are no-ops: the observer does not process events,
+// service checks, histogram buckets, or orchestrator payloads.
+
+func (s *observerSender) ServiceCheck(_ string, _ servicecheck.ServiceCheckStatus, _ string, _ []string, _ string) {
+}
+
+func (s *observerSender) HistogramBucket(_ string, _ int64, _, _ float64, _ bool, _ string, _ []string, _ bool) {
+}
+
+func (s *observerSender) OpenmetricsBucket(_ string, _ int64, _, _ float64, _ bool, _ string, _ []string, _ bool) {
+}
+
+func (s *observerSender) Event(_ event.Event) {}
+
+func (s *observerSender) EventPlatformEvent(_ []byte, _ string) {}
+
+func (s *observerSender) GetSenderStats() stats.SenderStats {
+	return stats.NewSenderStats()
+}
+
+func (s *observerSender) DisableDefaultHostname(_ bool) {}
+func (s *observerSender) SetCheckCustomTags(_ []string) {}
+func (s *observerSender) SetCheckService(_ string)      {}
+func (s *observerSender) SetNoIndex(_ bool)             {}
+func (s *observerSender) FinalizeCheckServiceTag()      {}
+
+func (s *observerSender) OrchestratorMetadata(_ []types.ProcessMessageBody, _ string, _ int) {}
+func (s *observerSender) OrchestratorManifest(_ []types.ProcessMessageBody, _ string)        {}

--- a/comp/anomalydetection/recorder/def/BUILD.bazel
+++ b/comp/anomalydetection/recorder/def/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "def",
+    srcs = ["component.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/anomalydetection/recorder/def",
+    visibility = ["//visibility:public"],
+    deps = ["//comp/anomalydetection/observer/def"],
+)

--- a/comp/anomalydetection/recorder/def/component.go
+++ b/comp/anomalydetection/recorder/def/component.go
@@ -1,0 +1,57 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package recorder provides a middleware component for recording and replaying observer data.
+//
+// The recorder intercepts metrics flowing through observer handles, optionally
+// recording them to parquet files. This enables:
+// - Capturing production data for offline analysis
+// - Loading recorded data for testing and debugging
+// - Building reproducible test scenarios from real workloads
+package recorder
+
+import (
+	observer "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
+)
+
+// team: q-branch
+
+// Component is the recorder middleware component.
+// It wraps observer handles to intercept and optionally record observations.
+type Component interface {
+	// GetHandle wraps the provided HandleFunc with recording capability.
+	// If recording is enabled via config, metrics will be written to parquet files.
+	// This is called by the observer's GetHandle to create the final handle chain.
+	GetHandle(handleFunc observer.HandleFunc) observer.HandleFunc
+
+	// ReadAllMetrics reads all metrics from parquet files and returns them as a slice.
+	// This is for batch loading scenarios (like testbench) where streaming via handles
+	// is not needed and direct access to all metrics at once is more efficient.
+	ReadAllMetrics(inputDir string) ([]MetricData, error)
+
+	// ReadAllLogs reads all logs from parquet files and returns them as a slice.
+	ReadAllLogs(inputDir string) ([]LogData, error)
+}
+
+// MetricData represents a single metric read from parquet files.
+// Used by ReadAllMetrics for batch loading scenarios.
+type MetricData struct {
+	Source    string   // Source/namespace (RunID in parquet)
+	Name      string   // Metric name
+	Value     float64  // Metric value
+	Timestamp int64    // Unix timestamp in seconds
+	Tags      []string // Tags in "key:value" format
+	Dropped   bool     // True if the live observer's channel dropped this observation
+}
+
+// LogData represents a log entry read from parquet files.
+type LogData struct {
+	Source      string   // Source/namespace (RunID in parquet)
+	TimestampMs int64    // Unix timestamp in milliseconds since epoch
+	Content     []byte   // Log message content (raw bytes)
+	Status      string   // Log severity level (debug, info, warn, error, etc.)
+	Hostname    string   // Hostname where log originated
+	Tags        []string // Tags in "key:value" format
+}

--- a/comp/anomalydetection/recorder/def/go.mod
+++ b/comp/anomalydetection/recorder/def/go.mod
@@ -1,0 +1,11 @@
+module github.com/DataDog/datadog-agent/comp/anomalydetection/recorder/def
+
+go 1.25.0
+
+require github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def v0.0.0-00010101000000-000000000000
+
+// This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually
+
+replace (
+	github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def => ../../../../comp/anomalydetection/observer/def
+)

--- a/comp/anomalydetection/recorder/fx-noop/BUILD.bazel
+++ b/comp/anomalydetection/recorder/fx-noop/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "fx-noop",
+    srcs = ["fx.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/anomalydetection/recorder/fx-noop",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/anomalydetection/recorder/def",
+        "//pkg/util/fxutil",
+    ],
+)

--- a/comp/anomalydetection/recorder/fx-noop/fx.go
+++ b/comp/anomalydetection/recorder/fx-noop/fx.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// Package fx provides the fx module for the recorder component.
+// This no-op variant provides an empty option so the observer starts
+// without recording. Wire recorder/fx instead when recording is needed.
+package fx
+
+import (
+	recorder "github.com/DataDog/datadog-agent/comp/anomalydetection/recorder/def"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Module defines the fx options for the no-op recorder component.
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fxutil.ProvideOptional[recorder.Component](),
+	)
+}

--- a/comp/anomalydetection/reporter/def/BUILD.bazel
+++ b/comp/anomalydetection/reporter/def/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "def",
+    srcs = ["component.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/anomalydetection/reporter/def",
+    visibility = ["//visibility:public"],
+    deps = ["//comp/anomalydetection/observer/def"],
+)

--- a/comp/anomalydetection/reporter/def/component.go
+++ b/comp/anomalydetection/reporter/def/component.go
@@ -1,0 +1,53 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package reporter defines the reporter component contracts.
+// Concrete reporters are provided through the `anomalydetection_reporters` Fx group.
+package reporter
+
+// team: q-branch
+
+import observerdef "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
+
+// Component is the top-level marker interface required by the component linter.
+// Concrete reporters register via the `anomalydetection_reporters` Fx group as
+// Reporter values rather than through this interface.
+type Component = any
+
+// Reporter is the per-reporter contract delivered through the
+// `anomalydetection_reporters` Fx group.
+type Reporter interface {
+	// Name returns the reporter name for identification.
+	Name() string
+	// Report is called by the observer after each detection cycle.
+	Report(output ReportOutput)
+}
+
+// ReportOutput carries the data reporters receive after each detection cycle.
+// It re-uses observerdef types directly so reporters can build rich messages
+// (log-rate annotations, debug info, correlation members) without lossy conversion.
+// reporter/def therefore depends on observer/def — observer/def owns the canonical schema.
+type ReportOutput struct {
+	// AdvancedToSec is the data time the engine advanced to.
+	AdvancedToSec int64
+	// NewAnomalies are anomalies detected in this advance cycle.
+	NewAnomalies []observerdef.Anomaly
+	// ActiveCorrelations are the current correlation patterns across all correlators.
+	ActiveCorrelations []observerdef.ActiveCorrelation
+}
+
+// StorageConsumer is an optional interface for reporters that need access to
+// the engine's time-series storage (e.g. for windowed log-rate annotations).
+// The observer calls SetStorage exactly once after engine construction, before
+// the first Report call.
+type StorageConsumer interface {
+	SetStorage(storage observerdef.StorageReader)
+}
+
+// CorrelationSender sends Datadog events for detected anomaly correlations.
+// Obtain one via reporterimpl.NewLiveCorrelationSender.
+type CorrelationSender interface {
+	Send(c observerdef.ActiveCorrelation) error
+}

--- a/comp/anomalydetection/reporter/fx-noop/BUILD.bazel
+++ b/comp/anomalydetection/reporter/fx-noop/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "fx-noop",
+    srcs = ["fx.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/anomalydetection/reporter/fx-noop",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/anomalydetection/reporter/def",
+        "//pkg/util/fxutil",
+    ],
+)

--- a/comp/anomalydetection/reporter/fx-noop/fx.go
+++ b/comp/anomalydetection/reporter/fx-noop/fx.go
@@ -1,0 +1,34 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package fx provides a no-op fx module for the reporter component.
+// Wire this in unit tests that build the observer but do not need reporting.
+package fx
+
+import (
+	reporter "github.com/DataDog/datadog-agent/comp/anomalydetection/reporter/def"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Module defines the fx options for the no-op reporter component.
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fxutil.ProvideComponentConstructor(newNoopReporter),
+	)
+}
+
+type noopReporterRequires struct{}
+type noopReporterProvides struct {
+	Reporter reporter.Reporter `group:"anomalydetection_reporters"`
+}
+
+func newNoopReporter(_ noopReporterRequires) noopReporterProvides {
+	return noopReporterProvides{Reporter: &noopReporter{}}
+}
+
+type noopReporter struct{}
+
+func (r *noopReporter) Name() string                   { return "noop_reporter" }
+func (r *noopReporter) Report(_ reporter.ReportOutput) {}

--- a/deps/go.MODULE.bazel
+++ b/deps/go.MODULE.bazel
@@ -107,6 +107,7 @@ use_repo(
     "com_github_data_dog_go_sqlmock",
     "com_github_datadog_agent_payload_v5",
     "com_github_datadog_aptly",
+    "com_github_datadog_datadog_agent_comp_anomalydetection_recorder_def",
     "com_github_datadog_datadog_agent_comp_core_agenttelemetry_fx",
     "com_github_datadog_datadog_agent_comp_otelcol_collector_contrib_impl",
     "com_github_datadog_datadog_agent_comp_otelcol_logsagentpipeline",

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/DataDog/agent-payload/v5 v5.0.195
 	github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def v0.0.0-00010101000000-000000000000
+	github.com/DataDog/datadog-agent/comp/anomalydetection/recorder/def v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/comp/api/api/def v0.76.0-rc.4
 	github.com/DataDog/datadog-agent/comp/core/agenttelemetry/def v0.0.0
 	github.com/DataDog/datadog-agent/comp/core/agenttelemetry/fx v0.0.0-20251027120702-0e91eee9852f
@@ -1283,6 +1284,7 @@ replace github.com/open-policy-agent/opa => github.com/DataDog/opa v0.0.0-202511
 
 replace (
 	github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def => ./comp/anomalydetection/observer/def
+	github.com/DataDog/datadog-agent/comp/anomalydetection/recorder/def => ./comp/anomalydetection/recorder/def
 	github.com/DataDog/datadog-agent/comp/api/api/def => ./comp/api/api/def
 	github.com/DataDog/datadog-agent/comp/core/agenttelemetry/def => ./comp/core/agenttelemetry/def
 	github.com/DataDog/datadog-agent/comp/core/agenttelemetry/fx => ./comp/core/agenttelemetry/fx

--- a/modules.yml
+++ b/modules.yml
@@ -13,6 +13,7 @@ modules:
     - ./cmd
     - ./comp
   comp/anomalydetection/observer/def: default
+  comp/anomalydetection/recorder/def: default
   comp/api/api/def:
     used_by_otel: true
   comp/core/agenttelemetry/def:


### PR DESCRIPTION
## Summary

This is similar to https://github.com/DataDog/datadog-agent/pull/50430, it adds component defs for:
- `reporter`
- `recorder`
- `hfrunner`

### Claude description

Prerequisite for the observer engine PR. Provides the compile-time foundations that `observer/impl` depends on:

- **observer/def/types.go**: expand from shell to full type set — `SeriesDescriptor`, `Detector`, `Correlator`, `LogMetricsExtractor`, `StorageReader`, `Anomaly`, `ActiveCorrelation`, `ReportOutput`, and all supporting types
- **reporter/def**: new package with `Reporter` interface and `ReportOutput` (observers fan out to reporters via `anomalydetection_reporters` Fx group)
- **reporter/fx-noop**: registers a noop via the reporters group so the agent builds without a real reporter wired
- **recorder/def**: new go module (`comp/anomalydetection/recorder/def`) with `Component` interface (`GetHandle`, `ReadAllMetrics`, `ReadAllLogs`)
- **recorder/fx-noop**: provides `option.None[recorder.Component]` so the agent starts without recording
- **observer/impl/hfrunner**: high-frequency system check runner (`runner.go` + `sender.go`); `BUILD.bazel` is `# gazelle:ignore` until `corechecks/system` is migrated to Bazel
