### PR TITLE
feat(workloadfilter): expose process.tcp_ports to CEL autodiscovery rules

### DIFF
--- a/comp/core/workloadfilter/impl/filter_test.go
+++ b/comp/core/workloadfilter/impl/filter_test.go
@@ -1267,6 +1267,7 @@ cel_workload_exclude:
   rules:
     processes:
       - "process.args.exists(arg, arg == 'ignore-me')"
+      - "process.tcp_ports.exists(p, p == 6379)"
 - products: ["logs"]
   rules:
     processes:
@@ -1335,6 +1336,24 @@ cel_workload_exclude:
 		filterBundle := filterStore.GetProcessFilters([][]workloadfilter.ProcessFilter{{workloadfilter.ProcessCELLogs}})
 		assert.Nil(t, filterBundle.GetErrors())
 		assert.Equal(t, workloadfilter.Excluded, filterBundle.GetResult(process))
+	})
+
+	t.Run("CEL exclude process by tcp port", func(t *testing.T) {
+		process := workloadmetafilter.CreateProcess(&workloadmeta.Process{
+			Name:    "redis-server",
+			Cmdline: []string{"/usr/bin/redis-server"},
+			Service: &workloadmeta.Service{TCPPorts: []uint16{6379}},
+		})
+		assert.Equal(t, workloadfilter.Excluded, filterBundle.GetResult(process))
+	})
+
+	t.Run("CEL no match when port absent", func(t *testing.T) {
+		process := workloadmetafilter.CreateProcess(&workloadmeta.Process{
+			Name:    "redis-server",
+			Cmdline: []string{"/usr/bin/redis-server"},
+			Service: &workloadmeta.Service{TCPPorts: []uint16{6380}},
+		})
+		assert.Equal(t, workloadfilter.Unknown, filterBundle.GetResult(process))
 	})
 }
 

--- a/comp/core/workloadfilter/program/cel_program_test.go
+++ b/comp/core/workloadfilter/program/cel_program_test.go
@@ -102,3 +102,50 @@ func TestCELFieldConfigurationErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestCELFieldConfigurationProcessTCPPorts(t *testing.T) {
+	env, err := cel.NewEnv(
+		cel.Types(&filterdef.Process{}),
+		cel.Variable("process", cel.ObjectType("datadog.workloadfilter.FilterProcess")),
+	)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		expr        string
+		expectError bool
+	}{
+		{
+			name:        "Valid: any port equals literal",
+			expr:        `process.tcp_ports.exists(p, p == 6379)`,
+			expectError: false,
+		},
+		{
+			name:        "Valid: empty list check",
+			expr:        `process.tcp_ports.size() == 0`,
+			expectError: false,
+		},
+		{
+			name:        "Valid: in operator",
+			expr:        `6379 in process.tcp_ports`,
+			expectError: false,
+		},
+		{
+			name:        "Invalid: typo in field name",
+			expr:        `process.tcp_portz.exists(p, p == 6379)`,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, iss := env.Compile(tt.expr)
+			errs := iss.Err()
+			if tt.expectError {
+				require.Error(t, errs, "expected compile error for expr: %s", tt.expr)
+			} else {
+				require.NoError(t, errs, "unexpected compile error for expr: %s", tt.expr)
+			}
+		})
+	}
+}

--- a/comp/core/workloadfilter/util/workloadmeta/BUILD.bazel
+++ b/comp/core/workloadfilter/util/workloadmeta/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "workloadmeta",
@@ -9,5 +9,16 @@ go_library(
         "//comp/core/workloadfilter/def",
         "//comp/core/workloadmeta/def",
         "//pkg/proto/pbgo/core",
+    ],
+)
+
+go_test(
+    name = "workloadmeta_test",
+    srcs = ["create_test.go"],
+    embed = [":workloadmeta"],
+    gotags = ["test"],
+    deps = [
+        "//comp/core/workloadmeta/def",
+        "@com_github_stretchr_testify//assert",
     ],
 )

--- a/comp/core/workloadfilter/util/workloadmeta/create.go
+++ b/comp/core/workloadfilter/util/workloadmeta/create.go
@@ -58,6 +58,13 @@ func CreateProcess(process *workloadmeta.Process) *workloadfilter.Process {
 		Args:    process.Cmdline,
 	}
 
+	if process.Service != nil && len(process.Service.TCPPorts) > 0 {
+		p.TcpPorts = make([]int32, len(process.Service.TCPPorts))
+		for i, port := range process.Service.TCPPorts {
+			p.TcpPorts[i] = int32(port)
+		}
+	}
+
 	return &workloadfilter.Process{
 		FilterProcess: p,
 	}

