### PR TITLE
fix(comp/core/status): derive FIPS Mode test expectation from production logic

### DIFF
--- a/comp/core/status/statusimpl/common_header_provider_test.go
+++ b/comp/core/status/statusimpl/common_header_provider_test.go
@@ -201,7 +201,7 @@ func TestCommonHeaderProviderHTML(t *testing.T) {
     Flavor: %s<br>
     PID: %d<br>
     Agent start: 2018-01-05 11:25:15 UTC (1515151515000)<br>
-    FIPS Mode: not available<br>
+    FIPS Mode: %s<br>
     Log Level: info<br>
     Config File: There is no config file<br>
     Conf.d Path: %s<br>
@@ -218,7 +218,7 @@ func TestCommonHeaderProviderHTML(t *testing.T) {
     <br>Build arch: %s
   </span>
 </div>
-`, version.AgentVersion, agentFlavor, pid, config.GetString("confd_path"), config.GetString("additional_checksd"), goVersion, arch)
+`, version.AgentVersion, agentFlavor, pid, populateFIPSStatus(config), config.GetString("confd_path"), config.GetString("additional_checksd"), goVersion, arch)
 
 	// We replace windows line break by linux so the tests pass on every OS
 	expectedResult := strings.ReplaceAll(expectedHTMLOutput, "\r\n", "\n")
@@ -261,7 +261,7 @@ func TestCommonHeaderProviderHTMLWithFipsInformation(t *testing.T) {
     Flavor: %s<br>
     PID: %d<br>
     Agent start: 2018-01-05 11:25:15 UTC (1515151515000)<br>
-    FIPS Mode: proxy<br>
+    FIPS Mode: %s<br>
     Log Level: info<br>
     Config File: There is no config file<br>
     Conf.d Path: %s<br>
@@ -286,7 +286,7 @@ func TestCommonHeaderProviderHTMLWithFipsInformation(t *testing.T) {
       - Starting port range: 9803<br>
   </span>
 </div>
-`, version.AgentVersion, agentFlavor, pid, config.GetString("confd_path"), config.GetString("additional_checksd"), goVersion, arch)
+`, version.AgentVersion, agentFlavor, pid, populateFIPSStatus(config), config.GetString("confd_path"), config.GetString("additional_checksd"), goVersion, arch)
 
 	// We replace windows line break by linux so the tests pass on every OS
 	expectedResult := strings.ReplaceAll(expectedHTMLOutput, "\r\n", "\n")

--- a/comp/core/status/statusimpl/status_test.go
+++ b/comp/core/status/statusimpl/status_test.go
@@ -148,11 +148,7 @@ func getTextStatusOutput(pid int, goVersion string, arch string, flavor string, 
   Agent flavor: %s
 `, pid, goVersion, arch, flavor)
 
-	if conf.GetBool("fips.enabled") {
-		res += "  FIPS Mode: proxy\n"
-	} else {
-		res += "  FIPS Mode: not available\n"
-	}
+	res += "  FIPS Mode: " + populateFIPSStatus(conf) + "\n"
 
 	res += "  Log Level: info\n"
 
@@ -391,7 +387,7 @@ X Section
     Flavor: %s<br>
     PID: %d<br>
     Agent start: 2018-01-05 11:25:15 UTC (1515151515000)<br>
-    FIPS Mode: not available<br>
+    FIPS Mode: %s<br>
     Log Level: info<br>
     Config File: There is no config file<br>
     Conf.d Path: %s<br>
@@ -420,7 +416,7 @@ X Section
     <br>Bar: bar
   </span>
 </div>
-`, agentVersion, agentFlavor, pid, deps.Config.GetString("confd_path"), deps.Config.GetString("additional_checksd"), goVersion, arch)
+`, agentVersion, agentFlavor, pid, populateFIPSStatus(deps.Config), deps.Config.GetString("confd_path"), deps.Config.GetString("additional_checksd"), goVersion, arch)
 
 				// We replace windows line break by linux so the tests pass on every OS
 				expectedResult := strings.ReplaceAll(expectedStatusHTMLOutput, "\r\n", "\n")
@@ -446,7 +442,7 @@ X Section
     Flavor: %s<br>
     PID: %d<br>
     Agent start: 2018-01-05 11:25:15 UTC (1515151515000)<br>
-    FIPS Mode: not available<br>
+    FIPS Mode: %s<br>
     Log Level: info<br>
     Config File: There is no config file<br>
     Conf.d Path: %s<br>
@@ -469,7 +465,7 @@ X Section
     <br>Header Bar: bar
   </span>
 </div>
-`, agentVersion, agentFlavor, pid, deps.Config.GetString("confd_path"), deps.Config.GetString("additional_checksd"), goVersion, arch)
+`, agentVersion, agentFlavor, pid, populateFIPSStatus(deps.Config), deps.Config.GetString("confd_path"), deps.Config.GetString("additional_checksd"), goVersion, arch)
 
 				// We replace windows line break by linux so the tests pass on every OS
 				expectedResult := strings.ReplaceAll(expectedStatusHTMLOutput, "\r\n", "\n")


### PR DESCRIPTION
### What does this PR do?

Replaces hardcoded `"FIPS Mode: not available"` / `"FIPS Mode: proxy"` literals in `comp/core/status/statusimpl`'s text and HTML rendering tests with the same `populateFIPSStatus(conf)` call that the production code uses, so the expectation tracks the actual rendering regardless of build tag.

### Motivation

The two hardcoded strings were exhaustive in the "fips proxy" era. Once the `goexperiment.systemcrypto` FIPS toolchain landed, `pkg/fips.Status()` gained two more outcomes (`"enabled"`, `"disabled"`) and the tests had no expectation for either.

These tests stay green on PR CI because `dda inv test --flavor=fips` doesn't run there, but as we migrate Go test execution to Bazel — which exercises the fips flavor in addition to base — the mismatch surfaces immediately.

### Describe how you validated your changes

`bazel test //comp/core/status/statusimpl:statusimpl_test_fips` locally.

### Additional Notes
