### PR TITLE
packaging/aix: remove sentinels from fast/lightweight stages

### DIFF
--- a/packaging/aix/package.sh
+++ b/packaging/aix/package.sh
@@ -7,7 +7,6 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 . "$SCRIPT_DIR/lib/env.sh"
 
 STAGE_NAME="package"
-SENTINEL="$BUILD_DIR/.done/$STAGE_NAME"
 LOG="$BUILD_DIR/logs/$STAGE_NAME.log"
 
 # Redirect all output to log file (follow with: tail -f "$LOG")
@@ -15,12 +14,6 @@ mkdir -p "$BUILD_DIR/logs"
 exec > "$LOG" 2>&1
 
 log "=== Stage: $STAGE_NAME ==="
-
-# --- Idempotency check ---
-if [ -f "$SENTINEL" ]; then
-    log "Already complete (sentinel: $SENTINEL) — skipping."
-    exit 0
-fi
 
 # --- Input validation ---
 : "${AGENT_VERSION:?AGENT_VERSION must be set}"
@@ -145,7 +138,4 @@ cp "$BFF_SRC" "$BFF_OUT"
 ls -l "$BFF_OUT"
 log "Package ready: $BFF_OUT"
 
-# --- Mark complete ---
-mkdir -p "$(dirname "$SENTINEL")"
-touch "$SENTINEL"
 log "=== $STAGE_NAME complete ==="

--- a/packaging/aix/stages/00-checkout.sh
+++ b/packaging/aix/stages/00-checkout.sh
@@ -7,7 +7,6 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 . "$SCRIPT_DIR/../lib/env.sh"
 
 STAGE_NAME="00-checkout"
-SENTINEL="$BUILD_DIR/.done/$STAGE_NAME"
 LOG="$BUILD_DIR/logs/$STAGE_NAME.log"
 
 # Redirect all output to log file (follow with: tail -f "$LOG")
@@ -15,12 +14,6 @@ mkdir -p "$BUILD_DIR/logs"
 exec > "$LOG" 2>&1
 
 log "=== Stage: $STAGE_NAME ==="
-
-# --- Idempotency check ---
-if [ -f "$SENTINEL" ]; then
-    log "Already complete (sentinel: $SENTINEL) — skipping."
-    exit 0
-fi
 
 # --- Input validation ---
 : "${BUILD_DIR:?BUILD_DIR must be set}"
@@ -111,7 +104,4 @@ fi
 git -C "$INTEGRATIONS_CORE" checkout --quiet "$INTEGRATIONS_CORE_VERSION"
 log "Checked out integrations-core at $(git -C "$INTEGRATIONS_CORE" rev-parse HEAD)"
 
-# --- Mark complete ---
-mkdir -p "$(dirname "$SENTINEL")"
-touch "$SENTINEL"
 log "=== $STAGE_NAME complete ==="

--- a/packaging/aix/stages/08-integrations.sh
+++ b/packaging/aix/stages/08-integrations.sh
@@ -7,7 +7,6 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 . "$SCRIPT_DIR/../lib/env.sh"
 
 STAGE_NAME="08-integrations"
-SENTINEL="$BUILD_DIR/.done/$STAGE_NAME"
 LOG="$BUILD_DIR/logs/$STAGE_NAME.log"
 
 # Redirect all output to log file (follow with: tail -f "$LOG")
@@ -15,12 +14,6 @@ mkdir -p "$BUILD_DIR/logs"
 exec > "$LOG" 2>&1
 
 log "=== Stage: $STAGE_NAME ==="
-
-# --- Idempotency check ---
-if [ -f "$SENTINEL" ]; then
-    log "Already complete (sentinel: $SENTINEL) — skipping."
-    exit 0
-fi
 
 # --- Input validation ---
 : "${STAGING:?STAGING must be set}"