--- a/comp/core/workloadfilter/util/workloadmeta/create_test.go
+++ b/comp/core/workloadfilter/util/workloadmeta/create_test.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package workloadmeta
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+)
+
+func TestCreateProcess_TcpPorts(t *testing.T) {
+	t.Run("populates TcpPorts from Service.TCPPorts", func(t *testing.T) {
+		p := CreateProcess(&workloadmeta.Process{
+			Name:    "redis-server",
+			Cmdline: []string{"/usr/bin/redis-server"},
+			Service: &workloadmeta.Service{
+				TCPPorts: []uint16{6379, 6380},
+			},
+		})
+		assert.Equal(t, []int32{6379, 6380}, p.GetTcpPorts())
+	})
+
+	t.Run("returns empty TcpPorts when Service is nil", func(t *testing.T) {
+		p := CreateProcess(&workloadmeta.Process{
+			Name:    "no-service",
+			Cmdline: []string{"no-service"},
+			Service: nil,
+		})
+		assert.Empty(t, p.GetTcpPorts())
+	})
+
+	t.Run("returns empty TcpPorts when Service.TCPPorts is empty", func(t *testing.T) {
+		p := CreateProcess(&workloadmeta.Process{
+			Name:    "no-ports",
+			Cmdline: []string{"no-ports"},
+			Service: &workloadmeta.Service{},
+		})
+		assert.Empty(t, p.GetTcpPorts())
+	})
+}

