### PR TITLE
Fix flaky TestTestServer/latency on Windows

### DIFF
--- a/pkg/trace/writer/testserver_test.go
+++ b/pkg/trace/writer/testserver_test.go
@@ -82,7 +82,8 @@ func TestTestServer(t *testing.T) {
 			start time.Time
 			d     time.Duration
 		)
-		ts := newTestServerWithLatency(50 * time.Millisecond)
+		const latency = 50 * time.Millisecond
+		ts := newTestServerWithLatency(latency)
 		defer ts.Close()
 
 		assert := assert.New(t)
@@ -97,7 +98,7 @@ func TestTestServer(t *testing.T) {
 		assert.NoError(err)
 		assert.Equal(200, resp.StatusCode)
 		resp.Body.Close()
-		assert.True(d > 50*time.Millisecond)
+		assert.GreaterOrEqual(d, latency)
 	})
 
 	t.Run("payloads", func(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Fix flaky test: Strict-greater (d > 50ms) had zero margin against time.Sleep's 'at least d' guarantee, so when d landed exactly at 50ms the assertion failed. Use GreaterOrEqual to match the contract.

### Motivation
Fix for: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1662753905

### Describe how you validated your changes
Existing tests

### Additional Notes