@@ -48,8 +41,6 @@ fi
 cleanup() {
     if [ $? -ne 0 ]; then
         log "ERROR: $STAGE_NAME failed."
-        log "       Re-run after fixing the error by deleting the sentinel:"
-        log "       rm $SENTINEL"
         log "       Common causes:"
         log "         - Stage 07 constraints.txt missing: ensure Stage 07 completed"
         log "         - integrations-core check not found: verify INTEGRATIONS_CORE=$INTEGRATIONS_CORE"
@@ -118,7 +109,4 @@ done
 
 log "All Python checks processed"
 
-# --- Mark complete ---
-mkdir -p "$(dirname "$SENTINEL")"
-touch "$SENTINEL"
 log "=== $STAGE_NAME complete ==="

--- a/packaging/aix/stages/09-strip-bytecode.sh
+++ b/packaging/aix/stages/09-strip-bytecode.sh
@@ -7,7 +7,6 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 . "$SCRIPT_DIR/../lib/env.sh"
 
 STAGE_NAME="09-strip-bytecode"
-SENTINEL="$BUILD_DIR/.done/$STAGE_NAME"
 LOG="$BUILD_DIR/logs/$STAGE_NAME.log"
 
 # Redirect all output to log file (follow with: tail -f "$LOG")
@@ -15,12 +14,6 @@ mkdir -p "$BUILD_DIR/logs"
 exec > "$LOG" 2>&1
 
 log "=== Stage: $STAGE_NAME ==="
-
-# --- Idempotency check ---
-if [ -f "$SENTINEL" ]; then
-    log "Already complete (sentinel: $SENTINEL) — skipping."
-    exit 0
-fi
 
 # --- Input validation ---
 : "${STAGING:?STAGING must be set}"
@@ -94,7 +87,4 @@ find "$EMBEDDED_DESTDIR" \( -name "*.pyc" -o -name "*.pyo" \) -print \
     > "$EMBEDDED_DESTDIR/.pyc_compiled_files.txt"
 log "Recorded $(wc -l < "$EMBEDDED_DESTDIR/.pyc_compiled_files.txt") .pyc files"
 
-# --- Mark complete ---
-mkdir -p "$(dirname "$SENTINEL")"
-touch "$SENTINEL"
 log "=== $STAGE_NAME complete ==="

--- a/packaging/aix/stages/10-assemble.sh
+++ b/packaging/aix/stages/10-assemble.sh
@@ -7,7 +7,6 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 . "$SCRIPT_DIR/../lib/env.sh"
 
 STAGE_NAME="10-assemble"
-SENTINEL="$BUILD_DIR/.done/$STAGE_NAME"
 LOG="$BUILD_DIR/logs/$STAGE_NAME.log"
 
 # Redirect all output to log file (follow with: tail -f "$LOG")
@@ -15,12 +14,6 @@ mkdir -p "$BUILD_DIR/logs"
 exec > "$LOG" 2>&1
 
 log "=== Stage: $STAGE_NAME ==="
-
-# --- Idempotency check ---
-if [ -f "$SENTINEL" ]; then
-    log "Already complete (sentinel: $SENTINEL) — skipping."
-    exit 0
-fi
 
 # --- Input validation ---
 : "${AGENT_VERSION:?AGENT_VERSION must be set}"
@@ -201,7 +194,4 @@ du -s \
     "$STAGING/opt/datadog-agent/embedded/lib" \
     "$STAGING/opt/datadog-agent/rtloader" 2>/dev/null || true
 
-# --- Mark complete ---
-mkdir -p "$(dirname "$SENTINEL")"
-touch "$SENTINEL"
 log "=== $STAGE_NAME complete ==="


### PR DESCRIPTION
## What does this PR do?

Removes sentinel guards from the five stages that are either fast enough to always re-run or where a stale sentinel causes silent correctness bugs.

Stages that keep their sentinels (01, 02, 03, 04, 05, 06, 07) perform expensive compilations (OpenSSL/Python/Go/Rust builds) where skipping on re-run is the right trade-off.

## Stages changed

**00-checkout**: git fetch + checkout of integrations-core, ~10s. Sentinel prevented picking up a new integrations-core commit when `INTEGRATIONS_CORE_VERSION` changed in `release.json`, silently using stale check code in stages 05–08.

**08-integrations**: pip install of Python checks — near-instant when already at the right version. Sentinel prevented re-installing after an integrations-core update.

**09-strip-bytecode**: strips debug symbols from `.so` files and compiles `.py` to `.pyc`, ~15s. Sentinel caused a correctness bug: if stage 05 or 06 re-ran and replaced pydantic-core or cryptography with fresh unstripped Rust binaries, stage 09 would be skipped, inflating the BFF by ~100 MB.

**10-assemble**: copies packaging scripts, check configs, and `sitecustomize.py` into the staging tree, ~5s. Sentinel prevented picking up changes to `package-scripts/` or `sitecustomize.py`.

**package**: runs mkinstallp to produce the BFF, ~2–3 min. Should always snapshot current staging tree contents into a fresh artifact.