--- a/pkg/proto/datadog/workloadfilter/workloadfilter.proto
+++ b/pkg/proto/datadog/workloadfilter/workloadfilter.proto
@@ -49,6 +49,10 @@ message FilterProcess {
   repeated string args = 3;
   // log_file is only set when the rules are evaluated by the logs component.
   string log_file = 4;
+  // tcp_ports lists the TCP ports the process is listening on, if any.
+  // Signed int32 (rather than uint32) so that CEL rules can compare with
+  // unsuffixed integer literals; ports never exceed 65535 in practice.
+  repeated int32 tcp_ports = 5;
 }
 
 message FilterECSTask {

--- a/pkg/proto/pbgo/core/workloadfilter.pb.go
+++ b/pkg/proto/pbgo/core/workloadfilter.pb.go
@@ -440,7 +440,11 @@ type FilterProcess struct {
 	Cmdline string                 `protobuf:"bytes,2,opt,name=cmdline,proto3" json:"cmdline,omitempty"`
 	Args    []string               `protobuf:"bytes,3,rep,name=args,proto3" json:"args,omitempty"`
 	// log_file is only set when the rules are evaluated by the logs component.
-	LogFile       string `protobuf:"bytes,4,opt,name=log_file,json=logFile,proto3" json:"log_file,omitempty"`
+	LogFile string `protobuf:"bytes,4,opt,name=log_file,json=logFile,proto3" json:"log_file,omitempty"`
+	// tcp_ports lists the TCP ports the process is listening on, if any.
+	// Signed int32 (rather than uint32) so that CEL rules can compare with
+	// unsuffixed integer literals; ports never exceed 65535 in practice.
+	TcpPorts      []int32 `protobuf:"varint,5,rep,packed,name=tcp_ports,json=tcpPorts,proto3" json:"tcp_ports,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -501,6 +505,13 @@ func (x *FilterProcess) GetLogFile() string {
 		return x.LogFile
 	}
 	return ""
+}
+
+func (x *FilterProcess) GetTcpPorts() []int32 {
+	if x != nil {
+		return x.TcpPorts
+	}
+	return nil
 }
 
 type FilterECSTask struct {
@@ -750,12 +761,13 @@ const file_datadog_workloadfilter_workloadfilter_proto_rawDesc = "" +
 	"\vannotations\x18\x04 \x03(\v22.datadog.workloadfilter.FilterPod.AnnotationsEntryR\vannotations\x1a>\n" +
 	"\x10AnnotationsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"l\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x89\x01\n" +
 	"\rFilterProcess\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x18\n" +
 	"\acmdline\x18\x02 \x01(\tR\acmdline\x12\x12\n" +
 	"\x04args\x18\x03 \x03(\tR\x04args\x12\x19\n" +
-	"\blog_file\x18\x04 \x01(\tR\alogFile\"1\n" +
+	"\blog_file\x18\x04 \x01(\tR\alogFile\x12\x1b\n" +
+	"\ttcp_ports\x18\x05 \x03(\x05R\btcpPorts\"1\n" +
 	"\rFilterECSTask\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x10\n" +
 	"\x03arn\x18\x02 \x01(\tR\x03arn\"\xe3\x01\n" +

--- a/test/new-e2e/tests/discovery/testdata/config/nginx_process_autodiscovery.yaml
+++ b/test/new-e2e/tests/discovery/testdata/config/nginx_process_autodiscovery.yaml
@@ -1,8 +1,9 @@
-# Nginx check configuration using process-based autodiscovery
-# This check will be scheduled when an nginx process is detected
+# Nginx check configuration using process-based autodiscovery.
+# Scheduled when a process listening on TCP 81 (the stub_status port the
+# E2E test configures) is detected.
 cel_selector:
   processes:
-    - process.cmdline.contains('nginx')
+    - process.tcp_ports.exists(p, p == 81)
 
 init_config:
 

--- a/test/new-e2e/tests/discovery/testdata/config/nginx_process_autodiscovery.yaml
+++ b/test/new-e2e/tests/discovery/testdata/config/nginx_process_autodiscovery.yaml
@@ -1,9 +1,9 @@
 # Nginx check configuration using process-based autodiscovery.
-# Scheduled when a process listening on TCP 81 (the stub_status port the
-# E2E test configures) is detected.
+# Scheduled when an nginx process listening on TCP 81 (the stub_status
+# port the E2E test configures) is detected.
 cel_selector:
   processes:
-    - process.tcp_ports.exists(p, p == 81)
+    - process.cmdline.contains('nginx') && process.tcp_ports.exists(p, p == 81)
 
 init_config:
 

--- a/test/new-e2e/tests/discovery/testdata/config/redisdb_process_autodiscovery.yaml
+++ b/test/new-e2e/tests/discovery/testdata/config/redisdb_process_autodiscovery.yaml
@@ -1,9 +1,9 @@
 # Redis check configuration using process-based autodiscovery.
-# Scheduled when a process listening on the canonical Redis TCP port is
-# detected.
+# Scheduled when a redis-server process listening on the canonical Redis
+# TCP port is detected.
 cel_selector:
   processes:
-    - process.tcp_ports.exists(p, p == 6379)
+    - process.cmdline.contains('redis-server') && process.tcp_ports.exists(p, p == 6379)
 
 init_config:
 

--- a/test/new-e2e/tests/discovery/testdata/config/redisdb_process_autodiscovery.yaml
+++ b/test/new-e2e/tests/discovery/testdata/config/redisdb_process_autodiscovery.yaml
@@ -1,12 +1,12 @@
-# Redis check configuration using process-based autodiscovery
-# This check will be scheduled when a redis-server process is detected
+# Redis check configuration using process-based autodiscovery.
+# Scheduled when a process listening on the canonical Redis TCP port is
+# detected.
 cel_selector:
   processes:
-    - process.cmdline.contains('redis-server')
+    - process.tcp_ports.exists(p, p == 6379)
 
 init_config:
 
 instances:
   - host: "%%host%%"
     port: 6379
-


### PR DESCRIPTION
### What does this PR do?

Adds a `tcp_ports` field to the `FilterProcess` protobuf message and populates it from `workloadmeta.Process.Service.TCPPorts`, so CEL-based process autodiscovery rules can match on listening TCP ports:

```yaml
cel_selector:
  processes:
    - process.tcp_ports.exists(p, p == 6379)
```

Changes:
- `pkg/proto/datadog/workloadfilter/workloadfilter.proto`: new `repeated int32 tcp_ports = 5` field on `FilterProcess`
- `comp/core/workloadfilter/util/workloadmeta/create.go`: `CreateProcess` now copies `Service.TCPPorts` (uint16) → `TcpPorts` (int32) when the service is present
- Unit tests in `create_test.go`, `cel_program_test.go`, and `filter_test.go` covering population, CEL compilation, and filter evaluation
- Two E2E YAML configs switched from cmdline-based to port-based rules as an end-to-end exercise

### Motivation

Process autodiscovery rules that key on `process.cmdline` are fragile — the cmdline string changes with packaging, wrappers, and flags. Matching on a well-known TCP port (e.g. 6379 for Redis) is more reliable and aligns with how service detection works in practice.

Spec: `docs/superpowers/specs/2026-05-05-cel-process-tcp-ports-design.md`

### Describe how you validated your changes

- `dda inv test --targets=./comp/core/workloadfilter/...` — all 152 tests pass, including three new subtests for `CreateProcess` port population and two new subtests for CEL exclusion evaluation
- `bazel build //pkg/proto/... //comp/core/workloadfilter/...` — clean build
- `dda inv linter.go --targets=./comp/core/workloadfilter/...` — no findings
- Two E2E configs (`redisdb_process_autodiscovery.yaml`, `nginx_process_autodiscovery.yaml`) switched to port-based rules; E2E runs in CI

### Additional Notes

**Out of scope (follow-ups):** UDP ports, per-interface/IP awareness, and migrating existing customer `auto_conf.yaml` files.

**Nginx E2E risk:** nginx forks worker processes; port 81 attribution depends on the discovery module selecting the main/master process as the port owner. If the nginx E2E test fails, the fix belongs upstream in the discovery module's port attribution logic, not in this PR's CEL rule.

The `tcp_ports` field uses `int32` (signed) rather than `uint32` so CEL rules can compare with unsuffixed integer literals without a cast — ports never exceed 65535 in practice.