### PR TITLE
fix(discovery): rescan /proc on each iteration in TestServicesDocker

### DIFF
--- a/pkg/discovery/module/impl_services_test.go
+++ b/pkg/discovery/module/impl_services_test.go
@@ -893,10 +893,24 @@ func (s *discoveryTestSuite) TestServicesDocker() {
 
 	proc, err := procfs.NewDefaultFS()
 	require.NoError(t, err)
-	processes, err := proc.AllProcs()
-	require.NoError(t, err)
 	pid1111 := 0
+	// Re-list /proc on each iteration rather than snapshotting once. A
+	// rare CI failure was observed where dockerutils.Run() reported
+	// success but python-1111 was not present in /proc at this point.
+	// The suspected cause is that dockerutils.Run reuses the same
+	// PatternScanner across retry attempts: PatternScanner.DoneChan is
+	// closed at most once, so if attempt #1's container output arrives
+	// late (after the per-attempt timeout but before attempt #2's
+	// checkReadiness runs), attempt #2 sees the already-closed channel
+	// and returns "success" before its own container has started. We
+	// are not fixing that pattern-matcher bug here; the loop just
+	// rescans /proc until python-1111 appears so a slightly-delayed
+	// container start cannot fail this assertion.
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		processes, err := proc.AllProcs()
+		if !assert.NoError(collect, err) {
+			return
+		}
 		for _, process := range processes {
 			comm, err := process.Comm()
 			if err != nil {


### PR DESCRIPTION
### What does this PR do?

`TestServicesDocker` previously called `proc.AllProcs()` once *before*
`require.EventuallyWithT` and then iterated the same stale snapshot. If
the `python-1111` process was not present in `/proc` at that single
moment, no amount of retrying inside the loop would discover it. This
change moves the `AllProcs()` call inside the loop so each iteration
re-lists `/proc`.

### Motivation

A rare CI flake was observed (~1/1000s of runs) where
`dockerutils.Run()` reported the container as up, yet the assertion
failed with `pid1111 = 0` and "Condition never satisfied":

```
impl_services_test.go:891: docker-compose command succeeded. foo-server container is running
impl_services_test.go:899:
        Error Trace:    pkg/discovery/module/impl_services_test.go:910
        Error:          Should not be zero, but was 0
...
        Error:          Condition never satisfied
```

The suspected underlying cause is in `dockerutils.Run` itself: it reuses
the same `PatternScanner` across retry attempts, and
`PatternScanner.DoneChan` is closed at most once (via `sync.Once`). If
attempt #1's container produces a `"Serving HTTP..."` line late — after
its per-attempt timeout but before attempt #2's `checkReadiness` runs —
the channel is already closed by the time attempt #2 selects on it, so
`Run()` returns success without attempt #2's container being ready. A
synthetic unit test confirms `Run()` returns in ~20 ms when the scanner
is pre-closed, even though the container is only running `sleep 60`.

That mechanism explains the symptom — `Run()` reports success but the
`python-1111` PID is not in `/proc` because the new container hasn't
started yet — but the CI log only shows the timeout's buffered output
(which ends at `Attaching to port-test-one-1`), so we cannot prove this
is what fired in this specific incident.

Rather than restructure `dockerutils.Run` for an unverified theory, this
PR makes the test itself robust to a slightly delayed container start
by rescanning `/proc` on each EventuallyWithT iteration. The suspected
pattern-matcher bug is documented in a code comment so it can be
revisited if the flake recurs.

### Describe how you validated your changes

- `dda inv -e system-probe.test -p ./pkg/discovery/module -r TestDiscovery/go/TestServicesDocker` passes locally.
- `go vet -tags="test linux_bpf" ./pkg/discovery/module/...` clean.