### PR TITLE
pkg/dyninst: Respect DD_SERVICE in the dyninst sample-service

### DIFF
--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -13,11 +13,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1406 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0xd0ed4a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0ed6a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1407 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0xd0ed85", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0eda5", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -84,11 +84,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1377 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0xd0d34e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0d36e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1378 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0xd0d402", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0d422", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -176,7 +176,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1257 EventRootType Probe[main.testArrayOfMaps]
-              InjectionPoints: [{PC: "0xd095e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd09600", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -241,11 +241,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1279 EventRootType Probe[main.testAtomicAdd]
-              InjectionPoints: [{PC: "0xd0b300", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0b320", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1280 EventRootType Probe[main.testAtomicAdd]Return
-              InjectionPoints: [{PC: "0xd0b312", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0b332", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -342,11 +342,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1425 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xd0f180", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f1a0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1426 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0xd0f1a2", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f1c2", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -476,7 +476,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1276 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0xd0af60", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0af80", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -495,7 +495,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1277 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0xd0af60", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0af80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -521,7 +521,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1433 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0xd0f2a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f2c0", Frameless: true}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -557,7 +557,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1281 EventRootType Probe[main.testChannel]
-              InjectionPoints: [{PC: "0xd0b320", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0b340", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -587,7 +587,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1275 EventRootType Probe[main.testCombinedByte]
-              InjectionPoints: [{PC: "0xd0af20", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0af40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{w}, {x}, {y}'
@@ -616,11 +616,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1342 EventRootType Probe[main.testConflictingReturn]
-              InjectionPoints: [{PC: "0xd0c5ae", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c5ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1343 EventRootType Probe[main.testConflictingReturn]Return
-              InjectionPoints: [{PC: "0xd0c674", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c694", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -642,7 +642,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1289 EventRootType Probe[main.testCycle]
-              InjectionPoints: [{PC: "0xd0b700", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0b720", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{t}'
@@ -796,7 +796,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1394 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0xd0e440", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0e460", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -823,7 +823,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1397 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0xd0e4a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0e4c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -851,7 +851,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1420 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0xd0ee80", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0eea0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -873,7 +873,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1434 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0xd0f300", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f320", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -894,7 +894,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1435 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0xd0f320", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f340", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1107,11 +1107,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1472 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0xd11f20", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11f40", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1473 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xd11f27", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11f47", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1125,11 +1125,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1474 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0xd11f44", Frameless: false}]
+              InjectionPoints: [{PC: "0xd11f64", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1475 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0xd11f91", Frameless: false}]
+              InjectionPoints: [{PC: "0xd11fb1", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1152,11 +1152,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1468 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0xd11e8a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd11eaa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1469 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0xd11e99", Frameless: false}]
+              InjectionPoints: [{PC: "0xd11eb9", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1170,11 +1170,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1470 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0xd11eca", Frameless: false}]
+              InjectionPoints: [{PC: "0xd11eea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1471 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0xd11ee2", Frameless: false}]
+              InjectionPoints: [{PC: "0xd11f02", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1197,14 +1197,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1476 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0xd11fa0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11fc0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1477 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0xd11fc0"
+                - PC: "0xd11fe0"
                   Frameless: true
-                - PC: "0xd11fc3"
+                - PC: "0xd11fe3"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1219,14 +1219,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1478 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0xd11fea", Frameless: false}]
+              InjectionPoints: [{PC: "0xd1200a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1479 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0xd1204b"
+                - PC: "0xd1206b"
                   Frameless: false
-                - PC: "0xd12053"
+                - PC: "0xd12073"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1253,7 +1253,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1480 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0xd11fa5", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11fc5", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1265,7 +1265,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1481 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0xd11fff", Frameless: false}]
+              InjectionPoints: [{PC: "0xd1201f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1286,11 +1286,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1456 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0xd11b40", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11b60", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1457 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0xd11b50", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11b70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1304,11 +1304,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1458 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0xd11be0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11c00", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1459 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0xd11be8", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11c08", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1332,11 +1332,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1444 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0xd116ce", Frameless: false}]
+              InjectionPoints: [{PC: "0xd116ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1445 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xd117b4", Frameless: false}]
+              InjectionPoints: [{PC: "0xd117d4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1378,11 +1378,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1448 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xd1180a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd1182a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1449 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xd11819", Frameless: false}]
+              InjectionPoints: [{PC: "0xd11839", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1405,11 +1405,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1482 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0xd120a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd120c0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1483 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0xd120a6", Frameless: true}]
+              InjectionPoints: [{PC: "0xd120c6", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1423,11 +1423,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1484 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0xd1212a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd1214a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1485 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0xd1214d", Frameless: false}]
+              InjectionPoints: [{PC: "0xd1216d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1450,11 +1450,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1440 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0xd11620", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11640", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1441 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xd11623", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11643", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1468,11 +1468,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1442 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0xd11640", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11660", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1443 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xd1164b", Frameless: true}]
+              InjectionPoints: [{PC: "0xd1166b", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1495,11 +1495,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1460 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0xd11ca0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11cc0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1461 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0xd11ca7", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11cc7", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1513,11 +1513,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1462 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0xd11d4a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd11d6a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1463 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0xd11d76", Frameless: false}]
+              InjectionPoints: [{PC: "0xd11d96", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1540,11 +1540,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1450 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0xd11ae0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11b00", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1451 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xd11ae3", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11b03", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1558,11 +1558,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1452 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0xd11b00", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11b20", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1453 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0xd11b03", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11b23", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1576,11 +1576,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1454 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0xd11b20", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11b40", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1455 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0xd11b23", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11b43", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1603,11 +1603,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1464 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0xd11e40", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11e60", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1465 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0xd11e47", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11e67", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1621,11 +1621,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1466 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xd11e60", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11e80", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1467 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xd11e6e", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11e8e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1648,11 +1648,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1436 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0xd115e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11600", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1437 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xd115e3", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11603", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1666,11 +1666,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1438 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0xd11600", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11620", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1439 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xd1160b", Frameless: true}]
+              InjectionPoints: [{PC: "0xd1162b", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1902,7 +1902,7 @@ Probes:
               InjectionPoints:
                 - PC: "0x51e6d2"
                   Frameless: true
-                - PC: "0xd094bd"
+                - PC: "0xd094dd"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2198,11 +2198,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1375 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0xd0d1ce", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0d1ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1376 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xd0d313", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0d333", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2224,7 +2224,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1283 EventRootType Probe[main.testLinkedList]
-              InjectionPoints: [{PC: "0xd0b520", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0b540", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -2336,11 +2336,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1381 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0xd0d673", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0d693", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1382 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0xd0d882", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0d8a2", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2449,7 +2449,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1255 EventRootType Probe[main.testMapArrayToArray]
-              InjectionPoints: [{PC: "0xd095a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd095c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2471,7 +2471,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1262 EventRootType Probe[main.testMapEmbeddedMaps]
-              InjectionPoints: [{PC: "0xd09660", Frameless: true}]
+              InjectionPoints: [{PC: "0xd09680", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2493,7 +2493,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1272 EventRootType Probe[main.testMapEmptyKey]
-              InjectionPoints: [{PC: "0xd097a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd097c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2515,7 +2515,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1274 EventRootType Probe[main.testMapEmptyKeyAndValue]
-              InjectionPoints: [{PC: "0xd097e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd09800", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2537,7 +2537,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1273 EventRootType Probe[main.testMapEmptyValue]
-              InjectionPoints: [{PC: "0xd097c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd097e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2559,7 +2559,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1259 EventRootType Probe[main.testMapIntToInt]
-              InjectionPoints: [{PC: "0xd09620", Frameless: true}]
+              InjectionPoints: [{PC: "0xd09640", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2581,7 +2581,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1271 EventRootType Probe[main.testMapLargeKeyLargeValue]
-              InjectionPoints: [{PC: "0xd09780", Frameless: true}]
+              InjectionPoints: [{PC: "0xd097a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2603,7 +2603,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1270 EventRootType Probe[main.testMapLargeKeySmallValue]
-              InjectionPoints: [{PC: "0xd09760", Frameless: true}]
+              InjectionPoints: [{PC: "0xd09780", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2627,7 +2627,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1260 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0xd09640", Frameless: true}]
+              InjectionPoints: [{PC: "0xd09660", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2651,7 +2651,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1261 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0xd09640", Frameless: true}]
+              InjectionPoints: [{PC: "0xd09660", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2673,7 +2673,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1269 EventRootType Probe[main.testMapSmallKeyLargeValue]
-              InjectionPoints: [{PC: "0xd09740", Frameless: true}]
+              InjectionPoints: [{PC: "0xd09760", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2695,7 +2695,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1268 EventRootType Probe[main.testMapSmallKeySmallValue]
-              InjectionPoints: [{PC: "0xd09720", Frameless: true}]
+              InjectionPoints: [{PC: "0xd09740", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2717,7 +2717,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1253 EventRootType Probe[main.testMapStringToInt]
-              InjectionPoints: [{PC: "0xd09560", Frameless: true}]
+              InjectionPoints: [{PC: "0xd09580", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2739,7 +2739,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1254 EventRootType Probe[main.testMapStringToSlice]
-              InjectionPoints: [{PC: "0xd09580", Frameless: true}]
+              InjectionPoints: [{PC: "0xd095a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2761,7 +2761,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1252 EventRootType Probe[main.testMapStringToStruct]
-              InjectionPoints: [{PC: "0xd09540", Frameless: true}]
+              InjectionPoints: [{PC: "0xd09560", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2783,7 +2783,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1263 EventRootType Probe[main.testMapWithLinkedList]
-              InjectionPoints: [{PC: "0xd09680", Frameless: true}]
+              InjectionPoints: [{PC: "0xd096a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2805,7 +2805,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1266 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-              InjectionPoints: [{PC: "0xd096e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd09700", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2827,7 +2827,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1267 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-              InjectionPoints: [{PC: "0xd09700", Frameless: true}]
+              InjectionPoints: [{PC: "0xd09720", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2849,7 +2849,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1264 EventRootType Probe[main.testMapWithSmallValue]
-              InjectionPoints: [{PC: "0xd096a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd096c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2873,7 +2873,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1265 EventRootType Probe[main.testMapWithSmallValueMassive]
-              InjectionPoints: [{PC: "0xd096c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd096e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2895,7 +2895,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1417 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xd0ee40", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0ee60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2918,7 +2918,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1418 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xd0ee40", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0ee60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2965,11 +2965,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1383 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0xd0d913", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0d933", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1384 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0xd0db4b", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0db6b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -3035,11 +3035,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1387 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0xd0dc8e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0dcae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1388 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0xd0dd56", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0dd76", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3070,11 +3070,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1379 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0xd0d42e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0d44e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1380 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0xd0d64a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0d66a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3100,11 +3100,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1320 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xd0c3ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c40e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1321 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0c48f", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c4af", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3140,7 +3140,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1278 EventRootType Probe[main.testMultipleSimpleParams]
-              InjectionPoints: [{PC: "0xd0b0e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0b100", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -3181,11 +3181,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1314 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xd0c34a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c36a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1315 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0c3b5", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c3d5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3209,11 +3209,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1316 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xd0c34a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c36a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1317 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0c3b5", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c3d5", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
       version: 0
@@ -3232,11 +3232,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1322 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xd0c3ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c40e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1323 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0c48f", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c4af", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
       version: 0
@@ -3256,11 +3256,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1324 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xd0c3ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c40e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1325 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0c48f", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c4af", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r1={result} r2={result2}
@@ -3293,11 +3293,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1318 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xd0c34a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c36a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1319 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0c3b5", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c3d5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Parameter {i} * 2 = result {result}
@@ -3325,7 +3325,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1429 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xd0f280", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f2a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3350,7 +3350,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1430 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xd0f280", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f2a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3381,7 +3381,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1431 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xd0f280", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f2a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3406,7 +3406,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1432 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xd0f280", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f2a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3433,7 +3433,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1288 EventRootType Probe[main.testNilPointer]
-              InjectionPoints: [{PC: "0xd0b6c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0b6e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}, {a}'
@@ -3460,7 +3460,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1401 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0xd0e520", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0e540", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3487,7 +3487,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1398 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0xd0e4c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0e4e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3522,7 +3522,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1400 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0xd0e500", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0e520", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3554,7 +3554,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1416 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0xd0ee20", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0ee40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3576,7 +3576,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1284 EventRootType Probe[main.testPointerLoop]
-              InjectionPoints: [{PC: "0xd0b540", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0b560", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3598,7 +3598,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1258 EventRootType Probe[main.testPointerToMap]
-              InjectionPoints: [{PC: "0xd09600", Frameless: true}]
+              InjectionPoints: [{PC: "0xd09620", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3620,7 +3620,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1282 EventRootType Probe[main.testPointerToSimpleStruct]
-              InjectionPoints: [{PC: "0xd0b500", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0b520", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3644,11 +3644,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1290 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xd0bc0a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0bc2a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1291 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xd0bc5b", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0bc7b", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
       version: 0
@@ -3668,11 +3668,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1334 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xd0c4ce", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c4ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1335 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0c56e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c58e", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3715,11 +3715,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1300 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xd0bd2e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0bd4e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1301 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xd0bde4", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0be04", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3759,11 +3759,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1292 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xd0bc0a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0bc2a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1293 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xd0bc5b", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0bc7b", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3806,11 +3806,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1302 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xd0bd2e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0bd4e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1303 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xd0bde4", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0be04", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3852,11 +3852,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1336 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xd0c4ce", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c4ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1337 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0c56e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c58e", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
       version: 0
@@ -3873,11 +3873,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1338 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xd0c4ce", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c4ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1339 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0c56e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c58e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r0={@return.r0}
@@ -3899,11 +3899,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1294 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xd0bc0a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0bc2a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1295 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xd0bc5b", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0bc7b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: result={@return}
@@ -3926,18 +3926,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1310 EventRootType Probe[main.testReturnsAny]
-              InjectionPoints: [{PC: "0xd0bfce", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0bfee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1311 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
-                - PC: "0xd0c084"
+                - PC: "0xd0c0a4"
                   Frameless: false
-                - PC: "0xd0c0bf"
+                - PC: "0xd0c0df"
                   Frameless: false
-                - PC: "0xd0c182"
+                - PC: "0xd0c1a2"
                   Frameless: false
-                - PC: "0xd0c18c"
+                - PC: "0xd0c1ac"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3965,18 +3965,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1308 EventRootType Probe[main.testReturnsAnyAndError]
-              InjectionPoints: [{PC: "0xd0be6e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0be8e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1309 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
-                - PC: "0xd0bed8"
+                - PC: "0xd0bef8"
                   Frameless: false
-                - PC: "0xd0bf13"
+                - PC: "0xd0bf33"
                   Frameless: false
-                - PC: "0xd0bf47"
+                - PC: "0xd0bf67"
                   Frameless: false
-                - PC: "0xd0bf79"
+                - PC: "0xd0bf99"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4003,11 +4003,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1353 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0xd0cc6a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0cc8a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1354 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0xd0cccd", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0cced", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -4024,11 +4024,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1355 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0xd0ccea", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0cd0a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1356 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0xd0cd2b", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0cd4b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -4045,11 +4045,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1357 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0xd0cd4a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0cd6a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1358 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0xd0cd86", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0cda6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4066,11 +4066,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1361 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0xd0ce2e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0ce4e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1362 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0xd0ceaa", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0ceca", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4087,11 +4087,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1373 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0xd0d16a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0d18a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1374 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0xd0d1b0", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0d1d0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4108,11 +4108,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1349 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0xd0cb2a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0cb4a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1350 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0xd0cb86", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0cba6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4130,14 +4130,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1306 EventRootType Probe[main.testReturnsError]
-              InjectionPoints: [{PC: "0xd0be0a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0be2a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1307 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
-                - PC: "0xd0be3a"
+                - PC: "0xd0be5a"
                   Frameless: false
-                - PC: "0xd0be45"
+                - PC: "0xd0be65"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4159,11 +4159,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1296 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xd0bc0a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0bc2a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1297 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xd0bc5b", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0bc7b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4184,11 +4184,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1304 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xd0bd2e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0bd4e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1305 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xd0bde4", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0be04", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4209,11 +4209,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1298 EventRootType Probe[main.testReturnsIntPointer]
-              InjectionPoints: [{PC: "0xd0bc8a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0bcaa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1299 EventRootType Probe[main.testReturnsIntPointer]Return
-              InjectionPoints: [{PC: "0xd0bcfb", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0bd1b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4235,14 +4235,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1312 EventRootType Probe[main.testReturnsInterface]
-              InjectionPoints: [{PC: "0xd0c1ce", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c1ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1313 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
-                - PC: "0xd0c2b1"
+                - PC: "0xd0c2d1"
                   Frameless: false
-                - PC: "0xd0c2bb"
+                - PC: "0xd0c2db"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4264,11 +4264,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1351 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0xd0cbae", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0cbce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1352 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0xd0cc33", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0cc53", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4285,11 +4285,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1347 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0xd0ca2e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0ca4e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1348 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0xd0cb05", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0cb25", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4306,11 +4306,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1365 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0xd0cf8a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0cfaa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1366 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0xd0cfec", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0d00c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4327,11 +4327,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1359 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0xd0cdaa", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0cdca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1360 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0xd0cdf8", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0ce18", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4348,11 +4348,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1371 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0xd0d0ea", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0d10a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1372 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0xd0d136", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0d156", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
@@ -4372,7 +4372,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1344 EventRootType Probe[main.testReturnsNamedDeferLine]Line
-              InjectionPoints: [{PC: "0xd0c7af", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c7cf", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4393,11 +4393,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1369 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0xd0d08a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0d0aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1370 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0xd0d0ce", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0d0ee", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4414,11 +4414,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1345 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0xd0c9aa", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c9ca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1346 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0xd0ca11", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0ca31", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4435,11 +4435,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1367 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0xd0d00a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0d02a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1368 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0xd0d06d", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0d08d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4456,11 +4456,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1363 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0xd0cece", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0ceee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1364 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0xd0cf54", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0cf74", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4513,11 +4513,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1326 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xd0c3ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c40e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1327 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0c48f", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c4af", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -4792,7 +4792,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1408 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0xd0eda0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0edc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4924,7 +4924,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1404 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0xd0e560", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0e580", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -4946,7 +4946,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1395 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0xd0e460", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0e480", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -4968,7 +4968,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1256 EventRootType Probe[main.testSmallMap]
-              InjectionPoints: [{PC: "0xd095c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd095e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -4989,11 +4989,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1340 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xd0c4ce", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c4ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1341 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0c56e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c58e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -5014,11 +5014,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1385 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0xd0dbea", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0dc0a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1386 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0xd0dc5c", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0dc7c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5062,7 +5062,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1287 EventRootType Probe[main.testStringPointer]
-              InjectionPoints: [{PC: "0xd0b680", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0b6a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}'
@@ -5084,7 +5084,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1399 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0xd0e4e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0e500", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5150,11 +5150,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1427 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xd0f180", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f1a0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1428 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0xd0f1a2", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f1c2", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5181,7 +5181,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1396 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0xd0e480", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0e4a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5229,11 +5229,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1389 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0xd0dd8e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0ddae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1390 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0xd0de3a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0de5a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5255,11 +5255,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1423 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0xd0f040", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f060", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1424 EventRootType Probe[main.testStructWithCyclicMaps]Return
-              InjectionPoints: [{PC: "0xd0f05e", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f07e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5280,7 +5280,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1422 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0xd0f020", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0f040", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5307,7 +5307,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1251 EventRootType Probe[main.testStructWithMap]
-              InjectionPoints: [{PC: "0xd09520", Frameless: true}]
+              InjectionPoints: [{PC: "0xd09540", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s} {@duration}'
@@ -5340,7 +5340,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1405 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0xd0e580", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0e5a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5380,7 +5380,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1421 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0xd0eea0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0eec0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5413,11 +5413,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1328 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xd0c3ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c40e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1329 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0c48f", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c4af", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{nonexistentVariable}'
@@ -5438,11 +5438,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1330 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xd0c3ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c40e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1331 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0c48f", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c4af", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{unsupportedExpression}'
@@ -5465,11 +5465,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1332 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xd0c3ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c40e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1333 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0c48f", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0c4af", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -5501,7 +5501,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1409 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0xd0edc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0ede0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5533,11 +5533,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1410 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xd0ede0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0ee00", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1411 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0xd0edfe", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0ee1e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5567,11 +5567,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1412 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xd0ede0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0ee00", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1413 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0xd0edfe", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0ee1e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5603,7 +5603,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1414 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xd0ee00", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0ee20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5633,7 +5633,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1415 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xd0ee00", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0ee20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5797,7 +5797,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1286 EventRootType Probe[main.testUintPointer]
-              InjectionPoints: [{PC: "0xd0b5a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0b5c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5819,7 +5819,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1393 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0xd0e420", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0e440", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5841,7 +5841,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1419 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0xd0ee60", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0ee80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5863,7 +5863,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1285 EventRootType Probe[main.testUnsafePointer]
-              InjectionPoints: [{PC: "0xd0b560", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0b580", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5907,7 +5907,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1402 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xd0e540", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0e560", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5929,7 +5929,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1403 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xd0e540", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0e560", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5954,7 +5954,7 @@ Probes:
               InjectionPoints:
                 - PC: "0xd08bea"
                   Frameless: false
-                - PC: "0xd12243"
+                - PC: "0xd12263"
                   Frameless: false
               Condition: null
             - Kind: Return
@@ -5981,11 +5981,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1391 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0xd0de6e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0de8e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1392 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xd0deec", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0df0c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -7070,140 +7070,127 @@ Subprograms:
       DictRegister: null
     - ID: 63
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0xd09520..0xd09521]
+      OutOfLinePCRanges: [0xd09540..0xd09541]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 165 StructureType main.structWithMap
-          Locations:
-            - Range: 0xd09520..0xd09521
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 64
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0xd09540..0xd09541]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 171 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0xd09540..0xd09541
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 65
-      Name: main.testMapStringToInt
+    - ID: 64
+      Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0xd09560..0xd09561]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 176 GoMapType map[string]int
+          Type: 171 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0xd09560..0xd09561
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 66
-      Name: main.testMapStringToSlice
+    - ID: 65
+      Name: main.testMapStringToInt
       OutOfLinePCRanges: [0xd09580..0xd09581]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 181 GoMapType map[string][]string
+          Type: 176 GoMapType map[string]int
           Locations:
             - Range: 0xd09580..0xd09581
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 67
-      Name: main.testMapArrayToArray
+    - ID: 66
+      Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0xd095a0..0xd095a1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 186 GoMapType map[[4]string][2]int
+          Type: 181 GoMapType map[string][]string
           Locations:
             - Range: 0xd095a0..0xd095a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 68
-      Name: main.testSmallMap
+    - ID: 67
+      Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0xd095c0..0xd095c1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 176 GoMapType map[string]int
+          Type: 186 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0xd095c0..0xd095c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 68
+      Name: main.testSmallMap
+      OutOfLinePCRanges: [0xd095e0..0xd095e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 176 GoMapType map[string]int
+          Locations:
+            - Range: 0xd095e0..0xd095e1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 69
       Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0xd095e0..0xd095e1]
+      OutOfLinePCRanges: [0xd09600..0xd09601]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 191 ArrayType [2]map[string]int
           Locations:
-            - Range: 0xd095e0..0xd095e1
+            - Range: 0xd09600..0xd09601
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 70
       Name: main.testPointerToMap
-      OutOfLinePCRanges: [0xd09600..0xd09601]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 192 PointerType *map[string]int
-          Locations:
-            - Range: 0xd09600..0xd09601
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 71
-      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0xd09620..0xd09621]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 166 GoMapType map[int]int
+          Type: 192 PointerType *map[string]int
           Locations:
             - Range: 0xd09620..0xd09621
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 72
-      Name: main.testMapMassive
+    - ID: 71
+      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0xd09640..0xd09641]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 193 GoMapType map[string][]main.structWithMap
+        - Name: m
+          Type: 166 GoMapType map[int]int
           Locations:
             - Range: 0xd09640..0xd09641
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 73
-      Name: main.testMapEmbeddedMaps
+    - ID: 72
+      Name: main.testMapMassive
       OutOfLinePCRanges: [0xd09660..0xd09661]
       InlinePCRanges: []
       Variables:
-        - Name: m
+        - Name: redactMyEntries
           Type: 193 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xd09660..0xd09661
@@ -7211,38 +7198,38 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 74
-      Name: main.testMapWithLinkedList
+    - ID: 73
+      Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0xd09680..0xd09681]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 198 GoMapType map[bool]main.node
+          Type: 193 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xd09680..0xd09681
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 75
-      Name: main.testMapWithSmallValue
+    - ID: 74
+      Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0xd096a0..0xd096a1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 203 GoMapType map[int]uint8
+          Type: 198 GoMapType map[bool]main.node
           Locations:
             - Range: 0xd096a0..0xd096a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 76
-      Name: main.testMapWithSmallValueMassive
+    - ID: 75
+      Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0xd096c0..0xd096c1]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
+        - Name: m
           Type: 203 GoMapType map[int]uint8
           Locations:
             - Range: 0xd096c0..0xd096c1
@@ -7250,21 +7237,21 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 77
-      Name: main.testMapWithSmallKeyAndValue
+    - ID: 76
+      Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0xd096e0..0xd096e1]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 208 GoMapType map[uint8]uint8
+        - Name: redactMyEntries
+          Type: 203 GoMapType map[int]uint8
           Locations:
             - Range: 0xd096e0..0xd096e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 78
-      Name: main.testMapWithSmallKeyAndValueMassive
+    - ID: 77
+      Name: main.testMapWithSmallKeyAndValue
       OutOfLinePCRanges: [0xd09700..0xd09701]
       InlinePCRanges: []
       Variables:
@@ -7276,8 +7263,8 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 79
-      Name: main.testMapSmallKeySmallValue
+    - ID: 78
+      Name: main.testMapWithSmallKeyAndValueMassive
       OutOfLinePCRanges: [0xd09720..0xd09721]
       InlinePCRanges: []
       Variables:
@@ -7289,127 +7276,140 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 80
-      Name: main.testMapSmallKeyLargeValue
+    - ID: 79
+      Name: main.testMapSmallKeySmallValue
       OutOfLinePCRanges: [0xd09740..0xd09741]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 213 GoMapType map[uint8][4]int
+          Type: 208 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xd09740..0xd09741
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 81
-      Name: main.testMapLargeKeySmallValue
+    - ID: 80
+      Name: main.testMapSmallKeyLargeValue
       OutOfLinePCRanges: [0xd09760..0xd09761]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 218 GoMapType map[[4]int]uint8
+          Type: 213 GoMapType map[uint8][4]int
           Locations:
             - Range: 0xd09760..0xd09761
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 82
-      Name: main.testMapLargeKeyLargeValue
+    - ID: 81
+      Name: main.testMapLargeKeySmallValue
       OutOfLinePCRanges: [0xd09780..0xd09781]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 223 GoMapType map[[4]int][4]int
+          Type: 218 GoMapType map[[4]int]uint8
           Locations:
             - Range: 0xd09780..0xd09781
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 83
-      Name: main.testMapEmptyKey
+    - ID: 82
+      Name: main.testMapLargeKeyLargeValue
       OutOfLinePCRanges: [0xd097a0..0xd097a1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 228 GoMapType map[struct {}]int
+          Type: 223 GoMapType map[[4]int][4]int
           Locations:
             - Range: 0xd097a0..0xd097a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 84
-      Name: main.testMapEmptyValue
+    - ID: 83
+      Name: main.testMapEmptyKey
       OutOfLinePCRanges: [0xd097c0..0xd097c1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 233 GoMapType map[int]struct {}
+          Type: 228 GoMapType map[struct {}]int
           Locations:
             - Range: 0xd097c0..0xd097c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 85
-      Name: main.testMapEmptyKeyAndValue
+    - ID: 84
+      Name: main.testMapEmptyValue
       OutOfLinePCRanges: [0xd097e0..0xd097e1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 238 GoMapType map[struct {}]struct {}
+          Type: 233 GoMapType map[int]struct {}
           Locations:
             - Range: 0xd097e0..0xd097e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 85
+      Name: main.testMapEmptyKeyAndValue
+      OutOfLinePCRanges: [0xd09800..0xd09801]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 238 GoMapType map[struct {}]struct {}
+          Locations:
+            - Range: 0xd09800..0xd09801
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 86
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0xd0af20..0xd0af21]
+      OutOfLinePCRanges: [0xd0af40..0xd0af41]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xd0af20..0xd0af21
+            - Range: 0xd0af40..0xd0af41
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xd0af20..0xd0af21
+            - Range: 0xd0af40..0xd0af41
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: "y"
           Type: 17 BaseType float32
           Locations:
-            - Range: 0xd0af20..0xd0af21
+            - Range: 0xd0af40..0xd0af41
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 87
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0xd0af60..0xd0af61]
+      OutOfLinePCRanges: [0xd0af80..0xd0af81]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xd0af60..0xd0af61
+            - Range: 0xd0af80..0xd0af81
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0xd0af60..0xd0af61
+            - Range: 0xd0af80..0xd0af81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -7420,48 +7420,48 @@ Subprograms:
         - Name: "y"
           Type: 17 BaseType float32
           Locations:
-            - Range: 0xd0af60..0xd0af61
+            - Range: 0xd0af80..0xd0af81
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 88
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0xd0b0e0..0xd0b0e1]
+      OutOfLinePCRanges: [0xd0b100..0xd0b101]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xd0b0e0..0xd0b0e1
+            - Range: 0xd0b100..0xd0b101
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xd0b0e0..0xd0b0e1
+            - Range: 0xd0b100..0xd0b101
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 13 BaseType int32
           Locations:
-            - Range: 0xd0b0e0..0xd0b0e1
+            - Range: 0xd0b100..0xd0b101
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 16 BaseType uint
           Locations:
-            - Range: 0xd0b0e0..0xd0b0e1
+            - Range: 0xd0b100..0xd0b101
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0xd0b0e0..0xd0b0e1
+            - Range: 0xd0b100..0xd0b101
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7472,61 +7472,61 @@ Subprograms:
       DictRegister: null
     - ID: 89
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0xd0b300..0xd0b313]
+      OutOfLinePCRanges: [0xd0b320..0xd0b333]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 BaseType uint64
           Locations:
-            - Range: 0xd0b300..0xd0b312
+            - Range: 0xd0b320..0xd0b332
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 11 BaseType uint64
           Locations:
-            - Range: 0xd0b300..0xd0b312
+            - Range: 0xd0b320..0xd0b332
               Pieces: []
-            - Range: 0xd0b312..0xd0b313
+            - Range: 0xd0b332..0xd0b333
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 90
       Name: main.testChannel
-      OutOfLinePCRanges: [0xd0b320..0xd0b321]
+      OutOfLinePCRanges: [0xd0b340..0xd0b341]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 243 GoChannelType chan bool
           Locations:
-            - Range: 0xd0b320..0xd0b321
+            - Range: 0xd0b340..0xd0b341
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 91
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xd0b500..0xd0b501]
+      OutOfLinePCRanges: [0xd0b520..0xd0b521]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 244 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xd0b500..0xd0b501
+            - Range: 0xd0b520..0xd0b521
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 92
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0xd0b520..0xd0b521]
+      OutOfLinePCRanges: [0xd0b540..0xd0b541]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 246 StructureType main.node
           Locations:
-            - Range: 0xd0b520..0xd0b521
+            - Range: 0xd0b540..0xd0b541
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7537,273 +7537,273 @@ Subprograms:
       DictRegister: null
     - ID: 93
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xd0b540..0xd0b541]
+      OutOfLinePCRanges: [0xd0b560..0xd0b561]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 247 PointerType *main.node
-          Locations:
-            - Range: 0xd0b540..0xd0b541
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 94
-      Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xd0b560..0xd0b561]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 20 VoidPointerType unsafe.Pointer
           Locations:
             - Range: 0xd0b560..0xd0b561
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 94
+      Name: main.testUnsafePointer
+      OutOfLinePCRanges: [0xd0b580..0xd0b581]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 20 VoidPointerType unsafe.Pointer
+          Locations:
+            - Range: 0xd0b580..0xd0b581
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 95
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0xd0b5a0..0xd0b5a1]
+      OutOfLinePCRanges: [0xd0b5c0..0xd0b5c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 101 PointerType *uint
           Locations:
-            - Range: 0xd0b5a0..0xd0b5a1
+            - Range: 0xd0b5c0..0xd0b5c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 96
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0xd0b680..0xd0b681]
+      OutOfLinePCRanges: [0xd0b6a0..0xd0b6a1]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 89 PointerType *string
           Locations:
-            - Range: 0xd0b680..0xd0b681
+            - Range: 0xd0b6a0..0xd0b6a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 97
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0xd0b6c0..0xd0b6c1]
+      OutOfLinePCRanges: [0xd0b6e0..0xd0b6e1]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 6 PointerType *bool
           Locations:
-            - Range: 0xd0b6c0..0xd0b6c1
+            - Range: 0xd0b6e0..0xd0b6e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 16 BaseType uint
           Locations:
-            - Range: 0xd0b6c0..0xd0b6c1
+            - Range: 0xd0b6e0..0xd0b6e1
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 98
       Name: main.testCycle
-      OutOfLinePCRanges: [0xd0b700..0xd0b701]
+      OutOfLinePCRanges: [0xd0b720..0xd0b721]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 248 PointerType *main.t
           Locations:
-            - Range: 0xd0b700..0xd0b701
+            - Range: 0xd0b720..0xd0b721
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 99
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0xd0bc00..0xd0bc72]
+      OutOfLinePCRanges: [0xd0bc20..0xd0bc92]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0bc00..0xd0bc12
+            - Range: 0xd0bc20..0xd0bc32
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0bc00..0xd0bc5b
+            - Range: 0xd0bc20..0xd0bc7b
               Pieces: []
-            - Range: 0xd0bc5b..0xd0bc5c
+            - Range: 0xd0bc7b..0xd0bc7c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0bc5c..0xd0bc72
+            - Range: 0xd0bc7c..0xd0bc92
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0bc12..0xd0bc25
+            - Range: 0xd0bc32..0xd0bc45
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0bc25..0xd0bc72
+            - Range: 0xd0bc45..0xd0bc92
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 100
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0xd0bc80..0xd0bd15]
+      OutOfLinePCRanges: [0xd0bca0..0xd0bd35]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0bc80..0xd0bc9a
+            - Range: 0xd0bca0..0xd0bcba
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0bc9a..0xd0bd15
+            - Range: 0xd0bcba..0xd0bd35
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 94 PointerType *int
           Locations:
-            - Range: 0xd0bc80..0xd0bcfb
+            - Range: 0xd0bca0..0xd0bd1b
               Pieces: []
-            - Range: 0xd0bcfb..0xd0bcfc
+            - Range: 0xd0bd1b..0xd0bd1c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0bcfc..0xd0bd15
+            - Range: 0xd0bd1c..0xd0bd35
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: '&result'
           Type: 94 PointerType *int
           Locations:
-            - Range: 0xd0bc9f..0xd0bcbc
+            - Range: 0xd0bcbf..0xd0bcdc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0bcbc..0xd0bd15
+            - Range: 0xd0bcdc..0xd0bd35
               Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 101
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0xd0bd20..0xd0bdfe]
+      OutOfLinePCRanges: [0xd0bd40..0xd0be1e]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0bd20..0xd0bd82
+            - Range: 0xd0bd40..0xd0bda2
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0bd20..0xd0bde4
+            - Range: 0xd0bd40..0xd0be04
               Pieces: []
-            - Range: 0xd0bde4..0xd0bde5
+            - Range: 0xd0be04..0xd0be05
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0bde5..0xd0bdfe
+            - Range: 0xd0be05..0xd0be1e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0bd20..0xd0bdfe, Pieces: []}]
+          Locations: [{Range: 0xd0bd40..0xd0be1e, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: resultInt
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0bd36..0xd0bd87
+            - Range: 0xd0bd56..0xd0bda7
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd0bd87..0xd0bdfe
+            - Range: 0xd0bda7..0xd0be1e
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
           Role: Local
           DictIndex: -1
         - Name: resultFloat
           Type: 18 BaseType float64
           Locations:
-            - Range: 0xd0bd4f..0xd0bd87
+            - Range: 0xd0bd6f..0xd0bda7
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
-            - Range: 0xd0bd87..0xd0bdfe
+            - Range: 0xd0bda7..0xd0be1e
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 102
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0xd0be00..0xd0be5b]
+      OutOfLinePCRanges: [0xd0be20..0xd0be7b]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xd0be00..0xd0be19
+            - Range: 0xd0be20..0xd0be39
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 19 GoInterfaceType error
           Locations:
-            - Range: 0xd0be00..0xd0be3a
+            - Range: 0xd0be20..0xd0be5a
               Pieces: []
-            - Range: 0xd0be3a..0xd0be3b
+            - Range: 0xd0be5a..0xd0be5b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0be3b..0xd0be45
+            - Range: 0xd0be5b..0xd0be65
               Pieces: []
-            - Range: 0xd0be45..0xd0be46
+            - Range: 0xd0be65..0xd0be66
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0be46..0xd0be5b
+            - Range: 0xd0be66..0xd0be7b
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 103
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0xd0be60..0xd0bfa6]
+      OutOfLinePCRanges: [0xd0be80..0xd0bfc6]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd0be60..0xd0beb1
+            - Range: 0xd0be80..0xd0bed1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0beb1..0xd0beb4
+            - Range: 0xd0bed1..0xd0bed4
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0bef7..0xd0bf05
+            - Range: 0xd0bf17..0xd0bf25
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0bf20..0xd0bf25
+            - Range: 0xd0bf40..0xd0bf45
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0bf54..0xd0bf59
+            - Range: 0xd0bf74..0xd0bf79
               Pieces:
                 - Size: 8
                   Op: null
@@ -7814,117 +7814,117 @@ Subprograms:
         - Name: failed
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xd0be60..0xd0beaf
+            - Range: 0xd0be80..0xd0becf
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd0be60..0xd0bed8
+            - Range: 0xd0be80..0xd0bef8
               Pieces: []
-            - Range: 0xd0bed8..0xd0bed9
+            - Range: 0xd0bef8..0xd0bef9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0bed9..0xd0bf13
+            - Range: 0xd0bef9..0xd0bf33
               Pieces: []
-            - Range: 0xd0bf13..0xd0bf14
+            - Range: 0xd0bf33..0xd0bf34
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0bf14..0xd0bf47
+            - Range: 0xd0bf34..0xd0bf67
               Pieces: []
-            - Range: 0xd0bf47..0xd0bf48
+            - Range: 0xd0bf67..0xd0bf68
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0bf48..0xd0bf79
+            - Range: 0xd0bf68..0xd0bf99
               Pieces: []
-            - Range: 0xd0bf79..0xd0bf7a
+            - Range: 0xd0bf99..0xd0bf9a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0bf7a..0xd0bfa6
+            - Range: 0xd0bf9a..0xd0bfc6
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 19 GoInterfaceType error
           Locations:
-            - Range: 0xd0be60..0xd0bed8
+            - Range: 0xd0be80..0xd0bef8
               Pieces: []
-            - Range: 0xd0bed8..0xd0bed9
+            - Range: 0xd0bef8..0xd0bef9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd0bed9..0xd0bf13
+            - Range: 0xd0bef9..0xd0bf33
               Pieces: []
-            - Range: 0xd0bf13..0xd0bf14
+            - Range: 0xd0bf33..0xd0bf34
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd0bf14..0xd0bf47
+            - Range: 0xd0bf34..0xd0bf67
               Pieces: []
-            - Range: 0xd0bf47..0xd0bf48
+            - Range: 0xd0bf67..0xd0bf68
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd0bf48..0xd0bf79
+            - Range: 0xd0bf68..0xd0bf99
               Pieces: []
-            - Range: 0xd0bf79..0xd0bf7a
+            - Range: 0xd0bf99..0xd0bf9a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd0bf7a..0xd0bfa6
+            - Range: 0xd0bf9a..0xd0bfc6
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0bef7..0xd0bf00
+            - Range: 0xd0bf17..0xd0bf20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 104
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0xd0bfc0..0xd0c1b4]
+      OutOfLinePCRanges: [0xd0bfe0..0xd0c1d4]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd0bfc0..0xd0c01f
+            - Range: 0xd0bfe0..0xd0c03f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0c01f..0xd0c022
+            - Range: 0xd0c03f..0xd0c042
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd0c022..0xd0c1b4
+            - Range: 0xd0c042..0xd0c1d4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -7935,1128 +7935,1128 @@ Subprograms:
         - Name: ~r0
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd0bfc0..0xd0c084
+            - Range: 0xd0bfe0..0xd0c0a4
               Pieces: []
-            - Range: 0xd0c084..0xd0c085
+            - Range: 0xd0c0a4..0xd0c0a5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0c085..0xd0c0bf
+            - Range: 0xd0c0a5..0xd0c0df
               Pieces: []
-            - Range: 0xd0c0bf..0xd0c0c0
+            - Range: 0xd0c0df..0xd0c0e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0c0c0..0xd0c182
+            - Range: 0xd0c0e0..0xd0c1a2
               Pieces: []
-            - Range: 0xd0c182..0xd0c183
+            - Range: 0xd0c1a2..0xd0c1a3
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0c183..0xd0c18c
+            - Range: 0xd0c1a3..0xd0c1ac
               Pieces: []
-            - Range: 0xd0c18c..0xd0c18d
+            - Range: 0xd0c1ac..0xd0c1ad
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0c18d..0xd0c1b4
+            - Range: 0xd0c1ad..0xd0c1d4
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0c0aa..0xd0c0b0
+            - Range: 0xd0c0ca..0xd0c0d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: '&result'
           Type: 94 PointerType *int
           Locations:
-            - Range: 0xd0c065..0xd0c084
+            - Range: 0xd0c085..0xd0c0a4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 105
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0xd0c1c0..0xd0c325]
+      OutOfLinePCRanges: [0xd0c1e0..0xd0c345]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd0c1c0..0xd0c200
+            - Range: 0xd0c1e0..0xd0c220
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0c200..0xd0c265
+            - Range: 0xd0c220..0xd0c285
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xd0c265..0xd0c2c1
+            - Range: 0xd0c285..0xd0c2e1
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xd0c2c1..0xd0c2e1
+            - Range: 0xd0c2e1..0xd0c301
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd0c2e1..0xd0c2e8
+            - Range: 0xd0c301..0xd0c308
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd0c2e8..0xd0c325
+            - Range: 0xd0c308..0xd0c345
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 162 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xd0c1c0..0xd0c2b1
+            - Range: 0xd0c1e0..0xd0c2d1
               Pieces: []
-            - Range: 0xd0c2b1..0xd0c2b2
+            - Range: 0xd0c2d1..0xd0c2d2
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0c2b2..0xd0c2bb
+            - Range: 0xd0c2d2..0xd0c2db
               Pieces: []
-            - Range: 0xd0c2bb..0xd0c2bc
+            - Range: 0xd0c2db..0xd0c2dc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0c2bc..0xd0c325
+            - Range: 0xd0c2dc..0xd0c345
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 162 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xd0c1c0..0xd0c200
+            - Range: 0xd0c1e0..0xd0c220
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0c200..0xd0c255
+            - Range: 0xd0c220..0xd0c275
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd0c255..0xd0c265
+            - Range: 0xd0c275..0xd0c285
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd0c265..0xd0c2b7
+            - Range: 0xd0c285..0xd0c2d7
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd0c2b7..0xd0c2b9
+            - Range: 0xd0c2d7..0xd0c2d9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd0c2b9..0xd0c2bb
+            - Range: 0xd0c2d9..0xd0c2db
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xd0c2bb..0xd0c325
+            - Range: 0xd0c2db..0xd0c345
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 106
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0xd0c340..0xd0c3cf]
+      OutOfLinePCRanges: [0xd0c360..0xd0c3ef]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0c340..0xd0c351
+            - Range: 0xd0c360..0xd0c371
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0c340..0xd0c3b5
+            - Range: 0xd0c360..0xd0c3d5
               Pieces: []
-            - Range: 0xd0c3b5..0xd0c3b6
+            - Range: 0xd0c3d5..0xd0c3d6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0c3b6..0xd0c3cf
+            - Range: 0xd0c3d6..0xd0c3ef
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 107
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0xd0c3e0..0xd0c4a9]
+      OutOfLinePCRanges: [0xd0c400..0xd0c4c9]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0c3e0..0xd0c433
+            - Range: 0xd0c400..0xd0c453
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0c3e0..0xd0c48f
+            - Range: 0xd0c400..0xd0c4af
               Pieces: []
-            - Range: 0xd0c48f..0xd0c490
+            - Range: 0xd0c4af..0xd0c4b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0c490..0xd0c4a9
+            - Range: 0xd0c4b0..0xd0c4c9
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0c3e0..0xd0c48f
+            - Range: 0xd0c400..0xd0c4af
               Pieces: []
-            - Range: 0xd0c48f..0xd0c490
+            - Range: 0xd0c4af..0xd0c4b0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0c490..0xd0c4a9
+            - Range: 0xd0c4b0..0xd0c4c9
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 108
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0xd0c4c0..0xd0c588]
+      OutOfLinePCRanges: [0xd0c4e0..0xd0c5a8]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0c4c0..0xd0c505
+            - Range: 0xd0c4e0..0xd0c525
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0c505..0xd0c588
+            - Range: 0xd0c525..0xd0c5a8
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0c4c0..0xd0c56e
+            - Range: 0xd0c4e0..0xd0c58e
               Pieces: []
-            - Range: 0xd0c56e..0xd0c56f
+            - Range: 0xd0c58e..0xd0c58f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0c56f..0xd0c588
+            - Range: 0xd0c58f..0xd0c5a8
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0c4c0..0xd0c56e
+            - Range: 0xd0c4e0..0xd0c58e
               Pieces: []
-            - Range: 0xd0c56e..0xd0c56f
+            - Range: 0xd0c58e..0xd0c58f
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0c56f..0xd0c588
+            - Range: 0xd0c58f..0xd0c5a8
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0c4c0..0xd0c56e
+            - Range: 0xd0c4e0..0xd0c58e
               Pieces: []
-            - Range: 0xd0c56e..0xd0c56f
+            - Range: 0xd0c58e..0xd0c58f
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd0c56f..0xd0c588
+            - Range: 0xd0c58f..0xd0c5a8
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 109
       Name: main.testConflictingReturn
-      OutOfLinePCRanges: [0xd0c5a0..0xd0c68f]
+      OutOfLinePCRanges: [0xd0c5c0..0xd0c6af]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0c5a0..0xd0c5e5
+            - Range: 0xd0c5c0..0xd0c605
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0c5e5..0xd0c68f
+            - Range: 0xd0c605..0xd0c6af
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0c5a0..0xd0c674
+            - Range: 0xd0c5c0..0xd0c694
               Pieces: []
-            - Range: 0xd0c674..0xd0c675
+            - Range: 0xd0c694..0xd0c695
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0c675..0xd0c68f
+            - Range: 0xd0c695..0xd0c6af
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: r0
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0xd0c5a0..0xd0c674
+            - Range: 0xd0c5c0..0xd0c694
               Pieces: []
-            - Range: 0xd0c674..0xd0c675
+            - Range: 0xd0c694..0xd0c695
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xd0c675..0xd0c68f
+            - Range: 0xd0c695..0xd0c6af
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 110
       Name: main.testReturnsNamedDeferLine
-      OutOfLinePCRanges: [0xd0c6a0..0xd0c8af]
+      OutOfLinePCRanges: [0xd0c6c0..0xd0c8cf]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0c6a0..0xd0c726
+            - Range: 0xd0c6c0..0xd0c746
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0c726..0xd0c8af
+            - Range: 0xd0c746..0xd0c8cf
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0xd0c6d7..0xd0c8af
+            - Range: 0xd0c6f7..0xd0c8cf
               Pieces: [{Size: 16, Op: {CfaOffset: -128}}]
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0xd0c6dd..0xd0c8af
+            - Range: 0xd0c6fd..0xd0c8cf
               Pieces: [{Size: 16, Op: {CfaOffset: -144}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 111
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0xd0c9a0..0xd0ca1e]
+      OutOfLinePCRanges: [0xd0c9c0..0xd0ca3e]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 15 BaseType int8
           Locations:
-            - Range: 0xd0c9a0..0xd0ca11
+            - Range: 0xd0c9c0..0xd0ca31
               Pieces: []
-            - Range: 0xd0ca11..0xd0ca12
+            - Range: 0xd0ca31..0xd0ca32
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0ca12..0xd0ca1e
+            - Range: 0xd0ca32..0xd0ca3e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 98 BaseType int16
           Locations:
-            - Range: 0xd0c9a0..0xd0ca11
+            - Range: 0xd0c9c0..0xd0ca31
               Pieces: []
-            - Range: 0xd0ca11..0xd0ca12
+            - Range: 0xd0ca31..0xd0ca32
               Pieces: [{Size: 2, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0ca12..0xd0ca1e
+            - Range: 0xd0ca32..0xd0ca3e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 13 BaseType int32
           Locations:
-            - Range: 0xd0c9a0..0xd0ca11
+            - Range: 0xd0c9c0..0xd0ca31
               Pieces: []
-            - Range: 0xd0ca11..0xd0ca12
+            - Range: 0xd0ca31..0xd0ca32
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd0ca12..0xd0ca1e
+            - Range: 0xd0ca32..0xd0ca3e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 14 BaseType int64
           Locations:
-            - Range: 0xd0c9a0..0xd0ca11
+            - Range: 0xd0c9c0..0xd0ca31
               Pieces: []
-            - Range: 0xd0ca11..0xd0ca12
+            - Range: 0xd0ca31..0xd0ca32
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xd0ca12..0xd0ca1e
+            - Range: 0xd0ca32..0xd0ca3e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xd0c9a0..0xd0ca11
+            - Range: 0xd0c9c0..0xd0ca31
               Pieces: []
-            - Range: 0xd0ca11..0xd0ca12
+            - Range: 0xd0ca31..0xd0ca32
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xd0ca12..0xd0ca1e
+            - Range: 0xd0ca32..0xd0ca3e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 8 BaseType uint16
           Locations:
-            - Range: 0xd0c9a0..0xd0ca11
+            - Range: 0xd0c9c0..0xd0ca31
               Pieces: []
-            - Range: 0xd0ca11..0xd0ca12
+            - Range: 0xd0ca31..0xd0ca32
               Pieces: [{Size: 2, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xd0ca12..0xd0ca1e
+            - Range: 0xd0ca32..0xd0ca3e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 3 BaseType uint32
           Locations:
-            - Range: 0xd0c9a0..0xd0ca11
+            - Range: 0xd0c9c0..0xd0ca31
               Pieces: []
-            - Range: 0xd0ca11..0xd0ca12
+            - Range: 0xd0ca31..0xd0ca32
               Pieces: [{Size: 4, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xd0ca12..0xd0ca1e
+            - Range: 0xd0ca32..0xd0ca3e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 11 BaseType uint64
           Locations:
-            - Range: 0xd0c9a0..0xd0ca11
+            - Range: 0xd0c9c0..0xd0ca31
               Pieces: []
-            - Range: 0xd0ca11..0xd0ca12
+            - Range: 0xd0ca31..0xd0ca32
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xd0ca12..0xd0ca1e
+            - Range: 0xd0ca32..0xd0ca3e
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 112
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0xd0ca20..0xd0cb15]
+      OutOfLinePCRanges: [0xd0ca40..0xd0cb35]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0ca20..0xd0cb15, Pieces: []}]
+          Locations: [{Range: 0xd0ca40..0xd0cb35, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0ca20..0xd0cb15, Pieces: []}]
+          Locations: [{Range: 0xd0ca40..0xd0cb35, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0ca20..0xd0cb15, Pieces: []}]
+          Locations: [{Range: 0xd0ca40..0xd0cb35, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0ca20..0xd0cb15, Pieces: []}]
+          Locations: [{Range: 0xd0ca40..0xd0cb35, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0ca20..0xd0cb15, Pieces: []}]
+          Locations: [{Range: 0xd0ca40..0xd0cb35, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0ca20..0xd0cb15, Pieces: []}]
+          Locations: [{Range: 0xd0ca40..0xd0cb35, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0ca20..0xd0cb15, Pieces: []}]
+          Locations: [{Range: 0xd0ca40..0xd0cb35, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0ca20..0xd0cb15, Pieces: []}]
+          Locations: [{Range: 0xd0ca40..0xd0cb35, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0ca20..0xd0cb15, Pieces: []}]
+          Locations: [{Range: 0xd0ca40..0xd0cb35, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r9
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0ca20..0xd0cb15, Pieces: []}]
+          Locations: [{Range: 0xd0ca40..0xd0cb35, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r10
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0ca20..0xd0cb15, Pieces: []}]
+          Locations: [{Range: 0xd0ca40..0xd0cb35, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r11
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0ca20..0xd0cb15, Pieces: []}]
+          Locations: [{Range: 0xd0ca40..0xd0cb35, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r12
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0ca20..0xd0cb15, Pieces: []}]
+          Locations: [{Range: 0xd0ca40..0xd0cb35, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r13
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0ca20..0xd0cb15, Pieces: []}]
+          Locations: [{Range: 0xd0ca40..0xd0cb35, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r14
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0ca20..0xd0cb15, Pieces: []}]
+          Locations: [{Range: 0xd0ca40..0xd0cb35, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: onlyOnAmd64_16
           Type: 18 BaseType float64
           Locations:
-            - Range: 0xd0ca20..0xd0cb05
+            - Range: 0xd0ca40..0xd0cb25
               Pieces: []
-            - Range: 0xd0cb05..0xd0cb06
+            - Range: 0xd0cb25..0xd0cb26
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xd0cb06..0xd0cb15
+            - Range: 0xd0cb26..0xd0cb35
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: bothArmAndAmd64
           Type: 18 BaseType float64
           Locations:
-            - Range: 0xd0ca20..0xd0cb05
+            - Range: 0xd0ca40..0xd0cb25
               Pieces: []
-            - Range: 0xd0cb05..0xd0cb06
+            - Range: 0xd0cb25..0xd0cb26
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xd0cb06..0xd0cb15
+            - Range: 0xd0cb26..0xd0cb35
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 113
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0xd0cb20..0xd0cb93]
+      OutOfLinePCRanges: [0xd0cb40..0xd0cbb3]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 90 BaseType complex64
-          Locations: [{Range: 0xd0cb20..0xd0cb93, Pieces: []}]
+          Locations: [{Range: 0xd0cb40..0xd0cbb3, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 91 BaseType complex128
-          Locations: [{Range: 0xd0cb20..0xd0cb93, Pieces: []}]
+          Locations: [{Range: 0xd0cb40..0xd0cbb3, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 114
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0xd0cba0..0xd0cc45]
+      OutOfLinePCRanges: [0xd0cbc0..0xd0cc65]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xd0cba0..0xd0cc33
+            - Range: 0xd0cbc0..0xd0cc53
               Pieces: []
-            - Range: 0xd0cc33..0xd0cc34
+            - Range: 0xd0cc53..0xd0cc54
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
-            - Range: 0xd0cc34..0xd0cc45
+            - Range: 0xd0cc54..0xd0cc65
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 115
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0xd0cc60..0xd0ccda]
+      OutOfLinePCRanges: [0xd0cc80..0xd0ccfa]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0xd0cc60..0xd0cccd
+            - Range: 0xd0cc80..0xd0cced
               Pieces: []
-            - Range: 0xd0cccd..0xd0ccce
+            - Range: 0xd0cced..0xd0ccee
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xd0ccce..0xd0ccda
+            - Range: 0xd0ccee..0xd0ccfa
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 116
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0xd0cce0..0xd0cd38]
+      OutOfLinePCRanges: [0xd0cd00..0xd0cd58]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 252 ArrayType [1]int
           Locations:
-            - Range: 0xd0cce0..0xd0cd2b
+            - Range: 0xd0cd00..0xd0cd4b
               Pieces: []
-            - Range: 0xd0cd2b..0xd0cd2c
+            - Range: 0xd0cd4b..0xd0cd4c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0cd2c..0xd0cd38
+            - Range: 0xd0cd4c..0xd0cd58
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 117
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0xd0cd40..0xd0cd93]
+      OutOfLinePCRanges: [0xd0cd60..0xd0cdb3]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 253 ArrayType [0]int
           Locations:
-            - Range: 0xd0cd40..0xd0cd86
+            - Range: 0xd0cd60..0xd0cda6
               Pieces: []
-            - Range: 0xd0cd86..0xd0cd87
+            - Range: 0xd0cda6..0xd0cda7
               Pieces: []
-            - Range: 0xd0cd87..0xd0cd93
+            - Range: 0xd0cda7..0xd0cdb3
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 118
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0xd0cda0..0xd0ce07]
+      OutOfLinePCRanges: [0xd0cdc0..0xd0ce27]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 254 StructureType main.mixedStruct
-          Locations: [{Range: 0xd0cda0..0xd0ce07, Pieces: []}]
+          Locations: [{Range: 0xd0cdc0..0xd0ce27, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 119
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0xd0ce20..0xd0ceba]
+      OutOfLinePCRanges: [0xd0ce40..0xd0ceda]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0ce20..0xd0ceaa
+            - Range: 0xd0ce40..0xd0ceca
               Pieces: []
-            - Range: 0xd0ceaa..0xd0ceab
+            - Range: 0xd0ceca..0xd0cecb
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0ceab..0xd0ceba
+            - Range: 0xd0cecb..0xd0ceda
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0ce20..0xd0ceaa
+            - Range: 0xd0ce40..0xd0ceca
               Pieces: []
-            - Range: 0xd0ceaa..0xd0ceab
+            - Range: 0xd0ceca..0xd0cecb
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0ceab..0xd0ceba
+            - Range: 0xd0cecb..0xd0ceda
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0ce20..0xd0ceaa
+            - Range: 0xd0ce40..0xd0ceca
               Pieces: []
-            - Range: 0xd0ceaa..0xd0ceab
+            - Range: 0xd0ceca..0xd0cecb
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd0ceab..0xd0ceba
+            - Range: 0xd0cecb..0xd0ceda
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0ce20..0xd0ceaa
+            - Range: 0xd0ce40..0xd0ceca
               Pieces: []
-            - Range: 0xd0ceaa..0xd0ceab
+            - Range: 0xd0ceca..0xd0cecb
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xd0ceab..0xd0ceba
+            - Range: 0xd0cecb..0xd0ceda
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0ce20..0xd0ceaa
+            - Range: 0xd0ce40..0xd0ceca
               Pieces: []
-            - Range: 0xd0ceaa..0xd0ceab
+            - Range: 0xd0ceca..0xd0cecb
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xd0ceab..0xd0ceba
+            - Range: 0xd0cecb..0xd0ceda
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0ce20..0xd0ceaa
+            - Range: 0xd0ce40..0xd0ceca
               Pieces: []
-            - Range: 0xd0ceaa..0xd0ceab
+            - Range: 0xd0ceca..0xd0cecb
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xd0ceab..0xd0ceba
+            - Range: 0xd0cecb..0xd0ceda
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0ce20..0xd0ceaa
+            - Range: 0xd0ce40..0xd0ceca
               Pieces: []
-            - Range: 0xd0ceaa..0xd0ceab
+            - Range: 0xd0ceca..0xd0cecb
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xd0ceab..0xd0ceba
+            - Range: 0xd0cecb..0xd0ceda
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0ce20..0xd0ceaa
+            - Range: 0xd0ce40..0xd0ceca
               Pieces: []
-            - Range: 0xd0ceaa..0xd0ceab
+            - Range: 0xd0ceca..0xd0cecb
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xd0ceab..0xd0ceba
+            - Range: 0xd0cecb..0xd0ceda
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0xd0ce20..0xd0ceaa
+            - Range: 0xd0ce40..0xd0ceca
               Pieces: []
-            - Range: 0xd0ceaa..0xd0ceab
+            - Range: 0xd0ceca..0xd0cecb
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xd0ceab..0xd0ceba
+            - Range: 0xd0cecb..0xd0ceda
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 120
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0xd0cec0..0xd0cf65]
+      OutOfLinePCRanges: [0xd0cee0..0xd0cf85]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 255 StructureType main.wideStruct
           Locations:
-            - Range: 0xd0cec0..0xd0cf54
+            - Range: 0xd0cee0..0xd0cf74
               Pieces: []
-            - Range: 0xd0cf54..0xd0cf55
+            - Range: 0xd0cf74..0xd0cf75
               Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
-            - Range: 0xd0cf55..0xd0cf65
+            - Range: 0xd0cf75..0xd0cf85
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 121
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0xd0cf80..0xd0cff9]
+      OutOfLinePCRanges: [0xd0cfa0..0xd0d019]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0cf80..0xd0cfec
+            - Range: 0xd0cfa0..0xd0d00c
               Pieces: []
-            - Range: 0xd0cfec..0xd0cfed
+            - Range: 0xd0d00c..0xd0d00d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0cfed..0xd0cff9
+            - Range: 0xd0d00d..0xd0d019
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0cf80..0xd0cff9, Pieces: []}]
+          Locations: [{Range: 0xd0cfa0..0xd0d019, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0cf80..0xd0cfec
+            - Range: 0xd0cfa0..0xd0d00c
               Pieces: []
-            - Range: 0xd0cfec..0xd0cfed
+            - Range: 0xd0d00c..0xd0d00d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0cfed..0xd0cff9
+            - Range: 0xd0d00d..0xd0d019
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0cf80..0xd0cff9, Pieces: []}]
+          Locations: [{Range: 0xd0cfa0..0xd0d019, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0xd0cf80..0xd0cfec
+            - Range: 0xd0cfa0..0xd0d00c
               Pieces: []
-            - Range: 0xd0cfec..0xd0cfed
+            - Range: 0xd0d00c..0xd0d00d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd0cfed..0xd0cff9
+            - Range: 0xd0d00d..0xd0d019
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 122
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0xd0d000..0xd0d07a]
+      OutOfLinePCRanges: [0xd0d020..0xd0d09a]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 256 StructureType main.structWithArray
           Locations:
-            - Range: 0xd0d000..0xd0d06d
+            - Range: 0xd0d020..0xd0d08d
               Pieces: []
-            - Range: 0xd0d06d..0xd0d06e
+            - Range: 0xd0d08d..0xd0d08e
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xd0d06e..0xd0d07a
+            - Range: 0xd0d08e..0xd0d09a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 123
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0xd0d080..0xd0d0db]
+      OutOfLinePCRanges: [0xd0d0a0..0xd0d0fb]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0d080..0xd0d0db, Pieces: []}]
+          Locations: [{Range: 0xd0d0a0..0xd0d0fb, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 124
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0xd0d0e0..0xd0d147]
+      OutOfLinePCRanges: [0xd0d100..0xd0d167]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float32
-          Locations: [{Range: 0xd0d0e0..0xd0d147, Pieces: []}]
+          Locations: [{Range: 0xd0d100..0xd0d167, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0xd0d0e0..0xd0d147, Pieces: []}]
+          Locations: [{Range: 0xd0d100..0xd0d167, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 125
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0xd0d160..0xd0d1bd]
+      OutOfLinePCRanges: [0xd0d180..0xd0d1dd]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xd0d160..0xd0d1b0
+            - Range: 0xd0d180..0xd0d1d0
               Pieces: []
-            - Range: 0xd0d1b0..0xd0d1b1
+            - Range: 0xd0d1d0..0xd0d1d1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0d1b1..0xd0d1bd
+            - Range: 0xd0d1d1..0xd0d1dd
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 2 BaseType uintptr
           Locations:
-            - Range: 0xd0d160..0xd0d1b0
+            - Range: 0xd0d180..0xd0d1d0
               Pieces: []
-            - Range: 0xd0d1b0..0xd0d1b1
+            - Range: 0xd0d1d0..0xd0d1d1
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0d1b1..0xd0d1bd
+            - Range: 0xd0d1d1..0xd0d1dd
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 126
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0xd0d1c0..0xd0d325]
+      OutOfLinePCRanges: [0xd0d1e0..0xd0d345]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xd0d1c0..0xd0d325
+            - Range: 0xd0d1e0..0xd0d345
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xd0d1c0..0xd0d313
+            - Range: 0xd0d1e0..0xd0d333
               Pieces: []
-            - Range: 0xd0d313..0xd0d314
+            - Range: 0xd0d333..0xd0d334
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
-            - Range: 0xd0d314..0xd0d325
+            - Range: 0xd0d334..0xd0d345
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 127
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0xd0d340..0xd0d412]
+      OutOfLinePCRanges: [0xd0d360..0xd0d432]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0xd0d340..0xd0d412
+            - Range: 0xd0d360..0xd0d432
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0xd0d340..0xd0d402
+            - Range: 0xd0d360..0xd0d422
               Pieces: []
-            - Range: 0xd0d402..0xd0d403
+            - Range: 0xd0d422..0xd0d423
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xd0d403..0xd0d412
+            - Range: 0xd0d423..0xd0d432
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 128
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0xd0d420..0xd0d65a]
+      OutOfLinePCRanges: [0xd0d440..0xd0d67a]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xd0d420..0xd0d65a
+            - Range: 0xd0d440..0xd0d67a
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s2
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xd0d420..0xd0d65a
+            - Range: 0xd0d440..0xd0d67a
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xd0d420..0xd0d64a
+            - Range: 0xd0d440..0xd0d66a
               Pieces: []
-            - Range: 0xd0d64a..0xd0d64b
+            - Range: 0xd0d66a..0xd0d66b
               Pieces: [{Size: 80, Op: {CfaOffset: 160}}]
-            - Range: 0xd0d64b..0xd0d65a
+            - Range: 0xd0d66b..0xd0d67a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 129
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0xd0d660..0xd0d8ef]
+      OutOfLinePCRanges: [0xd0d680..0xd0d90f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0d660..0xd0d710
+            - Range: 0xd0d680..0xd0d730
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0d710..0xd0d8ef
+            - Range: 0xd0d730..0xd0d90f
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0d660..0xd0d710
+            - Range: 0xd0d680..0xd0d730
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0d710..0xd0d8ef
+            - Range: 0xd0d730..0xd0d90f
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0d660..0xd0d710
+            - Range: 0xd0d680..0xd0d730
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd0d710..0xd0d8ef
+            - Range: 0xd0d730..0xd0d90f
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0d660..0xd0d6d0
+            - Range: 0xd0d680..0xd0d6f0
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xd0d6d0..0xd0d8ef
+            - Range: 0xd0d6f0..0xd0d90f
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0d660..0xd0d710
+            - Range: 0xd0d680..0xd0d730
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xd0d710..0xd0d8ef
+            - Range: 0xd0d730..0xd0d90f
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0d660..0xd0d710
+            - Range: 0xd0d680..0xd0d730
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xd0d710..0xd0d8ef
+            - Range: 0xd0d730..0xd0d90f
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0d660..0xd0d710
+            - Range: 0xd0d680..0xd0d730
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xd0d710..0xd0d8ef
+            - Range: 0xd0d730..0xd0d90f
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0d660..0xd0d710
+            - Range: 0xd0d680..0xd0d730
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xd0d710..0xd0d8ef
+            - Range: 0xd0d730..0xd0d90f
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
         - Name: i
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0d660..0xd0d710
+            - Range: 0xd0d680..0xd0d730
               Pieces: [{Size: 8, Op: {RegNo: 11, Shift: 0}}]
-            - Range: 0xd0d710..0xd0d8ef
+            - Range: 0xd0d730..0xd0d90f
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 107 ArrayType [2]int
           Locations:
-            - Range: 0xd0d660..0xd0d882
+            - Range: 0xd0d680..0xd0d8a2
               Pieces: []
-            - Range: 0xd0d882..0xd0d883
+            - Range: 0xd0d8a2..0xd0d8a3
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xd0d883..0xd0d8ef
+            - Range: 0xd0d8a3..0xd0d90f
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 130
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0xd0d900..0xd0dbcc]
+      OutOfLinePCRanges: [0xd0d920..0xd0dbec]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0d900..0xd0d9ab
+            - Range: 0xd0d920..0xd0d9cb
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0d9ab..0xd0dbcc
+            - Range: 0xd0d9cb..0xd0dbec
               Pieces: [{Size: 8, Op: {CfaOffset: 96}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0d900..0xd0d9ab
+            - Range: 0xd0d920..0xd0d9cb
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0d9ab..0xd0dbcc
+            - Range: 0xd0d9cb..0xd0dbec
               Pieces: [{Size: 8, Op: {CfaOffset: 104}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0d900..0xd0d9ab
+            - Range: 0xd0d920..0xd0d9cb
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd0d9ab..0xd0dbcc
+            - Range: 0xd0d9cb..0xd0dbec
               Pieces: [{Size: 8, Op: {CfaOffset: 112}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0d900..0xd0d962
+            - Range: 0xd0d920..0xd0d982
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xd0d962..0xd0dbcc
+            - Range: 0xd0d982..0xd0dbec
               Pieces: [{Size: 8, Op: {CfaOffset: 120}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0d900..0xd0d9ab
+            - Range: 0xd0d920..0xd0d9cb
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xd0d9ab..0xd0dbcc
+            - Range: 0xd0d9cb..0xd0dbec
               Pieces: [{Size: 8, Op: {CfaOffset: 128}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0d900..0xd0d9ab
+            - Range: 0xd0d920..0xd0d9cb
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xd0d9ab..0xd0dbcc
+            - Range: 0xd0d9cb..0xd0dbec
               Pieces: [{Size: 8, Op: {CfaOffset: 136}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0d900..0xd0d9ab
+            - Range: 0xd0d920..0xd0d9cb
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xd0d9ab..0xd0dbcc
+            - Range: 0xd0d9cb..0xd0dbec
               Pieces: [{Size: 8, Op: {CfaOffset: 144}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0d900..0xd0d9ab
+            - Range: 0xd0d920..0xd0d9cb
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xd0d9ab..0xd0dbcc
+            - Range: 0xd0d9cb..0xd0dbec
               Pieces: [{Size: 8, Op: {CfaOffset: 152}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0xd0d900..0xd0dbcc
+            - Range: 0xd0d920..0xd0dbec
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -9067,212 +9067,193 @@ Subprograms:
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xd0d900..0xd0db4b
+            - Range: 0xd0d920..0xd0db6b
               Pieces: []
-            - Range: 0xd0db4b..0xd0db4c
+            - Range: 0xd0db6b..0xd0db6c
               Pieces: [{Size: 80, Op: {CfaOffset: 16}}]
-            - Range: 0xd0db4c..0xd0dbcc
+            - Range: 0xd0db6c..0xd0dbec
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 131
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0xd0dbe0..0xd0dc6c]
+      OutOfLinePCRanges: [0xd0dc00..0xd0dc8c]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 161 ArrayType [5]int
           Locations:
-            - Range: 0xd0dbe0..0xd0dc6c
+            - Range: 0xd0dc00..0xd0dc8c
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0dbe0..0xd0dc5c
+            - Range: 0xd0dc00..0xd0dc7c
               Pieces: []
-            - Range: 0xd0dc5c..0xd0dc5d
+            - Range: 0xd0dc7c..0xd0dc7d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0dc5d..0xd0dc6c
+            - Range: 0xd0dc7d..0xd0dc8c
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0dbe0..0xd0dc5c
+            - Range: 0xd0dc00..0xd0dc7c
               Pieces: []
-            - Range: 0xd0dc5c..0xd0dc5d
+            - Range: 0xd0dc7c..0xd0dc7d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0dc5d..0xd0dc6c
+            - Range: 0xd0dc7d..0xd0dc8c
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0dbe0..0xd0dc5c
+            - Range: 0xd0dc00..0xd0dc7c
               Pieces: []
-            - Range: 0xd0dc5c..0xd0dc5d
+            - Range: 0xd0dc7c..0xd0dc7d
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd0dc5d..0xd0dc6c
+            - Range: 0xd0dc7d..0xd0dc8c
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 132
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0xd0dc80..0xd0dd6a]
+      OutOfLinePCRanges: [0xd0dca0..0xd0dd8a]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 107 ArrayType [2]int
           Locations:
-            - Range: 0xd0dc80..0xd0dd6a
+            - Range: 0xd0dca0..0xd0dd8a
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0xd0dc80..0xd0dd6a
+            - Range: 0xd0dca0..0xd0dd8a
               Pieces: [{Size: 24, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0dc80..0xd0dd56
+            - Range: 0xd0dca0..0xd0dd76
               Pieces: []
-            - Range: 0xd0dd56..0xd0dd57
+            - Range: 0xd0dd76..0xd0dd77
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0dd57..0xd0dd6a
+            - Range: 0xd0dd77..0xd0dd8a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 107 ArrayType [2]int
           Locations:
-            - Range: 0xd0dc80..0xd0dd56
+            - Range: 0xd0dca0..0xd0dd76
               Pieces: []
-            - Range: 0xd0dd56..0xd0dd57
+            - Range: 0xd0dd76..0xd0dd77
               Pieces: [{Size: 16, Op: {CfaOffset: 40}}]
-            - Range: 0xd0dd57..0xd0dd6a
+            - Range: 0xd0dd77..0xd0dd8a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 133
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0xd0dd80..0xd0de4b]
+      OutOfLinePCRanges: [0xd0dda0..0xd0de6b]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 256 StructureType main.structWithArray
           Locations:
-            - Range: 0xd0dd80..0xd0de4b
+            - Range: 0xd0dda0..0xd0de6b
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0dd80..0xd0de3a
+            - Range: 0xd0dda0..0xd0de5a
               Pieces: []
-            - Range: 0xd0de3a..0xd0de3b
+            - Range: 0xd0de5a..0xd0de5b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0de3b..0xd0de4b
+            - Range: 0xd0de5b..0xd0de6b
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 256 StructureType main.structWithArray
           Locations:
-            - Range: 0xd0dd80..0xd0de3a
+            - Range: 0xd0dda0..0xd0de5a
               Pieces: []
-            - Range: 0xd0de3a..0xd0de3b
+            - Range: 0xd0de5a..0xd0de5b
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xd0de3b..0xd0de4b
+            - Range: 0xd0de5b..0xd0de6b
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0de06..0xd0de4b
+            - Range: 0xd0de26..0xd0de6b
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 134
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0xd0de60..0xd0df06]
+      OutOfLinePCRanges: [0xd0de80..0xd0df26]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 253 ArrayType [0]int
-          Locations: [{Range: 0xd0de60..0xd0df06, Pieces: []}]
+          Locations: [{Range: 0xd0de80..0xd0df26, Pieces: []}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0de60..0xd0dea5
+            - Range: 0xd0de80..0xd0dec5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0dea5..0xd0dec7
+            - Range: 0xd0dec5..0xd0dee7
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xd0dec7..0xd0dee2
+            - Range: 0xd0dee7..0xd0df02
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xd0dee2..0xd0df06
+            - Range: 0xd0df02..0xd0df26
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0xd0de60..0xd0deec
+            - Range: 0xd0de80..0xd0df0c
               Pieces: []
-            - Range: 0xd0deec..0xd0deed
+            - Range: 0xd0df0c..0xd0df0d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0deed..0xd0df06
+            - Range: 0xd0df0d..0xd0df26
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 253 ArrayType [0]int
           Locations:
-            - Range: 0xd0de60..0xd0deec
+            - Range: 0xd0de80..0xd0df0c
               Pieces: []
-            - Range: 0xd0deec..0xd0deed
+            - Range: 0xd0df0c..0xd0df0d
               Pieces: []
-            - Range: 0xd0deed..0xd0df06
+            - Range: 0xd0df0d..0xd0df26
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 135
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0xd0e420..0xd0e421]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 257 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xd0e420..0xd0e421
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 136
-      Name: main.testEmptySlice
       OutOfLinePCRanges: [0xd0e440..0xd0e441]
       InlinePCRanges: []
       Variables:
@@ -9290,13 +9271,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 137
-      Name: main.testSliceOfSlices
+    - ID: 136
+      Name: main.testEmptySlice
       OutOfLinePCRanges: [0xd0e460..0xd0e461]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 258 GoSliceHeaderType [][]uint
+          Type: 257 GoSliceHeaderType []uint
           Locations:
             - Range: 0xd0e460..0xd0e461
               Pieces:
@@ -9309,13 +9290,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 138
-      Name: main.testStructSlice
+    - ID: 137
+      Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0xd0e480..0xd0e481]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 260 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 258 GoSliceHeaderType [][]uint
           Locations:
             - Range: 0xd0e480..0xd0e481
               Pieces:
@@ -9327,16 +9308,9 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
           DictIndex: -1
-        - Name: a
-          Type: 10 BaseType int
-          Locations:
-            - Range: 0xd0e480..0xd0e481
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
       DictRegister: null
-    - ID: 139
-      Name: main.testEmptySliceOfStructs
+    - ID: 138
+      Name: main.testStructSlice
       OutOfLinePCRanges: [0xd0e4a0..0xd0e4a1]
       InlinePCRanges: []
       Variables:
@@ -9361,8 +9335,8 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 140
-      Name: main.testNilSliceOfStructs
+    - ID: 139
+      Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0xd0e4c0..0xd0e4c1]
       InlinePCRanges: []
       Variables:
@@ -9387,15 +9361,41 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 140
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0xd0e4e0..0xd0e4e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 260 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xd0e4e0..0xd0e4e1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 10 BaseType int
+          Locations:
+            - Range: 0xd0e4e0..0xd0e4e1
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 141
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0xd0e4e0..0xd0e4e1]
+      OutOfLinePCRanges: [0xd0e500..0xd0e501]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 154 GoSliceHeaderType []string
           Locations:
-            - Range: 0xd0e4e0..0xd0e4e1
+            - Range: 0xd0e500..0xd0e501
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9408,20 +9408,20 @@ Subprograms:
       DictRegister: null
     - ID: 142
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xd0e500..0xd0e501]
+      OutOfLinePCRanges: [0xd0e520..0xd0e521]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 15 BaseType int8
           Locations:
-            - Range: 0xd0e500..0xd0e501
+            - Range: 0xd0e520..0xd0e521
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 263 GoSliceHeaderType []bool
           Locations:
-            - Range: 0xd0e500..0xd0e501
+            - Range: 0xd0e520..0xd0e521
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9434,37 +9434,18 @@ Subprograms:
         - Name: x
           Type: 16 BaseType uint
           Locations:
-            - Range: 0xd0e500..0xd0e501
+            - Range: 0xd0e520..0xd0e521
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 143
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0xd0e520..0xd0e521]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 264 GoSliceHeaderType []uint16
-          Locations:
-            - Range: 0xd0e520..0xd0e521
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 144
-      Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0xd0e540..0xd0e541]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 257 GoSliceHeaderType []uint
+          Type: 264 GoSliceHeaderType []uint16
           Locations:
             - Range: 0xd0e540..0xd0e541
               Pieces:
@@ -9477,13 +9458,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 145
-      Name: main.testSliceEmptyStructs
+    - ID: 144
+      Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0xd0e560..0xd0e561]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 265 GoSliceHeaderType []struct {}
+          Type: 257 GoSliceHeaderType []uint
           Locations:
             - Range: 0xd0e560..0xd0e561
               Pieces:
@@ -9496,15 +9477,34 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 145
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0xd0e580..0xd0e581]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 265 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0xd0e580..0xd0e581
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 146
       Name: main.testSubslices
-      OutOfLinePCRanges: [0xd0e580..0xd0e581]
+      OutOfLinePCRanges: [0xd0e5a0..0xd0e5a1]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd0e580..0xd0e581
+            - Range: 0xd0e5a0..0xd0e5a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9517,7 +9517,7 @@ Subprograms:
         - Name: bs
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd0e580..0xd0e581
+            - Range: 0xd0e5a0..0xd0e5a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -9530,7 +9530,7 @@ Subprograms:
         - Name: cs
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd0e580..0xd0e581
+            - Range: 0xd0e5a0..0xd0e5a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -9543,44 +9543,27 @@ Subprograms:
       DictRegister: null
     - ID: 147
       Name: main.stackC
-      OutOfLinePCRanges: [0xd0ed40..0xd0ed92]
+      OutOfLinePCRanges: [0xd0ed60..0xd0edb2]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0xd0ed40..0xd0ed85
+            - Range: 0xd0ed60..0xd0eda5
               Pieces: []
-            - Range: 0xd0ed85..0xd0ed86
+            - Range: 0xd0eda5..0xd0eda6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0ed86..0xd0ed92
+            - Range: 0xd0eda6..0xd0edb2
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 148
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xd0eda0..0xd0eda1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 12 GoStringHeaderType string
-          Locations:
-            - Range: 0xd0eda0..0xd0eda1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 149
-      Name: main.testThreeStrings
       OutOfLinePCRanges: [0xd0edc0..0xd0edc1]
       InlinePCRanges: []
       Variables:
@@ -9595,10 +9578,27 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
           DictIndex: -1
+      DictRegister: null
+    - ID: 149
+      Name: main.testThreeStrings
+      OutOfLinePCRanges: [0xd0ede0..0xd0ede1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 12 GoStringHeaderType string
+          Locations:
+            - Range: 0xd0ede0..0xd0ede1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
         - Name: "y"
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0xd0edc0..0xd0edc1
+            - Range: 0xd0ede0..0xd0ede1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9609,7 +9609,7 @@ Subprograms:
         - Name: z
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0xd0edc0..0xd0edc1
+            - Range: 0xd0ede0..0xd0ede1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9620,13 +9620,13 @@ Subprograms:
       DictRegister: null
     - ID: 150
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xd0ede0..0xd0edff]
+      OutOfLinePCRanges: [0xd0ee00..0xd0ee1f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 267 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xd0ede0..0xd0edff
+            - Range: 0xd0ee00..0xd0ee1f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9645,49 +9645,32 @@ Subprograms:
       DictRegister: null
     - ID: 151
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xd0ee00..0xd0ee01]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 268 PointerType *main.threeStringStruct
-          Locations:
-            - Range: 0xd0ee00..0xd0ee01
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 152
-      Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0xd0ee20..0xd0ee21]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 269 PointerType *main.oneStringStruct
+          Type: 268 PointerType *main.threeStringStruct
           Locations:
             - Range: 0xd0ee20..0xd0ee21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 153
-      Name: main.testMassiveString
+    - ID: 152
+      Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0xd0ee40..0xd0ee41]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 12 GoStringHeaderType string
+        - Name: a
+          Type: 269 PointerType *main.oneStringStruct
           Locations:
             - Range: 0xd0ee40..0xd0ee41
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 154
-      Name: main.testUnitializedString
+    - ID: 153
+      Name: main.testMassiveString
       OutOfLinePCRanges: [0xd0ee60..0xd0ee61]
       InlinePCRanges: []
       Variables:
@@ -9703,8 +9686,8 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 155
-      Name: main.testEmptyString
+    - ID: 154
+      Name: main.testUnitializedString
       OutOfLinePCRanges: [0xd0ee80..0xd0ee81]
       InlinePCRanges: []
       Variables:
@@ -9720,12 +9703,12 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 156
-      Name: main.testSubstrings
+    - ID: 155
+      Name: main.testEmptyString
       OutOfLinePCRanges: [0xd0eea0..0xd0eea1]
       InlinePCRanges: []
       Variables:
-        - Name: a
+        - Name: x
           Type: 12 GoStringHeaderType string
           Locations:
             - Range: 0xd0eea0..0xd0eea1
@@ -9736,10 +9719,27 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
           DictIndex: -1
+      DictRegister: null
+    - ID: 156
+      Name: main.testSubstrings
+      OutOfLinePCRanges: [0xd0eec0..0xd0eec1]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 12 GoStringHeaderType string
+          Locations:
+            - Range: 0xd0eec0..0xd0eec1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
         - Name: b
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0xd0eea0..0xd0eea1
+            - Range: 0xd0eec0..0xd0eec1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9750,7 +9750,7 @@ Subprograms:
         - Name: c
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0xd0eea0..0xd0eea1
+            - Range: 0xd0eec0..0xd0eec1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9761,26 +9761,26 @@ Subprograms:
       DictRegister: null
     - ID: 157
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0xd0f020..0xd0f021]
+      OutOfLinePCRanges: [0xd0f040..0xd0f041]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 271 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0xd0f020..0xd0f021
+            - Range: 0xd0f040..0xd0f041
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 158
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0xd0f040..0xd0f05f]
+      OutOfLinePCRanges: [0xd0f060..0xd0f07f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 284 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0xd0f040..0xd0f05f
+            - Range: 0xd0f060..0xd0f07f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9799,13 +9799,13 @@ Subprograms:
       DictRegister: null
     - ID: 159
       Name: main.testStruct
-      OutOfLinePCRanges: [0xd0f180..0xd0f1a3]
+      OutOfLinePCRanges: [0xd0f1a0..0xd0f1c3]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 315 StructureType main.aStruct
           Locations:
-            - Range: 0xd0f180..0xd0f1a3
+            - Range: 0xd0f1a0..0xd0f1c3
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -9826,91 +9826,91 @@ Subprograms:
       DictRegister: null
     - ID: 160
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0xd0f280..0xd0f281]
+      OutOfLinePCRanges: [0xd0f2a0..0xd0f2a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 316 PointerType *main.anotherStruct
           Locations:
-            - Range: 0xd0f280..0xd0f281
+            - Range: 0xd0f2a0..0xd0f2a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 161
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0xd0f2a0..0xd0f2a1]
+      OutOfLinePCRanges: [0xd0f2c0..0xd0f2c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 318 StructureType main.tenStrings
           Locations:
-            - Range: 0xd0f2a0..0xd0f2a1
+            - Range: 0xd0f2c0..0xd0f2c1
               Pieces: [{Size: 160, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 162
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xd0f300..0xd0f301]
+      OutOfLinePCRanges: [0xd0f320..0xd0f321]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 319 StructureType main.emptyStruct
-          Locations: [{Range: 0xd0f300..0xd0f301, Pieces: []}]
+          Locations: [{Range: 0xd0f320..0xd0f321, Pieces: []}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 163
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xd0f320..0xd0f321]
+      OutOfLinePCRanges: [0xd0f340..0xd0f341]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 320 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xd0f320..0xd0f321
+            - Range: 0xd0f340..0xd0f341
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 164
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0xd115e0..0xd115e4]
+      OutOfLinePCRanges: [0xd11600..0xd11604]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0xd115e0..0xd115e4
+            - Range: 0xd11600..0xd11604
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 322 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xd115e0..0xd115e3
+            - Range: 0xd11600..0xd11603
               Pieces: []
-            - Range: 0xd115e3..0xd115e4
+            - Range: 0xd11603..0xd11604
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 165
       Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0xd11600..0xd1160c]
+      OutOfLinePCRanges: [0xd11620..0xd1162c]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd11600..0xd1160b
+            - Range: 0xd11620..0xd1162b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xd1160b..0xd1160c
+            - Range: 0xd1162b..0xd1162c
               Pieces:
                 - Size: 8
                   Op: null
@@ -9921,9 +9921,9 @@ Subprograms:
         - Name: ~r0
           Type: 324 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xd11600..0xd1160b
+            - Range: 0xd11620..0xd1162b
               Pieces: []
-            - Range: 0xd1160b..0xd1160c
+            - Range: 0xd1162b..0xd1162c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9934,41 +9934,41 @@ Subprograms:
       DictRegister: 0
     - ID: 166
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0xd11620..0xd11624]
+      OutOfLinePCRanges: [0xd11640..0xd11644]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 322 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xd11620..0xd11624
+            - Range: 0xd11640..0xd11644
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0xd11620..0xd11623
+            - Range: 0xd11640..0xd11643
               Pieces: []
-            - Range: 0xd11623..0xd11624
+            - Range: 0xd11643..0xd11644
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 167
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0xd11640..0xd1164c]
+      OutOfLinePCRanges: [0xd11660..0xd1166c]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 324 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xd11640..0xd1164b
+            - Range: 0xd11660..0xd1166b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xd1164b..0xd1164c
+            - Range: 0xd1166b..0xd1166c
               Pieces:
                 - Size: 8
                   Op: null
@@ -9979,9 +9979,9 @@ Subprograms:
         - Name: ~r0
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd11640..0xd1164b
+            - Range: 0xd11660..0xd1166b
               Pieces: []
-            - Range: 0xd1164b..0xd1164c
+            - Range: 0xd1166b..0xd1166c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9992,13 +9992,13 @@ Subprograms:
       DictRegister: 0
     - ID: 168
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0xd116c0..0xd117f6]
+      OutOfLinePCRanges: [0xd116e0..0xd11816]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 325 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xd116c0..0xd116f3
+            - Range: 0xd116e0..0xd11713
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10006,7 +10006,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd116f3..0xd116fb
+            - Range: 0xd11713..0xd1171b
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -10014,7 +10014,7 @@ Subprograms:
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: null
-            - Range: 0xd116fb..0xd117f6
+            - Range: 0xd1171b..0xd11816
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -10027,18 +10027,18 @@ Subprograms:
         - Name: pred
           Type: 327 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0xd116c0..0xd116fb
+            - Range: 0xd116e0..0xd1171b
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xd116fb..0xd117f6
+            - Range: 0xd1171b..0xd11816
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 325 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xd116c0..0xd117b4
+            - Range: 0xd116e0..0xd117d4
               Pieces: []
-            - Range: 0xd117b4..0xd117b5
+            - Range: 0xd117d4..0xd117d5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10046,14 +10046,14 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xd117b5..0xd117f6
+            - Range: 0xd117d5..0xd11816
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
           Type: 325 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xd116fb..0xd11719
+            - Range: 0xd1171b..0xd11739
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10061,7 +10061,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xd11719..0xd11721
+            - Range: 0xd11739..0xd11741
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10069,7 +10069,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xd11721..0xd11729
+            - Range: 0xd11741..0xd11749
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10077,7 +10077,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xd11729..0xd11729
+            - Range: 0xd11749..0xd11749
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10085,7 +10085,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xd11729..0xd11753
+            - Range: 0xd11749..0xd11773
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
@@ -10093,7 +10093,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd11753..0xd117ab
+            - Range: 0xd11773..0xd117cb
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10101,7 +10101,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xd117ab..0xd117f6
+            - Range: 0xd117cb..0xd11816
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
@@ -10114,84 +10114,62 @@ Subprograms:
         - Name: item
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0xd11746..0xd11753
+            - Range: 0xd11766..0xd11773
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd11753..0xd117ab
+            - Range: 0xd11773..0xd117cb
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
     - ID: 169
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xd11800..0xd11844]
+      OutOfLinePCRanges: [0xd11820..0xd11864]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 322 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xd11800..0xd11819
+            - Range: 0xd11820..0xd11839
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
           Type: 328 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0xd11800..0xd11819
+            - Range: 0xd11820..0xd11839
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 324 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xd11800..0xd11819
+            - Range: 0xd11820..0xd11839
               Pieces: []
-            - Range: 0xd11819..0xd1181a
+            - Range: 0xd11839..0xd1183a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd1181a..0xd11844
+            - Range: 0xd1183a..0xd11864
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
     - ID: 170
       Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0xd11ae0..0xd11ae4]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 326 PointerType *go.shape.int
-          Locations:
-            - Range: 0xd11ae0..0xd11ae4
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 326 PointerType *go.shape.int
-          Locations:
-            - Range: 0xd11ae0..0xd11ae3
-              Pieces: []
-            - Range: 0xd11ae3..0xd11ae4
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 171
-      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
       OutOfLinePCRanges: [0xd11b00..0xd11b04]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 329 PointerType *go.shape.struct { Name string }
+          Type: 326 PointerType *go.shape.int
           Locations:
             - Range: 0xd11b00..0xd11b04
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 329 PointerType *go.shape.struct { Name string }
+          Type: 326 PointerType *go.shape.int
           Locations:
             - Range: 0xd11b00..0xd11b03
               Pieces: []
@@ -10200,20 +10178,20 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 172
-      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
+    - ID: 171
+      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
       OutOfLinePCRanges: [0xd11b20..0xd11b24]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 331 PointerType *go.shape.struct { X int; Y int }
+          Type: 329 PointerType *go.shape.struct { Name string }
           Locations:
             - Range: 0xd11b20..0xd11b24
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 331 PointerType *go.shape.struct { X int; Y int }
+          Type: 329 PointerType *go.shape.struct { Name string }
           Locations:
             - Range: 0xd11b20..0xd11b23
               Pieces: []
@@ -10222,24 +10200,46 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
+    - ID: 172
+      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
+      OutOfLinePCRanges: [0xd11b40..0xd11b44]
+      InlinePCRanges: []
+      Variables:
+        - Name: p
+          Type: 331 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0xd11b40..0xd11b44
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 331 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0xd11b40..0xd11b43
+              Pieces: []
+            - Range: 0xd11b43..0xd11b44
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
     - ID: 173
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0xd11b40..0xd11b51]
+      OutOfLinePCRanges: [0xd11b60..0xd11b71]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 333 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0xd11b40..0xd11b51
+            - Range: 0xd11b60..0xd11b71
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd11b40..0xd11b50
+            - Range: 0xd11b60..0xd11b70
               Pieces: []
-            - Range: 0xd11b50..0xd11b51
+            - Range: 0xd11b70..0xd11b71
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10250,69 +10250,69 @@ Subprograms:
       DictRegister: 0
     - ID: 174
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0xd11be0..0xd11be9]
+      OutOfLinePCRanges: [0xd11c00..0xd11c09]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 335 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0xd11be0..0xd11be9
+            - Range: 0xd11c00..0xd11c09
               Pieces: [{Size: 136, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0xd11be0..0xd11be8
+            - Range: 0xd11c00..0xd11c08
               Pieces: []
-            - Range: 0xd11be8..0xd11be9
+            - Range: 0xd11c08..0xd11c09
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 175
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0xd11ca0..0xd11ca8]
+      OutOfLinePCRanges: [0xd11cc0..0xd11cc8]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 336 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0xd11ca0..0xd11ca8
+            - Range: 0xd11cc0..0xd11cc8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0xd11ca0..0xd11ca8
+            - Range: 0xd11cc0..0xd11cc8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
           Type: 338 BaseType go.shape.bool
           Locations:
-            - Range: 0xd11ca0..0xd11ca8
+            - Range: 0xd11cc0..0xd11cc8
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
     - ID: 176
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0xd11d40..0xd11db1]
+      OutOfLinePCRanges: [0xd11d60..0xd11dd1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 339 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0xd11d40..0xd11db1
+            - Range: 0xd11d60..0xd11dd1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd11d40..0xd11db1
+            - Range: 0xd11d60..0xd11dd1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10323,20 +10323,20 @@ Subprograms:
         - Name: v
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0xd11d40..0xd11db1
+            - Range: 0xd11d60..0xd11dd1
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
     - ID: 177
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0xd11e40..0xd11e48]
+      OutOfLinePCRanges: [0xd11e60..0xd11e68]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd11e40..0xd11e48
+            - Range: 0xd11e60..0xd11e68
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10347,25 +10347,25 @@ Subprograms:
         - Name: b
           Type: 338 BaseType go.shape.bool
           Locations:
-            - Range: 0xd11e40..0xd11e48
+            - Range: 0xd11e60..0xd11e68
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 338 BaseType go.shape.bool
           Locations:
-            - Range: 0xd11e40..0xd11e47
+            - Range: 0xd11e60..0xd11e67
               Pieces: []
-            - Range: 0xd11e47..0xd11e48
+            - Range: 0xd11e67..0xd11e68
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd11e40..0xd11e47
+            - Range: 0xd11e60..0xd11e67
               Pieces: []
-            - Range: 0xd11e47..0xd11e48
+            - Range: 0xd11e67..0xd11e68
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10376,26 +10376,26 @@ Subprograms:
       DictRegister: 0
     - ID: 178
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xd11e60..0xd11e6f]
+      OutOfLinePCRanges: [0xd11e80..0xd11e8f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0xd11e60..0xd11e6e
+            - Range: 0xd11e80..0xd11e8e
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd11e60..0xd11e6b
+            - Range: 0xd11e80..0xd11e8b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd11e6b..0xd11e6f
+            - Range: 0xd11e8b..0xd11e8f
               Pieces:
                 - Size: 8
                   Op: null
@@ -10406,9 +10406,9 @@ Subprograms:
         - Name: ~r0
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd11e60..0xd11e6e
+            - Range: 0xd11e80..0xd11e8e
               Pieces: []
-            - Range: 0xd11e6e..0xd11e6f
+            - Range: 0xd11e8e..0xd11e8f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10419,56 +10419,56 @@ Subprograms:
         - Name: ~r1
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0xd11e60..0xd11e6e
+            - Range: 0xd11e80..0xd11e8e
               Pieces: []
-            - Range: 0xd11e6e..0xd11e6f
+            - Range: 0xd11e8e..0xd11e8f
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 179
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0xd11e80..0xd11eba]
+      OutOfLinePCRanges: [0xd11ea0..0xd11eda]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 341 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0xd11e80..0xd11e99
+            - Range: 0xd11ea0..0xd11eb9
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0xd11e80..0xd11e99
+            - Range: 0xd11ea0..0xd11eb9
               Pieces: []
-            - Range: 0xd11e99..0xd11e9a
+            - Range: 0xd11eb9..0xd11eba
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd11e9a..0xd11eba
+            - Range: 0xd11eba..0xd11eda
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 180
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0xd11ec0..0xd11f0d]
+      OutOfLinePCRanges: [0xd11ee0..0xd11f2d]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 342 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0xd11ec0..0xd11edf
+            - Range: 0xd11ee0..0xd11eff
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xd11edf..0xd11ee2
+            - Range: 0xd11eff..0xd11f02
               Pieces:
                 - Size: 8
                   Op: null
@@ -10479,37 +10479,37 @@ Subprograms:
         - Name: ~r0
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0xd11ec0..0xd11ee2
+            - Range: 0xd11ee0..0xd11f02
               Pieces: []
-            - Range: 0xd11ee2..0xd11ee3
+            - Range: 0xd11f02..0xd11f03
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd11ee3..0xd11f0d
+            - Range: 0xd11f03..0xd11f2d
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 181
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0xd11f20..0xd11f28]
+      OutOfLinePCRanges: [0xd11f40..0xd11f48]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 343 PointerType *go.shape.string
           Locations:
-            - Range: 0xd11f20..0xd11f27
+            - Range: 0xd11f40..0xd11f47
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd11f20..0xd11f27
+            - Range: 0xd11f40..0xd11f47
               Pieces: []
-            - Range: 0xd11f27..0xd11f28
+            - Range: 0xd11f47..0xd11f48
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10520,22 +10520,22 @@ Subprograms:
       DictRegister: 0
     - ID: 182
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0xd11f40..0xd11f97]
+      OutOfLinePCRanges: [0xd11f60..0xd11fb7]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 344 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xd11f40..0xd11f7d
+            - Range: 0xd11f60..0xd11f9d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 345 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xd11f40..0xd11f91
+            - Range: 0xd11f60..0xd11fb1
               Pieces: []
-            - Range: 0xd11f91..0xd11f92
+            - Range: 0xd11fb1..0xd11fb2
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10549,20 +10549,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xd11f92..0xd11f97
+            - Range: 0xd11fb2..0xd11fb7
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 183
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0xd11fa0..0xd11fc4]
+      OutOfLinePCRanges: [0xd11fc0..0xd11fe4]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 325 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xd11fa0..0xd11fc4
+            - Range: 0xd11fc0..0xd11fe4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10575,33 +10575,33 @@ Subprograms:
         - Name: needle
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0xd11fa0..0xd11fc4
+            - Range: 0xd11fc0..0xd11fe4
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xd11fa0..0xd11fc0
+            - Range: 0xd11fc0..0xd11fe0
               Pieces: []
-            - Range: 0xd11fc0..0xd11fc1
+            - Range: 0xd11fe0..0xd11fe1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd11fc1..0xd11fc3
+            - Range: 0xd11fe1..0xd11fe3
               Pieces: []
-            - Range: 0xd11fc3..0xd11fc4
+            - Range: 0xd11fe3..0xd11fe4
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 184
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0xd11fe0..0xd1209f]
+      OutOfLinePCRanges: [0xd12000..0xd120bf]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 346 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0xd11fe0..0xd11ffd
+            - Range: 0xd12000..0xd1201d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10609,7 +10609,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd11ffd..0xd11fff
+            - Range: 0xd1201d..0xd1201f
               Pieces:
                 - Size: 8
                   Op: null
@@ -10622,13 +10622,13 @@ Subprograms:
         - Name: needle
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd11fe0..0xd1202c
+            - Range: 0xd12000..0xd1204c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xd1202c..0xd1209f
+            - Range: 0xd1204c..0xd120bf
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
@@ -10639,28 +10639,28 @@ Subprograms:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xd11fe0..0xd1204b
+            - Range: 0xd12000..0xd1206b
               Pieces: []
-            - Range: 0xd1204b..0xd1204c
+            - Range: 0xd1206b..0xd1206c
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd1204c..0xd12053
+            - Range: 0xd1206c..0xd12073
               Pieces: []
-            - Range: 0xd12053..0xd12054
+            - Range: 0xd12073..0xd12074
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd12054..0xd1209f
+            - Range: 0xd12074..0xd120bf
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd1200f..0xd12021
+            - Range: 0xd1202f..0xd12041
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xd12021..0xd1202c
+            - Range: 0xd12041..0xd1204c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10671,54 +10671,54 @@ Subprograms:
       DictRegister: 0
     - ID: 185
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0xd120a0..0xd120a7]
+      OutOfLinePCRanges: [0xd120c0..0xd120c7]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 347 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0xd120a0..0xd120a6
+            - Range: 0xd120c0..0xd120c6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0xd120a0..0xd120a7
+            - Range: 0xd120c0..0xd120c7
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xd120a0..0xd120a6
+            - Range: 0xd120c0..0xd120c6
               Pieces: []
-            - Range: 0xd120a6..0xd120a7
+            - Range: 0xd120c6..0xd120c7
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 3
     - ID: 186
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0xd12120..0xd1218c]
+      OutOfLinePCRanges: [0xd12140..0xd121ac]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 348 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0xd12120..0xd12140
+            - Range: 0xd12140..0xd12160
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd12140..0xd12148
+            - Range: 0xd12160..0xd12168
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd12148..0xd1214d
+            - Range: 0xd12168..0xd1216d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10729,7 +10729,7 @@ Subprograms:
         - Name: value
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd12120..0xd1214d
+            - Range: 0xd12140..0xd1216d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -10740,11 +10740,11 @@ Subprograms:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xd12120..0xd1214d
+            - Range: 0xd12140..0xd1216d
               Pieces: []
-            - Range: 0xd1214d..0xd1214e
+            - Range: 0xd1216d..0xd1216e
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd1214e..0xd1218c
+            - Range: 0xd1216e..0xd121ac
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10973,8 +10973,8 @@ Subprograms:
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0xd08be0..0xd08c51]
       InlinePCRanges:
-        - Ranges: [0xd12243..0xd12285]
-          RootRanges: [0xd12220..0xd122b6]
+        - Ranges: [0xd12263..0xd122a5]
+          RootRanges: [0xd12240..0xd122d6]
       Variables:
         - Name: b
           Type: 353 StructureType main.firstBehavior
@@ -11013,8 +11013,8 @@ Subprograms:
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xd094bd..0xd094c4]
-          RootRanges: [0xd09420..0xd0950b]
+        - Ranges: [0xd094dd..0xd094e4]
+          RootRanges: [0xd09440..0xd0952b]
         - Ranges: [0x51e6d2..0x51e6d6, 0x51e6d7..0x51e6de]
           RootRanges: [0x51e6c0..0x51e6df]
       Variables: []

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -13,11 +13,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1581 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0xce018a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce01aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1582 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0xce01c5", Frameless: false}]
+              InjectionPoints: [{PC: "0xce01e5", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -84,11 +84,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1552 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0xcde78e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde7ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1553 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0xcde842", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde862", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -176,7 +176,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1432 EventRootType Probe[main.testArrayOfMaps]
-              InjectionPoints: [{PC: "0xcda900", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda920", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -241,11 +241,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1454 EventRootType Probe[main.testAtomicAdd]
-              InjectionPoints: [{PC: "0xcdc7e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc800", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1455 EventRootType Probe[main.testAtomicAdd]Return
-              InjectionPoints: [{PC: "0xcdc7f2", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc812", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -342,11 +342,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1600 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xce05c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce05e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1601 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0xce05e2", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0602", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -476,7 +476,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1451 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0xcdc440", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc460", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -495,7 +495,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1452 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0xcdc440", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc460", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -521,7 +521,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1608 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0xce06e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0700", Frameless: true}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -557,7 +557,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1456 EventRootType Probe[main.testChannel]
-              InjectionPoints: [{PC: "0xcdc800", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc820", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -587,7 +587,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1450 EventRootType Probe[main.testCombinedByte]
-              InjectionPoints: [{PC: "0xcdc400", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc420", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{w}, {x}, {y}'
@@ -616,11 +616,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1517 EventRootType Probe[main.testConflictingReturn]
-              InjectionPoints: [{PC: "0xcdd9ce", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd9ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1518 EventRootType Probe[main.testConflictingReturn]Return
-              InjectionPoints: [{PC: "0xcdda91", Frameless: false}]
+              InjectionPoints: [{PC: "0xcddab1", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -642,7 +642,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1464 EventRootType Probe[main.testCycle]
-              InjectionPoints: [{PC: "0xcdcbe0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdcc00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{t}'
@@ -796,7 +796,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1569 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0xcdf880", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf8a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -823,7 +823,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1572 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0xcdf8e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf900", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -851,7 +851,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1595 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0xce02c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce02e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -873,7 +873,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1609 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0xce0740", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0760", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -894,7 +894,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1610 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0xce0760", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0780", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1107,11 +1107,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1647 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0xce3360", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3380", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1648 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce3367", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3387", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1125,11 +1125,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1649 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0xce3384", Frameless: false}]
+              InjectionPoints: [{PC: "0xce33a4", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1650 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0xce33d1", Frameless: false}]
+              InjectionPoints: [{PC: "0xce33f1", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1152,11 +1152,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1643 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0xce32ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xce32ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1644 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0xce32d9", Frameless: false}]
+              InjectionPoints: [{PC: "0xce32f9", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1170,11 +1170,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1645 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0xce330a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce332a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1646 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0xce3322", Frameless: false}]
+              InjectionPoints: [{PC: "0xce3342", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1197,14 +1197,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1651 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0xce33e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3400", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1652 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0xce3400"
+                - PC: "0xce3420"
                   Frameless: true
-                - PC: "0xce3403"
+                - PC: "0xce3423"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1219,14 +1219,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1653 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0xce342a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce344a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1654 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0xce348b"
+                - PC: "0xce34ab"
                   Frameless: false
-                - PC: "0xce3493"
+                - PC: "0xce34b3"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1253,7 +1253,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1655 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0xce33e5", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3405", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1265,7 +1265,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1656 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0xce343f", Frameless: false}]
+              InjectionPoints: [{PC: "0xce345f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1286,11 +1286,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1631 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0xce2f80", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2fa0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1632 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0xce2f90", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2fb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1304,11 +1304,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1633 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0xce3020", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3040", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1634 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0xce3028", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3048", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1332,11 +1332,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1619 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0xce2b0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2b2e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1620 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce2bf4", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2c14", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1378,11 +1378,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1623 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xce2c4a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2c6a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1624 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce2c59", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2c79", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1405,11 +1405,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1657 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0xce34e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3500", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1658 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0xce34e6", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3506", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1423,11 +1423,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1659 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0xce356a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce358a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1660 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0xce358d", Frameless: false}]
+              InjectionPoints: [{PC: "0xce35ad", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1450,11 +1450,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1615 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0xce2a60", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2a80", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1616 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce2a63", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2a83", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1468,11 +1468,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1617 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0xce2a80", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2aa0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1618 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce2a8b", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2aab", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1495,11 +1495,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1635 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0xce30e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3100", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1636 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0xce30e7", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3107", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1513,11 +1513,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1637 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0xce318a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce31aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1638 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0xce31b6", Frameless: false}]
+              InjectionPoints: [{PC: "0xce31d6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1540,11 +1540,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1625 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0xce2f20", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2f40", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1626 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce2f23", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2f43", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1558,11 +1558,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1627 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0xce2f40", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2f60", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1628 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0xce2f43", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2f63", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1576,11 +1576,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1629 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0xce2f60", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2f80", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1630 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0xce2f63", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2f83", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1603,11 +1603,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1639 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0xce3280", Frameless: true}]
+              InjectionPoints: [{PC: "0xce32a0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1640 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0xce3287", Frameless: true}]
+              InjectionPoints: [{PC: "0xce32a7", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1621,11 +1621,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1641 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xce32a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce32c0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1642 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce32ae", Frameless: true}]
+              InjectionPoints: [{PC: "0xce32ce", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1648,11 +1648,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1611 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0xce2a20", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2a40", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1612 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce2a23", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2a43", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1666,11 +1666,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1613 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0xce2a40", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2a60", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1614 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce2a4b", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2a6b", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1902,7 +1902,7 @@ Probes:
               InjectionPoints:
                 - PC: "0x5230a1"
                   Frameless: true
-                - PC: "0xcda7dd"
+                - PC: "0xcda7fd"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2198,11 +2198,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1550 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0xcde5ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde60e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1551 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xcde753", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde773", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2224,7 +2224,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1458 EventRootType Probe[main.testLinkedList]
-              InjectionPoints: [{PC: "0xcdca00", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdca20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -2336,11 +2336,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1556 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0xcdeab3", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdead3", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1557 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0xcdecc2", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdece2", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2449,7 +2449,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1430 EventRootType Probe[main.testMapArrayToArray]
-              InjectionPoints: [{PC: "0xcda8c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda8e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2471,7 +2471,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1437 EventRootType Probe[main.testMapEmbeddedMaps]
-              InjectionPoints: [{PC: "0xcda980", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda9a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2493,7 +2493,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1447 EventRootType Probe[main.testMapEmptyKey]
-              InjectionPoints: [{PC: "0xcdaac0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdaae0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2515,7 +2515,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1449 EventRootType Probe[main.testMapEmptyKeyAndValue]
-              InjectionPoints: [{PC: "0xcdab00", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdab20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2537,7 +2537,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1448 EventRootType Probe[main.testMapEmptyValue]
-              InjectionPoints: [{PC: "0xcdaae0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdab00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2559,7 +2559,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1434 EventRootType Probe[main.testMapIntToInt]
-              InjectionPoints: [{PC: "0xcda940", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda960", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2581,7 +2581,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1446 EventRootType Probe[main.testMapLargeKeyLargeValue]
-              InjectionPoints: [{PC: "0xcdaaa0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdaac0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2603,7 +2603,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1445 EventRootType Probe[main.testMapLargeKeySmallValue]
-              InjectionPoints: [{PC: "0xcdaa80", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdaaa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2627,7 +2627,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1435 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0xcda960", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda980", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2651,7 +2651,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1436 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0xcda960", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda980", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2673,7 +2673,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1444 EventRootType Probe[main.testMapSmallKeyLargeValue]
-              InjectionPoints: [{PC: "0xcdaa60", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdaa80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2695,7 +2695,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1443 EventRootType Probe[main.testMapSmallKeySmallValue]
-              InjectionPoints: [{PC: "0xcdaa40", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdaa60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2717,7 +2717,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1428 EventRootType Probe[main.testMapStringToInt]
-              InjectionPoints: [{PC: "0xcda880", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda8a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2739,7 +2739,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1429 EventRootType Probe[main.testMapStringToSlice]
-              InjectionPoints: [{PC: "0xcda8a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda8c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2761,7 +2761,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1427 EventRootType Probe[main.testMapStringToStruct]
-              InjectionPoints: [{PC: "0xcda860", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda880", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2783,7 +2783,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1438 EventRootType Probe[main.testMapWithLinkedList]
-              InjectionPoints: [{PC: "0xcda9a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda9c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2805,7 +2805,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1441 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-              InjectionPoints: [{PC: "0xcdaa00", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdaa20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2827,7 +2827,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1442 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-              InjectionPoints: [{PC: "0xcdaa20", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdaa40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2849,7 +2849,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1439 EventRootType Probe[main.testMapWithSmallValue]
-              InjectionPoints: [{PC: "0xcda9c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda9e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2873,7 +2873,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1440 EventRootType Probe[main.testMapWithSmallValueMassive]
-              InjectionPoints: [{PC: "0xcda9e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdaa00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2895,7 +2895,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1592 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xce0280", Frameless: true}]
+              InjectionPoints: [{PC: "0xce02a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2918,7 +2918,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1593 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xce0280", Frameless: true}]
+              InjectionPoints: [{PC: "0xce02a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2965,11 +2965,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1558 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0xcded53", Frameless: false}]
+              InjectionPoints: [{PC: "0xcded73", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1559 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0xcdef8b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdefab", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -3035,11 +3035,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1562 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0xcdf0ce", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdf0ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1563 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0xcdf19e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdf1be", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3070,11 +3070,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1554 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0xcde86e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde88e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1555 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0xcdea8a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdeaaa", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3100,11 +3100,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1495 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcdd80e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd82e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1496 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdd8af", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd8cf", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3140,7 +3140,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1453 EventRootType Probe[main.testMultipleSimpleParams]
-              InjectionPoints: [{PC: "0xcdc5c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc5e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -3181,11 +3181,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1489 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xcdd76a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd78a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1490 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdd7d5", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd7f5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3209,11 +3209,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1491 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xcdd76a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd78a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1492 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdd7d5", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd7f5", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
       version: 0
@@ -3232,11 +3232,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1497 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcdd80e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd82e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1498 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdd8af", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd8cf", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
       version: 0
@@ -3256,11 +3256,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1499 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcdd80e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd82e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1500 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdd8af", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd8cf", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r1={result} r2={result2}
@@ -3293,11 +3293,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1493 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xcdd76a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd78a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1494 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdd7d5", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd7f5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Parameter {i} * 2 = result {result}
@@ -3325,7 +3325,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1604 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xce06c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce06e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3350,7 +3350,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1605 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xce06c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce06e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3381,7 +3381,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1606 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xce06c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce06e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3406,7 +3406,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1607 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xce06c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce06e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3433,7 +3433,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1463 EventRootType Probe[main.testNilPointer]
-              InjectionPoints: [{PC: "0xcdcba0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdcbc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}, {a}'
@@ -3460,7 +3460,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1576 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0xcdf960", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf980", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3487,7 +3487,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1573 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0xcdf900", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf920", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3522,7 +3522,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1575 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0xcdf940", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf960", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3554,7 +3554,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1591 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0xce0260", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0280", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3576,7 +3576,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1459 EventRootType Probe[main.testPointerLoop]
-              InjectionPoints: [{PC: "0xcdca20", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdca40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3598,7 +3598,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1433 EventRootType Probe[main.testPointerToMap]
-              InjectionPoints: [{PC: "0xcda920", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda940", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3620,7 +3620,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1457 EventRootType Probe[main.testPointerToSimpleStruct]
-              InjectionPoints: [{PC: "0xcdc9e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdca00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3644,11 +3644,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1465 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xcdd04a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd06a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1466 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xcdd09b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd0bb", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
       version: 0
@@ -3668,11 +3668,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1509 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xcdd8ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd90e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1510 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdd98b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd9ab", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3715,11 +3715,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1475 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xcdd16e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd18e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1476 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xcdd224", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd244", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3759,11 +3759,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1467 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xcdd04a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd06a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1468 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xcdd09b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd0bb", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3806,11 +3806,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1477 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xcdd16e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd18e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1478 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xcdd224", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd244", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3852,11 +3852,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1511 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xcdd8ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd90e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1512 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdd98b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd9ab", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
       version: 0
@@ -3873,11 +3873,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1513 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xcdd8ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd90e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1514 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdd98b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd9ab", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r0={@return.r0}
@@ -3899,11 +3899,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1469 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xcdd04a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd06a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1470 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xcdd09b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd0bb", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: result={@return}
@@ -3926,18 +3926,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1485 EventRootType Probe[main.testReturnsAny]
-              InjectionPoints: [{PC: "0xcdd40e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd42e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1486 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
-                - PC: "0xcdd4c4"
+                - PC: "0xcdd4e4"
                   Frameless: false
-                - PC: "0xcdd4ff"
+                - PC: "0xcdd51f"
                   Frameless: false
-                - PC: "0xcdd5c2"
+                - PC: "0xcdd5e2"
                   Frameless: false
-                - PC: "0xcdd5cc"
+                - PC: "0xcdd5ec"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3965,18 +3965,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1483 EventRootType Probe[main.testReturnsAnyAndError]
-              InjectionPoints: [{PC: "0xcdd2ae", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd2ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1484 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
-                - PC: "0xcdd304"
+                - PC: "0xcdd324"
                   Frameless: false
-                - PC: "0xcdd353"
+                - PC: "0xcdd373"
                   Frameless: false
-                - PC: "0xcdd387"
+                - PC: "0xcdd3a7"
                   Frameless: false
-                - PC: "0xcdd3b9"
+                - PC: "0xcdd3d9"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4003,11 +4003,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1528 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0xcde08a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde0aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1529 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0xcde0ed", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde10d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -4024,11 +4024,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1530 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0xcde10a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde12a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1531 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0xcde14b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde16b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -4045,11 +4045,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1532 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0xcde16a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde18a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1533 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0xcde1a6", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde1c6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4066,11 +4066,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1536 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0xcde24e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde26e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1537 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0xcde2ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde2ea", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4087,11 +4087,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1548 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0xcde58a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde5aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1549 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0xcde5d0", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde5f0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4108,11 +4108,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1524 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0xcddf4a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcddf6a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1525 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0xcddfa6", Frameless: false}]
+              InjectionPoints: [{PC: "0xcddfc6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4130,14 +4130,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1481 EventRootType Probe[main.testReturnsError]
-              InjectionPoints: [{PC: "0xcdd24a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd26a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1482 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
-                - PC: "0xcdd27a"
+                - PC: "0xcdd29a"
                   Frameless: false
-                - PC: "0xcdd285"
+                - PC: "0xcdd2a5"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4159,11 +4159,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1471 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xcdd04a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd06a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1472 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xcdd09b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd0bb", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4184,11 +4184,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1479 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xcdd16e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd18e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1480 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xcdd224", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd244", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4209,11 +4209,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1473 EventRootType Probe[main.testReturnsIntPointer]
-              InjectionPoints: [{PC: "0xcdd0ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd0ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1474 EventRootType Probe[main.testReturnsIntPointer]Return
-              InjectionPoints: [{PC: "0xcdd134", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd154", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4235,14 +4235,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1487 EventRootType Probe[main.testReturnsInterface]
-              InjectionPoints: [{PC: "0xcdd60e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd62e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1488 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
-                - PC: "0xcdd6ef"
+                - PC: "0xcdd70f"
                   Frameless: false
-                - PC: "0xcdd6f9"
+                - PC: "0xcdd719"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4264,11 +4264,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1526 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0xcddfce", Frameless: false}]
+              InjectionPoints: [{PC: "0xcddfee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1527 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0xcde053", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde073", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4285,11 +4285,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1522 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0xcdde4e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdde6e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1523 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0xcddf27", Frameless: false}]
+              InjectionPoints: [{PC: "0xcddf47", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4306,11 +4306,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1540 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0xcde3aa", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde3ca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1541 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0xcde40c", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde42c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4327,11 +4327,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1534 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0xcde1ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde1ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1535 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0xcde218", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde238", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4348,11 +4348,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1546 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0xcde50a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde52a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1547 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0xcde556", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde576", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
@@ -4372,7 +4372,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1519 EventRootType Probe[main.testReturnsNamedDeferLine]Line
-              InjectionPoints: [{PC: "0xcddbcf", Frameless: false}]
+              InjectionPoints: [{PC: "0xcddbef", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4393,11 +4393,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1544 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0xcde4aa", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde4ca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1545 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0xcde4ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde50e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4414,11 +4414,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1520 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0xcdddca", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdddea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1521 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0xcdde31", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdde51", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4435,11 +4435,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1542 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0xcde42a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde44a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1543 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0xcde48d", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde4ad", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4456,11 +4456,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1538 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0xcde2ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde30e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1539 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0xcde374", Frameless: false}]
+              InjectionPoints: [{PC: "0xcde394", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4513,11 +4513,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1501 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcdd80e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd82e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1502 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdd8af", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd8cf", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -4792,7 +4792,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1583 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0xce01e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0200", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4924,7 +4924,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1579 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0xcdf9a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf9c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -4946,7 +4946,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1570 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0xcdf8a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf8c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -4968,7 +4968,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1431 EventRootType Probe[main.testSmallMap]
-              InjectionPoints: [{PC: "0xcda8e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda900", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -4989,11 +4989,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1515 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xcdd8ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd90e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1516 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdd98b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd9ab", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -5014,11 +5014,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1560 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0xcdf02a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdf04a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1561 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0xcdf09c", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdf0bc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5062,7 +5062,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1462 EventRootType Probe[main.testStringPointer]
-              InjectionPoints: [{PC: "0xcdcb60", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdcb80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}'
@@ -5084,7 +5084,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1574 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0xcdf920", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf940", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5150,11 +5150,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1602 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xce05c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce05e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1603 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0xce05e2", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0602", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5181,7 +5181,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1571 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0xcdf8c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf8e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5229,11 +5229,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1564 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0xcdf1ce", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdf1ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1565 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0xcdf27a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdf29a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5255,11 +5255,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1598 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0xce0480", Frameless: true}]
+              InjectionPoints: [{PC: "0xce04a0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1599 EventRootType Probe[main.testStructWithCyclicMaps]Return
-              InjectionPoints: [{PC: "0xce049e", Frameless: true}]
+              InjectionPoints: [{PC: "0xce04be", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5280,7 +5280,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1597 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0xce0460", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0480", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5307,7 +5307,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1426 EventRootType Probe[main.testStructWithMap]
-              InjectionPoints: [{PC: "0xcda840", Frameless: true}]
+              InjectionPoints: [{PC: "0xcda860", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s} {@duration}'
@@ -5340,7 +5340,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1580 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0xcdf9c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf9e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5380,7 +5380,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1596 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0xce02e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0300", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5413,11 +5413,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1503 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcdd80e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd82e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1504 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdd8af", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd8cf", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{nonexistentVariable}'
@@ -5438,11 +5438,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1505 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcdd80e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd82e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1506 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdd8af", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd8cf", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{unsupportedExpression}'
@@ -5465,11 +5465,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1507 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcdd80e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd82e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1508 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcdd8af", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdd8cf", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -5501,7 +5501,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1584 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0xce0200", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0220", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5533,11 +5533,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1585 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xce0220", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0240", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1586 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0xce023e", Frameless: true}]
+              InjectionPoints: [{PC: "0xce025e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5567,11 +5567,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1587 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xce0220", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0240", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1588 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0xce023e", Frameless: true}]
+              InjectionPoints: [{PC: "0xce025e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5603,7 +5603,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1589 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xce0240", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0260", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5633,7 +5633,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1590 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xce0240", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0260", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5797,7 +5797,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1461 EventRootType Probe[main.testUintPointer]
-              InjectionPoints: [{PC: "0xcdca80", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdcaa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5819,7 +5819,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1568 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0xcdf860", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf880", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5841,7 +5841,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1594 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0xce02a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce02c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5863,7 +5863,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1460 EventRootType Probe[main.testUnsafePointer]
-              InjectionPoints: [{PC: "0xcdca40", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdca60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5907,7 +5907,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1577 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xcdf980", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf9a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5929,7 +5929,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1578 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xcdf980", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf9a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5954,7 +5954,7 @@ Probes:
               InjectionPoints:
                 - PC: "0xcd9f0a"
                   Frameless: false
-                - PC: "0xce3683"
+                - PC: "0xce36a3"
                   Frameless: false
               Condition: null
             - Kind: Return
@@ -5981,11 +5981,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1566 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0xcdf2ae", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdf2ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1567 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xcdf32c", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdf34c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -7070,140 +7070,127 @@ Subprograms:
       DictRegister: null
     - ID: 63
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0xcda840..0xcda841]
+      OutOfLinePCRanges: [0xcda860..0xcda861]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 168 StructureType main.structWithMap
-          Locations:
-            - Range: 0xcda840..0xcda841
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 64
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0xcda860..0xcda861]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 174 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0xcda860..0xcda861
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 65
-      Name: main.testMapStringToInt
+    - ID: 64
+      Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0xcda880..0xcda881]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 179 GoMapType map[string]int
+          Type: 174 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0xcda880..0xcda881
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 66
-      Name: main.testMapStringToSlice
+    - ID: 65
+      Name: main.testMapStringToInt
       OutOfLinePCRanges: [0xcda8a0..0xcda8a1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 184 GoMapType map[string][]string
+          Type: 179 GoMapType map[string]int
           Locations:
             - Range: 0xcda8a0..0xcda8a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 67
-      Name: main.testMapArrayToArray
+    - ID: 66
+      Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0xcda8c0..0xcda8c1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 189 GoMapType map[[4]string][2]int
+          Type: 184 GoMapType map[string][]string
           Locations:
             - Range: 0xcda8c0..0xcda8c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 68
-      Name: main.testSmallMap
+    - ID: 67
+      Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0xcda8e0..0xcda8e1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 179 GoMapType map[string]int
+          Type: 189 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0xcda8e0..0xcda8e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 68
+      Name: main.testSmallMap
+      OutOfLinePCRanges: [0xcda900..0xcda901]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 179 GoMapType map[string]int
+          Locations:
+            - Range: 0xcda900..0xcda901
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 69
       Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0xcda900..0xcda901]
+      OutOfLinePCRanges: [0xcda920..0xcda921]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 194 ArrayType [2]map[string]int
           Locations:
-            - Range: 0xcda900..0xcda901
+            - Range: 0xcda920..0xcda921
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 70
       Name: main.testPointerToMap
-      OutOfLinePCRanges: [0xcda920..0xcda921]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 195 PointerType *map[string]int
-          Locations:
-            - Range: 0xcda920..0xcda921
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 71
-      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0xcda940..0xcda941]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 169 GoMapType map[int]int
+          Type: 195 PointerType *map[string]int
           Locations:
             - Range: 0xcda940..0xcda941
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 72
-      Name: main.testMapMassive
+    - ID: 71
+      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0xcda960..0xcda961]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 196 GoMapType map[string][]main.structWithMap
+        - Name: m
+          Type: 169 GoMapType map[int]int
           Locations:
             - Range: 0xcda960..0xcda961
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 73
-      Name: main.testMapEmbeddedMaps
+    - ID: 72
+      Name: main.testMapMassive
       OutOfLinePCRanges: [0xcda980..0xcda981]
       InlinePCRanges: []
       Variables:
-        - Name: m
+        - Name: redactMyEntries
           Type: 196 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xcda980..0xcda981
@@ -7211,38 +7198,38 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 74
-      Name: main.testMapWithLinkedList
+    - ID: 73
+      Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0xcda9a0..0xcda9a1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 201 GoMapType map[bool]main.node
+          Type: 196 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xcda9a0..0xcda9a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 75
-      Name: main.testMapWithSmallValue
+    - ID: 74
+      Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0xcda9c0..0xcda9c1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 206 GoMapType map[int]uint8
+          Type: 201 GoMapType map[bool]main.node
           Locations:
             - Range: 0xcda9c0..0xcda9c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 76
-      Name: main.testMapWithSmallValueMassive
+    - ID: 75
+      Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0xcda9e0..0xcda9e1]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
+        - Name: m
           Type: 206 GoMapType map[int]uint8
           Locations:
             - Range: 0xcda9e0..0xcda9e1
@@ -7250,21 +7237,21 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 77
-      Name: main.testMapWithSmallKeyAndValue
+    - ID: 76
+      Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0xcdaa00..0xcdaa01]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 211 GoMapType map[uint8]uint8
+        - Name: redactMyEntries
+          Type: 206 GoMapType map[int]uint8
           Locations:
             - Range: 0xcdaa00..0xcdaa01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 78
-      Name: main.testMapWithSmallKeyAndValueMassive
+    - ID: 77
+      Name: main.testMapWithSmallKeyAndValue
       OutOfLinePCRanges: [0xcdaa20..0xcdaa21]
       InlinePCRanges: []
       Variables:
@@ -7276,8 +7263,8 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 79
-      Name: main.testMapSmallKeySmallValue
+    - ID: 78
+      Name: main.testMapWithSmallKeyAndValueMassive
       OutOfLinePCRanges: [0xcdaa40..0xcdaa41]
       InlinePCRanges: []
       Variables:
@@ -7289,127 +7276,140 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 80
-      Name: main.testMapSmallKeyLargeValue
+    - ID: 79
+      Name: main.testMapSmallKeySmallValue
       OutOfLinePCRanges: [0xcdaa60..0xcdaa61]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 216 GoMapType map[uint8][4]int
+          Type: 211 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xcdaa60..0xcdaa61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 81
-      Name: main.testMapLargeKeySmallValue
+    - ID: 80
+      Name: main.testMapSmallKeyLargeValue
       OutOfLinePCRanges: [0xcdaa80..0xcdaa81]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 221 GoMapType map[[4]int]uint8
+          Type: 216 GoMapType map[uint8][4]int
           Locations:
             - Range: 0xcdaa80..0xcdaa81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 82
-      Name: main.testMapLargeKeyLargeValue
+    - ID: 81
+      Name: main.testMapLargeKeySmallValue
       OutOfLinePCRanges: [0xcdaaa0..0xcdaaa1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 226 GoMapType map[[4]int][4]int
+          Type: 221 GoMapType map[[4]int]uint8
           Locations:
             - Range: 0xcdaaa0..0xcdaaa1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 83
-      Name: main.testMapEmptyKey
+    - ID: 82
+      Name: main.testMapLargeKeyLargeValue
       OutOfLinePCRanges: [0xcdaac0..0xcdaac1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 231 GoMapType map[struct {}]int
+          Type: 226 GoMapType map[[4]int][4]int
           Locations:
             - Range: 0xcdaac0..0xcdaac1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 84
-      Name: main.testMapEmptyValue
+    - ID: 83
+      Name: main.testMapEmptyKey
       OutOfLinePCRanges: [0xcdaae0..0xcdaae1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 236 GoMapType map[int]struct {}
+          Type: 231 GoMapType map[struct {}]int
           Locations:
             - Range: 0xcdaae0..0xcdaae1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 85
-      Name: main.testMapEmptyKeyAndValue
+    - ID: 84
+      Name: main.testMapEmptyValue
       OutOfLinePCRanges: [0xcdab00..0xcdab01]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 241 GoMapType map[struct {}]struct {}
+          Type: 236 GoMapType map[int]struct {}
           Locations:
             - Range: 0xcdab00..0xcdab01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 85
+      Name: main.testMapEmptyKeyAndValue
+      OutOfLinePCRanges: [0xcdab20..0xcdab21]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 241 GoMapType map[struct {}]struct {}
+          Locations:
+            - Range: 0xcdab20..0xcdab21
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 86
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0xcdc400..0xcdc401]
+      OutOfLinePCRanges: [0xcdc420..0xcdc421]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xcdc400..0xcdc401
+            - Range: 0xcdc420..0xcdc421
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xcdc400..0xcdc401
+            - Range: 0xcdc420..0xcdc421
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: "y"
           Type: 18 BaseType float32
           Locations:
-            - Range: 0xcdc400..0xcdc401
+            - Range: 0xcdc420..0xcdc421
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 87
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0xcdc440..0xcdc441]
+      OutOfLinePCRanges: [0xcdc460..0xcdc461]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xcdc440..0xcdc441
+            - Range: 0xcdc460..0xcdc461
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcdc440..0xcdc441
+            - Range: 0xcdc460..0xcdc461
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -7420,48 +7420,48 @@ Subprograms:
         - Name: "y"
           Type: 18 BaseType float32
           Locations:
-            - Range: 0xcdc440..0xcdc441
+            - Range: 0xcdc460..0xcdc461
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 88
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0xcdc5c0..0xcdc5c1]
+      OutOfLinePCRanges: [0xcdc5e0..0xcdc5e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xcdc5c0..0xcdc5c1
+            - Range: 0xcdc5e0..0xcdc5e1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xcdc5c0..0xcdc5c1
+            - Range: 0xcdc5e0..0xcdc5e1
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 11 BaseType int32
           Locations:
-            - Range: 0xcdc5c0..0xcdc5c1
+            - Range: 0xcdc5e0..0xcdc5e1
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 17 BaseType uint
           Locations:
-            - Range: 0xcdc5c0..0xcdc5c1
+            - Range: 0xcdc5e0..0xcdc5e1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcdc5c0..0xcdc5c1
+            - Range: 0xcdc5e0..0xcdc5e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7472,61 +7472,61 @@ Subprograms:
       DictRegister: null
     - ID: 89
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0xcdc7e0..0xcdc7f3]
+      OutOfLinePCRanges: [0xcdc800..0xcdc813]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0xcdc7e0..0xcdc7f2
+            - Range: 0xcdc800..0xcdc812
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0xcdc7e0..0xcdc7f2
+            - Range: 0xcdc800..0xcdc812
               Pieces: []
-            - Range: 0xcdc7f2..0xcdc7f3
+            - Range: 0xcdc812..0xcdc813
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 90
       Name: main.testChannel
-      OutOfLinePCRanges: [0xcdc800..0xcdc801]
+      OutOfLinePCRanges: [0xcdc820..0xcdc821]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 246 GoChannelType chan bool
           Locations:
-            - Range: 0xcdc800..0xcdc801
+            - Range: 0xcdc820..0xcdc821
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 91
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xcdc9e0..0xcdc9e1]
+      OutOfLinePCRanges: [0xcdca00..0xcdca01]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 247 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xcdc9e0..0xcdc9e1
+            - Range: 0xcdca00..0xcdca01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 92
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0xcdca00..0xcdca01]
+      OutOfLinePCRanges: [0xcdca20..0xcdca21]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 249 StructureType main.node
           Locations:
-            - Range: 0xcdca00..0xcdca01
+            - Range: 0xcdca20..0xcdca21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7537,273 +7537,273 @@ Subprograms:
       DictRegister: null
     - ID: 93
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xcdca20..0xcdca21]
+      OutOfLinePCRanges: [0xcdca40..0xcdca41]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 250 PointerType *main.node
-          Locations:
-            - Range: 0xcdca20..0xcdca21
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 94
-      Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xcdca40..0xcdca41]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 15 VoidPointerType unsafe.Pointer
           Locations:
             - Range: 0xcdca40..0xcdca41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 94
+      Name: main.testUnsafePointer
+      OutOfLinePCRanges: [0xcdca60..0xcdca61]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 15 VoidPointerType unsafe.Pointer
+          Locations:
+            - Range: 0xcdca60..0xcdca61
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 95
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0xcdca80..0xcdca81]
+      OutOfLinePCRanges: [0xcdcaa0..0xcdcaa1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 106 PointerType *uint
           Locations:
-            - Range: 0xcdca80..0xcdca81
+            - Range: 0xcdcaa0..0xcdcaa1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 96
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0xcdcb60..0xcdcb61]
+      OutOfLinePCRanges: [0xcdcb80..0xcdcb81]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 94 PointerType *string
           Locations:
-            - Range: 0xcdcb60..0xcdcb61
+            - Range: 0xcdcb80..0xcdcb81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 97
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0xcdcba0..0xcdcba1]
+      OutOfLinePCRanges: [0xcdcbc0..0xcdcbc1]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 12 PointerType *bool
           Locations:
-            - Range: 0xcdcba0..0xcdcba1
+            - Range: 0xcdcbc0..0xcdcbc1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 17 BaseType uint
           Locations:
-            - Range: 0xcdcba0..0xcdcba1
+            - Range: 0xcdcbc0..0xcdcbc1
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 98
       Name: main.testCycle
-      OutOfLinePCRanges: [0xcdcbe0..0xcdcbe1]
+      OutOfLinePCRanges: [0xcdcc00..0xcdcc01]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 251 PointerType *main.t
           Locations:
-            - Range: 0xcdcbe0..0xcdcbe1
+            - Range: 0xcdcc00..0xcdcc01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 99
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0xcdd040..0xcdd0b2]
+      OutOfLinePCRanges: [0xcdd060..0xcdd0d2]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdd040..0xcdd052
+            - Range: 0xcdd060..0xcdd072
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdd040..0xcdd09b
+            - Range: 0xcdd060..0xcdd0bb
               Pieces: []
-            - Range: 0xcdd09b..0xcdd09c
+            - Range: 0xcdd0bb..0xcdd0bc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd09c..0xcdd0b2
+            - Range: 0xcdd0bc..0xcdd0d2
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdd052..0xcdd065
+            - Range: 0xcdd072..0xcdd085
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd065..0xcdd0b2
+            - Range: 0xcdd085..0xcdd0d2
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 100
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0xcdd0c0..0xcdd14f]
+      OutOfLinePCRanges: [0xcdd0e0..0xcdd16f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdd0c0..0xcdd0da
+            - Range: 0xcdd0e0..0xcdd0fa
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd0da..0xcdd14f
+            - Range: 0xcdd0fa..0xcdd16f
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 99 PointerType *int
           Locations:
-            - Range: 0xcdd0c0..0xcdd134
+            - Range: 0xcdd0e0..0xcdd154
               Pieces: []
-            - Range: 0xcdd134..0xcdd135
+            - Range: 0xcdd154..0xcdd155
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd135..0xcdd14f
+            - Range: 0xcdd155..0xcdd16f
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: '&result'
           Type: 99 PointerType *int
           Locations:
-            - Range: 0xcdd0df..0xcdd0f9
+            - Range: 0xcdd0ff..0xcdd119
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd0f9..0xcdd14f
+            - Range: 0xcdd119..0xcdd16f
               Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 101
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0xcdd160..0xcdd23e]
+      OutOfLinePCRanges: [0xcdd180..0xcdd25e]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdd160..0xcdd1c2
+            - Range: 0xcdd180..0xcdd1e2
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdd160..0xcdd224
+            - Range: 0xcdd180..0xcdd244
               Pieces: []
-            - Range: 0xcdd224..0xcdd225
+            - Range: 0xcdd244..0xcdd245
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd225..0xcdd23e
+            - Range: 0xcdd245..0xcdd25e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcdd160..0xcdd23e, Pieces: []}]
+          Locations: [{Range: 0xcdd180..0xcdd25e, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: resultInt
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdd176..0xcdd1c7
+            - Range: 0xcdd196..0xcdd1e7
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcdd1c7..0xcdd23e
+            - Range: 0xcdd1e7..0xcdd25e
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
           Role: Local
           DictIndex: -1
         - Name: resultFloat
           Type: 19 BaseType float64
           Locations:
-            - Range: 0xcdd18f..0xcdd1c7
+            - Range: 0xcdd1af..0xcdd1e7
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
-            - Range: 0xcdd1c7..0xcdd23e
+            - Range: 0xcdd1e7..0xcdd25e
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 102
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0xcdd240..0xcdd29b]
+      OutOfLinePCRanges: [0xcdd260..0xcdd2bb]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xcdd240..0xcdd259
+            - Range: 0xcdd260..0xcdd279
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0xcdd240..0xcdd27a
+            - Range: 0xcdd260..0xcdd29a
               Pieces: []
-            - Range: 0xcdd27a..0xcdd27b
+            - Range: 0xcdd29a..0xcdd29b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd27b..0xcdd285
+            - Range: 0xcdd29b..0xcdd2a5
               Pieces: []
-            - Range: 0xcdd285..0xcdd286
+            - Range: 0xcdd2a5..0xcdd2a6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd286..0xcdd29b
+            - Range: 0xcdd2a6..0xcdd2bb
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 103
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0xcdd2a0..0xcdd3e6]
+      OutOfLinePCRanges: [0xcdd2c0..0xcdd406]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 160 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcdd2a0..0xcdd2eb
+            - Range: 0xcdd2c0..0xcdd30b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd2eb..0xcdd2f6
+            - Range: 0xcdd30b..0xcdd316
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd327..0xcdd32a
+            - Range: 0xcdd347..0xcdd34a
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd360..0xcdd365
+            - Range: 0xcdd380..0xcdd385
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd394..0xcdd399
+            - Range: 0xcdd3b4..0xcdd3b9
               Pieces:
                 - Size: 8
                   Op: null
@@ -7814,117 +7814,117 @@ Subprograms:
         - Name: failed
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xcdd2a0..0xcdd2e3
+            - Range: 0xcdd2c0..0xcdd303
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 160 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcdd2a0..0xcdd304
+            - Range: 0xcdd2c0..0xcdd324
               Pieces: []
-            - Range: 0xcdd304..0xcdd305
+            - Range: 0xcdd324..0xcdd325
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd305..0xcdd353
+            - Range: 0xcdd325..0xcdd373
               Pieces: []
-            - Range: 0xcdd353..0xcdd354
+            - Range: 0xcdd373..0xcdd374
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd354..0xcdd387
+            - Range: 0xcdd374..0xcdd3a7
               Pieces: []
-            - Range: 0xcdd387..0xcdd388
+            - Range: 0xcdd3a7..0xcdd3a8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd388..0xcdd3b9
+            - Range: 0xcdd3a8..0xcdd3d9
               Pieces: []
-            - Range: 0xcdd3b9..0xcdd3ba
+            - Range: 0xcdd3d9..0xcdd3da
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd3ba..0xcdd3e6
+            - Range: 0xcdd3da..0xcdd406
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0xcdd2a0..0xcdd304
+            - Range: 0xcdd2c0..0xcdd324
               Pieces: []
-            - Range: 0xcdd304..0xcdd305
+            - Range: 0xcdd324..0xcdd325
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcdd305..0xcdd353
+            - Range: 0xcdd325..0xcdd373
               Pieces: []
-            - Range: 0xcdd353..0xcdd354
+            - Range: 0xcdd373..0xcdd374
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcdd354..0xcdd387
+            - Range: 0xcdd374..0xcdd3a7
               Pieces: []
-            - Range: 0xcdd387..0xcdd388
+            - Range: 0xcdd3a7..0xcdd3a8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcdd388..0xcdd3b9
+            - Range: 0xcdd3a8..0xcdd3d9
               Pieces: []
-            - Range: 0xcdd3b9..0xcdd3ba
+            - Range: 0xcdd3d9..0xcdd3da
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcdd3ba..0xcdd3e6
+            - Range: 0xcdd3da..0xcdd406
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdd2eb..0xcdd2f1
+            - Range: 0xcdd30b..0xcdd311
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 104
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0xcdd400..0xcdd5f4]
+      OutOfLinePCRanges: [0xcdd420..0xcdd614]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 160 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcdd400..0xcdd44b
+            - Range: 0xcdd420..0xcdd46b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd44b..0xcdd452
+            - Range: 0xcdd46b..0xcdd472
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcdd452..0xcdd5f4
+            - Range: 0xcdd472..0xcdd614
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -7935,1128 +7935,1128 @@ Subprograms:
         - Name: ~r0
           Type: 160 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcdd400..0xcdd4c4
+            - Range: 0xcdd420..0xcdd4e4
               Pieces: []
-            - Range: 0xcdd4c4..0xcdd4c5
+            - Range: 0xcdd4e4..0xcdd4e5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd4c5..0xcdd4ff
+            - Range: 0xcdd4e5..0xcdd51f
               Pieces: []
-            - Range: 0xcdd4ff..0xcdd500
+            - Range: 0xcdd51f..0xcdd520
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd500..0xcdd5c2
+            - Range: 0xcdd520..0xcdd5e2
               Pieces: []
-            - Range: 0xcdd5c2..0xcdd5c3
+            - Range: 0xcdd5e2..0xcdd5e3
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd5c3..0xcdd5cc
+            - Range: 0xcdd5e3..0xcdd5ec
               Pieces: []
-            - Range: 0xcdd5cc..0xcdd5cd
+            - Range: 0xcdd5ec..0xcdd5ed
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd5cd..0xcdd5f4
+            - Range: 0xcdd5ed..0xcdd614
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdd4ea..0xcdd4f0
+            - Range: 0xcdd50a..0xcdd510
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: '&result'
           Type: 99 PointerType *int
           Locations:
-            - Range: 0xcdd4a5..0xcdd4c4
+            - Range: 0xcdd4c5..0xcdd4e4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 105
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0xcdd600..0xcdd75d]
+      OutOfLinePCRanges: [0xcdd620..0xcdd77d]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 160 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcdd600..0xcdd640
+            - Range: 0xcdd620..0xcdd660
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd640..0xcdd68e
+            - Range: 0xcdd660..0xcdd6ae
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcdd68e..0xcdd6ff
+            - Range: 0xcdd6ae..0xcdd71f
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcdd6ff..0xcdd71f
+            - Range: 0xcdd71f..0xcdd73f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcdd71f..0xcdd726
+            - Range: 0xcdd73f..0xcdd746
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcdd726..0xcdd75d
+            - Range: 0xcdd746..0xcdd77d
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 165 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcdd600..0xcdd6ef
+            - Range: 0xcdd620..0xcdd70f
               Pieces: []
-            - Range: 0xcdd6ef..0xcdd6f0
+            - Range: 0xcdd70f..0xcdd710
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd6f0..0xcdd6f9
+            - Range: 0xcdd710..0xcdd719
               Pieces: []
-            - Range: 0xcdd6f9..0xcdd6fa
+            - Range: 0xcdd719..0xcdd71a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd6fa..0xcdd75d
+            - Range: 0xcdd71a..0xcdd77d
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 165 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcdd600..0xcdd640
+            - Range: 0xcdd620..0xcdd660
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd640..0xcdd68e
+            - Range: 0xcdd660..0xcdd6ae
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcdd68e..0xcdd695
+            - Range: 0xcdd6ae..0xcdd6b5
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcdd695..0xcdd6f5
+            - Range: 0xcdd6b5..0xcdd715
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcdd6f5..0xcdd6f7
+            - Range: 0xcdd715..0xcdd717
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcdd6f7..0xcdd6f9
+            - Range: 0xcdd717..0xcdd719
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcdd6f9..0xcdd75d
+            - Range: 0xcdd719..0xcdd77d
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 106
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0xcdd760..0xcdd7ef]
+      OutOfLinePCRanges: [0xcdd780..0xcdd80f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdd760..0xcdd771
+            - Range: 0xcdd780..0xcdd791
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdd760..0xcdd7d5
+            - Range: 0xcdd780..0xcdd7f5
               Pieces: []
-            - Range: 0xcdd7d5..0xcdd7d6
+            - Range: 0xcdd7f5..0xcdd7f6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd7d6..0xcdd7ef
+            - Range: 0xcdd7f6..0xcdd80f
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 107
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0xcdd800..0xcdd8c9]
+      OutOfLinePCRanges: [0xcdd820..0xcdd8e9]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdd800..0xcdd853
+            - Range: 0xcdd820..0xcdd873
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdd800..0xcdd8af
+            - Range: 0xcdd820..0xcdd8cf
               Pieces: []
-            - Range: 0xcdd8af..0xcdd8b0
+            - Range: 0xcdd8cf..0xcdd8d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd8b0..0xcdd8c9
+            - Range: 0xcdd8d0..0xcdd8e9
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdd800..0xcdd8af
+            - Range: 0xcdd820..0xcdd8cf
               Pieces: []
-            - Range: 0xcdd8af..0xcdd8b0
+            - Range: 0xcdd8cf..0xcdd8d0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcdd8b0..0xcdd8c9
+            - Range: 0xcdd8d0..0xcdd8e9
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 108
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0xcdd8e0..0xcdd9a5]
+      OutOfLinePCRanges: [0xcdd900..0xcdd9c5]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdd8e0..0xcdd925
+            - Range: 0xcdd900..0xcdd945
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd925..0xcdd9a5
+            - Range: 0xcdd945..0xcdd9c5
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdd8e0..0xcdd98b
+            - Range: 0xcdd900..0xcdd9ab
               Pieces: []
-            - Range: 0xcdd98b..0xcdd98c
+            - Range: 0xcdd9ab..0xcdd9ac
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd98c..0xcdd9a5
+            - Range: 0xcdd9ac..0xcdd9c5
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdd8e0..0xcdd98b
+            - Range: 0xcdd900..0xcdd9ab
               Pieces: []
-            - Range: 0xcdd98b..0xcdd98c
+            - Range: 0xcdd9ab..0xcdd9ac
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcdd98c..0xcdd9a5
+            - Range: 0xcdd9ac..0xcdd9c5
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdd8e0..0xcdd98b
+            - Range: 0xcdd900..0xcdd9ab
               Pieces: []
-            - Range: 0xcdd98b..0xcdd98c
+            - Range: 0xcdd9ab..0xcdd9ac
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcdd98c..0xcdd9a5
+            - Range: 0xcdd9ac..0xcdd9c5
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 109
       Name: main.testConflictingReturn
-      OutOfLinePCRanges: [0xcdd9c0..0xcddaaf]
+      OutOfLinePCRanges: [0xcdd9e0..0xcddacf]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdd9c0..0xcdda05
+            - Range: 0xcdd9e0..0xcdda25
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdda05..0xcddaaf
+            - Range: 0xcdda25..0xcddacf
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdd9c0..0xcdda91
+            - Range: 0xcdd9e0..0xcddab1
               Pieces: []
-            - Range: 0xcdda91..0xcdda92
+            - Range: 0xcddab1..0xcddab2
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdda92..0xcddaaf
+            - Range: 0xcddab2..0xcddacf
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcdd9c0..0xcdda91
+            - Range: 0xcdd9e0..0xcddab1
               Pieces: []
-            - Range: 0xcdda91..0xcdda92
+            - Range: 0xcddab1..0xcddab2
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcdda92..0xcddaaf
+            - Range: 0xcddab2..0xcddacf
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 110
       Name: main.testReturnsNamedDeferLine
-      OutOfLinePCRanges: [0xcddac0..0xcddccf]
+      OutOfLinePCRanges: [0xcddae0..0xcddcef]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcddac0..0xcddb46
+            - Range: 0xcddae0..0xcddb66
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcddb46..0xcddccf
+            - Range: 0xcddb66..0xcddcef
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcddaf7..0xcddccf
+            - Range: 0xcddb17..0xcddcef
               Pieces: [{Size: 16, Op: {CfaOffset: -128}}]
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcddafd..0xcddccf
+            - Range: 0xcddb1d..0xcddcef
               Pieces: [{Size: 16, Op: {CfaOffset: -144}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 111
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0xcdddc0..0xcdde3e]
+      OutOfLinePCRanges: [0xcddde0..0xcdde5e]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 16 BaseType int8
           Locations:
-            - Range: 0xcdddc0..0xcdde31
+            - Range: 0xcddde0..0xcdde51
               Pieces: []
-            - Range: 0xcdde31..0xcdde32
+            - Range: 0xcdde51..0xcdde52
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdde32..0xcdde3e
+            - Range: 0xcdde52..0xcdde5e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 103 BaseType int16
           Locations:
-            - Range: 0xcdddc0..0xcdde31
+            - Range: 0xcddde0..0xcdde51
               Pieces: []
-            - Range: 0xcdde31..0xcdde32
+            - Range: 0xcdde51..0xcdde52
               Pieces: [{Size: 2, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcdde32..0xcdde3e
+            - Range: 0xcdde52..0xcdde5e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 11 BaseType int32
           Locations:
-            - Range: 0xcdddc0..0xcdde31
+            - Range: 0xcddde0..0xcdde51
               Pieces: []
-            - Range: 0xcdde31..0xcdde32
+            - Range: 0xcdde51..0xcdde52
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcdde32..0xcdde3e
+            - Range: 0xcdde52..0xcdde5e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 13 BaseType int64
           Locations:
-            - Range: 0xcdddc0..0xcdde31
+            - Range: 0xcddde0..0xcdde51
               Pieces: []
-            - Range: 0xcdde31..0xcdde32
+            - Range: 0xcdde51..0xcdde52
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcdde32..0xcdde3e
+            - Range: 0xcdde52..0xcdde5e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xcdddc0..0xcdde31
+            - Range: 0xcddde0..0xcdde51
               Pieces: []
-            - Range: 0xcdde31..0xcdde32
+            - Range: 0xcdde51..0xcdde52
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcdde32..0xcdde3e
+            - Range: 0xcdde52..0xcdde5e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 7 BaseType uint16
           Locations:
-            - Range: 0xcdddc0..0xcdde31
+            - Range: 0xcddde0..0xcdde51
               Pieces: []
-            - Range: 0xcdde31..0xcdde32
+            - Range: 0xcdde51..0xcdde52
               Pieces: [{Size: 2, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcdde32..0xcdde3e
+            - Range: 0xcdde52..0xcdde5e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 3 BaseType uint32
           Locations:
-            - Range: 0xcdddc0..0xcdde31
+            - Range: 0xcddde0..0xcdde51
               Pieces: []
-            - Range: 0xcdde31..0xcdde32
+            - Range: 0xcdde51..0xcdde52
               Pieces: [{Size: 4, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcdde32..0xcdde3e
+            - Range: 0xcdde52..0xcdde5e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0xcdddc0..0xcdde31
+            - Range: 0xcddde0..0xcdde51
               Pieces: []
-            - Range: 0xcdde31..0xcdde32
+            - Range: 0xcdde51..0xcdde52
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcdde32..0xcdde3e
+            - Range: 0xcdde52..0xcdde5e
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 112
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0xcdde40..0xcddf37]
+      OutOfLinePCRanges: [0xcdde60..0xcddf57]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcdde40..0xcddf37, Pieces: []}]
+          Locations: [{Range: 0xcdde60..0xcddf57, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcdde40..0xcddf37, Pieces: []}]
+          Locations: [{Range: 0xcdde60..0xcddf57, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcdde40..0xcddf37, Pieces: []}]
+          Locations: [{Range: 0xcdde60..0xcddf57, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcdde40..0xcddf37, Pieces: []}]
+          Locations: [{Range: 0xcdde60..0xcddf57, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcdde40..0xcddf37, Pieces: []}]
+          Locations: [{Range: 0xcdde60..0xcddf57, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcdde40..0xcddf37, Pieces: []}]
+          Locations: [{Range: 0xcdde60..0xcddf57, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcdde40..0xcddf37, Pieces: []}]
+          Locations: [{Range: 0xcdde60..0xcddf57, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcdde40..0xcddf37, Pieces: []}]
+          Locations: [{Range: 0xcdde60..0xcddf57, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcdde40..0xcddf37, Pieces: []}]
+          Locations: [{Range: 0xcdde60..0xcddf57, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r9
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcdde40..0xcddf37, Pieces: []}]
+          Locations: [{Range: 0xcdde60..0xcddf57, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r10
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcdde40..0xcddf37, Pieces: []}]
+          Locations: [{Range: 0xcdde60..0xcddf57, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r11
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcdde40..0xcddf37, Pieces: []}]
+          Locations: [{Range: 0xcdde60..0xcddf57, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r12
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcdde40..0xcddf37, Pieces: []}]
+          Locations: [{Range: 0xcdde60..0xcddf57, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r13
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcdde40..0xcddf37, Pieces: []}]
+          Locations: [{Range: 0xcdde60..0xcddf57, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r14
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcdde40..0xcddf37, Pieces: []}]
+          Locations: [{Range: 0xcdde60..0xcddf57, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: onlyOnAmd64_16
           Type: 19 BaseType float64
           Locations:
-            - Range: 0xcdde40..0xcddf27
+            - Range: 0xcdde60..0xcddf47
               Pieces: []
-            - Range: 0xcddf27..0xcddf28
+            - Range: 0xcddf47..0xcddf48
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xcddf28..0xcddf37
+            - Range: 0xcddf48..0xcddf57
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: bothArmAndAmd64
           Type: 19 BaseType float64
           Locations:
-            - Range: 0xcdde40..0xcddf27
+            - Range: 0xcdde60..0xcddf47
               Pieces: []
-            - Range: 0xcddf27..0xcddf28
+            - Range: 0xcddf47..0xcddf48
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcddf28..0xcddf37
+            - Range: 0xcddf48..0xcddf57
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 113
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0xcddf40..0xcddfb3]
+      OutOfLinePCRanges: [0xcddf60..0xcddfd3]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 95 BaseType complex64
-          Locations: [{Range: 0xcddf40..0xcddfb3, Pieces: []}]
+          Locations: [{Range: 0xcddf60..0xcddfd3, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 96 BaseType complex128
-          Locations: [{Range: 0xcddf40..0xcddfb3, Pieces: []}]
+          Locations: [{Range: 0xcddf60..0xcddfd3, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 114
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0xcddfc0..0xcde065]
+      OutOfLinePCRanges: [0xcddfe0..0xcde085]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 253 StructureType main.largeStruct
           Locations:
-            - Range: 0xcddfc0..0xcde053
+            - Range: 0xcddfe0..0xcde073
               Pieces: []
-            - Range: 0xcde053..0xcde054
+            - Range: 0xcde073..0xcde074
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
-            - Range: 0xcde054..0xcde065
+            - Range: 0xcde074..0xcde085
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 115
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0xcde080..0xcde0fa]
+      OutOfLinePCRanges: [0xcde0a0..0xcde11a]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 254 ArrayType [3]int
           Locations:
-            - Range: 0xcde080..0xcde0ed
+            - Range: 0xcde0a0..0xcde10d
               Pieces: []
-            - Range: 0xcde0ed..0xcde0ee
+            - Range: 0xcde10d..0xcde10e
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xcde0ee..0xcde0fa
+            - Range: 0xcde10e..0xcde11a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 116
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0xcde100..0xcde158]
+      OutOfLinePCRanges: [0xcde120..0xcde178]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 255 ArrayType [1]int
           Locations:
-            - Range: 0xcde100..0xcde14b
+            - Range: 0xcde120..0xcde16b
               Pieces: []
-            - Range: 0xcde14b..0xcde14c
+            - Range: 0xcde16b..0xcde16c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcde14c..0xcde158
+            - Range: 0xcde16c..0xcde178
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 117
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0xcde160..0xcde1b3]
+      OutOfLinePCRanges: [0xcde180..0xcde1d3]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 256 ArrayType [0]int
           Locations:
-            - Range: 0xcde160..0xcde1a6
+            - Range: 0xcde180..0xcde1c6
               Pieces: []
-            - Range: 0xcde1a6..0xcde1a7
+            - Range: 0xcde1c6..0xcde1c7
               Pieces: []
-            - Range: 0xcde1a7..0xcde1b3
+            - Range: 0xcde1c7..0xcde1d3
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 118
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0xcde1c0..0xcde227]
+      OutOfLinePCRanges: [0xcde1e0..0xcde247]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 257 StructureType main.mixedStruct
-          Locations: [{Range: 0xcde1c0..0xcde227, Pieces: []}]
+          Locations: [{Range: 0xcde1e0..0xcde247, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 119
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0xcde240..0xcde2da]
+      OutOfLinePCRanges: [0xcde260..0xcde2fa]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde240..0xcde2ca
+            - Range: 0xcde260..0xcde2ea
               Pieces: []
-            - Range: 0xcde2ca..0xcde2cb
+            - Range: 0xcde2ea..0xcde2eb
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcde2cb..0xcde2da
+            - Range: 0xcde2eb..0xcde2fa
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde240..0xcde2ca
+            - Range: 0xcde260..0xcde2ea
               Pieces: []
-            - Range: 0xcde2ca..0xcde2cb
+            - Range: 0xcde2ea..0xcde2eb
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcde2cb..0xcde2da
+            - Range: 0xcde2eb..0xcde2fa
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde240..0xcde2ca
+            - Range: 0xcde260..0xcde2ea
               Pieces: []
-            - Range: 0xcde2ca..0xcde2cb
+            - Range: 0xcde2ea..0xcde2eb
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcde2cb..0xcde2da
+            - Range: 0xcde2eb..0xcde2fa
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde240..0xcde2ca
+            - Range: 0xcde260..0xcde2ea
               Pieces: []
-            - Range: 0xcde2ca..0xcde2cb
+            - Range: 0xcde2ea..0xcde2eb
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcde2cb..0xcde2da
+            - Range: 0xcde2eb..0xcde2fa
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde240..0xcde2ca
+            - Range: 0xcde260..0xcde2ea
               Pieces: []
-            - Range: 0xcde2ca..0xcde2cb
+            - Range: 0xcde2ea..0xcde2eb
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcde2cb..0xcde2da
+            - Range: 0xcde2eb..0xcde2fa
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde240..0xcde2ca
+            - Range: 0xcde260..0xcde2ea
               Pieces: []
-            - Range: 0xcde2ca..0xcde2cb
+            - Range: 0xcde2ea..0xcde2eb
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcde2cb..0xcde2da
+            - Range: 0xcde2eb..0xcde2fa
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde240..0xcde2ca
+            - Range: 0xcde260..0xcde2ea
               Pieces: []
-            - Range: 0xcde2ca..0xcde2cb
+            - Range: 0xcde2ea..0xcde2eb
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcde2cb..0xcde2da
+            - Range: 0xcde2eb..0xcde2fa
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde240..0xcde2ca
+            - Range: 0xcde260..0xcde2ea
               Pieces: []
-            - Range: 0xcde2ca..0xcde2cb
+            - Range: 0xcde2ea..0xcde2eb
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcde2cb..0xcde2da
+            - Range: 0xcde2eb..0xcde2fa
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcde240..0xcde2ca
+            - Range: 0xcde260..0xcde2ea
               Pieces: []
-            - Range: 0xcde2ca..0xcde2cb
+            - Range: 0xcde2ea..0xcde2eb
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xcde2cb..0xcde2da
+            - Range: 0xcde2eb..0xcde2fa
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 120
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0xcde2e0..0xcde385]
+      OutOfLinePCRanges: [0xcde300..0xcde3a5]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 258 StructureType main.wideStruct
           Locations:
-            - Range: 0xcde2e0..0xcde374
+            - Range: 0xcde300..0xcde394
               Pieces: []
-            - Range: 0xcde374..0xcde375
+            - Range: 0xcde394..0xcde395
               Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
-            - Range: 0xcde375..0xcde385
+            - Range: 0xcde395..0xcde3a5
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 121
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0xcde3a0..0xcde419]
+      OutOfLinePCRanges: [0xcde3c0..0xcde439]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde3a0..0xcde40c
+            - Range: 0xcde3c0..0xcde42c
               Pieces: []
-            - Range: 0xcde40c..0xcde40d
+            - Range: 0xcde42c..0xcde42d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcde40d..0xcde419
+            - Range: 0xcde42d..0xcde439
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcde3a0..0xcde419, Pieces: []}]
+          Locations: [{Range: 0xcde3c0..0xcde439, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcde3a0..0xcde40c
+            - Range: 0xcde3c0..0xcde42c
               Pieces: []
-            - Range: 0xcde40c..0xcde40d
+            - Range: 0xcde42c..0xcde42d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcde40d..0xcde419
+            - Range: 0xcde42d..0xcde439
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcde3a0..0xcde419, Pieces: []}]
+          Locations: [{Range: 0xcde3c0..0xcde439, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcde3a0..0xcde40c
+            - Range: 0xcde3c0..0xcde42c
               Pieces: []
-            - Range: 0xcde40c..0xcde40d
+            - Range: 0xcde42c..0xcde42d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcde40d..0xcde419
+            - Range: 0xcde42d..0xcde439
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 122
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0xcde420..0xcde49a]
+      OutOfLinePCRanges: [0xcde440..0xcde4ba]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 259 StructureType main.structWithArray
           Locations:
-            - Range: 0xcde420..0xcde48d
+            - Range: 0xcde440..0xcde4ad
               Pieces: []
-            - Range: 0xcde48d..0xcde48e
+            - Range: 0xcde4ad..0xcde4ae
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xcde48e..0xcde49a
+            - Range: 0xcde4ae..0xcde4ba
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 123
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0xcde4a0..0xcde4fb]
+      OutOfLinePCRanges: [0xcde4c0..0xcde51b]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcde4a0..0xcde4fb, Pieces: []}]
+          Locations: [{Range: 0xcde4c0..0xcde51b, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 124
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0xcde500..0xcde567]
+      OutOfLinePCRanges: [0xcde520..0xcde587]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float32
-          Locations: [{Range: 0xcde500..0xcde567, Pieces: []}]
+          Locations: [{Range: 0xcde520..0xcde587, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 19 BaseType float64
-          Locations: [{Range: 0xcde500..0xcde567, Pieces: []}]
+          Locations: [{Range: 0xcde520..0xcde587, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 125
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0xcde580..0xcde5dd]
+      OutOfLinePCRanges: [0xcde5a0..0xcde5fd]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xcde580..0xcde5d0
+            - Range: 0xcde5a0..0xcde5f0
               Pieces: []
-            - Range: 0xcde5d0..0xcde5d1
+            - Range: 0xcde5f0..0xcde5f1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcde5d1..0xcde5dd
+            - Range: 0xcde5f1..0xcde5fd
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 2 BaseType uintptr
           Locations:
-            - Range: 0xcde580..0xcde5d0
+            - Range: 0xcde5a0..0xcde5f0
               Pieces: []
-            - Range: 0xcde5d0..0xcde5d1
+            - Range: 0xcde5f0..0xcde5f1
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcde5d1..0xcde5dd
+            - Range: 0xcde5f1..0xcde5fd
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 126
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0xcde5e0..0xcde765]
+      OutOfLinePCRanges: [0xcde600..0xcde785]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 253 StructureType main.largeStruct
           Locations:
-            - Range: 0xcde5e0..0xcde765
+            - Range: 0xcde600..0xcde785
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 253 StructureType main.largeStruct
           Locations:
-            - Range: 0xcde5e0..0xcde753
+            - Range: 0xcde600..0xcde773
               Pieces: []
-            - Range: 0xcde753..0xcde754
+            - Range: 0xcde773..0xcde774
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
-            - Range: 0xcde754..0xcde765
+            - Range: 0xcde774..0xcde785
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 127
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0xcde780..0xcde852]
+      OutOfLinePCRanges: [0xcde7a0..0xcde872]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 254 ArrayType [3]int
           Locations:
-            - Range: 0xcde780..0xcde852
+            - Range: 0xcde7a0..0xcde872
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 254 ArrayType [3]int
           Locations:
-            - Range: 0xcde780..0xcde842
+            - Range: 0xcde7a0..0xcde862
               Pieces: []
-            - Range: 0xcde842..0xcde843
+            - Range: 0xcde862..0xcde863
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xcde843..0xcde852
+            - Range: 0xcde863..0xcde872
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 128
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0xcde860..0xcdea9a]
+      OutOfLinePCRanges: [0xcde880..0xcdeaba]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 253 StructureType main.largeStruct
           Locations:
-            - Range: 0xcde860..0xcdea9a
+            - Range: 0xcde880..0xcdeaba
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s2
           Type: 253 StructureType main.largeStruct
           Locations:
-            - Range: 0xcde860..0xcdea9a
+            - Range: 0xcde880..0xcdeaba
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 253 StructureType main.largeStruct
           Locations:
-            - Range: 0xcde860..0xcdea8a
+            - Range: 0xcde880..0xcdeaaa
               Pieces: []
-            - Range: 0xcdea8a..0xcdea8b
+            - Range: 0xcdeaaa..0xcdeaab
               Pieces: [{Size: 80, Op: {CfaOffset: 160}}]
-            - Range: 0xcdea8b..0xcdea9a
+            - Range: 0xcdeaab..0xcdeaba
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 129
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0xcdeaa0..0xcded2f]
+      OutOfLinePCRanges: [0xcdeac0..0xcded4f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdeaa0..0xcdeb50
+            - Range: 0xcdeac0..0xcdeb70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdeb50..0xcded2f
+            - Range: 0xcdeb70..0xcded4f
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdeaa0..0xcdeb50
+            - Range: 0xcdeac0..0xcdeb70
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcdeb50..0xcded2f
+            - Range: 0xcdeb70..0xcded4f
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdeaa0..0xcdeb3a
+            - Range: 0xcdeac0..0xcdeb5a
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcdeb3a..0xcded2f
+            - Range: 0xcdeb5a..0xcded4f
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdeaa0..0xcdeb10
+            - Range: 0xcdeac0..0xcdeb30
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcdeb10..0xcded2f
+            - Range: 0xcdeb30..0xcded4f
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdeaa0..0xcdeb50
+            - Range: 0xcdeac0..0xcdeb70
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcdeb50..0xcded2f
+            - Range: 0xcdeb70..0xcded4f
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdeaa0..0xcdeb50
+            - Range: 0xcdeac0..0xcdeb70
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcdeb50..0xcded2f
+            - Range: 0xcdeb70..0xcded4f
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdeaa0..0xcdeb50
+            - Range: 0xcdeac0..0xcdeb70
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcdeb50..0xcded2f
+            - Range: 0xcdeb70..0xcded4f
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdeaa0..0xcdeb50
+            - Range: 0xcdeac0..0xcdeb70
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcdeb50..0xcded2f
+            - Range: 0xcdeb70..0xcded4f
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdeaa0..0xcdeb50
+            - Range: 0xcdeac0..0xcdeb70
               Pieces: [{Size: 8, Op: {RegNo: 11, Shift: 0}}]
-            - Range: 0xcdeb50..0xcded2f
+            - Range: 0xcdeb70..0xcded4f
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 112 ArrayType [2]int
           Locations:
-            - Range: 0xcdeaa0..0xcdecc2
+            - Range: 0xcdeac0..0xcdece2
               Pieces: []
-            - Range: 0xcdecc2..0xcdecc3
+            - Range: 0xcdece2..0xcdece3
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xcdecc3..0xcded2f
+            - Range: 0xcdece3..0xcded4f
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 130
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0xcded40..0xcdf00c]
+      OutOfLinePCRanges: [0xcded60..0xcdf02c]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcded40..0xcdedeb
+            - Range: 0xcded60..0xcdee0b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdedeb..0xcdf00c
+            - Range: 0xcdee0b..0xcdf02c
               Pieces: [{Size: 8, Op: {CfaOffset: 96}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcded40..0xcdedeb
+            - Range: 0xcded60..0xcdee0b
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcdedeb..0xcdf00c
+            - Range: 0xcdee0b..0xcdf02c
               Pieces: [{Size: 8, Op: {CfaOffset: 104}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcded40..0xcdedd5
+            - Range: 0xcded60..0xcdedf5
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcdedd5..0xcdf00c
+            - Range: 0xcdedf5..0xcdf02c
               Pieces: [{Size: 8, Op: {CfaOffset: 112}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcded40..0xcdeda2
+            - Range: 0xcded60..0xcdedc2
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcdeda2..0xcdf00c
+            - Range: 0xcdedc2..0xcdf02c
               Pieces: [{Size: 8, Op: {CfaOffset: 120}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcded40..0xcdedeb
+            - Range: 0xcded60..0xcdee0b
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcdedeb..0xcdf00c
+            - Range: 0xcdee0b..0xcdf02c
               Pieces: [{Size: 8, Op: {CfaOffset: 128}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcded40..0xcdedeb
+            - Range: 0xcded60..0xcdee0b
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcdedeb..0xcdf00c
+            - Range: 0xcdee0b..0xcdf02c
               Pieces: [{Size: 8, Op: {CfaOffset: 136}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcded40..0xcdedeb
+            - Range: 0xcded60..0xcdee0b
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcdedeb..0xcdf00c
+            - Range: 0xcdee0b..0xcdf02c
               Pieces: [{Size: 8, Op: {CfaOffset: 144}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcded40..0xcdedeb
+            - Range: 0xcded60..0xcdee0b
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcdedeb..0xcdf00c
+            - Range: 0xcdee0b..0xcdf02c
               Pieces: [{Size: 8, Op: {CfaOffset: 152}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcded40..0xcdf00c
+            - Range: 0xcded60..0xcdf02c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -9067,212 +9067,193 @@ Subprograms:
         - Name: ~r0
           Type: 253 StructureType main.largeStruct
           Locations:
-            - Range: 0xcded40..0xcdef8b
+            - Range: 0xcded60..0xcdefab
               Pieces: []
-            - Range: 0xcdef8b..0xcdef8c
+            - Range: 0xcdefab..0xcdefac
               Pieces: [{Size: 80, Op: {CfaOffset: 16}}]
-            - Range: 0xcdef8c..0xcdf00c
+            - Range: 0xcdefac..0xcdf02c
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 131
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0xcdf020..0xcdf0ac]
+      OutOfLinePCRanges: [0xcdf040..0xcdf0cc]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 164 ArrayType [5]int
           Locations:
-            - Range: 0xcdf020..0xcdf0ac
+            - Range: 0xcdf040..0xcdf0cc
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdf020..0xcdf09c
+            - Range: 0xcdf040..0xcdf0bc
               Pieces: []
-            - Range: 0xcdf09c..0xcdf09d
+            - Range: 0xcdf0bc..0xcdf0bd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdf09d..0xcdf0ac
+            - Range: 0xcdf0bd..0xcdf0cc
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdf020..0xcdf09c
+            - Range: 0xcdf040..0xcdf0bc
               Pieces: []
-            - Range: 0xcdf09c..0xcdf09d
+            - Range: 0xcdf0bc..0xcdf0bd
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcdf09d..0xcdf0ac
+            - Range: 0xcdf0bd..0xcdf0cc
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdf020..0xcdf09c
+            - Range: 0xcdf040..0xcdf0bc
               Pieces: []
-            - Range: 0xcdf09c..0xcdf09d
+            - Range: 0xcdf0bc..0xcdf0bd
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcdf09d..0xcdf0ac
+            - Range: 0xcdf0bd..0xcdf0cc
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 132
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0xcdf0c0..0xcdf1ae]
+      OutOfLinePCRanges: [0xcdf0e0..0xcdf1ce]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 112 ArrayType [2]int
           Locations:
-            - Range: 0xcdf0c0..0xcdf1ae
+            - Range: 0xcdf0e0..0xcdf1ce
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 254 ArrayType [3]int
           Locations:
-            - Range: 0xcdf0c0..0xcdf1ae
+            - Range: 0xcdf0e0..0xcdf1ce
               Pieces: [{Size: 24, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdf0c0..0xcdf19e
+            - Range: 0xcdf0e0..0xcdf1be
               Pieces: []
-            - Range: 0xcdf19e..0xcdf19f
+            - Range: 0xcdf1be..0xcdf1bf
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdf19f..0xcdf1ae
+            - Range: 0xcdf1bf..0xcdf1ce
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 112 ArrayType [2]int
           Locations:
-            - Range: 0xcdf0c0..0xcdf19e
+            - Range: 0xcdf0e0..0xcdf1be
               Pieces: []
-            - Range: 0xcdf19e..0xcdf19f
+            - Range: 0xcdf1be..0xcdf1bf
               Pieces: [{Size: 16, Op: {CfaOffset: 40}}]
-            - Range: 0xcdf19f..0xcdf1ae
+            - Range: 0xcdf1bf..0xcdf1ce
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 133
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0xcdf1c0..0xcdf28b]
+      OutOfLinePCRanges: [0xcdf1e0..0xcdf2ab]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 259 StructureType main.structWithArray
           Locations:
-            - Range: 0xcdf1c0..0xcdf28b
+            - Range: 0xcdf1e0..0xcdf2ab
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdf1c0..0xcdf27a
+            - Range: 0xcdf1e0..0xcdf29a
               Pieces: []
-            - Range: 0xcdf27a..0xcdf27b
+            - Range: 0xcdf29a..0xcdf29b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdf27b..0xcdf28b
+            - Range: 0xcdf29b..0xcdf2ab
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 259 StructureType main.structWithArray
           Locations:
-            - Range: 0xcdf1c0..0xcdf27a
+            - Range: 0xcdf1e0..0xcdf29a
               Pieces: []
-            - Range: 0xcdf27a..0xcdf27b
+            - Range: 0xcdf29a..0xcdf29b
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xcdf27b..0xcdf28b
+            - Range: 0xcdf29b..0xcdf2ab
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdf246..0xcdf28b
+            - Range: 0xcdf266..0xcdf2ab
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 134
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0xcdf2a0..0xcdf346]
+      OutOfLinePCRanges: [0xcdf2c0..0xcdf366]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 256 ArrayType [0]int
-          Locations: [{Range: 0xcdf2a0..0xcdf346, Pieces: []}]
+          Locations: [{Range: 0xcdf2c0..0xcdf366, Pieces: []}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdf2a0..0xcdf2e5
+            - Range: 0xcdf2c0..0xcdf305
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdf2e5..0xcdf307
+            - Range: 0xcdf305..0xcdf327
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xcdf307..0xcdf31a
+            - Range: 0xcdf327..0xcdf33a
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xcdf31a..0xcdf346
+            - Range: 0xcdf33a..0xcdf366
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcdf2a0..0xcdf32c
+            - Range: 0xcdf2c0..0xcdf34c
               Pieces: []
-            - Range: 0xcdf32c..0xcdf32d
+            - Range: 0xcdf34c..0xcdf34d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdf32d..0xcdf346
+            - Range: 0xcdf34d..0xcdf366
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 256 ArrayType [0]int
           Locations:
-            - Range: 0xcdf2a0..0xcdf32c
+            - Range: 0xcdf2c0..0xcdf34c
               Pieces: []
-            - Range: 0xcdf32c..0xcdf32d
+            - Range: 0xcdf34c..0xcdf34d
               Pieces: []
-            - Range: 0xcdf32d..0xcdf346
+            - Range: 0xcdf34d..0xcdf366
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 135
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0xcdf860..0xcdf861]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 260 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcdf860..0xcdf861
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 136
-      Name: main.testEmptySlice
       OutOfLinePCRanges: [0xcdf880..0xcdf881]
       InlinePCRanges: []
       Variables:
@@ -9290,13 +9271,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 137
-      Name: main.testSliceOfSlices
+    - ID: 136
+      Name: main.testEmptySlice
       OutOfLinePCRanges: [0xcdf8a0..0xcdf8a1]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 261 GoSliceHeaderType [][]uint
+          Type: 260 GoSliceHeaderType []uint
           Locations:
             - Range: 0xcdf8a0..0xcdf8a1
               Pieces:
@@ -9309,13 +9290,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 138
-      Name: main.testStructSlice
+    - ID: 137
+      Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0xcdf8c0..0xcdf8c1]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 263 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 261 GoSliceHeaderType [][]uint
           Locations:
             - Range: 0xcdf8c0..0xcdf8c1
               Pieces:
@@ -9327,16 +9308,9 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
           DictIndex: -1
-        - Name: a
-          Type: 8 BaseType int
-          Locations:
-            - Range: 0xcdf8c0..0xcdf8c1
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
       DictRegister: null
-    - ID: 139
-      Name: main.testEmptySliceOfStructs
+    - ID: 138
+      Name: main.testStructSlice
       OutOfLinePCRanges: [0xcdf8e0..0xcdf8e1]
       InlinePCRanges: []
       Variables:
@@ -9361,8 +9335,8 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 140
-      Name: main.testNilSliceOfStructs
+    - ID: 139
+      Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0xcdf900..0xcdf901]
       InlinePCRanges: []
       Variables:
@@ -9387,15 +9361,41 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 140
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0xcdf920..0xcdf921]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 263 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcdf920..0xcdf921
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 8 BaseType int
+          Locations:
+            - Range: 0xcdf920..0xcdf921
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 141
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0xcdf920..0xcdf921]
+      OutOfLinePCRanges: [0xcdf940..0xcdf941]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 157 GoSliceHeaderType []string
           Locations:
-            - Range: 0xcdf920..0xcdf921
+            - Range: 0xcdf940..0xcdf941
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9408,20 +9408,20 @@ Subprograms:
       DictRegister: null
     - ID: 142
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xcdf940..0xcdf941]
+      OutOfLinePCRanges: [0xcdf960..0xcdf961]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 16 BaseType int8
           Locations:
-            - Range: 0xcdf940..0xcdf941
+            - Range: 0xcdf960..0xcdf961
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 266 GoSliceHeaderType []bool
           Locations:
-            - Range: 0xcdf940..0xcdf941
+            - Range: 0xcdf960..0xcdf961
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9434,37 +9434,18 @@ Subprograms:
         - Name: x
           Type: 17 BaseType uint
           Locations:
-            - Range: 0xcdf940..0xcdf941
+            - Range: 0xcdf960..0xcdf961
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 143
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0xcdf960..0xcdf961]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 267 GoSliceHeaderType []uint16
-          Locations:
-            - Range: 0xcdf960..0xcdf961
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 144
-      Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0xcdf980..0xcdf981]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 260 GoSliceHeaderType []uint
+          Type: 267 GoSliceHeaderType []uint16
           Locations:
             - Range: 0xcdf980..0xcdf981
               Pieces:
@@ -9477,13 +9458,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 145
-      Name: main.testSliceEmptyStructs
+    - ID: 144
+      Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0xcdf9a0..0xcdf9a1]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 268 GoSliceHeaderType []struct {}
+          Type: 260 GoSliceHeaderType []uint
           Locations:
             - Range: 0xcdf9a0..0xcdf9a1
               Pieces:
@@ -9496,15 +9477,34 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 145
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0xcdf9c0..0xcdf9c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 268 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0xcdf9c0..0xcdf9c1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 146
       Name: main.testSubslices
-      OutOfLinePCRanges: [0xcdf9c0..0xcdf9c1]
+      OutOfLinePCRanges: [0xcdf9e0..0xcdf9e1]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 260 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcdf9c0..0xcdf9c1
+            - Range: 0xcdf9e0..0xcdf9e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9517,7 +9517,7 @@ Subprograms:
         - Name: bs
           Type: 260 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcdf9c0..0xcdf9c1
+            - Range: 0xcdf9e0..0xcdf9e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -9530,7 +9530,7 @@ Subprograms:
         - Name: cs
           Type: 260 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcdf9c0..0xcdf9c1
+            - Range: 0xcdf9e0..0xcdf9e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -9543,44 +9543,27 @@ Subprograms:
       DictRegister: null
     - ID: 147
       Name: main.stackC
-      OutOfLinePCRanges: [0xce0180..0xce01d2]
+      OutOfLinePCRanges: [0xce01a0..0xce01f2]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce0180..0xce01c5
+            - Range: 0xce01a0..0xce01e5
               Pieces: []
-            - Range: 0xce01c5..0xce01c6
+            - Range: 0xce01e5..0xce01e6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce01c6..0xce01d2
+            - Range: 0xce01e6..0xce01f2
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 148
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xce01e0..0xce01e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 10 GoStringHeaderType string
-          Locations:
-            - Range: 0xce01e0..0xce01e1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 149
-      Name: main.testThreeStrings
       OutOfLinePCRanges: [0xce0200..0xce0201]
       InlinePCRanges: []
       Variables:
@@ -9595,10 +9578,27 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
           DictIndex: -1
+      DictRegister: null
+    - ID: 149
+      Name: main.testThreeStrings
+      OutOfLinePCRanges: [0xce0220..0xce0221]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0xce0220..0xce0221
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
         - Name: "y"
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce0200..0xce0201
+            - Range: 0xce0220..0xce0221
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9609,7 +9609,7 @@ Subprograms:
         - Name: z
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce0200..0xce0201
+            - Range: 0xce0220..0xce0221
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9620,13 +9620,13 @@ Subprograms:
       DictRegister: null
     - ID: 150
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xce0220..0xce023f]
+      OutOfLinePCRanges: [0xce0240..0xce025f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 270 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xce0220..0xce023f
+            - Range: 0xce0240..0xce025f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9645,49 +9645,32 @@ Subprograms:
       DictRegister: null
     - ID: 151
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xce0240..0xce0241]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 271 PointerType *main.threeStringStruct
-          Locations:
-            - Range: 0xce0240..0xce0241
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 152
-      Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0xce0260..0xce0261]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 272 PointerType *main.oneStringStruct
+          Type: 271 PointerType *main.threeStringStruct
           Locations:
             - Range: 0xce0260..0xce0261
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 153
-      Name: main.testMassiveString
+    - ID: 152
+      Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0xce0280..0xce0281]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 10 GoStringHeaderType string
+        - Name: a
+          Type: 272 PointerType *main.oneStringStruct
           Locations:
             - Range: 0xce0280..0xce0281
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 154
-      Name: main.testUnitializedString
+    - ID: 153
+      Name: main.testMassiveString
       OutOfLinePCRanges: [0xce02a0..0xce02a1]
       InlinePCRanges: []
       Variables:
@@ -9703,8 +9686,8 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 155
-      Name: main.testEmptyString
+    - ID: 154
+      Name: main.testUnitializedString
       OutOfLinePCRanges: [0xce02c0..0xce02c1]
       InlinePCRanges: []
       Variables:
@@ -9720,12 +9703,12 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 156
-      Name: main.testSubstrings
+    - ID: 155
+      Name: main.testEmptyString
       OutOfLinePCRanges: [0xce02e0..0xce02e1]
       InlinePCRanges: []
       Variables:
-        - Name: a
+        - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
             - Range: 0xce02e0..0xce02e1
@@ -9736,10 +9719,27 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
           DictIndex: -1
+      DictRegister: null
+    - ID: 156
+      Name: main.testSubstrings
+      OutOfLinePCRanges: [0xce0300..0xce0301]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0xce0300..0xce0301
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
         - Name: b
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce02e0..0xce02e1
+            - Range: 0xce0300..0xce0301
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9750,7 +9750,7 @@ Subprograms:
         - Name: c
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce02e0..0xce02e1
+            - Range: 0xce0300..0xce0301
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9761,26 +9761,26 @@ Subprograms:
       DictRegister: null
     - ID: 157
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0xce0460..0xce0461]
+      OutOfLinePCRanges: [0xce0480..0xce0481]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 274 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0xce0460..0xce0461
+            - Range: 0xce0480..0xce0481
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 158
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0xce0480..0xce049f]
+      OutOfLinePCRanges: [0xce04a0..0xce04bf]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 287 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0xce0480..0xce049f
+            - Range: 0xce04a0..0xce04bf
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9799,13 +9799,13 @@ Subprograms:
       DictRegister: null
     - ID: 159
       Name: main.testStruct
-      OutOfLinePCRanges: [0xce05c0..0xce05e3]
+      OutOfLinePCRanges: [0xce05e0..0xce0603]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 318 StructureType main.aStruct
           Locations:
-            - Range: 0xce05c0..0xce05e3
+            - Range: 0xce05e0..0xce0603
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -9826,91 +9826,91 @@ Subprograms:
       DictRegister: null
     - ID: 160
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0xce06c0..0xce06c1]
+      OutOfLinePCRanges: [0xce06e0..0xce06e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 319 PointerType *main.anotherStruct
           Locations:
-            - Range: 0xce06c0..0xce06c1
+            - Range: 0xce06e0..0xce06e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 161
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0xce06e0..0xce06e1]
+      OutOfLinePCRanges: [0xce0700..0xce0701]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 321 StructureType main.tenStrings
           Locations:
-            - Range: 0xce06e0..0xce06e1
+            - Range: 0xce0700..0xce0701
               Pieces: [{Size: 160, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 162
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xce0740..0xce0741]
+      OutOfLinePCRanges: [0xce0760..0xce0761]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 322 StructureType main.emptyStruct
-          Locations: [{Range: 0xce0740..0xce0741, Pieces: []}]
+          Locations: [{Range: 0xce0760..0xce0761, Pieces: []}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 163
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xce0760..0xce0761]
+      OutOfLinePCRanges: [0xce0780..0xce0781]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 323 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xce0760..0xce0761
+            - Range: 0xce0780..0xce0781
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 164
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0xce2a20..0xce2a24]
+      OutOfLinePCRanges: [0xce2a40..0xce2a44]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0xce2a20..0xce2a24
+            - Range: 0xce2a40..0xce2a44
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 325 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xce2a20..0xce2a23
+            - Range: 0xce2a40..0xce2a43
               Pieces: []
-            - Range: 0xce2a23..0xce2a24
+            - Range: 0xce2a43..0xce2a44
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 165
       Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0xce2a40..0xce2a4c]
+      OutOfLinePCRanges: [0xce2a60..0xce2a6c]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce2a40..0xce2a4b
+            - Range: 0xce2a60..0xce2a6b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce2a4b..0xce2a4c
+            - Range: 0xce2a6b..0xce2a6c
               Pieces:
                 - Size: 8
                   Op: null
@@ -9921,9 +9921,9 @@ Subprograms:
         - Name: ~r0
           Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xce2a40..0xce2a4b
+            - Range: 0xce2a60..0xce2a6b
               Pieces: []
-            - Range: 0xce2a4b..0xce2a4c
+            - Range: 0xce2a6b..0xce2a6c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9934,41 +9934,41 @@ Subprograms:
       DictRegister: 0
     - ID: 166
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0xce2a60..0xce2a64]
+      OutOfLinePCRanges: [0xce2a80..0xce2a84]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 325 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xce2a60..0xce2a64
+            - Range: 0xce2a80..0xce2a84
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0xce2a60..0xce2a63
+            - Range: 0xce2a80..0xce2a83
               Pieces: []
-            - Range: 0xce2a63..0xce2a64
+            - Range: 0xce2a83..0xce2a84
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 167
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0xce2a80..0xce2a8c]
+      OutOfLinePCRanges: [0xce2aa0..0xce2aac]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xce2a80..0xce2a8b
+            - Range: 0xce2aa0..0xce2aab
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce2a8b..0xce2a8c
+            - Range: 0xce2aab..0xce2aac
               Pieces:
                 - Size: 8
                   Op: null
@@ -9979,9 +9979,9 @@ Subprograms:
         - Name: ~r0
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce2a80..0xce2a8b
+            - Range: 0xce2aa0..0xce2aab
               Pieces: []
-            - Range: 0xce2a8b..0xce2a8c
+            - Range: 0xce2aab..0xce2aac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9992,13 +9992,13 @@ Subprograms:
       DictRegister: 0
     - ID: 168
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0xce2b00..0xce2c36]
+      OutOfLinePCRanges: [0xce2b20..0xce2c56]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 328 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce2b00..0xce2b33
+            - Range: 0xce2b20..0xce2b53
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10006,7 +10006,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce2b33..0xce2b3b
+            - Range: 0xce2b53..0xce2b5b
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -10014,7 +10014,7 @@ Subprograms:
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: null
-            - Range: 0xce2b3b..0xce2c36
+            - Range: 0xce2b5b..0xce2c56
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -10027,18 +10027,18 @@ Subprograms:
         - Name: pred
           Type: 330 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0xce2b00..0xce2b3b
+            - Range: 0xce2b20..0xce2b5b
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xce2b3b..0xce2c36
+            - Range: 0xce2b5b..0xce2c56
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 328 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce2b00..0xce2bf4
+            - Range: 0xce2b20..0xce2c14
               Pieces: []
-            - Range: 0xce2bf4..0xce2bf5
+            - Range: 0xce2c14..0xce2c15
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10046,14 +10046,14 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce2bf5..0xce2c36
+            - Range: 0xce2c15..0xce2c56
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
           Type: 328 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce2b3b..0xce2b59
+            - Range: 0xce2b5b..0xce2b79
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10061,7 +10061,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce2b59..0xce2b61
+            - Range: 0xce2b79..0xce2b81
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10069,7 +10069,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce2b61..0xce2b69
+            - Range: 0xce2b81..0xce2b89
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10077,7 +10077,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce2b69..0xce2b69
+            - Range: 0xce2b89..0xce2b89
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10085,7 +10085,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce2b69..0xce2b93
+            - Range: 0xce2b89..0xce2bb3
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
@@ -10093,7 +10093,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce2b93..0xce2beb
+            - Range: 0xce2bb3..0xce2c0b
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10101,7 +10101,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce2beb..0xce2c36
+            - Range: 0xce2c0b..0xce2c56
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
@@ -10114,84 +10114,62 @@ Subprograms:
         - Name: item
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0xce2b86..0xce2b93
+            - Range: 0xce2ba6..0xce2bb3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce2b93..0xce2beb
+            - Range: 0xce2bb3..0xce2c0b
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
     - ID: 169
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xce2c40..0xce2c84]
+      OutOfLinePCRanges: [0xce2c60..0xce2ca4]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 325 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xce2c40..0xce2c59
+            - Range: 0xce2c60..0xce2c79
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
           Type: 331 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0xce2c40..0xce2c59
+            - Range: 0xce2c60..0xce2c79
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xce2c40..0xce2c59
+            - Range: 0xce2c60..0xce2c79
               Pieces: []
-            - Range: 0xce2c59..0xce2c5a
+            - Range: 0xce2c79..0xce2c7a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce2c5a..0xce2c84
+            - Range: 0xce2c7a..0xce2ca4
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
     - ID: 170
       Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0xce2f20..0xce2f24]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 329 PointerType *go.shape.int
-          Locations:
-            - Range: 0xce2f20..0xce2f24
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 329 PointerType *go.shape.int
-          Locations:
-            - Range: 0xce2f20..0xce2f23
-              Pieces: []
-            - Range: 0xce2f23..0xce2f24
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 171
-      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
       OutOfLinePCRanges: [0xce2f40..0xce2f44]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 332 PointerType *go.shape.struct { Name string }
+          Type: 329 PointerType *go.shape.int
           Locations:
             - Range: 0xce2f40..0xce2f44
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 332 PointerType *go.shape.struct { Name string }
+          Type: 329 PointerType *go.shape.int
           Locations:
             - Range: 0xce2f40..0xce2f43
               Pieces: []
@@ -10200,20 +10178,20 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 172
-      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
+    - ID: 171
+      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
       OutOfLinePCRanges: [0xce2f60..0xce2f64]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 334 PointerType *go.shape.struct { X int; Y int }
+          Type: 332 PointerType *go.shape.struct { Name string }
           Locations:
             - Range: 0xce2f60..0xce2f64
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 334 PointerType *go.shape.struct { X int; Y int }
+          Type: 332 PointerType *go.shape.struct { Name string }
           Locations:
             - Range: 0xce2f60..0xce2f63
               Pieces: []
@@ -10222,24 +10200,46 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
+    - ID: 172
+      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
+      OutOfLinePCRanges: [0xce2f80..0xce2f84]
+      InlinePCRanges: []
+      Variables:
+        - Name: p
+          Type: 334 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0xce2f80..0xce2f84
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 334 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0xce2f80..0xce2f83
+              Pieces: []
+            - Range: 0xce2f83..0xce2f84
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
     - ID: 173
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0xce2f80..0xce2f91]
+      OutOfLinePCRanges: [0xce2fa0..0xce2fb1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 336 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0xce2f80..0xce2f91
+            - Range: 0xce2fa0..0xce2fb1
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce2f80..0xce2f90
+            - Range: 0xce2fa0..0xce2fb0
               Pieces: []
-            - Range: 0xce2f90..0xce2f91
+            - Range: 0xce2fb0..0xce2fb1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10250,69 +10250,69 @@ Subprograms:
       DictRegister: 0
     - ID: 174
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0xce3020..0xce3029]
+      OutOfLinePCRanges: [0xce3040..0xce3049]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 338 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0xce3020..0xce3029
+            - Range: 0xce3040..0xce3049
               Pieces: [{Size: 136, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0xce3020..0xce3028
+            - Range: 0xce3040..0xce3048
               Pieces: []
-            - Range: 0xce3028..0xce3029
+            - Range: 0xce3048..0xce3049
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 175
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0xce30e0..0xce30e8]
+      OutOfLinePCRanges: [0xce3100..0xce3108]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 339 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0xce30e0..0xce30e8
+            - Range: 0xce3100..0xce3108
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0xce30e0..0xce30e8
+            - Range: 0xce3100..0xce3108
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
           Type: 341 BaseType go.shape.bool
           Locations:
-            - Range: 0xce30e0..0xce30e8
+            - Range: 0xce3100..0xce3108
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
     - ID: 176
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0xce3180..0xce31f1]
+      OutOfLinePCRanges: [0xce31a0..0xce3211]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 342 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0xce3180..0xce31f1
+            - Range: 0xce31a0..0xce3211
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce3180..0xce31f1
+            - Range: 0xce31a0..0xce3211
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10323,20 +10323,20 @@ Subprograms:
         - Name: v
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0xce3180..0xce31f1
+            - Range: 0xce31a0..0xce3211
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
     - ID: 177
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0xce3280..0xce3288]
+      OutOfLinePCRanges: [0xce32a0..0xce32a8]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce3280..0xce3288
+            - Range: 0xce32a0..0xce32a8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10347,25 +10347,25 @@ Subprograms:
         - Name: b
           Type: 341 BaseType go.shape.bool
           Locations:
-            - Range: 0xce3280..0xce3288
+            - Range: 0xce32a0..0xce32a8
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 341 BaseType go.shape.bool
           Locations:
-            - Range: 0xce3280..0xce3287
+            - Range: 0xce32a0..0xce32a7
               Pieces: []
-            - Range: 0xce3287..0xce3288
+            - Range: 0xce32a7..0xce32a8
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce3280..0xce3287
+            - Range: 0xce32a0..0xce32a7
               Pieces: []
-            - Range: 0xce3287..0xce3288
+            - Range: 0xce32a7..0xce32a8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10376,26 +10376,26 @@ Subprograms:
       DictRegister: 0
     - ID: 178
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xce32a0..0xce32af]
+      OutOfLinePCRanges: [0xce32c0..0xce32cf]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0xce32a0..0xce32ae
+            - Range: 0xce32c0..0xce32ce
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce32a0..0xce32ab
+            - Range: 0xce32c0..0xce32cb
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce32ab..0xce32af
+            - Range: 0xce32cb..0xce32cf
               Pieces:
                 - Size: 8
                   Op: null
@@ -10406,9 +10406,9 @@ Subprograms:
         - Name: ~r0
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce32a0..0xce32ae
+            - Range: 0xce32c0..0xce32ce
               Pieces: []
-            - Range: 0xce32ae..0xce32af
+            - Range: 0xce32ce..0xce32cf
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10419,56 +10419,56 @@ Subprograms:
         - Name: ~r1
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0xce32a0..0xce32ae
+            - Range: 0xce32c0..0xce32ce
               Pieces: []
-            - Range: 0xce32ae..0xce32af
+            - Range: 0xce32ce..0xce32cf
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 179
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0xce32c0..0xce32fa]
+      OutOfLinePCRanges: [0xce32e0..0xce331a]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 344 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0xce32c0..0xce32d9
+            - Range: 0xce32e0..0xce32f9
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce32c0..0xce32d9
+            - Range: 0xce32e0..0xce32f9
               Pieces: []
-            - Range: 0xce32d9..0xce32da
+            - Range: 0xce32f9..0xce32fa
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce32da..0xce32fa
+            - Range: 0xce32fa..0xce331a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 180
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0xce3300..0xce334d]
+      OutOfLinePCRanges: [0xce3320..0xce336d]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 345 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0xce3300..0xce331f
+            - Range: 0xce3320..0xce333f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce331f..0xce3322
+            - Range: 0xce333f..0xce3342
               Pieces:
                 - Size: 8
                   Op: null
@@ -10479,37 +10479,37 @@ Subprograms:
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce3300..0xce3322
+            - Range: 0xce3320..0xce3342
               Pieces: []
-            - Range: 0xce3322..0xce3323
+            - Range: 0xce3342..0xce3343
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce3323..0xce334d
+            - Range: 0xce3343..0xce336d
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 181
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0xce3360..0xce3368]
+      OutOfLinePCRanges: [0xce3380..0xce3388]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 346 PointerType *go.shape.string
           Locations:
-            - Range: 0xce3360..0xce3367
+            - Range: 0xce3380..0xce3387
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce3360..0xce3367
+            - Range: 0xce3380..0xce3387
               Pieces: []
-            - Range: 0xce3367..0xce3368
+            - Range: 0xce3387..0xce3388
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10520,22 +10520,22 @@ Subprograms:
       DictRegister: 0
     - ID: 182
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0xce3380..0xce33d7]
+      OutOfLinePCRanges: [0xce33a0..0xce33f7]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 347 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xce3380..0xce33bd
+            - Range: 0xce33a0..0xce33dd
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 348 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xce3380..0xce33d1
+            - Range: 0xce33a0..0xce33f1
               Pieces: []
-            - Range: 0xce33d1..0xce33d2
+            - Range: 0xce33f1..0xce33f2
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10549,20 +10549,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xce33d2..0xce33d7
+            - Range: 0xce33f2..0xce33f7
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 183
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0xce33e0..0xce3404]
+      OutOfLinePCRanges: [0xce3400..0xce3424]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 328 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce33e0..0xce3404
+            - Range: 0xce3400..0xce3424
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10575,33 +10575,33 @@ Subprograms:
         - Name: needle
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0xce33e0..0xce3404
+            - Range: 0xce3400..0xce3424
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xce33e0..0xce3400
+            - Range: 0xce3400..0xce3420
               Pieces: []
-            - Range: 0xce3400..0xce3401
+            - Range: 0xce3420..0xce3421
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce3401..0xce3403
+            - Range: 0xce3421..0xce3423
               Pieces: []
-            - Range: 0xce3403..0xce3404
+            - Range: 0xce3423..0xce3424
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 184
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0xce3420..0xce34df]
+      OutOfLinePCRanges: [0xce3440..0xce34ff]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 349 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0xce3420..0xce343d
+            - Range: 0xce3440..0xce345d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10609,7 +10609,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce343d..0xce343f
+            - Range: 0xce345d..0xce345f
               Pieces:
                 - Size: 8
                   Op: null
@@ -10622,13 +10622,13 @@ Subprograms:
         - Name: needle
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce3420..0xce346c
+            - Range: 0xce3440..0xce348c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xce346c..0xce34df
+            - Range: 0xce348c..0xce34ff
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
@@ -10639,28 +10639,28 @@ Subprograms:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xce3420..0xce348b
+            - Range: 0xce3440..0xce34ab
               Pieces: []
-            - Range: 0xce348b..0xce348c
+            - Range: 0xce34ab..0xce34ac
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce348c..0xce3493
+            - Range: 0xce34ac..0xce34b3
               Pieces: []
-            - Range: 0xce3493..0xce3494
+            - Range: 0xce34b3..0xce34b4
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce3494..0xce34df
+            - Range: 0xce34b4..0xce34ff
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce344f..0xce3461
+            - Range: 0xce346f..0xce3481
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xce3461..0xce346c
+            - Range: 0xce3481..0xce348c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10671,54 +10671,54 @@ Subprograms:
       DictRegister: 0
     - ID: 185
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0xce34e0..0xce34e7]
+      OutOfLinePCRanges: [0xce3500..0xce3507]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 350 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0xce34e0..0xce34e6
+            - Range: 0xce3500..0xce3506
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0xce34e0..0xce34e7
+            - Range: 0xce3500..0xce3507
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xce34e0..0xce34e6
+            - Range: 0xce3500..0xce3506
               Pieces: []
-            - Range: 0xce34e6..0xce34e7
+            - Range: 0xce3506..0xce3507
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 3
     - ID: 186
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0xce3560..0xce35cc]
+      OutOfLinePCRanges: [0xce3580..0xce35ec]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 351 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0xce3560..0xce3580
+            - Range: 0xce3580..0xce35a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce3580..0xce3588
+            - Range: 0xce35a0..0xce35a8
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce3588..0xce358d
+            - Range: 0xce35a8..0xce35ad
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10729,7 +10729,7 @@ Subprograms:
         - Name: value
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce3560..0xce358d
+            - Range: 0xce3580..0xce35ad
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -10740,11 +10740,11 @@ Subprograms:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xce3560..0xce358d
+            - Range: 0xce3580..0xce35ad
               Pieces: []
-            - Range: 0xce358d..0xce358e
+            - Range: 0xce35ad..0xce35ae
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce358e..0xce35cc
+            - Range: 0xce35ae..0xce35ec
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10973,8 +10973,8 @@ Subprograms:
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0xcd9f00..0xcd9f71]
       InlinePCRanges:
-        - Ranges: [0xce3683..0xce36c5]
-          RootRanges: [0xce3660..0xce36f6]
+        - Ranges: [0xce36a3..0xce36e5]
+          RootRanges: [0xce3680..0xce3716]
       Variables:
         - Name: b
           Type: 356 StructureType main.firstBehavior
@@ -11013,8 +11013,8 @@ Subprograms:
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcda7dd..0xcda7e4]
-          RootRanges: [0xcda740..0xcda82b]
+        - Ranges: [0xcda7fd..0xcda804]
+          RootRanges: [0xcda760..0xcda84b]
         - Ranges: [0x5230a1..0x5230a9]
           RootRanges: [0x5230a0..0x5230aa]
       Variables: []

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -13,11 +13,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1600 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0xce492a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce494a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1601 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0xce4965", Frameless: false}]
+              InjectionPoints: [{PC: "0xce4985", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -84,11 +84,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1571 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0xce2f4e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2f6e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1572 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0xce3002", Frameless: false}]
+              InjectionPoints: [{PC: "0xce3022", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -176,7 +176,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1451 EventRootType Probe[main.testArrayOfMaps]
-              InjectionPoints: [{PC: "0xcdf100", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf120", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -241,11 +241,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1473 EventRootType Probe[main.testAtomicAdd]
-              InjectionPoints: [{PC: "0xce0fe0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1000", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1474 EventRootType Probe[main.testAtomicAdd]Return
-              InjectionPoints: [{PC: "0xce0ff2", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1012", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -342,11 +342,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1619 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xce4d60", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4d80", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1620 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0xce4d82", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4da2", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -476,7 +476,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1470 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0xce0c40", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0c60", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -495,7 +495,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1471 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0xce0c40", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0c60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -521,7 +521,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1627 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0xce4e80", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4ea0", Frameless: true}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -557,7 +557,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1475 EventRootType Probe[main.testChannel]
-              InjectionPoints: [{PC: "0xce1000", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1020", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -587,7 +587,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1469 EventRootType Probe[main.testCombinedByte]
-              InjectionPoints: [{PC: "0xce0c00", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0c20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{w}, {x}, {y}'
@@ -616,11 +616,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1536 EventRootType Probe[main.testConflictingReturn]
-              InjectionPoints: [{PC: "0xce218e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce21ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1537 EventRootType Probe[main.testConflictingReturn]Return
-              InjectionPoints: [{PC: "0xce2251", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2271", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -642,7 +642,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1483 EventRootType Probe[main.testCycle]
-              InjectionPoints: [{PC: "0xce13c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce13e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{t}'
@@ -796,7 +796,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1588 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0xce4020", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4040", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -823,7 +823,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1591 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0xce4080", Frameless: true}]
+              InjectionPoints: [{PC: "0xce40a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -851,7 +851,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1614 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0xce4a60", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4a80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -873,7 +873,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1628 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0xce4ee0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4f00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -894,7 +894,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1629 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0xce4f00", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4f20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1107,11 +1107,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1666 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0xce7a00", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7a20", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1667 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce7a07", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7a27", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1125,11 +1125,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1668 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0xce7a24", Frameless: false}]
+              InjectionPoints: [{PC: "0xce7a44", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1669 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0xce7a71", Frameless: false}]
+              InjectionPoints: [{PC: "0xce7a91", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1152,11 +1152,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1662 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0xce796a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce798a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1663 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0xce7979", Frameless: false}]
+              InjectionPoints: [{PC: "0xce7999", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1170,11 +1170,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1664 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0xce79aa", Frameless: false}]
+              InjectionPoints: [{PC: "0xce79ca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1665 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0xce79c2", Frameless: false}]
+              InjectionPoints: [{PC: "0xce79e2", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1197,14 +1197,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1670 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0xce7a80", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7aa0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1671 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0xce7aa0"
+                - PC: "0xce7ac0"
                   Frameless: true
-                - PC: "0xce7aa3"
+                - PC: "0xce7ac3"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1219,14 +1219,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1672 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0xce7aca", Frameless: false}]
+              InjectionPoints: [{PC: "0xce7aea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1673 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0xce7b2b"
+                - PC: "0xce7b4b"
                   Frameless: false
-                - PC: "0xce7b33"
+                - PC: "0xce7b53"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1253,7 +1253,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1674 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0xce7a85", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7aa5", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1265,7 +1265,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1675 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0xce7adf", Frameless: false}]
+              InjectionPoints: [{PC: "0xce7aff", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1286,11 +1286,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1650 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0xce7620", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7640", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1651 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0xce7630", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7650", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1304,11 +1304,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1652 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0xce76c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce76e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1653 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0xce76c8", Frameless: true}]
+              InjectionPoints: [{PC: "0xce76e8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1332,11 +1332,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1638 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0xce71ae", Frameless: false}]
+              InjectionPoints: [{PC: "0xce71ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1639 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce7294", Frameless: false}]
+              InjectionPoints: [{PC: "0xce72b4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1378,11 +1378,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1642 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xce72ea", Frameless: false}]
+              InjectionPoints: [{PC: "0xce730a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1643 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce72f9", Frameless: false}]
+              InjectionPoints: [{PC: "0xce7319", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1405,11 +1405,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1676 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0xce7b80", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7ba0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1677 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0xce7b86", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7ba6", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1423,11 +1423,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1678 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0xce7c0a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce7c2a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1679 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0xce7c2d", Frameless: false}]
+              InjectionPoints: [{PC: "0xce7c4d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1450,11 +1450,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1634 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0xce7100", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7120", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1635 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce7103", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7123", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1468,11 +1468,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1636 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0xce7120", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7140", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1637 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce712b", Frameless: true}]
+              InjectionPoints: [{PC: "0xce714b", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1495,11 +1495,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1654 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0xce7780", Frameless: true}]
+              InjectionPoints: [{PC: "0xce77a0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1655 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0xce7787", Frameless: true}]
+              InjectionPoints: [{PC: "0xce77a7", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1513,11 +1513,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1656 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0xce782a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce784a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1657 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0xce7853", Frameless: false}]
+              InjectionPoints: [{PC: "0xce7873", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1540,11 +1540,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1644 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0xce75c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce75e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1645 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce75c3", Frameless: true}]
+              InjectionPoints: [{PC: "0xce75e3", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1558,11 +1558,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1646 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0xce75e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7600", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1647 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0xce75e3", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7603", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1576,11 +1576,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1648 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0xce7600", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7620", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1649 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0xce7603", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7623", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1603,11 +1603,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1658 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0xce7920", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7940", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1659 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0xce7927", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7947", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1621,11 +1621,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1660 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xce7940", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7960", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1661 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce794e", Frameless: true}]
+              InjectionPoints: [{PC: "0xce796e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1648,11 +1648,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1630 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0xce70c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce70e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1631 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce70c3", Frameless: true}]
+              InjectionPoints: [{PC: "0xce70e3", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1666,11 +1666,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1632 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0xce70e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7100", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1633 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce70eb", Frameless: true}]
+              InjectionPoints: [{PC: "0xce710b", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1902,7 +1902,7 @@ Probes:
               InjectionPoints:
                 - PC: "0x52bec1"
                   Frameless: true
-                - PC: "0xcdefdd"
+                - PC: "0xcdeffd"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2198,11 +2198,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1569 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0xce2dae", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2dce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1570 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xce2f13", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2f33", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2224,7 +2224,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1477 EventRootType Probe[main.testLinkedList]
-              InjectionPoints: [{PC: "0xce11e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1200", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -2336,11 +2336,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1575 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0xce3273", Frameless: false}]
+              InjectionPoints: [{PC: "0xce3293", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1576 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0xce3482", Frameless: false}]
+              InjectionPoints: [{PC: "0xce34a2", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2449,7 +2449,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1449 EventRootType Probe[main.testMapArrayToArray]
-              InjectionPoints: [{PC: "0xcdf0c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf0e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2471,7 +2471,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1456 EventRootType Probe[main.testMapEmbeddedMaps]
-              InjectionPoints: [{PC: "0xcdf180", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf1a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2493,7 +2493,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1466 EventRootType Probe[main.testMapEmptyKey]
-              InjectionPoints: [{PC: "0xcdf2c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf2e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2515,7 +2515,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1468 EventRootType Probe[main.testMapEmptyKeyAndValue]
-              InjectionPoints: [{PC: "0xcdf300", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf320", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2537,7 +2537,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1467 EventRootType Probe[main.testMapEmptyValue]
-              InjectionPoints: [{PC: "0xcdf2e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf300", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2559,7 +2559,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1453 EventRootType Probe[main.testMapIntToInt]
-              InjectionPoints: [{PC: "0xcdf140", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf160", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2581,7 +2581,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1465 EventRootType Probe[main.testMapLargeKeyLargeValue]
-              InjectionPoints: [{PC: "0xcdf2a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf2c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2603,7 +2603,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1464 EventRootType Probe[main.testMapLargeKeySmallValue]
-              InjectionPoints: [{PC: "0xcdf280", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf2a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2627,7 +2627,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1454 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0xcdf160", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf180", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2651,7 +2651,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1455 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0xcdf160", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf180", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2673,7 +2673,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1463 EventRootType Probe[main.testMapSmallKeyLargeValue]
-              InjectionPoints: [{PC: "0xcdf260", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf280", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2695,7 +2695,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1462 EventRootType Probe[main.testMapSmallKeySmallValue]
-              InjectionPoints: [{PC: "0xcdf240", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf260", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2717,7 +2717,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1447 EventRootType Probe[main.testMapStringToInt]
-              InjectionPoints: [{PC: "0xcdf080", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf0a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2739,7 +2739,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1448 EventRootType Probe[main.testMapStringToSlice]
-              InjectionPoints: [{PC: "0xcdf0a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf0c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2761,7 +2761,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1446 EventRootType Probe[main.testMapStringToStruct]
-              InjectionPoints: [{PC: "0xcdf060", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf080", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2783,7 +2783,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1457 EventRootType Probe[main.testMapWithLinkedList]
-              InjectionPoints: [{PC: "0xcdf1a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf1c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2805,7 +2805,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1460 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-              InjectionPoints: [{PC: "0xcdf200", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf220", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2827,7 +2827,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1461 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-              InjectionPoints: [{PC: "0xcdf220", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf240", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2849,7 +2849,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1458 EventRootType Probe[main.testMapWithSmallValue]
-              InjectionPoints: [{PC: "0xcdf1c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf1e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2873,7 +2873,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1459 EventRootType Probe[main.testMapWithSmallValueMassive]
-              InjectionPoints: [{PC: "0xcdf1e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf200", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2895,7 +2895,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1611 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xce4a20", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4a40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2918,7 +2918,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1612 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xce4a20", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4a40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2965,11 +2965,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1577 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0xce3513", Frameless: false}]
+              InjectionPoints: [{PC: "0xce3533", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1578 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0xce374b", Frameless: false}]
+              InjectionPoints: [{PC: "0xce376b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -3035,11 +3035,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1581 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0xce388e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce38ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1582 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0xce395f", Frameless: false}]
+              InjectionPoints: [{PC: "0xce397f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3070,11 +3070,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1573 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0xce302e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce304e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1574 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0xce324a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce326a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3100,11 +3100,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1514 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xce1fce", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1fee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1515 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xce206f", Frameless: false}]
+              InjectionPoints: [{PC: "0xce208f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3140,7 +3140,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1472 EventRootType Probe[main.testMultipleSimpleParams]
-              InjectionPoints: [{PC: "0xce0dc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0de0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -3181,11 +3181,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1508 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xce1f2a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1f4a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1509 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xce1f95", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1fb5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3209,11 +3209,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1510 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xce1f2a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1f4a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1511 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xce1f95", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1fb5", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
       version: 0
@@ -3232,11 +3232,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1516 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xce1fce", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1fee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1517 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xce206f", Frameless: false}]
+              InjectionPoints: [{PC: "0xce208f", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
       version: 0
@@ -3256,11 +3256,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1518 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xce1fce", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1fee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1519 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xce206f", Frameless: false}]
+              InjectionPoints: [{PC: "0xce208f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r1={result} r2={result2}
@@ -3293,11 +3293,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1512 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xce1f2a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1f4a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1513 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xce1f95", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1fb5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Parameter {i} * 2 = result {result}
@@ -3325,7 +3325,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1623 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xce4e60", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4e80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3350,7 +3350,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1624 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xce4e60", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4e80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3381,7 +3381,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1625 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xce4e60", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4e80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3406,7 +3406,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1626 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xce4e60", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4e80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3433,7 +3433,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1482 EventRootType Probe[main.testNilPointer]
-              InjectionPoints: [{PC: "0xce1380", Frameless: true}]
+              InjectionPoints: [{PC: "0xce13a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}, {a}'
@@ -3460,7 +3460,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1595 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0xce4100", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4120", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3487,7 +3487,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1592 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0xce40a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce40c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3522,7 +3522,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1594 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0xce40e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4100", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3554,7 +3554,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1610 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0xce4a00", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4a20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3576,7 +3576,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1478 EventRootType Probe[main.testPointerLoop]
-              InjectionPoints: [{PC: "0xce1200", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1220", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3598,7 +3598,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1452 EventRootType Probe[main.testPointerToMap]
-              InjectionPoints: [{PC: "0xcdf120", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf140", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3620,7 +3620,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1476 EventRootType Probe[main.testPointerToSimpleStruct]
-              InjectionPoints: [{PC: "0xce11c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce11e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3644,11 +3644,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1484 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xce180a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce182a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1485 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xce185b", Frameless: false}]
+              InjectionPoints: [{PC: "0xce187b", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
       version: 0
@@ -3668,11 +3668,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1528 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xce20ae", Frameless: false}]
+              InjectionPoints: [{PC: "0xce20ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1529 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xce214d", Frameless: false}]
+              InjectionPoints: [{PC: "0xce216d", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3715,11 +3715,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1494 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xce192e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce194e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1495 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xce19e4", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1a04", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3759,11 +3759,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1486 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xce180a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce182a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1487 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xce185b", Frameless: false}]
+              InjectionPoints: [{PC: "0xce187b", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3806,11 +3806,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1496 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xce192e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce194e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1497 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xce19e4", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1a04", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3852,11 +3852,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1530 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xce20ae", Frameless: false}]
+              InjectionPoints: [{PC: "0xce20ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1531 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xce214d", Frameless: false}]
+              InjectionPoints: [{PC: "0xce216d", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
       version: 0
@@ -3873,11 +3873,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1532 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xce20ae", Frameless: false}]
+              InjectionPoints: [{PC: "0xce20ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1533 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xce214d", Frameless: false}]
+              InjectionPoints: [{PC: "0xce216d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r0={@return.r0}
@@ -3899,11 +3899,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1488 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xce180a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce182a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1489 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xce185b", Frameless: false}]
+              InjectionPoints: [{PC: "0xce187b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: result={@return}
@@ -3926,18 +3926,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1504 EventRootType Probe[main.testReturnsAny]
-              InjectionPoints: [{PC: "0xce1bce", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1bee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1505 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
-                - PC: "0xce1c75"
+                - PC: "0xce1c95"
                   Frameless: false
-                - PC: "0xce1cc4"
+                - PC: "0xce1ce4"
                   Frameless: false
-                - PC: "0xce1d80"
+                - PC: "0xce1da0"
                   Frameless: false
-                - PC: "0xce1d8a"
+                - PC: "0xce1daa"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3965,18 +3965,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1502 EventRootType Probe[main.testReturnsAnyAndError]
-              InjectionPoints: [{PC: "0xce1a6e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1a8e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1503 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
-                - PC: "0xce1ac4"
+                - PC: "0xce1ae4"
                   Frameless: false
-                - PC: "0xce1b13"
+                - PC: "0xce1b33"
                   Frameless: false
-                - PC: "0xce1b47"
+                - PC: "0xce1b67"
                   Frameless: false
-                - PC: "0xce1b79"
+                - PC: "0xce1b99"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4003,11 +4003,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1547 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0xce284a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce286a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1548 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0xce28ad", Frameless: false}]
+              InjectionPoints: [{PC: "0xce28cd", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -4024,11 +4024,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1549 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0xce28ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xce28ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1550 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0xce290b", Frameless: false}]
+              InjectionPoints: [{PC: "0xce292b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -4045,11 +4045,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1551 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0xce292a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce294a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1552 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0xce2966", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2986", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4066,11 +4066,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1555 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0xce2a0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2a2e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1556 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0xce2a8a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2aaa", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4087,11 +4087,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1567 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0xce2d4a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2d6a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1568 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0xce2d90", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2db0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4108,11 +4108,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1543 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0xce270a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce272a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1544 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0xce2766", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2786", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4130,14 +4130,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1500 EventRootType Probe[main.testReturnsError]
-              InjectionPoints: [{PC: "0xce1a0a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1a2a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1501 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
-                - PC: "0xce1a3a"
+                - PC: "0xce1a5a"
                   Frameless: false
-                - PC: "0xce1a45"
+                - PC: "0xce1a65"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4159,11 +4159,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1490 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xce180a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce182a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1491 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xce185b", Frameless: false}]
+              InjectionPoints: [{PC: "0xce187b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4184,11 +4184,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1498 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xce192e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce194e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1499 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xce19e4", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1a04", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4209,11 +4209,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1492 EventRootType Probe[main.testReturnsIntPointer]
-              InjectionPoints: [{PC: "0xce188a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce18aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1493 EventRootType Probe[main.testReturnsIntPointer]Return
-              InjectionPoints: [{PC: "0xce18f4", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1914", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4235,14 +4235,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1506 EventRootType Probe[main.testReturnsInterface]
-              InjectionPoints: [{PC: "0xce1dce", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1dee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1507 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
-                - PC: "0xce1e9f"
+                - PC: "0xce1ebf"
                   Frameless: false
-                - PC: "0xce1ea9"
+                - PC: "0xce1ec9"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4264,11 +4264,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1545 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0xce278e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce27ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1546 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0xce2813", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2833", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4285,11 +4285,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1541 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0xce260e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce262e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1542 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0xce26e7", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2707", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4306,11 +4306,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1559 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0xce2b6a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2b8a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1560 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0xce2bcc", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2bec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4327,11 +4327,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1553 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0xce298a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce29aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1554 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0xce29d8", Frameless: false}]
+              InjectionPoints: [{PC: "0xce29f8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4348,11 +4348,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1565 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0xce2cca", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2cea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1566 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0xce2d16", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2d36", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
@@ -4372,7 +4372,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1538 EventRootType Probe[main.testReturnsNamedDeferLine]Line
-              InjectionPoints: [{PC: "0xce238f", Frameless: false}]
+              InjectionPoints: [{PC: "0xce23af", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4393,11 +4393,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1563 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0xce2c6a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2c8a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1564 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0xce2cae", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2cce", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4414,11 +4414,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1539 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0xce258a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce25aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1540 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0xce25f1", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2611", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4435,11 +4435,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1561 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0xce2bea", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2c0a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1562 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0xce2c4d", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2c6d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4456,11 +4456,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1557 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0xce2aae", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2ace", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1558 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0xce2b34", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2b54", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4513,11 +4513,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1520 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xce1fce", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1fee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1521 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xce206f", Frameless: false}]
+              InjectionPoints: [{PC: "0xce208f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -4792,7 +4792,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1602 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0xce4980", Frameless: true}]
+              InjectionPoints: [{PC: "0xce49a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4924,7 +4924,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1598 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0xce4140", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4160", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -4946,7 +4946,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1589 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0xce4040", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4060", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -4968,7 +4968,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1450 EventRootType Probe[main.testSmallMap]
-              InjectionPoints: [{PC: "0xcdf0e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf100", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -4989,11 +4989,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1534 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xce20ae", Frameless: false}]
+              InjectionPoints: [{PC: "0xce20ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1535 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xce214d", Frameless: false}]
+              InjectionPoints: [{PC: "0xce216d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -5014,11 +5014,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1579 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0xce37ea", Frameless: false}]
+              InjectionPoints: [{PC: "0xce380a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1580 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0xce385c", Frameless: false}]
+              InjectionPoints: [{PC: "0xce387c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5062,7 +5062,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1481 EventRootType Probe[main.testStringPointer]
-              InjectionPoints: [{PC: "0xce1340", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1360", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}'
@@ -5084,7 +5084,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1593 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0xce40c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce40e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5150,11 +5150,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1621 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xce4d60", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4d80", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1622 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0xce4d82", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4da2", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5181,7 +5181,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1590 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0xce4060", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4080", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5229,11 +5229,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1583 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0xce398e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce39ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1584 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0xce3a3c", Frameless: false}]
+              InjectionPoints: [{PC: "0xce3a5c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5255,11 +5255,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1617 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0xce4c20", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4c40", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1618 EventRootType Probe[main.testStructWithCyclicMaps]Return
-              InjectionPoints: [{PC: "0xce4c3e", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4c5e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5280,7 +5280,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1616 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0xce4c00", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4c20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5307,7 +5307,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1445 EventRootType Probe[main.testStructWithMap]
-              InjectionPoints: [{PC: "0xcdf040", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf060", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s} {@duration}'
@@ -5340,7 +5340,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1599 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0xce4160", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4180", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5380,7 +5380,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1615 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0xce4a80", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4aa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5413,11 +5413,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1522 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xce1fce", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1fee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1523 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xce206f", Frameless: false}]
+              InjectionPoints: [{PC: "0xce208f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{nonexistentVariable}'
@@ -5438,11 +5438,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1524 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xce1fce", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1fee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1525 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xce206f", Frameless: false}]
+              InjectionPoints: [{PC: "0xce208f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{unsupportedExpression}'
@@ -5465,11 +5465,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1526 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xce1fce", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1fee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1527 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xce206f", Frameless: false}]
+              InjectionPoints: [{PC: "0xce208f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -5501,7 +5501,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1603 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0xce49a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce49c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5533,11 +5533,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1604 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xce49c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce49e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1605 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0xce49de", Frameless: true}]
+              InjectionPoints: [{PC: "0xce49fe", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5567,11 +5567,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1606 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xce49c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce49e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1607 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0xce49de", Frameless: true}]
+              InjectionPoints: [{PC: "0xce49fe", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5603,7 +5603,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1608 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xce49e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4a00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5633,7 +5633,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1609 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xce49e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4a00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5797,7 +5797,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1480 EventRootType Probe[main.testUintPointer]
-              InjectionPoints: [{PC: "0xce1260", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1280", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5819,7 +5819,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1587 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0xce4000", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4020", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5841,7 +5841,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1613 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0xce4a40", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4a60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5863,7 +5863,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1479 EventRootType Probe[main.testUnsafePointer]
-              InjectionPoints: [{PC: "0xce1220", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1240", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5907,7 +5907,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1596 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xce4120", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4140", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5929,7 +5929,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1597 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xce4120", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4140", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5954,7 +5954,7 @@ Probes:
               InjectionPoints:
                 - PC: "0xcde76a"
                   Frameless: false
-                - PC: "0xce7d23"
+                - PC: "0xce7d43"
                   Frameless: false
               Condition: null
             - Kind: Return
@@ -5981,11 +5981,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1585 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0xce3a6e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce3a8e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1586 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xce3aec", Frameless: false}]
+              InjectionPoints: [{PC: "0xce3b0c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -7066,140 +7066,127 @@ Subprograms:
       DictRegister: null
     - ID: 63
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0xcdf040..0xcdf041]
+      OutOfLinePCRanges: [0xcdf060..0xcdf061]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 170 StructureType main.structWithMap
-          Locations:
-            - Range: 0xcdf040..0xcdf041
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 64
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0xcdf060..0xcdf061]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 176 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0xcdf060..0xcdf061
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 65
-      Name: main.testMapStringToInt
+    - ID: 64
+      Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0xcdf080..0xcdf081]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 181 GoMapType map[string]int
+          Type: 176 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0xcdf080..0xcdf081
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 66
-      Name: main.testMapStringToSlice
+    - ID: 65
+      Name: main.testMapStringToInt
       OutOfLinePCRanges: [0xcdf0a0..0xcdf0a1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 186 GoMapType map[string][]string
+          Type: 181 GoMapType map[string]int
           Locations:
             - Range: 0xcdf0a0..0xcdf0a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 67
-      Name: main.testMapArrayToArray
+    - ID: 66
+      Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0xcdf0c0..0xcdf0c1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 191 GoMapType map[[4]string][2]int
+          Type: 186 GoMapType map[string][]string
           Locations:
             - Range: 0xcdf0c0..0xcdf0c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 68
-      Name: main.testSmallMap
+    - ID: 67
+      Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0xcdf0e0..0xcdf0e1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 181 GoMapType map[string]int
+          Type: 191 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0xcdf0e0..0xcdf0e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 68
+      Name: main.testSmallMap
+      OutOfLinePCRanges: [0xcdf100..0xcdf101]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 181 GoMapType map[string]int
+          Locations:
+            - Range: 0xcdf100..0xcdf101
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 69
       Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0xcdf100..0xcdf101]
+      OutOfLinePCRanges: [0xcdf120..0xcdf121]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 196 ArrayType [2]map[string]int
           Locations:
-            - Range: 0xcdf100..0xcdf101
+            - Range: 0xcdf120..0xcdf121
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 70
       Name: main.testPointerToMap
-      OutOfLinePCRanges: [0xcdf120..0xcdf121]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 197 PointerType *map[string]int
-          Locations:
-            - Range: 0xcdf120..0xcdf121
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 71
-      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0xcdf140..0xcdf141]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 171 GoMapType map[int]int
+          Type: 197 PointerType *map[string]int
           Locations:
             - Range: 0xcdf140..0xcdf141
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 72
-      Name: main.testMapMassive
+    - ID: 71
+      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0xcdf160..0xcdf161]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 198 GoMapType map[string][]main.structWithMap
+        - Name: m
+          Type: 171 GoMapType map[int]int
           Locations:
             - Range: 0xcdf160..0xcdf161
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 73
-      Name: main.testMapEmbeddedMaps
+    - ID: 72
+      Name: main.testMapMassive
       OutOfLinePCRanges: [0xcdf180..0xcdf181]
       InlinePCRanges: []
       Variables:
-        - Name: m
+        - Name: redactMyEntries
           Type: 198 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xcdf180..0xcdf181
@@ -7207,38 +7194,38 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 74
-      Name: main.testMapWithLinkedList
+    - ID: 73
+      Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0xcdf1a0..0xcdf1a1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 203 GoMapType map[bool]main.node
+          Type: 198 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xcdf1a0..0xcdf1a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 75
-      Name: main.testMapWithSmallValue
+    - ID: 74
+      Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0xcdf1c0..0xcdf1c1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 208 GoMapType map[int]uint8
+          Type: 203 GoMapType map[bool]main.node
           Locations:
             - Range: 0xcdf1c0..0xcdf1c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 76
-      Name: main.testMapWithSmallValueMassive
+    - ID: 75
+      Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0xcdf1e0..0xcdf1e1]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
+        - Name: m
           Type: 208 GoMapType map[int]uint8
           Locations:
             - Range: 0xcdf1e0..0xcdf1e1
@@ -7246,21 +7233,21 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 77
-      Name: main.testMapWithSmallKeyAndValue
+    - ID: 76
+      Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0xcdf200..0xcdf201]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 213 GoMapType map[uint8]uint8
+        - Name: redactMyEntries
+          Type: 208 GoMapType map[int]uint8
           Locations:
             - Range: 0xcdf200..0xcdf201
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 78
-      Name: main.testMapWithSmallKeyAndValueMassive
+    - ID: 77
+      Name: main.testMapWithSmallKeyAndValue
       OutOfLinePCRanges: [0xcdf220..0xcdf221]
       InlinePCRanges: []
       Variables:
@@ -7272,8 +7259,8 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 79
-      Name: main.testMapSmallKeySmallValue
+    - ID: 78
+      Name: main.testMapWithSmallKeyAndValueMassive
       OutOfLinePCRanges: [0xcdf240..0xcdf241]
       InlinePCRanges: []
       Variables:
@@ -7285,127 +7272,140 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 80
-      Name: main.testMapSmallKeyLargeValue
+    - ID: 79
+      Name: main.testMapSmallKeySmallValue
       OutOfLinePCRanges: [0xcdf260..0xcdf261]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 218 GoMapType map[uint8][4]int
+          Type: 213 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xcdf260..0xcdf261
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 81
-      Name: main.testMapLargeKeySmallValue
+    - ID: 80
+      Name: main.testMapSmallKeyLargeValue
       OutOfLinePCRanges: [0xcdf280..0xcdf281]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 223 GoMapType map[[4]int]uint8
+          Type: 218 GoMapType map[uint8][4]int
           Locations:
             - Range: 0xcdf280..0xcdf281
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 82
-      Name: main.testMapLargeKeyLargeValue
+    - ID: 81
+      Name: main.testMapLargeKeySmallValue
       OutOfLinePCRanges: [0xcdf2a0..0xcdf2a1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 228 GoMapType map[[4]int][4]int
+          Type: 223 GoMapType map[[4]int]uint8
           Locations:
             - Range: 0xcdf2a0..0xcdf2a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 83
-      Name: main.testMapEmptyKey
+    - ID: 82
+      Name: main.testMapLargeKeyLargeValue
       OutOfLinePCRanges: [0xcdf2c0..0xcdf2c1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 233 GoMapType map[struct {}]int
+          Type: 228 GoMapType map[[4]int][4]int
           Locations:
             - Range: 0xcdf2c0..0xcdf2c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 84
-      Name: main.testMapEmptyValue
+    - ID: 83
+      Name: main.testMapEmptyKey
       OutOfLinePCRanges: [0xcdf2e0..0xcdf2e1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 238 GoMapType map[int]struct {}
+          Type: 233 GoMapType map[struct {}]int
           Locations:
             - Range: 0xcdf2e0..0xcdf2e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 85
-      Name: main.testMapEmptyKeyAndValue
+    - ID: 84
+      Name: main.testMapEmptyValue
       OutOfLinePCRanges: [0xcdf300..0xcdf301]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 243 GoMapType map[struct {}]struct {}
+          Type: 238 GoMapType map[int]struct {}
           Locations:
             - Range: 0xcdf300..0xcdf301
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 85
+      Name: main.testMapEmptyKeyAndValue
+      OutOfLinePCRanges: [0xcdf320..0xcdf321]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 243 GoMapType map[struct {}]struct {}
+          Locations:
+            - Range: 0xcdf320..0xcdf321
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 86
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0xce0c00..0xce0c01]
+      OutOfLinePCRanges: [0xce0c20..0xce0c21]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xce0c00..0xce0c01
+            - Range: 0xce0c20..0xce0c21
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xce0c00..0xce0c01
+            - Range: 0xce0c20..0xce0c21
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: "y"
           Type: 19 BaseType float32
           Locations:
-            - Range: 0xce0c00..0xce0c01
+            - Range: 0xce0c20..0xce0c21
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 87
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0xce0c40..0xce0c41]
+      OutOfLinePCRanges: [0xce0c60..0xce0c61]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xce0c40..0xce0c41
+            - Range: 0xce0c60..0xce0c61
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce0c40..0xce0c41
+            - Range: 0xce0c60..0xce0c61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -7416,48 +7416,48 @@ Subprograms:
         - Name: "y"
           Type: 19 BaseType float32
           Locations:
-            - Range: 0xce0c40..0xce0c41
+            - Range: 0xce0c60..0xce0c61
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 88
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0xce0dc0..0xce0dc1]
+      OutOfLinePCRanges: [0xce0de0..0xce0de1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xce0dc0..0xce0dc1
+            - Range: 0xce0de0..0xce0de1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xce0dc0..0xce0dc1
+            - Range: 0xce0de0..0xce0de1
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 11 BaseType int32
           Locations:
-            - Range: 0xce0dc0..0xce0dc1
+            - Range: 0xce0de0..0xce0de1
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 18 BaseType uint
           Locations:
-            - Range: 0xce0dc0..0xce0dc1
+            - Range: 0xce0de0..0xce0de1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce0dc0..0xce0dc1
+            - Range: 0xce0de0..0xce0de1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7468,61 +7468,61 @@ Subprograms:
       DictRegister: null
     - ID: 89
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0xce0fe0..0xce0ff3]
+      OutOfLinePCRanges: [0xce1000..0xce1013]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0xce0fe0..0xce0ff2
+            - Range: 0xce1000..0xce1012
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0xce0fe0..0xce0ff2
+            - Range: 0xce1000..0xce1012
               Pieces: []
-            - Range: 0xce0ff2..0xce0ff3
+            - Range: 0xce1012..0xce1013
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 90
       Name: main.testChannel
-      OutOfLinePCRanges: [0xce1000..0xce1001]
+      OutOfLinePCRanges: [0xce1020..0xce1021]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 248 GoChannelType chan bool
           Locations:
-            - Range: 0xce1000..0xce1001
+            - Range: 0xce1020..0xce1021
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 91
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xce11c0..0xce11c1]
+      OutOfLinePCRanges: [0xce11e0..0xce11e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 249 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xce11c0..0xce11c1
+            - Range: 0xce11e0..0xce11e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 92
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0xce11e0..0xce11e1]
+      OutOfLinePCRanges: [0xce1200..0xce1201]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 251 StructureType main.node
           Locations:
-            - Range: 0xce11e0..0xce11e1
+            - Range: 0xce1200..0xce1201
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7533,273 +7533,273 @@ Subprograms:
       DictRegister: null
     - ID: 93
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xce1200..0xce1201]
+      OutOfLinePCRanges: [0xce1220..0xce1221]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 252 PointerType *main.node
-          Locations:
-            - Range: 0xce1200..0xce1201
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 94
-      Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xce1220..0xce1221]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 15 VoidPointerType unsafe.Pointer
           Locations:
             - Range: 0xce1220..0xce1221
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 94
+      Name: main.testUnsafePointer
+      OutOfLinePCRanges: [0xce1240..0xce1241]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 15 VoidPointerType unsafe.Pointer
+          Locations:
+            - Range: 0xce1240..0xce1241
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 95
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0xce1260..0xce1261]
+      OutOfLinePCRanges: [0xce1280..0xce1281]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 108 PointerType *uint
           Locations:
-            - Range: 0xce1260..0xce1261
+            - Range: 0xce1280..0xce1281
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 96
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0xce1340..0xce1341]
+      OutOfLinePCRanges: [0xce1360..0xce1361]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 96 PointerType *string
           Locations:
-            - Range: 0xce1340..0xce1341
+            - Range: 0xce1360..0xce1361
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 97
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0xce1380..0xce1381]
+      OutOfLinePCRanges: [0xce13a0..0xce13a1]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 12 PointerType *bool
           Locations:
-            - Range: 0xce1380..0xce1381
+            - Range: 0xce13a0..0xce13a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 18 BaseType uint
           Locations:
-            - Range: 0xce1380..0xce1381
+            - Range: 0xce13a0..0xce13a1
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 98
       Name: main.testCycle
-      OutOfLinePCRanges: [0xce13c0..0xce13c1]
+      OutOfLinePCRanges: [0xce13e0..0xce13e1]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 253 PointerType *main.t
           Locations:
-            - Range: 0xce13c0..0xce13c1
+            - Range: 0xce13e0..0xce13e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 99
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0xce1800..0xce1872]
+      OutOfLinePCRanges: [0xce1820..0xce1892]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce1800..0xce1812
+            - Range: 0xce1820..0xce1832
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce1800..0xce185b
+            - Range: 0xce1820..0xce187b
               Pieces: []
-            - Range: 0xce185b..0xce185c
+            - Range: 0xce187b..0xce187c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce185c..0xce1872
+            - Range: 0xce187c..0xce1892
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce1812..0xce1825
+            - Range: 0xce1832..0xce1845
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce1825..0xce1872
+            - Range: 0xce1845..0xce1892
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 100
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0xce1880..0xce190f]
+      OutOfLinePCRanges: [0xce18a0..0xce192f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce1880..0xce189a
+            - Range: 0xce18a0..0xce18ba
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce189a..0xce190f
+            - Range: 0xce18ba..0xce192f
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 100 PointerType *int
           Locations:
-            - Range: 0xce1880..0xce18f4
+            - Range: 0xce18a0..0xce1914
               Pieces: []
-            - Range: 0xce18f4..0xce18f5
+            - Range: 0xce1914..0xce1915
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce18f5..0xce190f
+            - Range: 0xce1915..0xce192f
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: '&result'
           Type: 100 PointerType *int
           Locations:
-            - Range: 0xce189f..0xce18b9
+            - Range: 0xce18bf..0xce18d9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce18b9..0xce190f
+            - Range: 0xce18d9..0xce192f
               Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 101
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0xce1920..0xce19fe]
+      OutOfLinePCRanges: [0xce1940..0xce1a1e]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce1920..0xce1982
+            - Range: 0xce1940..0xce19a2
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce1920..0xce19e4
+            - Range: 0xce1940..0xce1a04
               Pieces: []
-            - Range: 0xce19e4..0xce19e5
+            - Range: 0xce1a04..0xce1a05
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce19e5..0xce19fe
+            - Range: 0xce1a05..0xce1a1e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce1920..0xce19fe, Pieces: []}]
+          Locations: [{Range: 0xce1940..0xce1a1e, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: resultInt
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce1936..0xce1987
+            - Range: 0xce1956..0xce19a7
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce1987..0xce19fe
+            - Range: 0xce19a7..0xce1a1e
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
           Role: Local
           DictIndex: -1
         - Name: resultFloat
           Type: 16 BaseType float64
           Locations:
-            - Range: 0xce194f..0xce1987
+            - Range: 0xce196f..0xce19a7
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
-            - Range: 0xce1987..0xce19fe
+            - Range: 0xce19a7..0xce1a1e
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 102
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0xce1a00..0xce1a5b]
+      OutOfLinePCRanges: [0xce1a20..0xce1a7b]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xce1a00..0xce1a19
+            - Range: 0xce1a20..0xce1a39
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0xce1a00..0xce1a3a
+            - Range: 0xce1a20..0xce1a5a
               Pieces: []
-            - Range: 0xce1a3a..0xce1a3b
+            - Range: 0xce1a5a..0xce1a5b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce1a3b..0xce1a45
+            - Range: 0xce1a5b..0xce1a65
               Pieces: []
-            - Range: 0xce1a45..0xce1a46
+            - Range: 0xce1a65..0xce1a66
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce1a46..0xce1a5b
+            - Range: 0xce1a66..0xce1a7b
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 103
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0xce1a60..0xce1ba6]
+      OutOfLinePCRanges: [0xce1a80..0xce1bc6]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 162 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xce1a60..0xce1aab
+            - Range: 0xce1a80..0xce1acb
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce1aab..0xce1ab6
+            - Range: 0xce1acb..0xce1ad6
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce1ae7..0xce1aea
+            - Range: 0xce1b07..0xce1b0a
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce1b20..0xce1b25
+            - Range: 0xce1b40..0xce1b45
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce1b54..0xce1b59
+            - Range: 0xce1b74..0xce1b79
               Pieces:
                 - Size: 8
                   Op: null
@@ -7810,117 +7810,117 @@ Subprograms:
         - Name: failed
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xce1a60..0xce1aa3
+            - Range: 0xce1a80..0xce1ac3
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 162 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xce1a60..0xce1ac4
+            - Range: 0xce1a80..0xce1ae4
               Pieces: []
-            - Range: 0xce1ac4..0xce1ac5
+            - Range: 0xce1ae4..0xce1ae5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce1ac5..0xce1b13
+            - Range: 0xce1ae5..0xce1b33
               Pieces: []
-            - Range: 0xce1b13..0xce1b14
+            - Range: 0xce1b33..0xce1b34
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce1b14..0xce1b47
+            - Range: 0xce1b34..0xce1b67
               Pieces: []
-            - Range: 0xce1b47..0xce1b48
+            - Range: 0xce1b67..0xce1b68
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce1b48..0xce1b79
+            - Range: 0xce1b68..0xce1b99
               Pieces: []
-            - Range: 0xce1b79..0xce1b7a
+            - Range: 0xce1b99..0xce1b9a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce1b7a..0xce1ba6
+            - Range: 0xce1b9a..0xce1bc6
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0xce1a60..0xce1ac4
+            - Range: 0xce1a80..0xce1ae4
               Pieces: []
-            - Range: 0xce1ac4..0xce1ac5
+            - Range: 0xce1ae4..0xce1ae5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce1ac5..0xce1b13
+            - Range: 0xce1ae5..0xce1b33
               Pieces: []
-            - Range: 0xce1b13..0xce1b14
+            - Range: 0xce1b33..0xce1b34
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce1b14..0xce1b47
+            - Range: 0xce1b34..0xce1b67
               Pieces: []
-            - Range: 0xce1b47..0xce1b48
+            - Range: 0xce1b67..0xce1b68
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce1b48..0xce1b79
+            - Range: 0xce1b68..0xce1b99
               Pieces: []
-            - Range: 0xce1b79..0xce1b7a
+            - Range: 0xce1b99..0xce1b9a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce1b7a..0xce1ba6
+            - Range: 0xce1b9a..0xce1bc6
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce1aab..0xce1ab1
+            - Range: 0xce1acb..0xce1ad1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 104
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0xce1bc0..0xce1dae]
+      OutOfLinePCRanges: [0xce1be0..0xce1dce]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 162 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xce1bc0..0xce1c0b
+            - Range: 0xce1be0..0xce1c2b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce1c0b..0xce1c12
+            - Range: 0xce1c2b..0xce1c32
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xce1c12..0xce1dae
+            - Range: 0xce1c32..0xce1dce
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -7931,1128 +7931,1128 @@ Subprograms:
         - Name: ~r0
           Type: 162 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xce1bc0..0xce1c75
+            - Range: 0xce1be0..0xce1c95
               Pieces: []
-            - Range: 0xce1c75..0xce1c76
+            - Range: 0xce1c95..0xce1c96
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce1c76..0xce1cc4
+            - Range: 0xce1c96..0xce1ce4
               Pieces: []
-            - Range: 0xce1cc4..0xce1cc5
+            - Range: 0xce1ce4..0xce1ce5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce1cc5..0xce1d80
+            - Range: 0xce1ce5..0xce1da0
               Pieces: []
-            - Range: 0xce1d80..0xce1d81
+            - Range: 0xce1da0..0xce1da1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce1d81..0xce1d8a
+            - Range: 0xce1da1..0xce1daa
               Pieces: []
-            - Range: 0xce1d8a..0xce1d8b
+            - Range: 0xce1daa..0xce1dab
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce1d8b..0xce1dae
+            - Range: 0xce1dab..0xce1dce
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce1c60..0xce1c66
+            - Range: 0xce1c80..0xce1c86
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: '&result'
           Type: 100 PointerType *int
           Locations:
-            - Range: 0xce1ca5..0xce1cc4
+            - Range: 0xce1cc5..0xce1ce4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 105
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0xce1dc0..0xce1f14]
+      OutOfLinePCRanges: [0xce1de0..0xce1f34]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 162 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xce1dc0..0xce1e00
+            - Range: 0xce1de0..0xce1e20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce1e00..0xce1e4e
+            - Range: 0xce1e20..0xce1e6e
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xce1e4e..0xce1eaf
+            - Range: 0xce1e6e..0xce1ecf
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xce1eaf..0xce1ed1
+            - Range: 0xce1ecf..0xce1ef1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xce1ed1..0xce1ed8
+            - Range: 0xce1ef1..0xce1ef8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xce1ed8..0xce1f14
+            - Range: 0xce1ef8..0xce1f34
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 167 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xce1dc0..0xce1e9f
+            - Range: 0xce1de0..0xce1ebf
               Pieces: []
-            - Range: 0xce1e9f..0xce1ea0
+            - Range: 0xce1ebf..0xce1ec0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce1ea0..0xce1ea9
+            - Range: 0xce1ec0..0xce1ec9
               Pieces: []
-            - Range: 0xce1ea9..0xce1eaa
+            - Range: 0xce1ec9..0xce1eca
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce1eaa..0xce1f14
+            - Range: 0xce1eca..0xce1f34
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 167 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xce1dc0..0xce1e00
+            - Range: 0xce1de0..0xce1e20
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce1e00..0xce1e4e
+            - Range: 0xce1e20..0xce1e6e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xce1e4e..0xce1e55
+            - Range: 0xce1e6e..0xce1e75
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xce1e55..0xce1ea5
+            - Range: 0xce1e75..0xce1ec5
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xce1ea5..0xce1ea7
+            - Range: 0xce1ec5..0xce1ec7
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xce1ea7..0xce1ea9
+            - Range: 0xce1ec7..0xce1ec9
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xce1ea9..0xce1f14
+            - Range: 0xce1ec9..0xce1f34
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 106
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0xce1f20..0xce1faf]
+      OutOfLinePCRanges: [0xce1f40..0xce1fcf]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce1f20..0xce1f31
+            - Range: 0xce1f40..0xce1f51
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce1f20..0xce1f95
+            - Range: 0xce1f40..0xce1fb5
               Pieces: []
-            - Range: 0xce1f95..0xce1f96
+            - Range: 0xce1fb5..0xce1fb6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce1f96..0xce1faf
+            - Range: 0xce1fb6..0xce1fcf
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 107
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0xce1fc0..0xce2089]
+      OutOfLinePCRanges: [0xce1fe0..0xce20a9]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce1fc0..0xce2011
+            - Range: 0xce1fe0..0xce2031
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce1fc0..0xce206f
+            - Range: 0xce1fe0..0xce208f
               Pieces: []
-            - Range: 0xce206f..0xce2070
+            - Range: 0xce208f..0xce2090
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce2070..0xce2089
+            - Range: 0xce2090..0xce20a9
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce1fc0..0xce206f
+            - Range: 0xce1fe0..0xce208f
               Pieces: []
-            - Range: 0xce206f..0xce2070
+            - Range: 0xce208f..0xce2090
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce2070..0xce2089
+            - Range: 0xce2090..0xce20a9
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 108
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0xce20a0..0xce2167]
+      OutOfLinePCRanges: [0xce20c0..0xce2187]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce20a0..0xce20e5
+            - Range: 0xce20c0..0xce2105
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce20e5..0xce2167
+            - Range: 0xce2105..0xce2187
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce20a0..0xce214d
+            - Range: 0xce20c0..0xce216d
               Pieces: []
-            - Range: 0xce214d..0xce214e
+            - Range: 0xce216d..0xce216e
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce214e..0xce2167
+            - Range: 0xce216e..0xce2187
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce20a0..0xce214d
+            - Range: 0xce20c0..0xce216d
               Pieces: []
-            - Range: 0xce214d..0xce214e
+            - Range: 0xce216d..0xce216e
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce214e..0xce2167
+            - Range: 0xce216e..0xce2187
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce20a0..0xce214d
+            - Range: 0xce20c0..0xce216d
               Pieces: []
-            - Range: 0xce214d..0xce214e
+            - Range: 0xce216d..0xce216e
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce214e..0xce2167
+            - Range: 0xce216e..0xce2187
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 109
       Name: main.testConflictingReturn
-      OutOfLinePCRanges: [0xce2180..0xce226f]
+      OutOfLinePCRanges: [0xce21a0..0xce228f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce2180..0xce21c5
+            - Range: 0xce21a0..0xce21e5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce21c5..0xce226f
+            - Range: 0xce21e5..0xce228f
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce2180..0xce2251
+            - Range: 0xce21a0..0xce2271
               Pieces: []
-            - Range: 0xce2251..0xce2252
+            - Range: 0xce2271..0xce2272
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce2252..0xce226f
+            - Range: 0xce2272..0xce228f
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce2180..0xce2251
+            - Range: 0xce21a0..0xce2271
               Pieces: []
-            - Range: 0xce2251..0xce2252
+            - Range: 0xce2271..0xce2272
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce2252..0xce226f
+            - Range: 0xce2272..0xce228f
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 110
       Name: main.testReturnsNamedDeferLine
-      OutOfLinePCRanges: [0xce2280..0xce248f]
+      OutOfLinePCRanges: [0xce22a0..0xce24af]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce2280..0xce2306
+            - Range: 0xce22a0..0xce2326
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce2306..0xce248f
+            - Range: 0xce2326..0xce24af
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce22b7..0xce248f
+            - Range: 0xce22d7..0xce24af
               Pieces: [{Size: 16, Op: {CfaOffset: -128}}]
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce22bd..0xce248f
+            - Range: 0xce22dd..0xce24af
               Pieces: [{Size: 16, Op: {CfaOffset: -144}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 111
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0xce2580..0xce25fe]
+      OutOfLinePCRanges: [0xce25a0..0xce261e]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType int8
           Locations:
-            - Range: 0xce2580..0xce25f1
+            - Range: 0xce25a0..0xce2611
               Pieces: []
-            - Range: 0xce25f1..0xce25f2
+            - Range: 0xce2611..0xce2612
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce25f2..0xce25fe
+            - Range: 0xce2612..0xce261e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 105 BaseType int16
           Locations:
-            - Range: 0xce2580..0xce25f1
+            - Range: 0xce25a0..0xce2611
               Pieces: []
-            - Range: 0xce25f1..0xce25f2
+            - Range: 0xce2611..0xce2612
               Pieces: [{Size: 2, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce25f2..0xce25fe
+            - Range: 0xce2612..0xce261e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 11 BaseType int32
           Locations:
-            - Range: 0xce2580..0xce25f1
+            - Range: 0xce25a0..0xce2611
               Pieces: []
-            - Range: 0xce25f1..0xce25f2
+            - Range: 0xce2611..0xce2612
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce25f2..0xce25fe
+            - Range: 0xce2612..0xce261e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 13 BaseType int64
           Locations:
-            - Range: 0xce2580..0xce25f1
+            - Range: 0xce25a0..0xce2611
               Pieces: []
-            - Range: 0xce25f1..0xce25f2
+            - Range: 0xce2611..0xce2612
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xce25f2..0xce25fe
+            - Range: 0xce2612..0xce261e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xce2580..0xce25f1
+            - Range: 0xce25a0..0xce2611
               Pieces: []
-            - Range: 0xce25f1..0xce25f2
+            - Range: 0xce2611..0xce2612
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xce25f2..0xce25fe
+            - Range: 0xce2612..0xce261e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 7 BaseType uint16
           Locations:
-            - Range: 0xce2580..0xce25f1
+            - Range: 0xce25a0..0xce2611
               Pieces: []
-            - Range: 0xce25f1..0xce25f2
+            - Range: 0xce2611..0xce2612
               Pieces: [{Size: 2, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xce25f2..0xce25fe
+            - Range: 0xce2612..0xce261e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 3 BaseType uint32
           Locations:
-            - Range: 0xce2580..0xce25f1
+            - Range: 0xce25a0..0xce2611
               Pieces: []
-            - Range: 0xce25f1..0xce25f2
+            - Range: 0xce2611..0xce2612
               Pieces: [{Size: 4, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xce25f2..0xce25fe
+            - Range: 0xce2612..0xce261e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0xce2580..0xce25f1
+            - Range: 0xce25a0..0xce2611
               Pieces: []
-            - Range: 0xce25f1..0xce25f2
+            - Range: 0xce2611..0xce2612
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xce25f2..0xce25fe
+            - Range: 0xce2612..0xce261e
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 112
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0xce2600..0xce26f7]
+      OutOfLinePCRanges: [0xce2620..0xce2717]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce2600..0xce26f7, Pieces: []}]
+          Locations: [{Range: 0xce2620..0xce2717, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce2600..0xce26f7, Pieces: []}]
+          Locations: [{Range: 0xce2620..0xce2717, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce2600..0xce26f7, Pieces: []}]
+          Locations: [{Range: 0xce2620..0xce2717, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce2600..0xce26f7, Pieces: []}]
+          Locations: [{Range: 0xce2620..0xce2717, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce2600..0xce26f7, Pieces: []}]
+          Locations: [{Range: 0xce2620..0xce2717, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce2600..0xce26f7, Pieces: []}]
+          Locations: [{Range: 0xce2620..0xce2717, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce2600..0xce26f7, Pieces: []}]
+          Locations: [{Range: 0xce2620..0xce2717, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce2600..0xce26f7, Pieces: []}]
+          Locations: [{Range: 0xce2620..0xce2717, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce2600..0xce26f7, Pieces: []}]
+          Locations: [{Range: 0xce2620..0xce2717, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r9
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce2600..0xce26f7, Pieces: []}]
+          Locations: [{Range: 0xce2620..0xce2717, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r10
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce2600..0xce26f7, Pieces: []}]
+          Locations: [{Range: 0xce2620..0xce2717, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r11
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce2600..0xce26f7, Pieces: []}]
+          Locations: [{Range: 0xce2620..0xce2717, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r12
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce2600..0xce26f7, Pieces: []}]
+          Locations: [{Range: 0xce2620..0xce2717, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r13
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce2600..0xce26f7, Pieces: []}]
+          Locations: [{Range: 0xce2620..0xce2717, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r14
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce2600..0xce26f7, Pieces: []}]
+          Locations: [{Range: 0xce2620..0xce2717, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: onlyOnAmd64_16
           Type: 16 BaseType float64
           Locations:
-            - Range: 0xce2600..0xce26e7
+            - Range: 0xce2620..0xce2707
               Pieces: []
-            - Range: 0xce26e7..0xce26e8
+            - Range: 0xce2707..0xce2708
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xce26e8..0xce26f7
+            - Range: 0xce2708..0xce2717
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: bothArmAndAmd64
           Type: 16 BaseType float64
           Locations:
-            - Range: 0xce2600..0xce26e7
+            - Range: 0xce2620..0xce2707
               Pieces: []
-            - Range: 0xce26e7..0xce26e8
+            - Range: 0xce2707..0xce2708
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xce26e8..0xce26f7
+            - Range: 0xce2708..0xce2717
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 113
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0xce2700..0xce2773]
+      OutOfLinePCRanges: [0xce2720..0xce2793]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 97 BaseType complex64
-          Locations: [{Range: 0xce2700..0xce2773, Pieces: []}]
+          Locations: [{Range: 0xce2720..0xce2793, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 98 BaseType complex128
-          Locations: [{Range: 0xce2700..0xce2773, Pieces: []}]
+          Locations: [{Range: 0xce2720..0xce2793, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 114
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0xce2780..0xce2825]
+      OutOfLinePCRanges: [0xce27a0..0xce2845]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 255 StructureType main.largeStruct
           Locations:
-            - Range: 0xce2780..0xce2813
+            - Range: 0xce27a0..0xce2833
               Pieces: []
-            - Range: 0xce2813..0xce2814
+            - Range: 0xce2833..0xce2834
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
-            - Range: 0xce2814..0xce2825
+            - Range: 0xce2834..0xce2845
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 115
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0xce2840..0xce28ba]
+      OutOfLinePCRanges: [0xce2860..0xce28da]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 256 ArrayType [3]int
           Locations:
-            - Range: 0xce2840..0xce28ad
+            - Range: 0xce2860..0xce28cd
               Pieces: []
-            - Range: 0xce28ad..0xce28ae
+            - Range: 0xce28cd..0xce28ce
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xce28ae..0xce28ba
+            - Range: 0xce28ce..0xce28da
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 116
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0xce28c0..0xce2918]
+      OutOfLinePCRanges: [0xce28e0..0xce2938]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 257 ArrayType [1]int
           Locations:
-            - Range: 0xce28c0..0xce290b
+            - Range: 0xce28e0..0xce292b
               Pieces: []
-            - Range: 0xce290b..0xce290c
+            - Range: 0xce292b..0xce292c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce290c..0xce2918
+            - Range: 0xce292c..0xce2938
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 117
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0xce2920..0xce2973]
+      OutOfLinePCRanges: [0xce2940..0xce2993]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 258 ArrayType [0]int
           Locations:
-            - Range: 0xce2920..0xce2966
+            - Range: 0xce2940..0xce2986
               Pieces: []
-            - Range: 0xce2966..0xce2967
+            - Range: 0xce2986..0xce2987
               Pieces: []
-            - Range: 0xce2967..0xce2973
+            - Range: 0xce2987..0xce2993
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 118
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0xce2980..0xce29e7]
+      OutOfLinePCRanges: [0xce29a0..0xce2a07]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 259 StructureType main.mixedStruct
-          Locations: [{Range: 0xce2980..0xce29e7, Pieces: []}]
+          Locations: [{Range: 0xce29a0..0xce2a07, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 119
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0xce2a00..0xce2a9a]
+      OutOfLinePCRanges: [0xce2a20..0xce2aba]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce2a00..0xce2a8a
+            - Range: 0xce2a20..0xce2aaa
               Pieces: []
-            - Range: 0xce2a8a..0xce2a8b
+            - Range: 0xce2aaa..0xce2aab
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce2a8b..0xce2a9a
+            - Range: 0xce2aab..0xce2aba
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce2a00..0xce2a8a
+            - Range: 0xce2a20..0xce2aaa
               Pieces: []
-            - Range: 0xce2a8a..0xce2a8b
+            - Range: 0xce2aaa..0xce2aab
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce2a8b..0xce2a9a
+            - Range: 0xce2aab..0xce2aba
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce2a00..0xce2a8a
+            - Range: 0xce2a20..0xce2aaa
               Pieces: []
-            - Range: 0xce2a8a..0xce2a8b
+            - Range: 0xce2aaa..0xce2aab
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce2a8b..0xce2a9a
+            - Range: 0xce2aab..0xce2aba
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce2a00..0xce2a8a
+            - Range: 0xce2a20..0xce2aaa
               Pieces: []
-            - Range: 0xce2a8a..0xce2a8b
+            - Range: 0xce2aaa..0xce2aab
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xce2a8b..0xce2a9a
+            - Range: 0xce2aab..0xce2aba
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce2a00..0xce2a8a
+            - Range: 0xce2a20..0xce2aaa
               Pieces: []
-            - Range: 0xce2a8a..0xce2a8b
+            - Range: 0xce2aaa..0xce2aab
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xce2a8b..0xce2a9a
+            - Range: 0xce2aab..0xce2aba
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce2a00..0xce2a8a
+            - Range: 0xce2a20..0xce2aaa
               Pieces: []
-            - Range: 0xce2a8a..0xce2a8b
+            - Range: 0xce2aaa..0xce2aab
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xce2a8b..0xce2a9a
+            - Range: 0xce2aab..0xce2aba
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce2a00..0xce2a8a
+            - Range: 0xce2a20..0xce2aaa
               Pieces: []
-            - Range: 0xce2a8a..0xce2a8b
+            - Range: 0xce2aaa..0xce2aab
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xce2a8b..0xce2a9a
+            - Range: 0xce2aab..0xce2aba
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce2a00..0xce2a8a
+            - Range: 0xce2a20..0xce2aaa
               Pieces: []
-            - Range: 0xce2a8a..0xce2a8b
+            - Range: 0xce2aaa..0xce2aab
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xce2a8b..0xce2a9a
+            - Range: 0xce2aab..0xce2aba
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce2a00..0xce2a8a
+            - Range: 0xce2a20..0xce2aaa
               Pieces: []
-            - Range: 0xce2a8a..0xce2a8b
+            - Range: 0xce2aaa..0xce2aab
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xce2a8b..0xce2a9a
+            - Range: 0xce2aab..0xce2aba
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 120
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0xce2aa0..0xce2b45]
+      OutOfLinePCRanges: [0xce2ac0..0xce2b65]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 260 StructureType main.wideStruct
           Locations:
-            - Range: 0xce2aa0..0xce2b34
+            - Range: 0xce2ac0..0xce2b54
               Pieces: []
-            - Range: 0xce2b34..0xce2b35
+            - Range: 0xce2b54..0xce2b55
               Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
-            - Range: 0xce2b35..0xce2b45
+            - Range: 0xce2b55..0xce2b65
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 121
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0xce2b60..0xce2bd9]
+      OutOfLinePCRanges: [0xce2b80..0xce2bf9]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce2b60..0xce2bcc
+            - Range: 0xce2b80..0xce2bec
               Pieces: []
-            - Range: 0xce2bcc..0xce2bcd
+            - Range: 0xce2bec..0xce2bed
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce2bcd..0xce2bd9
+            - Range: 0xce2bed..0xce2bf9
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce2b60..0xce2bd9, Pieces: []}]
+          Locations: [{Range: 0xce2b80..0xce2bf9, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce2b60..0xce2bcc
+            - Range: 0xce2b80..0xce2bec
               Pieces: []
-            - Range: 0xce2bcc..0xce2bcd
+            - Range: 0xce2bec..0xce2bed
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce2bcd..0xce2bd9
+            - Range: 0xce2bed..0xce2bf9
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce2b60..0xce2bd9, Pieces: []}]
+          Locations: [{Range: 0xce2b80..0xce2bf9, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce2b60..0xce2bcc
+            - Range: 0xce2b80..0xce2bec
               Pieces: []
-            - Range: 0xce2bcc..0xce2bcd
+            - Range: 0xce2bec..0xce2bed
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce2bcd..0xce2bd9
+            - Range: 0xce2bed..0xce2bf9
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 122
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0xce2be0..0xce2c5a]
+      OutOfLinePCRanges: [0xce2c00..0xce2c7a]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 261 StructureType main.structWithArray
           Locations:
-            - Range: 0xce2be0..0xce2c4d
+            - Range: 0xce2c00..0xce2c6d
               Pieces: []
-            - Range: 0xce2c4d..0xce2c4e
+            - Range: 0xce2c6d..0xce2c6e
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xce2c4e..0xce2c5a
+            - Range: 0xce2c6e..0xce2c7a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 123
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0xce2c60..0xce2cbb]
+      OutOfLinePCRanges: [0xce2c80..0xce2cdb]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce2c60..0xce2cbb, Pieces: []}]
+          Locations: [{Range: 0xce2c80..0xce2cdb, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 124
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0xce2cc0..0xce2d27]
+      OutOfLinePCRanges: [0xce2ce0..0xce2d47]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 19 BaseType float32
-          Locations: [{Range: 0xce2cc0..0xce2d27, Pieces: []}]
+          Locations: [{Range: 0xce2ce0..0xce2d47, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 16 BaseType float64
-          Locations: [{Range: 0xce2cc0..0xce2d27, Pieces: []}]
+          Locations: [{Range: 0xce2ce0..0xce2d47, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 125
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0xce2d40..0xce2d9d]
+      OutOfLinePCRanges: [0xce2d60..0xce2dbd]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xce2d40..0xce2d90
+            - Range: 0xce2d60..0xce2db0
               Pieces: []
-            - Range: 0xce2d90..0xce2d91
+            - Range: 0xce2db0..0xce2db1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce2d91..0xce2d9d
+            - Range: 0xce2db1..0xce2dbd
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 2 BaseType uintptr
           Locations:
-            - Range: 0xce2d40..0xce2d90
+            - Range: 0xce2d60..0xce2db0
               Pieces: []
-            - Range: 0xce2d90..0xce2d91
+            - Range: 0xce2db0..0xce2db1
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce2d91..0xce2d9d
+            - Range: 0xce2db1..0xce2dbd
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 126
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0xce2da0..0xce2f25]
+      OutOfLinePCRanges: [0xce2dc0..0xce2f45]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 255 StructureType main.largeStruct
           Locations:
-            - Range: 0xce2da0..0xce2f25
+            - Range: 0xce2dc0..0xce2f45
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 255 StructureType main.largeStruct
           Locations:
-            - Range: 0xce2da0..0xce2f13
+            - Range: 0xce2dc0..0xce2f33
               Pieces: []
-            - Range: 0xce2f13..0xce2f14
+            - Range: 0xce2f33..0xce2f34
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
-            - Range: 0xce2f14..0xce2f25
+            - Range: 0xce2f34..0xce2f45
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 127
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0xce2f40..0xce3012]
+      OutOfLinePCRanges: [0xce2f60..0xce3032]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 256 ArrayType [3]int
           Locations:
-            - Range: 0xce2f40..0xce3012
+            - Range: 0xce2f60..0xce3032
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 256 ArrayType [3]int
           Locations:
-            - Range: 0xce2f40..0xce3002
+            - Range: 0xce2f60..0xce3022
               Pieces: []
-            - Range: 0xce3002..0xce3003
+            - Range: 0xce3022..0xce3023
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xce3003..0xce3012
+            - Range: 0xce3023..0xce3032
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 128
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0xce3020..0xce325a]
+      OutOfLinePCRanges: [0xce3040..0xce327a]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 255 StructureType main.largeStruct
           Locations:
-            - Range: 0xce3020..0xce325a
+            - Range: 0xce3040..0xce327a
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s2
           Type: 255 StructureType main.largeStruct
           Locations:
-            - Range: 0xce3020..0xce325a
+            - Range: 0xce3040..0xce327a
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 255 StructureType main.largeStruct
           Locations:
-            - Range: 0xce3020..0xce324a
+            - Range: 0xce3040..0xce326a
               Pieces: []
-            - Range: 0xce324a..0xce324b
+            - Range: 0xce326a..0xce326b
               Pieces: [{Size: 80, Op: {CfaOffset: 160}}]
-            - Range: 0xce324b..0xce325a
+            - Range: 0xce326b..0xce327a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 129
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0xce3260..0xce34ef]
+      OutOfLinePCRanges: [0xce3280..0xce350f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce3260..0xce3310
+            - Range: 0xce3280..0xce3330
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce3310..0xce34ef
+            - Range: 0xce3330..0xce350f
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce3260..0xce3310
+            - Range: 0xce3280..0xce3330
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce3310..0xce34ef
+            - Range: 0xce3330..0xce350f
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce3260..0xce32fa
+            - Range: 0xce3280..0xce331a
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce32fa..0xce34ef
+            - Range: 0xce331a..0xce350f
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce3260..0xce32d0
+            - Range: 0xce3280..0xce32f0
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xce32d0..0xce34ef
+            - Range: 0xce32f0..0xce350f
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce3260..0xce3310
+            - Range: 0xce3280..0xce3330
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xce3310..0xce34ef
+            - Range: 0xce3330..0xce350f
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce3260..0xce3310
+            - Range: 0xce3280..0xce3330
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xce3310..0xce34ef
+            - Range: 0xce3330..0xce350f
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce3260..0xce3310
+            - Range: 0xce3280..0xce3330
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xce3310..0xce34ef
+            - Range: 0xce3330..0xce350f
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce3260..0xce3310
+            - Range: 0xce3280..0xce3330
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xce3310..0xce34ef
+            - Range: 0xce3330..0xce350f
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce3260..0xce3310
+            - Range: 0xce3280..0xce3330
               Pieces: [{Size: 8, Op: {RegNo: 11, Shift: 0}}]
-            - Range: 0xce3310..0xce34ef
+            - Range: 0xce3330..0xce350f
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 114 ArrayType [2]int
           Locations:
-            - Range: 0xce3260..0xce3482
+            - Range: 0xce3280..0xce34a2
               Pieces: []
-            - Range: 0xce3482..0xce3483
+            - Range: 0xce34a2..0xce34a3
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xce3483..0xce34ef
+            - Range: 0xce34a3..0xce350f
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 130
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0xce3500..0xce37cc]
+      OutOfLinePCRanges: [0xce3520..0xce37ec]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce3500..0xce35ab
+            - Range: 0xce3520..0xce35cb
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce35ab..0xce37cc
+            - Range: 0xce35cb..0xce37ec
               Pieces: [{Size: 8, Op: {CfaOffset: 96}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce3500..0xce35ab
+            - Range: 0xce3520..0xce35cb
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce35ab..0xce37cc
+            - Range: 0xce35cb..0xce37ec
               Pieces: [{Size: 8, Op: {CfaOffset: 104}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce3500..0xce3595
+            - Range: 0xce3520..0xce35b5
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce3595..0xce37cc
+            - Range: 0xce35b5..0xce37ec
               Pieces: [{Size: 8, Op: {CfaOffset: 112}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce3500..0xce3562
+            - Range: 0xce3520..0xce3582
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xce3562..0xce37cc
+            - Range: 0xce3582..0xce37ec
               Pieces: [{Size: 8, Op: {CfaOffset: 120}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce3500..0xce35ab
+            - Range: 0xce3520..0xce35cb
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xce35ab..0xce37cc
+            - Range: 0xce35cb..0xce37ec
               Pieces: [{Size: 8, Op: {CfaOffset: 128}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce3500..0xce35ab
+            - Range: 0xce3520..0xce35cb
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xce35ab..0xce37cc
+            - Range: 0xce35cb..0xce37ec
               Pieces: [{Size: 8, Op: {CfaOffset: 136}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce3500..0xce35ab
+            - Range: 0xce3520..0xce35cb
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xce35ab..0xce37cc
+            - Range: 0xce35cb..0xce37ec
               Pieces: [{Size: 8, Op: {CfaOffset: 144}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce3500..0xce35ab
+            - Range: 0xce3520..0xce35cb
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xce35ab..0xce37cc
+            - Range: 0xce35cb..0xce37ec
               Pieces: [{Size: 8, Op: {CfaOffset: 152}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce3500..0xce37cc
+            - Range: 0xce3520..0xce37ec
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -9063,212 +9063,193 @@ Subprograms:
         - Name: ~r0
           Type: 255 StructureType main.largeStruct
           Locations:
-            - Range: 0xce3500..0xce374b
+            - Range: 0xce3520..0xce376b
               Pieces: []
-            - Range: 0xce374b..0xce374c
+            - Range: 0xce376b..0xce376c
               Pieces: [{Size: 80, Op: {CfaOffset: 16}}]
-            - Range: 0xce374c..0xce37cc
+            - Range: 0xce376c..0xce37ec
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 131
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0xce37e0..0xce386c]
+      OutOfLinePCRanges: [0xce3800..0xce388c]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 166 ArrayType [5]int
           Locations:
-            - Range: 0xce37e0..0xce386c
+            - Range: 0xce3800..0xce388c
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce37e0..0xce385c
+            - Range: 0xce3800..0xce387c
               Pieces: []
-            - Range: 0xce385c..0xce385d
+            - Range: 0xce387c..0xce387d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce385d..0xce386c
+            - Range: 0xce387d..0xce388c
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce37e0..0xce385c
+            - Range: 0xce3800..0xce387c
               Pieces: []
-            - Range: 0xce385c..0xce385d
+            - Range: 0xce387c..0xce387d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce385d..0xce386c
+            - Range: 0xce387d..0xce388c
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce37e0..0xce385c
+            - Range: 0xce3800..0xce387c
               Pieces: []
-            - Range: 0xce385c..0xce385d
+            - Range: 0xce387c..0xce387d
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce385d..0xce386c
+            - Range: 0xce387d..0xce388c
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 132
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0xce3880..0xce396f]
+      OutOfLinePCRanges: [0xce38a0..0xce398f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 114 ArrayType [2]int
           Locations:
-            - Range: 0xce3880..0xce396f
+            - Range: 0xce38a0..0xce398f
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 256 ArrayType [3]int
           Locations:
-            - Range: 0xce3880..0xce396f
+            - Range: 0xce38a0..0xce398f
               Pieces: [{Size: 24, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce3880..0xce395f
+            - Range: 0xce38a0..0xce397f
               Pieces: []
-            - Range: 0xce395f..0xce3960
+            - Range: 0xce397f..0xce3980
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce3960..0xce396f
+            - Range: 0xce3980..0xce398f
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 114 ArrayType [2]int
           Locations:
-            - Range: 0xce3880..0xce395f
+            - Range: 0xce38a0..0xce397f
               Pieces: []
-            - Range: 0xce395f..0xce3960
+            - Range: 0xce397f..0xce3980
               Pieces: [{Size: 16, Op: {CfaOffset: 40}}]
-            - Range: 0xce3960..0xce396f
+            - Range: 0xce3980..0xce398f
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 133
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0xce3980..0xce3a4c]
+      OutOfLinePCRanges: [0xce39a0..0xce3a6c]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 261 StructureType main.structWithArray
           Locations:
-            - Range: 0xce3980..0xce3a4c
+            - Range: 0xce39a0..0xce3a6c
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce3980..0xce3a3c
+            - Range: 0xce39a0..0xce3a5c
               Pieces: []
-            - Range: 0xce3a3c..0xce3a3d
+            - Range: 0xce3a5c..0xce3a5d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce3a3d..0xce3a4c
+            - Range: 0xce3a5d..0xce3a6c
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 261 StructureType main.structWithArray
           Locations:
-            - Range: 0xce3980..0xce3a3c
+            - Range: 0xce39a0..0xce3a5c
               Pieces: []
-            - Range: 0xce3a3c..0xce3a3d
+            - Range: 0xce3a5c..0xce3a5d
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xce3a3d..0xce3a4c
+            - Range: 0xce3a5d..0xce3a6c
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce3a06..0xce3a4c
+            - Range: 0xce3a26..0xce3a6c
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 134
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0xce3a60..0xce3b06]
+      OutOfLinePCRanges: [0xce3a80..0xce3b26]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 258 ArrayType [0]int
-          Locations: [{Range: 0xce3a60..0xce3b06, Pieces: []}]
+          Locations: [{Range: 0xce3a80..0xce3b26, Pieces: []}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce3a60..0xce3aa5
+            - Range: 0xce3a80..0xce3ac5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce3aa5..0xce3ac7
+            - Range: 0xce3ac5..0xce3ae7
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xce3ac7..0xce3ada
+            - Range: 0xce3ae7..0xce3afa
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xce3ada..0xce3b06
+            - Range: 0xce3afa..0xce3b26
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xce3a60..0xce3aec
+            - Range: 0xce3a80..0xce3b0c
               Pieces: []
-            - Range: 0xce3aec..0xce3aed
+            - Range: 0xce3b0c..0xce3b0d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce3aed..0xce3b06
+            - Range: 0xce3b0d..0xce3b26
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 258 ArrayType [0]int
           Locations:
-            - Range: 0xce3a60..0xce3aec
+            - Range: 0xce3a80..0xce3b0c
               Pieces: []
-            - Range: 0xce3aec..0xce3aed
+            - Range: 0xce3b0c..0xce3b0d
               Pieces: []
-            - Range: 0xce3aed..0xce3b06
+            - Range: 0xce3b0d..0xce3b26
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 135
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0xce4000..0xce4001]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 262 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xce4000..0xce4001
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 136
-      Name: main.testEmptySlice
       OutOfLinePCRanges: [0xce4020..0xce4021]
       InlinePCRanges: []
       Variables:
@@ -9286,13 +9267,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 137
-      Name: main.testSliceOfSlices
+    - ID: 136
+      Name: main.testEmptySlice
       OutOfLinePCRanges: [0xce4040..0xce4041]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 263 GoSliceHeaderType [][]uint
+          Type: 262 GoSliceHeaderType []uint
           Locations:
             - Range: 0xce4040..0xce4041
               Pieces:
@@ -9305,13 +9286,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 138
-      Name: main.testStructSlice
+    - ID: 137
+      Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0xce4060..0xce4061]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 265 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 263 GoSliceHeaderType [][]uint
           Locations:
             - Range: 0xce4060..0xce4061
               Pieces:
@@ -9323,16 +9304,9 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
           DictIndex: -1
-        - Name: a
-          Type: 8 BaseType int
-          Locations:
-            - Range: 0xce4060..0xce4061
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
       DictRegister: null
-    - ID: 139
-      Name: main.testEmptySliceOfStructs
+    - ID: 138
+      Name: main.testStructSlice
       OutOfLinePCRanges: [0xce4080..0xce4081]
       InlinePCRanges: []
       Variables:
@@ -9357,8 +9331,8 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 140
-      Name: main.testNilSliceOfStructs
+    - ID: 139
+      Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0xce40a0..0xce40a1]
       InlinePCRanges: []
       Variables:
@@ -9383,15 +9357,41 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 140
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0xce40c0..0xce40c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 265 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xce40c0..0xce40c1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 8 BaseType int
+          Locations:
+            - Range: 0xce40c0..0xce40c1
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 141
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0xce40c0..0xce40c1]
+      OutOfLinePCRanges: [0xce40e0..0xce40e1]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 159 GoSliceHeaderType []string
           Locations:
-            - Range: 0xce40c0..0xce40c1
+            - Range: 0xce40e0..0xce40e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9404,20 +9404,20 @@ Subprograms:
       DictRegister: null
     - ID: 142
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xce40e0..0xce40e1]
+      OutOfLinePCRanges: [0xce4100..0xce4101]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 17 BaseType int8
           Locations:
-            - Range: 0xce40e0..0xce40e1
+            - Range: 0xce4100..0xce4101
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 268 GoSliceHeaderType []bool
           Locations:
-            - Range: 0xce40e0..0xce40e1
+            - Range: 0xce4100..0xce4101
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9430,37 +9430,18 @@ Subprograms:
         - Name: x
           Type: 18 BaseType uint
           Locations:
-            - Range: 0xce40e0..0xce40e1
+            - Range: 0xce4100..0xce4101
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 143
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0xce4100..0xce4101]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 269 GoSliceHeaderType []uint16
-          Locations:
-            - Range: 0xce4100..0xce4101
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 144
-      Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0xce4120..0xce4121]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 262 GoSliceHeaderType []uint
+          Type: 269 GoSliceHeaderType []uint16
           Locations:
             - Range: 0xce4120..0xce4121
               Pieces:
@@ -9473,13 +9454,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 145
-      Name: main.testSliceEmptyStructs
+    - ID: 144
+      Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0xce4140..0xce4141]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 270 GoSliceHeaderType []struct {}
+          Type: 262 GoSliceHeaderType []uint
           Locations:
             - Range: 0xce4140..0xce4141
               Pieces:
@@ -9492,15 +9473,34 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 145
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0xce4160..0xce4161]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 270 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0xce4160..0xce4161
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 146
       Name: main.testSubslices
-      OutOfLinePCRanges: [0xce4160..0xce4161]
+      OutOfLinePCRanges: [0xce4180..0xce4181]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 262 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xce4160..0xce4161
+            - Range: 0xce4180..0xce4181
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9513,7 +9513,7 @@ Subprograms:
         - Name: bs
           Type: 262 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xce4160..0xce4161
+            - Range: 0xce4180..0xce4181
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -9526,7 +9526,7 @@ Subprograms:
         - Name: cs
           Type: 262 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xce4160..0xce4161
+            - Range: 0xce4180..0xce4181
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -9539,44 +9539,27 @@ Subprograms:
       DictRegister: null
     - ID: 147
       Name: main.stackC
-      OutOfLinePCRanges: [0xce4920..0xce4972]
+      OutOfLinePCRanges: [0xce4940..0xce4992]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce4920..0xce4965
+            - Range: 0xce4940..0xce4985
               Pieces: []
-            - Range: 0xce4965..0xce4966
+            - Range: 0xce4985..0xce4986
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce4966..0xce4972
+            - Range: 0xce4986..0xce4992
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 148
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xce4980..0xce4981]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 10 GoStringHeaderType string
-          Locations:
-            - Range: 0xce4980..0xce4981
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 149
-      Name: main.testThreeStrings
       OutOfLinePCRanges: [0xce49a0..0xce49a1]
       InlinePCRanges: []
       Variables:
@@ -9591,10 +9574,27 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
           DictIndex: -1
+      DictRegister: null
+    - ID: 149
+      Name: main.testThreeStrings
+      OutOfLinePCRanges: [0xce49c0..0xce49c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0xce49c0..0xce49c1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
         - Name: "y"
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce49a0..0xce49a1
+            - Range: 0xce49c0..0xce49c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9605,7 +9605,7 @@ Subprograms:
         - Name: z
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce49a0..0xce49a1
+            - Range: 0xce49c0..0xce49c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9616,13 +9616,13 @@ Subprograms:
       DictRegister: null
     - ID: 150
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xce49c0..0xce49df]
+      OutOfLinePCRanges: [0xce49e0..0xce49ff]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 272 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xce49c0..0xce49df
+            - Range: 0xce49e0..0xce49ff
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9641,49 +9641,32 @@ Subprograms:
       DictRegister: null
     - ID: 151
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xce49e0..0xce49e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 273 PointerType *main.threeStringStruct
-          Locations:
-            - Range: 0xce49e0..0xce49e1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 152
-      Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0xce4a00..0xce4a01]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 274 PointerType *main.oneStringStruct
+          Type: 273 PointerType *main.threeStringStruct
           Locations:
             - Range: 0xce4a00..0xce4a01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 153
-      Name: main.testMassiveString
+    - ID: 152
+      Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0xce4a20..0xce4a21]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 10 GoStringHeaderType string
+        - Name: a
+          Type: 274 PointerType *main.oneStringStruct
           Locations:
             - Range: 0xce4a20..0xce4a21
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 154
-      Name: main.testUnitializedString
+    - ID: 153
+      Name: main.testMassiveString
       OutOfLinePCRanges: [0xce4a40..0xce4a41]
       InlinePCRanges: []
       Variables:
@@ -9699,8 +9682,8 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 155
-      Name: main.testEmptyString
+    - ID: 154
+      Name: main.testUnitializedString
       OutOfLinePCRanges: [0xce4a60..0xce4a61]
       InlinePCRanges: []
       Variables:
@@ -9716,12 +9699,12 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 156
-      Name: main.testSubstrings
+    - ID: 155
+      Name: main.testEmptyString
       OutOfLinePCRanges: [0xce4a80..0xce4a81]
       InlinePCRanges: []
       Variables:
-        - Name: a
+        - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
             - Range: 0xce4a80..0xce4a81
@@ -9732,10 +9715,27 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
           DictIndex: -1
+      DictRegister: null
+    - ID: 156
+      Name: main.testSubstrings
+      OutOfLinePCRanges: [0xce4aa0..0xce4aa1]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0xce4aa0..0xce4aa1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
         - Name: b
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce4a80..0xce4a81
+            - Range: 0xce4aa0..0xce4aa1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9746,7 +9746,7 @@ Subprograms:
         - Name: c
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce4a80..0xce4a81
+            - Range: 0xce4aa0..0xce4aa1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9757,26 +9757,26 @@ Subprograms:
       DictRegister: null
     - ID: 157
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0xce4c00..0xce4c01]
+      OutOfLinePCRanges: [0xce4c20..0xce4c21]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 276 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0xce4c00..0xce4c01
+            - Range: 0xce4c20..0xce4c21
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 158
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0xce4c20..0xce4c3f]
+      OutOfLinePCRanges: [0xce4c40..0xce4c5f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 289 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0xce4c20..0xce4c3f
+            - Range: 0xce4c40..0xce4c5f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9795,13 +9795,13 @@ Subprograms:
       DictRegister: null
     - ID: 159
       Name: main.testStruct
-      OutOfLinePCRanges: [0xce4d60..0xce4d83]
+      OutOfLinePCRanges: [0xce4d80..0xce4da3]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 320 StructureType main.aStruct
           Locations:
-            - Range: 0xce4d60..0xce4d83
+            - Range: 0xce4d80..0xce4da3
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -9822,91 +9822,91 @@ Subprograms:
       DictRegister: null
     - ID: 160
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0xce4e60..0xce4e61]
+      OutOfLinePCRanges: [0xce4e80..0xce4e81]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 321 PointerType *main.anotherStruct
           Locations:
-            - Range: 0xce4e60..0xce4e61
+            - Range: 0xce4e80..0xce4e81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 161
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0xce4e80..0xce4e81]
+      OutOfLinePCRanges: [0xce4ea0..0xce4ea1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 323 StructureType main.tenStrings
           Locations:
-            - Range: 0xce4e80..0xce4e81
+            - Range: 0xce4ea0..0xce4ea1
               Pieces: [{Size: 160, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 162
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xce4ee0..0xce4ee1]
+      OutOfLinePCRanges: [0xce4f00..0xce4f01]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 324 StructureType main.emptyStruct
-          Locations: [{Range: 0xce4ee0..0xce4ee1, Pieces: []}]
+          Locations: [{Range: 0xce4f00..0xce4f01, Pieces: []}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 163
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xce4f00..0xce4f01]
+      OutOfLinePCRanges: [0xce4f20..0xce4f21]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 325 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xce4f00..0xce4f01
+            - Range: 0xce4f20..0xce4f21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 164
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0xce70c0..0xce70c4]
+      OutOfLinePCRanges: [0xce70e0..0xce70e4]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0xce70c0..0xce70c4
+            - Range: 0xce70e0..0xce70e4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xce70c0..0xce70c3
+            - Range: 0xce70e0..0xce70e3
               Pieces: []
-            - Range: 0xce70c3..0xce70c4
+            - Range: 0xce70e3..0xce70e4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 165
       Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0xce70e0..0xce70ec]
+      OutOfLinePCRanges: [0xce7100..0xce710c]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce70e0..0xce70eb
+            - Range: 0xce7100..0xce710b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce70eb..0xce70ec
+            - Range: 0xce710b..0xce710c
               Pieces:
                 - Size: 8
                   Op: null
@@ -9917,9 +9917,9 @@ Subprograms:
         - Name: ~r0
           Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xce70e0..0xce70eb
+            - Range: 0xce7100..0xce710b
               Pieces: []
-            - Range: 0xce70eb..0xce70ec
+            - Range: 0xce710b..0xce710c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9930,41 +9930,41 @@ Subprograms:
       DictRegister: 0
     - ID: 166
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0xce7100..0xce7104]
+      OutOfLinePCRanges: [0xce7120..0xce7124]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xce7100..0xce7104
+            - Range: 0xce7120..0xce7124
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0xce7100..0xce7103
+            - Range: 0xce7120..0xce7123
               Pieces: []
-            - Range: 0xce7103..0xce7104
+            - Range: 0xce7123..0xce7124
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 167
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0xce7120..0xce712c]
+      OutOfLinePCRanges: [0xce7140..0xce714c]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xce7120..0xce712b
+            - Range: 0xce7140..0xce714b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce712b..0xce712c
+            - Range: 0xce714b..0xce714c
               Pieces:
                 - Size: 8
                   Op: null
@@ -9975,9 +9975,9 @@ Subprograms:
         - Name: ~r0
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce7120..0xce712b
+            - Range: 0xce7140..0xce714b
               Pieces: []
-            - Range: 0xce712b..0xce712c
+            - Range: 0xce714b..0xce714c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9988,13 +9988,13 @@ Subprograms:
       DictRegister: 0
     - ID: 168
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0xce71a0..0xce72d6]
+      OutOfLinePCRanges: [0xce71c0..0xce72f6]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 330 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce71a0..0xce71d3
+            - Range: 0xce71c0..0xce71f3
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10002,7 +10002,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce71d3..0xce71db
+            - Range: 0xce71f3..0xce71fb
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -10010,7 +10010,7 @@ Subprograms:
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: null
-            - Range: 0xce71db..0xce72d6
+            - Range: 0xce71fb..0xce72f6
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -10023,18 +10023,18 @@ Subprograms:
         - Name: pred
           Type: 332 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0xce71a0..0xce71db
+            - Range: 0xce71c0..0xce71fb
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xce71db..0xce72d6
+            - Range: 0xce71fb..0xce72f6
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 330 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce71a0..0xce7294
+            - Range: 0xce71c0..0xce72b4
               Pieces: []
-            - Range: 0xce7294..0xce7295
+            - Range: 0xce72b4..0xce72b5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10042,14 +10042,14 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce7295..0xce72d6
+            - Range: 0xce72b5..0xce72f6
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
           Type: 330 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce71db..0xce71f9
+            - Range: 0xce71fb..0xce7219
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10057,7 +10057,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce71f9..0xce7201
+            - Range: 0xce7219..0xce7221
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10065,7 +10065,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce7201..0xce7209
+            - Range: 0xce7221..0xce7229
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10073,7 +10073,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce7209..0xce7209
+            - Range: 0xce7229..0xce7229
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10081,7 +10081,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce7209..0xce7233
+            - Range: 0xce7229..0xce7253
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
@@ -10089,7 +10089,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce7233..0xce728b
+            - Range: 0xce7253..0xce72ab
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10097,7 +10097,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce728b..0xce72d6
+            - Range: 0xce72ab..0xce72f6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
@@ -10110,84 +10110,62 @@ Subprograms:
         - Name: item
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0xce7226..0xce7233
+            - Range: 0xce7246..0xce7253
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce7233..0xce728b
+            - Range: 0xce7253..0xce72ab
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
     - ID: 169
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xce72e0..0xce7324]
+      OutOfLinePCRanges: [0xce7300..0xce7344]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xce72e0..0xce72f9
+            - Range: 0xce7300..0xce7319
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
           Type: 333 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0xce72e0..0xce72f9
+            - Range: 0xce7300..0xce7319
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xce72e0..0xce72f9
+            - Range: 0xce7300..0xce7319
               Pieces: []
-            - Range: 0xce72f9..0xce72fa
+            - Range: 0xce7319..0xce731a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce72fa..0xce7324
+            - Range: 0xce731a..0xce7344
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
     - ID: 170
       Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0xce75c0..0xce75c4]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 331 PointerType *go.shape.int
-          Locations:
-            - Range: 0xce75c0..0xce75c4
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 331 PointerType *go.shape.int
-          Locations:
-            - Range: 0xce75c0..0xce75c3
-              Pieces: []
-            - Range: 0xce75c3..0xce75c4
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 171
-      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
       OutOfLinePCRanges: [0xce75e0..0xce75e4]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 334 PointerType *go.shape.struct { Name string }
+          Type: 331 PointerType *go.shape.int
           Locations:
             - Range: 0xce75e0..0xce75e4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 334 PointerType *go.shape.struct { Name string }
+          Type: 331 PointerType *go.shape.int
           Locations:
             - Range: 0xce75e0..0xce75e3
               Pieces: []
@@ -10196,20 +10174,20 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 172
-      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
+    - ID: 171
+      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
       OutOfLinePCRanges: [0xce7600..0xce7604]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 336 PointerType *go.shape.struct { X int; Y int }
+          Type: 334 PointerType *go.shape.struct { Name string }
           Locations:
             - Range: 0xce7600..0xce7604
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 336 PointerType *go.shape.struct { X int; Y int }
+          Type: 334 PointerType *go.shape.struct { Name string }
           Locations:
             - Range: 0xce7600..0xce7603
               Pieces: []
@@ -10218,24 +10196,46 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
+    - ID: 172
+      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
+      OutOfLinePCRanges: [0xce7620..0xce7624]
+      InlinePCRanges: []
+      Variables:
+        - Name: p
+          Type: 336 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0xce7620..0xce7624
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 336 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0xce7620..0xce7623
+              Pieces: []
+            - Range: 0xce7623..0xce7624
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
     - ID: 173
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0xce7620..0xce7631]
+      OutOfLinePCRanges: [0xce7640..0xce7651]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 338 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0xce7620..0xce7631
+            - Range: 0xce7640..0xce7651
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce7620..0xce7630
+            - Range: 0xce7640..0xce7650
               Pieces: []
-            - Range: 0xce7630..0xce7631
+            - Range: 0xce7650..0xce7651
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10246,69 +10246,69 @@ Subprograms:
       DictRegister: 0
     - ID: 174
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0xce76c0..0xce76c9]
+      OutOfLinePCRanges: [0xce76e0..0xce76e9]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 340 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0xce76c0..0xce76c9
+            - Range: 0xce76e0..0xce76e9
               Pieces: [{Size: 136, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0xce76c0..0xce76c8
+            - Range: 0xce76e0..0xce76e8
               Pieces: []
-            - Range: 0xce76c8..0xce76c9
+            - Range: 0xce76e8..0xce76e9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 175
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0xce7780..0xce7788]
+      OutOfLinePCRanges: [0xce77a0..0xce77a8]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 341 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0xce7780..0xce7788
+            - Range: 0xce77a0..0xce77a8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0xce7780..0xce7788
+            - Range: 0xce77a0..0xce77a8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
           Type: 343 BaseType go.shape.bool
           Locations:
-            - Range: 0xce7780..0xce7788
+            - Range: 0xce77a0..0xce77a8
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
     - ID: 176
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0xce7820..0xce788e]
+      OutOfLinePCRanges: [0xce7840..0xce78ae]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 344 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0xce7820..0xce788e
+            - Range: 0xce7840..0xce78ae
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce7820..0xce788e
+            - Range: 0xce7840..0xce78ae
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10319,20 +10319,20 @@ Subprograms:
         - Name: v
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0xce7820..0xce788e
+            - Range: 0xce7840..0xce78ae
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
     - ID: 177
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0xce7920..0xce7928]
+      OutOfLinePCRanges: [0xce7940..0xce7948]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce7920..0xce7928
+            - Range: 0xce7940..0xce7948
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10343,25 +10343,25 @@ Subprograms:
         - Name: b
           Type: 343 BaseType go.shape.bool
           Locations:
-            - Range: 0xce7920..0xce7928
+            - Range: 0xce7940..0xce7948
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 343 BaseType go.shape.bool
           Locations:
-            - Range: 0xce7920..0xce7927
+            - Range: 0xce7940..0xce7947
               Pieces: []
-            - Range: 0xce7927..0xce7928
+            - Range: 0xce7947..0xce7948
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce7920..0xce7927
+            - Range: 0xce7940..0xce7947
               Pieces: []
-            - Range: 0xce7927..0xce7928
+            - Range: 0xce7947..0xce7948
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10372,26 +10372,26 @@ Subprograms:
       DictRegister: 0
     - ID: 178
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xce7940..0xce794f]
+      OutOfLinePCRanges: [0xce7960..0xce796f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0xce7940..0xce794e
+            - Range: 0xce7960..0xce796e
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce7940..0xce794b
+            - Range: 0xce7960..0xce796b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce794b..0xce794f
+            - Range: 0xce796b..0xce796f
               Pieces:
                 - Size: 8
                   Op: null
@@ -10402,9 +10402,9 @@ Subprograms:
         - Name: ~r0
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce7940..0xce794e
+            - Range: 0xce7960..0xce796e
               Pieces: []
-            - Range: 0xce794e..0xce794f
+            - Range: 0xce796e..0xce796f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10415,56 +10415,56 @@ Subprograms:
         - Name: ~r1
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0xce7940..0xce794e
+            - Range: 0xce7960..0xce796e
               Pieces: []
-            - Range: 0xce794e..0xce794f
+            - Range: 0xce796e..0xce796f
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 179
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0xce7960..0xce799a]
+      OutOfLinePCRanges: [0xce7980..0xce79ba]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 346 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0xce7960..0xce7979
+            - Range: 0xce7980..0xce7999
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce7960..0xce7979
+            - Range: 0xce7980..0xce7999
               Pieces: []
-            - Range: 0xce7979..0xce797a
+            - Range: 0xce7999..0xce799a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce797a..0xce799a
+            - Range: 0xce799a..0xce79ba
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 180
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0xce79a0..0xce79ed]
+      OutOfLinePCRanges: [0xce79c0..0xce7a0d]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 347 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0xce79a0..0xce79bf
+            - Range: 0xce79c0..0xce79df
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce79bf..0xce79c2
+            - Range: 0xce79df..0xce79e2
               Pieces:
                 - Size: 8
                   Op: null
@@ -10475,37 +10475,37 @@ Subprograms:
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xce79a0..0xce79c2
+            - Range: 0xce79c0..0xce79e2
               Pieces: []
-            - Range: 0xce79c2..0xce79c3
+            - Range: 0xce79e2..0xce79e3
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce79c3..0xce79ed
+            - Range: 0xce79e3..0xce7a0d
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 181
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0xce7a00..0xce7a08]
+      OutOfLinePCRanges: [0xce7a20..0xce7a28]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 348 PointerType *go.shape.string
           Locations:
-            - Range: 0xce7a00..0xce7a07
+            - Range: 0xce7a20..0xce7a27
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce7a00..0xce7a07
+            - Range: 0xce7a20..0xce7a27
               Pieces: []
-            - Range: 0xce7a07..0xce7a08
+            - Range: 0xce7a27..0xce7a28
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10516,22 +10516,22 @@ Subprograms:
       DictRegister: 0
     - ID: 182
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0xce7a20..0xce7a77]
+      OutOfLinePCRanges: [0xce7a40..0xce7a97]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 349 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xce7a20..0xce7a5d
+            - Range: 0xce7a40..0xce7a7d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 350 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xce7a20..0xce7a71
+            - Range: 0xce7a40..0xce7a91
               Pieces: []
-            - Range: 0xce7a71..0xce7a72
+            - Range: 0xce7a91..0xce7a92
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10545,20 +10545,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xce7a72..0xce7a77
+            - Range: 0xce7a92..0xce7a97
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 183
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0xce7a80..0xce7aa4]
+      OutOfLinePCRanges: [0xce7aa0..0xce7ac4]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 330 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce7a80..0xce7aa4
+            - Range: 0xce7aa0..0xce7ac4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10571,33 +10571,33 @@ Subprograms:
         - Name: needle
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0xce7a80..0xce7aa4
+            - Range: 0xce7aa0..0xce7ac4
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xce7a80..0xce7aa0
+            - Range: 0xce7aa0..0xce7ac0
               Pieces: []
-            - Range: 0xce7aa0..0xce7aa1
+            - Range: 0xce7ac0..0xce7ac1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce7aa1..0xce7aa3
+            - Range: 0xce7ac1..0xce7ac3
               Pieces: []
-            - Range: 0xce7aa3..0xce7aa4
+            - Range: 0xce7ac3..0xce7ac4
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 184
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0xce7ac0..0xce7b7f]
+      OutOfLinePCRanges: [0xce7ae0..0xce7b9f]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 351 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0xce7ac0..0xce7add
+            - Range: 0xce7ae0..0xce7afd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10605,7 +10605,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce7add..0xce7adf
+            - Range: 0xce7afd..0xce7aff
               Pieces:
                 - Size: 8
                   Op: null
@@ -10618,13 +10618,13 @@ Subprograms:
         - Name: needle
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce7ac0..0xce7b0c
+            - Range: 0xce7ae0..0xce7b2c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xce7b0c..0xce7b7f
+            - Range: 0xce7b2c..0xce7b9f
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
@@ -10635,28 +10635,28 @@ Subprograms:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xce7ac0..0xce7b2b
+            - Range: 0xce7ae0..0xce7b4b
               Pieces: []
-            - Range: 0xce7b2b..0xce7b2c
+            - Range: 0xce7b4b..0xce7b4c
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce7b2c..0xce7b33
+            - Range: 0xce7b4c..0xce7b53
               Pieces: []
-            - Range: 0xce7b33..0xce7b34
+            - Range: 0xce7b53..0xce7b54
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce7b34..0xce7b7f
+            - Range: 0xce7b54..0xce7b9f
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce7aef..0xce7b01
+            - Range: 0xce7b0f..0xce7b21
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xce7b01..0xce7b0c
+            - Range: 0xce7b21..0xce7b2c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10667,54 +10667,54 @@ Subprograms:
       DictRegister: 0
     - ID: 185
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0xce7b80..0xce7b87]
+      OutOfLinePCRanges: [0xce7ba0..0xce7ba7]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 352 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0xce7b80..0xce7b86
+            - Range: 0xce7ba0..0xce7ba6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0xce7b80..0xce7b87
+            - Range: 0xce7ba0..0xce7ba7
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xce7b80..0xce7b86
+            - Range: 0xce7ba0..0xce7ba6
               Pieces: []
-            - Range: 0xce7b86..0xce7b87
+            - Range: 0xce7ba6..0xce7ba7
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 3
     - ID: 186
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0xce7c00..0xce7c6c]
+      OutOfLinePCRanges: [0xce7c20..0xce7c8c]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 353 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0xce7c00..0xce7c20
+            - Range: 0xce7c20..0xce7c40
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce7c20..0xce7c28
+            - Range: 0xce7c40..0xce7c48
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce7c28..0xce7c2d
+            - Range: 0xce7c48..0xce7c4d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10725,7 +10725,7 @@ Subprograms:
         - Name: value
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce7c00..0xce7c2d
+            - Range: 0xce7c20..0xce7c4d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -10736,11 +10736,11 @@ Subprograms:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xce7c00..0xce7c2d
+            - Range: 0xce7c20..0xce7c4d
               Pieces: []
-            - Range: 0xce7c2d..0xce7c2e
+            - Range: 0xce7c4d..0xce7c4e
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce7c2e..0xce7c6c
+            - Range: 0xce7c4e..0xce7c8c
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10969,8 +10969,8 @@ Subprograms:
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0xcde760..0xcde7c6]
       InlinePCRanges:
-        - Ranges: [0xce7d23..0xce7d51]
-          RootRanges: [0xce7d00..0xce7d7f]
+        - Ranges: [0xce7d43..0xce7d71]
+          RootRanges: [0xce7d20..0xce7d9f]
       Variables:
         - Name: b
           Type: 358 StructureType main.firstBehavior
@@ -11003,8 +11003,8 @@ Subprograms:
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcdefdd..0xcdefe4]
-          RootRanges: [0xcdef40..0xcdf02b]
+        - Ranges: [0xcdeffd..0xcdf004]
+          RootRanges: [0xcdef60..0xcdf04b]
         - Ranges: [0x52bec1..0x52bec9]
           RootRanges: [0x52bec0..0x52beca]
       Variables: []

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.26rc1.yaml
@@ -13,11 +13,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1600 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0xcf0daa", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf0dca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1601 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0xcf0de5", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf0e05", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -84,11 +84,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1571 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0xcef3ae", Frameless: false}]
+              InjectionPoints: [{PC: "0xcef3ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1572 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0xcef46a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcef48a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -176,7 +176,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1451 EventRootType Probe[main.testArrayOfMaps]
-              InjectionPoints: [{PC: "0xceb620", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb640", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -241,11 +241,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1473 EventRootType Probe[main.testAtomicAdd]
-              InjectionPoints: [{PC: "0xced440", Frameless: true}]
+              InjectionPoints: [{PC: "0xced460", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1474 EventRootType Probe[main.testAtomicAdd]Return
-              InjectionPoints: [{PC: "0xced452", Frameless: true}]
+              InjectionPoints: [{PC: "0xced472", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -338,7 +338,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1616 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xcf11e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf1200", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -468,7 +468,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1470 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0xced0a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xced0c0", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -487,7 +487,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1471 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0xced0a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xced0c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -513,7 +513,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1622 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0xcf12c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf12e0", Frameless: true}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -549,7 +549,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1475 EventRootType Probe[main.testChannel]
-              InjectionPoints: [{PC: "0xced460", Frameless: true}]
+              InjectionPoints: [{PC: "0xced480", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -579,7 +579,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1469 EventRootType Probe[main.testCombinedByte]
-              InjectionPoints: [{PC: "0xced060", Frameless: true}]
+              InjectionPoints: [{PC: "0xced080", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{w}, {x}, {y}'
@@ -608,11 +608,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1536 EventRootType Probe[main.testConflictingReturn]
-              InjectionPoints: [{PC: "0xcee5ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee60e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1537 EventRootType Probe[main.testConflictingReturn]Return
-              InjectionPoints: [{PC: "0xcee6b1", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee6d1", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -634,7 +634,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1483 EventRootType Probe[main.testCycle]
-              InjectionPoints: [{PC: "0xced820", Frameless: true}]
+              InjectionPoints: [{PC: "0xced840", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{t}'
@@ -788,7 +788,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1588 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0xcf0500", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0520", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -815,7 +815,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1591 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0xcf0560", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0580", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -843,7 +843,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1612 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0xcf0ee0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0f00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -865,7 +865,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1623 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0xcf1320", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf1340", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -886,7 +886,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1624 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0xcf1340", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf1360", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1099,11 +1099,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1661 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0xcf3c40", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3c60", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1662 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xcf3c47", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3c67", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1117,11 +1117,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1663 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0xcf3c64", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf3c84", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1664 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0xcf3cb5", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf3cd5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1144,11 +1144,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1657 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0xcf3baa", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf3bca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1658 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0xcf3bb9", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf3bd9", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1162,11 +1162,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1659 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0xcf3bea", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf3c0a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1660 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0xcf3c02", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf3c22", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1189,14 +1189,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1665 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0xcf3cc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3ce0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1666 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0xcf3ce0"
+                - PC: "0xcf3d00"
                   Frameless: true
-                - PC: "0xcf3ce3"
+                - PC: "0xcf3d03"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1211,14 +1211,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1667 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0xcf3d0a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf3d2a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1668 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0xcf3d6b"
+                - PC: "0xcf3d8b"
                   Frameless: false
-                - PC: "0xcf3d73"
+                - PC: "0xcf3d93"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1245,7 +1245,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1669 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0xcf3cc5", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3ce5", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1257,7 +1257,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1670 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0xcf3d1f", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf3d3f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1278,11 +1278,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1645 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0xcf3860", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3880", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1646 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0xcf3870", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3890", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1296,11 +1296,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1647 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0xcf3940", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3960", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1648 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0xcf3948", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3968", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1324,11 +1324,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1633 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0xcf3393", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf33b3", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1634 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xcf351a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf353a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1370,11 +1370,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1637 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xcf358a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf35aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1638 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xcf3599", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf35b9", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1397,11 +1397,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1671 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0xcf3dc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3de0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1672 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0xcf3dc6", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3de6", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1415,11 +1415,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1673 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0xcf3e2a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf3e4a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1674 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0xcf3e4d", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf3e6d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1442,11 +1442,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1629 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0xcf32e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3300", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1630 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xcf32e3", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3303", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1460,11 +1460,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1631 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0xcf3300", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3320", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1632 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xcf330b", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf332b", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1487,11 +1487,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1649 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0xcf3a00", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3a20", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1650 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0xcf3a07", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3a27", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1505,11 +1505,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1651 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0xcf3a8a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf3aaa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1652 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0xcf3ab3", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf3ad3", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1532,11 +1532,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1639 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0xcf3800", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3820", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1640 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xcf3803", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3823", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1550,11 +1550,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1641 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0xcf3820", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3840", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1642 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0xcf3823", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3843", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1568,11 +1568,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1643 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0xcf3840", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3860", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1644 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0xcf3843", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3863", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1595,11 +1595,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1653 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0xcf3b60", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3b80", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1654 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0xcf3b67", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3b87", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1613,11 +1613,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1655 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xcf3b80", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3ba0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1656 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xcf3b8e", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3bae", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1640,11 +1640,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1625 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0xcf32a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf32c0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1626 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xcf32a3", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf32c3", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1658,11 +1658,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1627 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0xcf32c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf32e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1628 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xcf32cb", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf32eb", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1894,7 +1894,7 @@ Probes:
               InjectionPoints:
                 - PC: "0x53dae1"
                   Frameless: true
-                - PC: "0xceb4fd"
+                - PC: "0xceb51d"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2190,11 +2190,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1569 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0xcef22e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcef24e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1570 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xcef38d", Frameless: false}]
+              InjectionPoints: [{PC: "0xcef3ad", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2216,7 +2216,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1477 EventRootType Probe[main.testLinkedList]
-              InjectionPoints: [{PC: "0xced640", Frameless: true}]
+              InjectionPoints: [{PC: "0xced660", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -2328,11 +2328,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1575 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0xcef6d3", Frameless: false}]
+              InjectionPoints: [{PC: "0xcef6f3", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1576 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0xcef902", Frameless: false}]
+              InjectionPoints: [{PC: "0xcef922", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2441,7 +2441,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1449 EventRootType Probe[main.testMapArrayToArray]
-              InjectionPoints: [{PC: "0xceb5e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb600", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2463,7 +2463,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1456 EventRootType Probe[main.testMapEmbeddedMaps]
-              InjectionPoints: [{PC: "0xceb6a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb6c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2485,7 +2485,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1466 EventRootType Probe[main.testMapEmptyKey]
-              InjectionPoints: [{PC: "0xceb7e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb800", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2507,7 +2507,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1468 EventRootType Probe[main.testMapEmptyKeyAndValue]
-              InjectionPoints: [{PC: "0xceb820", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb840", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2529,7 +2529,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1467 EventRootType Probe[main.testMapEmptyValue]
-              InjectionPoints: [{PC: "0xceb800", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb820", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2551,7 +2551,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1453 EventRootType Probe[main.testMapIntToInt]
-              InjectionPoints: [{PC: "0xceb660", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb680", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2573,7 +2573,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1465 EventRootType Probe[main.testMapLargeKeyLargeValue]
-              InjectionPoints: [{PC: "0xceb7c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb7e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2595,7 +2595,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1464 EventRootType Probe[main.testMapLargeKeySmallValue]
-              InjectionPoints: [{PC: "0xceb7a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb7c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2619,7 +2619,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1454 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0xceb680", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb6a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2643,7 +2643,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1455 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0xceb680", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb6a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2665,7 +2665,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1463 EventRootType Probe[main.testMapSmallKeyLargeValue]
-              InjectionPoints: [{PC: "0xceb780", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb7a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2687,7 +2687,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1462 EventRootType Probe[main.testMapSmallKeySmallValue]
-              InjectionPoints: [{PC: "0xceb760", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb780", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2709,7 +2709,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1447 EventRootType Probe[main.testMapStringToInt]
-              InjectionPoints: [{PC: "0xceb5a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb5c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2731,7 +2731,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1448 EventRootType Probe[main.testMapStringToSlice]
-              InjectionPoints: [{PC: "0xceb5c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb5e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2753,7 +2753,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1446 EventRootType Probe[main.testMapStringToStruct]
-              InjectionPoints: [{PC: "0xceb580", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb5a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2775,7 +2775,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1457 EventRootType Probe[main.testMapWithLinkedList]
-              InjectionPoints: [{PC: "0xceb6c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb6e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2797,7 +2797,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1460 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-              InjectionPoints: [{PC: "0xceb720", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb740", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2819,7 +2819,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1461 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-              InjectionPoints: [{PC: "0xceb740", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb760", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2841,7 +2841,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1458 EventRootType Probe[main.testMapWithSmallValue]
-              InjectionPoints: [{PC: "0xceb6e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb700", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2865,7 +2865,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1459 EventRootType Probe[main.testMapWithSmallValueMassive]
-              InjectionPoints: [{PC: "0xceb700", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb720", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2887,7 +2887,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1609 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xcf0ea0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0ec0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2910,7 +2910,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1610 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xcf0ea0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0ec0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2957,11 +2957,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1577 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0xcef993", Frameless: false}]
+              InjectionPoints: [{PC: "0xcef9b3", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1578 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0xcefbc2", Frameless: false}]
+              InjectionPoints: [{PC: "0xcefbe2", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -3027,11 +3027,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1581 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0xcefd0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcefd2e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1582 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0xcefddd", Frameless: false}]
+              InjectionPoints: [{PC: "0xcefdfd", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3062,11 +3062,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1573 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0xcef48e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcef4ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1574 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0xcef6ab", Frameless: false}]
+              InjectionPoints: [{PC: "0xcef6cb", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3092,11 +3092,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1514 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcee42e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee44e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1515 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcee4cf", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee4ef", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3132,7 +3132,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1472 EventRootType Probe[main.testMultipleSimpleParams]
-              InjectionPoints: [{PC: "0xced220", Frameless: true}]
+              InjectionPoints: [{PC: "0xced240", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -3173,11 +3173,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1508 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xcee38a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee3aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1509 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xcee3fb", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee41b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3201,11 +3201,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1510 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xcee38a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee3aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1511 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xcee3fb", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee41b", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
       version: 0
@@ -3224,11 +3224,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1516 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcee42e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee44e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1517 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcee4cf", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee4ef", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
       version: 0
@@ -3248,11 +3248,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1518 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcee42e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee44e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1519 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcee4cf", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee4ef", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r1={result} r2={result2}
@@ -3285,11 +3285,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1512 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xcee38a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee3aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1513 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xcee3fb", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee41b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Parameter {i} * 2 = result {result}
@@ -3317,7 +3317,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1618 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xcf12a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf12c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3342,7 +3342,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1619 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xcf12a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf12c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3373,7 +3373,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1620 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xcf12a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf12c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3398,7 +3398,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1621 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xcf12a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf12c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3425,7 +3425,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1482 EventRootType Probe[main.testNilPointer]
-              InjectionPoints: [{PC: "0xced7e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xced800", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}, {a}'
@@ -3452,7 +3452,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1595 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0xcf05e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0600", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3479,7 +3479,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1592 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0xcf0580", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf05a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3514,7 +3514,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1594 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0xcf05c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf05e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3546,7 +3546,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1608 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0xcf0e80", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0ea0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3568,7 +3568,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1478 EventRootType Probe[main.testPointerLoop]
-              InjectionPoints: [{PC: "0xced660", Frameless: true}]
+              InjectionPoints: [{PC: "0xced680", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3590,7 +3590,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1452 EventRootType Probe[main.testPointerToMap]
-              InjectionPoints: [{PC: "0xceb640", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb660", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3612,7 +3612,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1476 EventRootType Probe[main.testPointerToSimpleStruct]
-              InjectionPoints: [{PC: "0xced620", Frameless: true}]
+              InjectionPoints: [{PC: "0xced640", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3636,11 +3636,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1484 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xcedc4a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcedc6a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1485 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xcedc9b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcedcbb", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
       version: 0
@@ -3660,11 +3660,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1528 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xcee50e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee52e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1529 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xcee5ad", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee5cd", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3707,11 +3707,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1494 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xcedd6e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcedd8e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1495 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xcede25", Frameless: false}]
+              InjectionPoints: [{PC: "0xcede45", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3751,11 +3751,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1486 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xcedc4a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcedc6a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1487 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xcedc9b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcedcbb", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3798,11 +3798,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1496 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xcedd6e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcedd8e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1497 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xcede25", Frameless: false}]
+              InjectionPoints: [{PC: "0xcede45", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3844,11 +3844,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1530 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xcee50e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee52e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1531 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xcee5ad", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee5cd", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
       version: 0
@@ -3865,11 +3865,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1532 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xcee50e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee52e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1533 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xcee5ad", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee5cd", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r0={@return.r0}
@@ -3891,11 +3891,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1488 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xcedc4a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcedc6a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1489 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xcedc9b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcedcbb", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: result={@return}
@@ -3918,18 +3918,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1504 EventRootType Probe[main.testReturnsAny]
-              InjectionPoints: [{PC: "0xcee02e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee04e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1505 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
-                - PC: "0xcee0d5"
+                - PC: "0xcee0f5"
                   Frameless: false
-                - PC: "0xcee124"
+                - PC: "0xcee144"
                   Frameless: false
-                - PC: "0xcee1ef"
+                - PC: "0xcee20f"
                   Frameless: false
-                - PC: "0xcee1f9"
+                - PC: "0xcee219"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3957,18 +3957,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1502 EventRootType Probe[main.testReturnsAnyAndError]
-              InjectionPoints: [{PC: "0xcedece", Frameless: false}]
+              InjectionPoints: [{PC: "0xcedeee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1503 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
-                - PC: "0xcedf24"
+                - PC: "0xcedf44"
                   Frameless: false
-                - PC: "0xcedf73"
+                - PC: "0xcedf93"
                   Frameless: false
-                - PC: "0xcedfb3"
+                - PC: "0xcedfd3"
                   Frameless: false
-                - PC: "0xcedfef"
+                - PC: "0xcee00f"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3995,11 +3995,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1547 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0xceecaa", Frameless: false}]
+              InjectionPoints: [{PC: "0xceecca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1548 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0xceed0f", Frameless: false}]
+              InjectionPoints: [{PC: "0xceed2f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -4016,11 +4016,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1549 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0xceed2a", Frameless: false}]
+              InjectionPoints: [{PC: "0xceed4a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1550 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0xceed6b", Frameless: false}]
+              InjectionPoints: [{PC: "0xceed8b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -4037,11 +4037,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1551 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0xceed8a", Frameless: false}]
+              InjectionPoints: [{PC: "0xceedaa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1552 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0xceedc6", Frameless: false}]
+              InjectionPoints: [{PC: "0xceede6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4058,11 +4058,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1555 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0xceee6e", Frameless: false}]
+              InjectionPoints: [{PC: "0xceee8e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1556 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0xceeeea", Frameless: false}]
+              InjectionPoints: [{PC: "0xceef0a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4079,11 +4079,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1567 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0xcef1ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xcef1ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1568 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0xcef210", Frameless: false}]
+              InjectionPoints: [{PC: "0xcef230", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4100,11 +4100,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1543 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0xceeb6a", Frameless: false}]
+              InjectionPoints: [{PC: "0xceeb8a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1544 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0xceebc6", Frameless: false}]
+              InjectionPoints: [{PC: "0xceebe6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4122,14 +4122,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1500 EventRootType Probe[main.testReturnsError]
-              InjectionPoints: [{PC: "0xcede4a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcede6a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1501 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
-                - PC: "0xcede84"
+                - PC: "0xcedea4"
                   Frameless: false
-                - PC: "0xcede8e"
+                - PC: "0xcedeae"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4151,11 +4151,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1490 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xcedc4a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcedc6a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1491 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xcedc9b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcedcbb", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4176,11 +4176,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1498 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xcedd6e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcedd8e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1499 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xcede25", Frameless: false}]
+              InjectionPoints: [{PC: "0xcede45", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4201,11 +4201,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1492 EventRootType Probe[main.testReturnsIntPointer]
-              InjectionPoints: [{PC: "0xcedcca", Frameless: false}]
+              InjectionPoints: [{PC: "0xcedcea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1493 EventRootType Probe[main.testReturnsIntPointer]Return
-              InjectionPoints: [{PC: "0xcedd34", Frameless: false}]
+              InjectionPoints: [{PC: "0xcedd54", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4227,14 +4227,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1506 EventRootType Probe[main.testReturnsInterface]
-              InjectionPoints: [{PC: "0xcee22e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee24e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1507 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
-                - PC: "0xcee2fd"
+                - PC: "0xcee31d"
                   Frameless: false
-                - PC: "0xcee307"
+                - PC: "0xcee327"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4256,11 +4256,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1545 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0xceebee", Frameless: false}]
+              InjectionPoints: [{PC: "0xceec0e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1546 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0xceec83", Frameless: false}]
+              InjectionPoints: [{PC: "0xceeca3", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4277,11 +4277,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1541 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0xceea6e", Frameless: false}]
+              InjectionPoints: [{PC: "0xceea8e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1542 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0xceeb47", Frameless: false}]
+              InjectionPoints: [{PC: "0xceeb67", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4298,11 +4298,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1559 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0xceefea", Frameless: false}]
+              InjectionPoints: [{PC: "0xcef00a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1560 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0xcef04c", Frameless: false}]
+              InjectionPoints: [{PC: "0xcef06c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4319,11 +4319,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1553 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0xceedea", Frameless: false}]
+              InjectionPoints: [{PC: "0xceee0a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1554 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0xceee38", Frameless: false}]
+              InjectionPoints: [{PC: "0xceee58", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4340,11 +4340,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1565 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0xcef14a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcef16a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1566 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0xcef196", Frameless: false}]
+              InjectionPoints: [{PC: "0xcef1b6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
@@ -4364,7 +4364,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1538 EventRootType Probe[main.testReturnsNamedDeferLine]Line
-              InjectionPoints: [{PC: "0xcee7ef", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee80f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4385,11 +4385,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1563 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0xcef0ea", Frameless: false}]
+              InjectionPoints: [{PC: "0xcef10a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1564 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0xcef12e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcef14e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4406,11 +4406,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1539 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0xcee9ea", Frameless: false}]
+              InjectionPoints: [{PC: "0xceea0a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1540 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0xceea51", Frameless: false}]
+              InjectionPoints: [{PC: "0xceea71", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4427,11 +4427,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1561 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0xcef06a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcef08a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1562 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0xcef0cf", Frameless: false}]
+              InjectionPoints: [{PC: "0xcef0ef", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4448,11 +4448,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1557 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0xceef0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xceef2e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1558 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0xceefb2", Frameless: false}]
+              InjectionPoints: [{PC: "0xceefd2", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4505,11 +4505,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1520 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcee42e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee44e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1521 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcee4cf", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee4ef", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -4784,7 +4784,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1602 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0xcf0e00", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0e20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4916,7 +4916,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1598 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0xcf0620", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0640", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -4938,7 +4938,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1589 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0xcf0520", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0540", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -4960,7 +4960,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1450 EventRootType Probe[main.testSmallMap]
-              InjectionPoints: [{PC: "0xceb600", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb620", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -4981,11 +4981,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1534 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xcee50e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee52e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1535 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xcee5ad", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee5cd", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -5006,11 +5006,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1579 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0xcefc6a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcefc8a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1580 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0xcefcde", Frameless: false}]
+              InjectionPoints: [{PC: "0xcefcfe", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5054,7 +5054,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1481 EventRootType Probe[main.testStringPointer]
-              InjectionPoints: [{PC: "0xced7a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xced7c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}'
@@ -5076,7 +5076,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1593 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0xcf05a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf05c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5142,7 +5142,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1617 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xcf11e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf1200", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5169,7 +5169,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1590 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0xcf0540", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0560", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5217,11 +5217,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1583 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0xcefe0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcefe2e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1584 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0xcefec4", Frameless: false}]
+              InjectionPoints: [{PC: "0xcefee4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5243,7 +5243,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1615 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0xcf10a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf10c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5264,7 +5264,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1614 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0xcf1080", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf10a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5291,7 +5291,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1445 EventRootType Probe[main.testStructWithMap]
-              InjectionPoints: [{PC: "0xceb560", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb580", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s} {@duration}'
@@ -5324,7 +5324,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1599 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0xcf0640", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0660", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5364,7 +5364,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1613 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0xcf0f00", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0f20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5397,11 +5397,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1522 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcee42e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee44e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1523 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcee4cf", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee4ef", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{nonexistentVariable}'
@@ -5422,11 +5422,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1524 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcee42e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee44e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1525 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcee4cf", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee4ef", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{unsupportedExpression}'
@@ -5449,11 +5449,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1526 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcee42e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee44e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1527 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcee4cf", Frameless: false}]
+              InjectionPoints: [{PC: "0xcee4ef", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -5485,7 +5485,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1603 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0xcf0e20", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0e40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5517,7 +5517,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1604 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xcf0e40", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0e60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5547,7 +5547,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1605 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xcf0e40", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0e60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5579,7 +5579,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1606 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xcf0e60", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0e80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5609,7 +5609,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1607 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xcf0e60", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0e80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5773,7 +5773,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1480 EventRootType Probe[main.testUintPointer]
-              InjectionPoints: [{PC: "0xced6c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xced6e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5795,7 +5795,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1587 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0xcf04e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0500", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5817,7 +5817,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1611 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0xcf0ec0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0ee0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5839,7 +5839,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1479 EventRootType Probe[main.testUnsafePointer]
-              InjectionPoints: [{PC: "0xced680", Frameless: true}]
+              InjectionPoints: [{PC: "0xced6a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5883,7 +5883,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1596 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xcf0600", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0620", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5905,7 +5905,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1597 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xcf0600", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0620", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5930,7 +5930,7 @@ Probes:
               InjectionPoints:
                 - PC: "0xceac2a"
                   Frameless: false
-                - PC: "0xcf3f1a"
+                - PC: "0xcf3f3a"
                   Frameless: false
               Condition: null
             - Kind: Return
@@ -5957,11 +5957,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1585 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0xcefeee", Frameless: false}]
+              InjectionPoints: [{PC: "0xceff0e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1586 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xceff6c", Frameless: false}]
+              InjectionPoints: [{PC: "0xceff8c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -7044,140 +7044,127 @@ Subprograms:
       DictRegister: null
     - ID: 63
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0xceb560..0xceb561]
+      OutOfLinePCRanges: [0xceb580..0xceb581]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 176 StructureType main.structWithMap
-          Locations:
-            - Range: 0xceb560..0xceb561
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 64
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0xceb580..0xceb581]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 182 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0xceb580..0xceb581
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 65
-      Name: main.testMapStringToInt
+    - ID: 64
+      Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0xceb5a0..0xceb5a1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 187 GoMapType map[string]int
+          Type: 182 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0xceb5a0..0xceb5a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 66
-      Name: main.testMapStringToSlice
+    - ID: 65
+      Name: main.testMapStringToInt
       OutOfLinePCRanges: [0xceb5c0..0xceb5c1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 192 GoMapType map[string][]string
+          Type: 187 GoMapType map[string]int
           Locations:
             - Range: 0xceb5c0..0xceb5c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 67
-      Name: main.testMapArrayToArray
+    - ID: 66
+      Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0xceb5e0..0xceb5e1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 197 GoMapType map[[4]string][2]int
+          Type: 192 GoMapType map[string][]string
           Locations:
             - Range: 0xceb5e0..0xceb5e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 68
-      Name: main.testSmallMap
+    - ID: 67
+      Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0xceb600..0xceb601]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 187 GoMapType map[string]int
+          Type: 197 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0xceb600..0xceb601
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 68
+      Name: main.testSmallMap
+      OutOfLinePCRanges: [0xceb620..0xceb621]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 187 GoMapType map[string]int
+          Locations:
+            - Range: 0xceb620..0xceb621
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 69
       Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0xceb620..0xceb621]
+      OutOfLinePCRanges: [0xceb640..0xceb641]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 202 ArrayType [2]map[string]int
           Locations:
-            - Range: 0xceb620..0xceb621
+            - Range: 0xceb640..0xceb641
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 70
       Name: main.testPointerToMap
-      OutOfLinePCRanges: [0xceb640..0xceb641]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 203 PointerType *map[string]int
-          Locations:
-            - Range: 0xceb640..0xceb641
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 71
-      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0xceb660..0xceb661]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 177 GoMapType map[int]int
+          Type: 203 PointerType *map[string]int
           Locations:
             - Range: 0xceb660..0xceb661
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 72
-      Name: main.testMapMassive
+    - ID: 71
+      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0xceb680..0xceb681]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 204 GoMapType map[string][]main.structWithMap
+        - Name: m
+          Type: 177 GoMapType map[int]int
           Locations:
             - Range: 0xceb680..0xceb681
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 73
-      Name: main.testMapEmbeddedMaps
+    - ID: 72
+      Name: main.testMapMassive
       OutOfLinePCRanges: [0xceb6a0..0xceb6a1]
       InlinePCRanges: []
       Variables:
-        - Name: m
+        - Name: redactMyEntries
           Type: 204 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xceb6a0..0xceb6a1
@@ -7185,38 +7172,38 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 74
-      Name: main.testMapWithLinkedList
+    - ID: 73
+      Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0xceb6c0..0xceb6c1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 209 GoMapType map[bool]main.node
+          Type: 204 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xceb6c0..0xceb6c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 75
-      Name: main.testMapWithSmallValue
+    - ID: 74
+      Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0xceb6e0..0xceb6e1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 214 GoMapType map[int]uint8
+          Type: 209 GoMapType map[bool]main.node
           Locations:
             - Range: 0xceb6e0..0xceb6e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 76
-      Name: main.testMapWithSmallValueMassive
+    - ID: 75
+      Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0xceb700..0xceb701]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
+        - Name: m
           Type: 214 GoMapType map[int]uint8
           Locations:
             - Range: 0xceb700..0xceb701
@@ -7224,21 +7211,21 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 77
-      Name: main.testMapWithSmallKeyAndValue
+    - ID: 76
+      Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0xceb720..0xceb721]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 219 GoMapType map[uint8]uint8
+        - Name: redactMyEntries
+          Type: 214 GoMapType map[int]uint8
           Locations:
             - Range: 0xceb720..0xceb721
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 78
-      Name: main.testMapWithSmallKeyAndValueMassive
+    - ID: 77
+      Name: main.testMapWithSmallKeyAndValue
       OutOfLinePCRanges: [0xceb740..0xceb741]
       InlinePCRanges: []
       Variables:
@@ -7250,8 +7237,8 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 79
-      Name: main.testMapSmallKeySmallValue
+    - ID: 78
+      Name: main.testMapWithSmallKeyAndValueMassive
       OutOfLinePCRanges: [0xceb760..0xceb761]
       InlinePCRanges: []
       Variables:
@@ -7263,127 +7250,140 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 80
-      Name: main.testMapSmallKeyLargeValue
+    - ID: 79
+      Name: main.testMapSmallKeySmallValue
       OutOfLinePCRanges: [0xceb780..0xceb781]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 224 GoMapType map[uint8][4]int
+          Type: 219 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xceb780..0xceb781
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 81
-      Name: main.testMapLargeKeySmallValue
+    - ID: 80
+      Name: main.testMapSmallKeyLargeValue
       OutOfLinePCRanges: [0xceb7a0..0xceb7a1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 229 GoMapType map[[4]int]uint8
+          Type: 224 GoMapType map[uint8][4]int
           Locations:
             - Range: 0xceb7a0..0xceb7a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 82
-      Name: main.testMapLargeKeyLargeValue
+    - ID: 81
+      Name: main.testMapLargeKeySmallValue
       OutOfLinePCRanges: [0xceb7c0..0xceb7c1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 234 GoMapType map[[4]int][4]int
+          Type: 229 GoMapType map[[4]int]uint8
           Locations:
             - Range: 0xceb7c0..0xceb7c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 83
-      Name: main.testMapEmptyKey
+    - ID: 82
+      Name: main.testMapLargeKeyLargeValue
       OutOfLinePCRanges: [0xceb7e0..0xceb7e1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 239 GoMapType map[struct {}]int
+          Type: 234 GoMapType map[[4]int][4]int
           Locations:
             - Range: 0xceb7e0..0xceb7e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 84
-      Name: main.testMapEmptyValue
+    - ID: 83
+      Name: main.testMapEmptyKey
       OutOfLinePCRanges: [0xceb800..0xceb801]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 244 GoMapType map[int]struct {}
+          Type: 239 GoMapType map[struct {}]int
           Locations:
             - Range: 0xceb800..0xceb801
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 85
-      Name: main.testMapEmptyKeyAndValue
+    - ID: 84
+      Name: main.testMapEmptyValue
       OutOfLinePCRanges: [0xceb820..0xceb821]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 249 GoMapType map[struct {}]struct {}
+          Type: 244 GoMapType map[int]struct {}
           Locations:
             - Range: 0xceb820..0xceb821
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 85
+      Name: main.testMapEmptyKeyAndValue
+      OutOfLinePCRanges: [0xceb840..0xceb841]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 249 GoMapType map[struct {}]struct {}
+          Locations:
+            - Range: 0xceb840..0xceb841
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 86
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0xced060..0xced061]
+      OutOfLinePCRanges: [0xced080..0xced081]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xced060..0xced061
+            - Range: 0xced080..0xced081
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xced060..0xced061
+            - Range: 0xced080..0xced081
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: "y"
           Type: 18 BaseType float32
           Locations:
-            - Range: 0xced060..0xced061
+            - Range: 0xced080..0xced081
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 87
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0xced0a0..0xced0a1]
+      OutOfLinePCRanges: [0xced0c0..0xced0c1]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xced0a0..0xced0a1
+            - Range: 0xced0c0..0xced0c1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xced0a0..0xced0a1
+            - Range: 0xced0c0..0xced0c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -7394,48 +7394,48 @@ Subprograms:
         - Name: "y"
           Type: 18 BaseType float32
           Locations:
-            - Range: 0xced0a0..0xced0a1
+            - Range: 0xced0c0..0xced0c1
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 88
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0xced220..0xced221]
+      OutOfLinePCRanges: [0xced240..0xced241]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xced220..0xced221
+            - Range: 0xced240..0xced241
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xced220..0xced221
+            - Range: 0xced240..0xced241
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 11 BaseType int32
           Locations:
-            - Range: 0xced220..0xced221
+            - Range: 0xced240..0xced241
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 15 BaseType uint
           Locations:
-            - Range: 0xced220..0xced221
+            - Range: 0xced240..0xced241
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xced220..0xced221
+            - Range: 0xced240..0xced241
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7446,61 +7446,61 @@ Subprograms:
       DictRegister: null
     - ID: 89
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0xced440..0xced453]
+      OutOfLinePCRanges: [0xced460..0xced473]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0xced440..0xced452
+            - Range: 0xced460..0xced472
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0xced440..0xced452
+            - Range: 0xced460..0xced472
               Pieces: []
-            - Range: 0xced452..0xced453
+            - Range: 0xced472..0xced473
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 90
       Name: main.testChannel
-      OutOfLinePCRanges: [0xced460..0xced461]
+      OutOfLinePCRanges: [0xced480..0xced481]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 254 GoChannelType chan bool
           Locations:
-            - Range: 0xced460..0xced461
+            - Range: 0xced480..0xced481
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 91
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xced620..0xced621]
+      OutOfLinePCRanges: [0xced640..0xced641]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 255 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xced620..0xced621
+            - Range: 0xced640..0xced641
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 92
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0xced640..0xced641]
+      OutOfLinePCRanges: [0xced660..0xced661]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 257 StructureType main.node
           Locations:
-            - Range: 0xced640..0xced641
+            - Range: 0xced660..0xced661
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7511,273 +7511,273 @@ Subprograms:
       DictRegister: null
     - ID: 93
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xced660..0xced661]
+      OutOfLinePCRanges: [0xced680..0xced681]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 258 PointerType *main.node
-          Locations:
-            - Range: 0xced660..0xced661
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 94
-      Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xced680..0xced681]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 17 VoidPointerType unsafe.Pointer
           Locations:
             - Range: 0xced680..0xced681
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 94
+      Name: main.testUnsafePointer
+      OutOfLinePCRanges: [0xced6a0..0xced6a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 17 VoidPointerType unsafe.Pointer
+          Locations:
+            - Range: 0xced6a0..0xced6a1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 95
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0xced6c0..0xced6c1]
+      OutOfLinePCRanges: [0xced6e0..0xced6e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 113 PointerType *uint
           Locations:
-            - Range: 0xced6c0..0xced6c1
+            - Range: 0xced6e0..0xced6e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 96
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0xced7a0..0xced7a1]
+      OutOfLinePCRanges: [0xced7c0..0xced7c1]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 102 PointerType *string
           Locations:
-            - Range: 0xced7a0..0xced7a1
+            - Range: 0xced7c0..0xced7c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 97
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0xced7e0..0xced7e1]
+      OutOfLinePCRanges: [0xced800..0xced801]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 12 PointerType *bool
           Locations:
-            - Range: 0xced7e0..0xced7e1
+            - Range: 0xced800..0xced801
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 15 BaseType uint
           Locations:
-            - Range: 0xced7e0..0xced7e1
+            - Range: 0xced800..0xced801
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 98
       Name: main.testCycle
-      OutOfLinePCRanges: [0xced820..0xced821]
+      OutOfLinePCRanges: [0xced840..0xced841]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 259 PointerType *main.t
           Locations:
-            - Range: 0xced820..0xced821
+            - Range: 0xced840..0xced841
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 99
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0xcedc40..0xcedcb2]
+      OutOfLinePCRanges: [0xcedc60..0xcedcd2]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcedc40..0xcedc52
+            - Range: 0xcedc60..0xcedc72
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcedc40..0xcedc9b
+            - Range: 0xcedc60..0xcedcbb
               Pieces: []
-            - Range: 0xcedc9b..0xcedc9c
+            - Range: 0xcedcbb..0xcedcbc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcedc9c..0xcedcb2
+            - Range: 0xcedcbc..0xcedcd2
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcedc52..0xcedc65
+            - Range: 0xcedc72..0xcedc85
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcedc65..0xcedcb2
+            - Range: 0xcedc85..0xcedcd2
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 100
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0xcedcc0..0xcedd4f]
+      OutOfLinePCRanges: [0xcedce0..0xcedd6f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcedcc0..0xcedcda
+            - Range: 0xcedce0..0xcedcfa
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcedcda..0xcedd4f
+            - Range: 0xcedcfa..0xcedd6f
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 105 PointerType *int
           Locations:
-            - Range: 0xcedcc0..0xcedd34
+            - Range: 0xcedce0..0xcedd54
               Pieces: []
-            - Range: 0xcedd34..0xcedd35
+            - Range: 0xcedd54..0xcedd55
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcedd35..0xcedd4f
+            - Range: 0xcedd55..0xcedd6f
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: '&result'
           Type: 105 PointerType *int
           Locations:
-            - Range: 0xcedcdf..0xcedcf9
+            - Range: 0xcedcff..0xcedd19
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcedcf9..0xcedd4f
+            - Range: 0xcedd19..0xcedd6f
               Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 101
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0xcedd60..0xcede3f]
+      OutOfLinePCRanges: [0xcedd80..0xcede5f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcedd60..0xceddc3
+            - Range: 0xcedd80..0xcedde3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcedd60..0xcede25
+            - Range: 0xcedd80..0xcede45
               Pieces: []
-            - Range: 0xcede25..0xcede26
+            - Range: 0xcede45..0xcede46
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcede26..0xcede3f
+            - Range: 0xcede46..0xcede5f
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 14 BaseType float64
-          Locations: [{Range: 0xcedd60..0xcede3f, Pieces: []}]
+          Locations: [{Range: 0xcedd80..0xcede5f, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: resultInt
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcedd76..0xceddc8
+            - Range: 0xcedd96..0xcedde8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xceddc8..0xcede3f
+            - Range: 0xcedde8..0xcede5f
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
           Role: Local
           DictIndex: -1
         - Name: resultFloat
           Type: 14 BaseType float64
           Locations:
-            - Range: 0xcedd8f..0xceddc8
+            - Range: 0xceddaf..0xcedde8
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
-            - Range: 0xceddc8..0xcede3f
+            - Range: 0xcedde8..0xcede5f
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 102
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0xcede40..0xcedea4]
+      OutOfLinePCRanges: [0xcede60..0xcedec4]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xcede40..0xcede57
+            - Range: 0xcede60..0xcede77
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 16 GoInterfaceType error
           Locations:
-            - Range: 0xcede40..0xcede84
+            - Range: 0xcede60..0xcedea4
               Pieces: []
-            - Range: 0xcede84..0xcede85
+            - Range: 0xcedea4..0xcedea5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcede85..0xcede8e
+            - Range: 0xcedea5..0xcedeae
               Pieces: []
-            - Range: 0xcede8e..0xcede8f
+            - Range: 0xcedeae..0xcedeaf
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcede8f..0xcedea4
+            - Range: 0xcedeaf..0xcedec4
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 103
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0xcedec0..0xcee01c]
+      OutOfLinePCRanges: [0xcedee0..0xcee03c]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 168 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcedec0..0xcedf0b
+            - Range: 0xcedee0..0xcedf2b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcedf0b..0xcedf16
+            - Range: 0xcedf2b..0xcedf36
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcedf47..0xcedf4a
+            - Range: 0xcedf67..0xcedf6a
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcedf7e..0xcedf85
+            - Range: 0xcedf9e..0xcedfa5
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcedfbe..0xcedfc5
+            - Range: 0xcedfde..0xcedfe5
               Pieces:
                 - Size: 8
                   Op: null
@@ -7788,117 +7788,117 @@ Subprograms:
         - Name: failed
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xcedec0..0xcedf16
+            - Range: 0xcedee0..0xcedf36
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 168 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcedec0..0xcedf24
+            - Range: 0xcedee0..0xcedf44
               Pieces: []
-            - Range: 0xcedf24..0xcedf25
+            - Range: 0xcedf44..0xcedf45
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcedf25..0xcedf73
+            - Range: 0xcedf45..0xcedf93
               Pieces: []
-            - Range: 0xcedf73..0xcedf74
+            - Range: 0xcedf93..0xcedf94
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcedf74..0xcedfb3
+            - Range: 0xcedf94..0xcedfd3
               Pieces: []
-            - Range: 0xcedfb3..0xcedfb4
+            - Range: 0xcedfd3..0xcedfd4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcedfb4..0xcedfef
+            - Range: 0xcedfd4..0xcee00f
               Pieces: []
-            - Range: 0xcedfef..0xcedff0
+            - Range: 0xcee00f..0xcee010
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcedff0..0xcee01c
+            - Range: 0xcee010..0xcee03c
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 16 GoInterfaceType error
           Locations:
-            - Range: 0xcedec0..0xcedf24
+            - Range: 0xcedee0..0xcedf44
               Pieces: []
-            - Range: 0xcedf24..0xcedf25
+            - Range: 0xcedf44..0xcedf45
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcedf25..0xcedf73
+            - Range: 0xcedf45..0xcedf93
               Pieces: []
-            - Range: 0xcedf73..0xcedf74
+            - Range: 0xcedf93..0xcedf94
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcedf74..0xcedfb3
+            - Range: 0xcedf94..0xcedfd3
               Pieces: []
-            - Range: 0xcedfb3..0xcedfb4
+            - Range: 0xcedfd3..0xcedfd4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcedfb4..0xcedfef
+            - Range: 0xcedfd4..0xcee00f
               Pieces: []
-            - Range: 0xcedfef..0xcedff0
+            - Range: 0xcee00f..0xcee010
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcedff0..0xcee01c
+            - Range: 0xcee010..0xcee03c
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcedf0b..0xcedf11
+            - Range: 0xcedf2b..0xcedf31
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 104
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0xcee020..0xcee21d]
+      OutOfLinePCRanges: [0xcee040..0xcee23d]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 168 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcee020..0xcee06b
+            - Range: 0xcee040..0xcee08b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcee06b..0xcee072
+            - Range: 0xcee08b..0xcee092
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcee072..0xcee21d
+            - Range: 0xcee092..0xcee23d
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -7909,1128 +7909,1128 @@ Subprograms:
         - Name: ~r0
           Type: 168 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcee020..0xcee0d5
+            - Range: 0xcee040..0xcee0f5
               Pieces: []
-            - Range: 0xcee0d5..0xcee0d6
+            - Range: 0xcee0f5..0xcee0f6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcee0d6..0xcee124
+            - Range: 0xcee0f6..0xcee144
               Pieces: []
-            - Range: 0xcee124..0xcee125
+            - Range: 0xcee144..0xcee145
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcee125..0xcee1ef
+            - Range: 0xcee145..0xcee20f
               Pieces: []
-            - Range: 0xcee1ef..0xcee1f0
+            - Range: 0xcee20f..0xcee210
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcee1f0..0xcee1f9
+            - Range: 0xcee210..0xcee219
               Pieces: []
-            - Range: 0xcee1f9..0xcee1fa
+            - Range: 0xcee219..0xcee21a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcee1fa..0xcee21d
+            - Range: 0xcee21a..0xcee23d
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcee0c0..0xcee0c6
+            - Range: 0xcee0e0..0xcee0e6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: '&result'
           Type: 105 PointerType *int
           Locations:
-            - Range: 0xcee105..0xcee124
+            - Range: 0xcee125..0xcee144
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 105
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0xcee220..0xcee374]
+      OutOfLinePCRanges: [0xcee240..0xcee394]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 168 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcee220..0xcee260
+            - Range: 0xcee240..0xcee280
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcee260..0xcee2b0
+            - Range: 0xcee280..0xcee2d0
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcee2b0..0xcee30d
+            - Range: 0xcee2d0..0xcee32d
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcee30d..0xcee331
+            - Range: 0xcee32d..0xcee351
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcee331..0xcee338
+            - Range: 0xcee351..0xcee358
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcee338..0xcee374
+            - Range: 0xcee358..0xcee394
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 173 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcee220..0xcee2fd
+            - Range: 0xcee240..0xcee31d
               Pieces: []
-            - Range: 0xcee2fd..0xcee2fe
+            - Range: 0xcee31d..0xcee31e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcee2fe..0xcee307
+            - Range: 0xcee31e..0xcee327
               Pieces: []
-            - Range: 0xcee307..0xcee308
+            - Range: 0xcee327..0xcee328
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcee308..0xcee374
+            - Range: 0xcee328..0xcee394
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 173 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcee220..0xcee260
+            - Range: 0xcee240..0xcee280
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcee260..0xcee2b0
+            - Range: 0xcee280..0xcee2d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcee2b0..0xcee2b7
+            - Range: 0xcee2d0..0xcee2d7
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcee2b7..0xcee303
+            - Range: 0xcee2d7..0xcee323
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcee303..0xcee305
+            - Range: 0xcee323..0xcee325
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcee305..0xcee307
+            - Range: 0xcee325..0xcee327
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcee307..0xcee374
+            - Range: 0xcee327..0xcee394
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 106
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0xcee380..0xcee415]
+      OutOfLinePCRanges: [0xcee3a0..0xcee435]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcee380..0xcee391
+            - Range: 0xcee3a0..0xcee3b1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcee380..0xcee3fb
+            - Range: 0xcee3a0..0xcee41b
               Pieces: []
-            - Range: 0xcee3fb..0xcee3fc
+            - Range: 0xcee41b..0xcee41c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcee3fc..0xcee415
+            - Range: 0xcee41c..0xcee435
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 107
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0xcee420..0xcee4e9]
+      OutOfLinePCRanges: [0xcee440..0xcee509]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcee420..0xcee472
+            - Range: 0xcee440..0xcee492
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcee420..0xcee4cf
+            - Range: 0xcee440..0xcee4ef
               Pieces: []
-            - Range: 0xcee4cf..0xcee4d0
+            - Range: 0xcee4ef..0xcee4f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcee4d0..0xcee4e9
+            - Range: 0xcee4f0..0xcee509
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcee420..0xcee4cf
+            - Range: 0xcee440..0xcee4ef
               Pieces: []
-            - Range: 0xcee4cf..0xcee4d0
+            - Range: 0xcee4ef..0xcee4f0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcee4d0..0xcee4e9
+            - Range: 0xcee4f0..0xcee509
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 108
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0xcee500..0xcee5c7]
+      OutOfLinePCRanges: [0xcee520..0xcee5e7]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcee500..0xcee545
+            - Range: 0xcee520..0xcee565
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcee545..0xcee5c7
+            - Range: 0xcee565..0xcee5e7
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcee500..0xcee5ad
+            - Range: 0xcee520..0xcee5cd
               Pieces: []
-            - Range: 0xcee5ad..0xcee5ae
+            - Range: 0xcee5cd..0xcee5ce
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcee5ae..0xcee5c7
+            - Range: 0xcee5ce..0xcee5e7
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcee500..0xcee5ad
+            - Range: 0xcee520..0xcee5cd
               Pieces: []
-            - Range: 0xcee5ad..0xcee5ae
+            - Range: 0xcee5cd..0xcee5ce
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcee5ae..0xcee5c7
+            - Range: 0xcee5ce..0xcee5e7
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcee500..0xcee5ad
+            - Range: 0xcee520..0xcee5cd
               Pieces: []
-            - Range: 0xcee5ad..0xcee5ae
+            - Range: 0xcee5cd..0xcee5ce
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcee5ae..0xcee5c7
+            - Range: 0xcee5ce..0xcee5e7
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 109
       Name: main.testConflictingReturn
-      OutOfLinePCRanges: [0xcee5e0..0xcee6cf]
+      OutOfLinePCRanges: [0xcee600..0xcee6ef]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcee5e0..0xcee625
+            - Range: 0xcee600..0xcee645
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcee625..0xcee6cf
+            - Range: 0xcee645..0xcee6ef
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcee5e0..0xcee6b1
+            - Range: 0xcee600..0xcee6d1
               Pieces: []
-            - Range: 0xcee6b1..0xcee6b2
+            - Range: 0xcee6d1..0xcee6d2
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcee6b2..0xcee6cf
+            - Range: 0xcee6d2..0xcee6ef
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcee5e0..0xcee6b1
+            - Range: 0xcee600..0xcee6d1
               Pieces: []
-            - Range: 0xcee6b1..0xcee6b2
+            - Range: 0xcee6d1..0xcee6d2
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcee6b2..0xcee6cf
+            - Range: 0xcee6d2..0xcee6ef
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 110
       Name: main.testReturnsNamedDeferLine
-      OutOfLinePCRanges: [0xcee6e0..0xcee8ef]
+      OutOfLinePCRanges: [0xcee700..0xcee90f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcee6e0..0xcee766
+            - Range: 0xcee700..0xcee786
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcee766..0xcee8ef
+            - Range: 0xcee786..0xcee90f
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcee717..0xcee8ef
+            - Range: 0xcee737..0xcee90f
               Pieces: [{Size: 16, Op: {CfaOffset: -128}}]
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcee71d..0xcee8ef
+            - Range: 0xcee73d..0xcee90f
               Pieces: [{Size: 16, Op: {CfaOffset: -144}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 111
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0xcee9e0..0xceea5e]
+      OutOfLinePCRanges: [0xceea00..0xceea7e]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 21 BaseType int8
           Locations:
-            - Range: 0xcee9e0..0xceea51
+            - Range: 0xceea00..0xceea71
               Pieces: []
-            - Range: 0xceea51..0xceea52
+            - Range: 0xceea71..0xceea72
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xceea52..0xceea5e
+            - Range: 0xceea72..0xceea7e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 110 BaseType int16
           Locations:
-            - Range: 0xcee9e0..0xceea51
+            - Range: 0xceea00..0xceea71
               Pieces: []
-            - Range: 0xceea51..0xceea52
+            - Range: 0xceea71..0xceea72
               Pieces: [{Size: 2, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xceea52..0xceea5e
+            - Range: 0xceea72..0xceea7e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 11 BaseType int32
           Locations:
-            - Range: 0xcee9e0..0xceea51
+            - Range: 0xceea00..0xceea71
               Pieces: []
-            - Range: 0xceea51..0xceea52
+            - Range: 0xceea71..0xceea72
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xceea52..0xceea5e
+            - Range: 0xceea72..0xceea7e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 13 BaseType int64
           Locations:
-            - Range: 0xcee9e0..0xceea51
+            - Range: 0xceea00..0xceea71
               Pieces: []
-            - Range: 0xceea51..0xceea52
+            - Range: 0xceea71..0xceea72
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xceea52..0xceea5e
+            - Range: 0xceea72..0xceea7e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xcee9e0..0xceea51
+            - Range: 0xceea00..0xceea71
               Pieces: []
-            - Range: 0xceea51..0xceea52
+            - Range: 0xceea71..0xceea72
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xceea52..0xceea5e
+            - Range: 0xceea72..0xceea7e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 7 BaseType uint16
           Locations:
-            - Range: 0xcee9e0..0xceea51
+            - Range: 0xceea00..0xceea71
               Pieces: []
-            - Range: 0xceea51..0xceea52
+            - Range: 0xceea71..0xceea72
               Pieces: [{Size: 2, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xceea52..0xceea5e
+            - Range: 0xceea72..0xceea7e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 3 BaseType uint32
           Locations:
-            - Range: 0xcee9e0..0xceea51
+            - Range: 0xceea00..0xceea71
               Pieces: []
-            - Range: 0xceea51..0xceea52
+            - Range: 0xceea71..0xceea72
               Pieces: [{Size: 4, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xceea52..0xceea5e
+            - Range: 0xceea72..0xceea7e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0xcee9e0..0xceea51
+            - Range: 0xceea00..0xceea71
               Pieces: []
-            - Range: 0xceea51..0xceea52
+            - Range: 0xceea71..0xceea72
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xceea52..0xceea5e
+            - Range: 0xceea72..0xceea7e
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 112
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0xceea60..0xceeb57]
+      OutOfLinePCRanges: [0xceea80..0xceeb77]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 14 BaseType float64
-          Locations: [{Range: 0xceea60..0xceeb57, Pieces: []}]
+          Locations: [{Range: 0xceea80..0xceeb77, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 14 BaseType float64
-          Locations: [{Range: 0xceea60..0xceeb57, Pieces: []}]
+          Locations: [{Range: 0xceea80..0xceeb77, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 14 BaseType float64
-          Locations: [{Range: 0xceea60..0xceeb57, Pieces: []}]
+          Locations: [{Range: 0xceea80..0xceeb77, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 14 BaseType float64
-          Locations: [{Range: 0xceea60..0xceeb57, Pieces: []}]
+          Locations: [{Range: 0xceea80..0xceeb77, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 14 BaseType float64
-          Locations: [{Range: 0xceea60..0xceeb57, Pieces: []}]
+          Locations: [{Range: 0xceea80..0xceeb77, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 14 BaseType float64
-          Locations: [{Range: 0xceea60..0xceeb57, Pieces: []}]
+          Locations: [{Range: 0xceea80..0xceeb77, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 14 BaseType float64
-          Locations: [{Range: 0xceea60..0xceeb57, Pieces: []}]
+          Locations: [{Range: 0xceea80..0xceeb77, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 14 BaseType float64
-          Locations: [{Range: 0xceea60..0xceeb57, Pieces: []}]
+          Locations: [{Range: 0xceea80..0xceeb77, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 14 BaseType float64
-          Locations: [{Range: 0xceea60..0xceeb57, Pieces: []}]
+          Locations: [{Range: 0xceea80..0xceeb77, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r9
           Type: 14 BaseType float64
-          Locations: [{Range: 0xceea60..0xceeb57, Pieces: []}]
+          Locations: [{Range: 0xceea80..0xceeb77, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r10
           Type: 14 BaseType float64
-          Locations: [{Range: 0xceea60..0xceeb57, Pieces: []}]
+          Locations: [{Range: 0xceea80..0xceeb77, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r11
           Type: 14 BaseType float64
-          Locations: [{Range: 0xceea60..0xceeb57, Pieces: []}]
+          Locations: [{Range: 0xceea80..0xceeb77, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r12
           Type: 14 BaseType float64
-          Locations: [{Range: 0xceea60..0xceeb57, Pieces: []}]
+          Locations: [{Range: 0xceea80..0xceeb77, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r13
           Type: 14 BaseType float64
-          Locations: [{Range: 0xceea60..0xceeb57, Pieces: []}]
+          Locations: [{Range: 0xceea80..0xceeb77, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r14
           Type: 14 BaseType float64
-          Locations: [{Range: 0xceea60..0xceeb57, Pieces: []}]
+          Locations: [{Range: 0xceea80..0xceeb77, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: onlyOnAmd64_16
           Type: 14 BaseType float64
           Locations:
-            - Range: 0xceea60..0xceeb47
+            - Range: 0xceea80..0xceeb67
               Pieces: []
-            - Range: 0xceeb47..0xceeb48
+            - Range: 0xceeb67..0xceeb68
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xceeb48..0xceeb57
+            - Range: 0xceeb68..0xceeb77
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: bothArmAndAmd64
           Type: 14 BaseType float64
           Locations:
-            - Range: 0xceea60..0xceeb47
+            - Range: 0xceea80..0xceeb67
               Pieces: []
-            - Range: 0xceeb47..0xceeb48
+            - Range: 0xceeb67..0xceeb68
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xceeb48..0xceeb57
+            - Range: 0xceeb68..0xceeb77
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 113
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0xceeb60..0xceebd3]
+      OutOfLinePCRanges: [0xceeb80..0xceebf3]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 103 BaseType complex64
-          Locations: [{Range: 0xceeb60..0xceebd3, Pieces: []}]
+          Locations: [{Range: 0xceeb80..0xceebf3, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 19 BaseType complex128
-          Locations: [{Range: 0xceeb60..0xceebd3, Pieces: []}]
+          Locations: [{Range: 0xceeb80..0xceebf3, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 114
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0xceebe0..0xceec93]
+      OutOfLinePCRanges: [0xceec00..0xceecb3]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0xceebe0..0xceec83
+            - Range: 0xceec00..0xceeca3
               Pieces: []
-            - Range: 0xceec83..0xceec84
+            - Range: 0xceeca3..0xceeca4
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
-            - Range: 0xceec84..0xceec93
+            - Range: 0xceeca4..0xceecb3
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 115
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0xceeca0..0xceed1c]
+      OutOfLinePCRanges: [0xceecc0..0xceed3c]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 262 ArrayType [3]int
           Locations:
-            - Range: 0xceeca0..0xceed0f
+            - Range: 0xceecc0..0xceed2f
               Pieces: []
-            - Range: 0xceed0f..0xceed10
+            - Range: 0xceed2f..0xceed30
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xceed10..0xceed1c
+            - Range: 0xceed30..0xceed3c
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 116
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0xceed20..0xceed78]
+      OutOfLinePCRanges: [0xceed40..0xceed98]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 263 ArrayType [1]int
           Locations:
-            - Range: 0xceed20..0xceed6b
+            - Range: 0xceed40..0xceed8b
               Pieces: []
-            - Range: 0xceed6b..0xceed6c
+            - Range: 0xceed8b..0xceed8c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xceed6c..0xceed78
+            - Range: 0xceed8c..0xceed98
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 117
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0xceed80..0xceedd3]
+      OutOfLinePCRanges: [0xceeda0..0xceedf3]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 264 ArrayType [0]int
           Locations:
-            - Range: 0xceed80..0xceedc6
+            - Range: 0xceeda0..0xceede6
               Pieces: []
-            - Range: 0xceedc6..0xceedc7
+            - Range: 0xceede6..0xceede7
               Pieces: []
-            - Range: 0xceedc7..0xceedd3
+            - Range: 0xceede7..0xceedf3
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 118
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0xceede0..0xceee47]
+      OutOfLinePCRanges: [0xceee00..0xceee67]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 265 StructureType main.mixedStruct
-          Locations: [{Range: 0xceede0..0xceee47, Pieces: []}]
+          Locations: [{Range: 0xceee00..0xceee67, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 119
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0xceee60..0xceeefa]
+      OutOfLinePCRanges: [0xceee80..0xceef1a]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xceee60..0xceeeea
+            - Range: 0xceee80..0xceef0a
               Pieces: []
-            - Range: 0xceeeea..0xceeeeb
+            - Range: 0xceef0a..0xceef0b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xceeeeb..0xceeefa
+            - Range: 0xceef0b..0xceef1a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 8 BaseType int
           Locations:
-            - Range: 0xceee60..0xceeeea
+            - Range: 0xceee80..0xceef0a
               Pieces: []
-            - Range: 0xceeeea..0xceeeeb
+            - Range: 0xceef0a..0xceef0b
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xceeeeb..0xceeefa
+            - Range: 0xceef0b..0xceef1a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0xceee60..0xceeeea
+            - Range: 0xceee80..0xceef0a
               Pieces: []
-            - Range: 0xceeeea..0xceeeeb
+            - Range: 0xceef0a..0xceef0b
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xceeeeb..0xceeefa
+            - Range: 0xceef0b..0xceef1a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 8 BaseType int
           Locations:
-            - Range: 0xceee60..0xceeeea
+            - Range: 0xceee80..0xceef0a
               Pieces: []
-            - Range: 0xceeeea..0xceeeeb
+            - Range: 0xceef0a..0xceef0b
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xceeeeb..0xceeefa
+            - Range: 0xceef0b..0xceef1a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 8 BaseType int
           Locations:
-            - Range: 0xceee60..0xceeeea
+            - Range: 0xceee80..0xceef0a
               Pieces: []
-            - Range: 0xceeeea..0xceeeeb
+            - Range: 0xceef0a..0xceef0b
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xceeeeb..0xceeefa
+            - Range: 0xceef0b..0xceef1a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 8 BaseType int
           Locations:
-            - Range: 0xceee60..0xceeeea
+            - Range: 0xceee80..0xceef0a
               Pieces: []
-            - Range: 0xceeeea..0xceeeeb
+            - Range: 0xceef0a..0xceef0b
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xceeeeb..0xceeefa
+            - Range: 0xceef0b..0xceef1a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 8 BaseType int
           Locations:
-            - Range: 0xceee60..0xceeeea
+            - Range: 0xceee80..0xceef0a
               Pieces: []
-            - Range: 0xceeeea..0xceeeeb
+            - Range: 0xceef0a..0xceef0b
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xceeeeb..0xceeefa
+            - Range: 0xceef0b..0xceef1a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 8 BaseType int
           Locations:
-            - Range: 0xceee60..0xceeeea
+            - Range: 0xceee80..0xceef0a
               Pieces: []
-            - Range: 0xceeeea..0xceeeeb
+            - Range: 0xceef0a..0xceef0b
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xceeeeb..0xceeefa
+            - Range: 0xceef0b..0xceef1a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xceee60..0xceeeea
+            - Range: 0xceee80..0xceef0a
               Pieces: []
-            - Range: 0xceeeea..0xceeeeb
+            - Range: 0xceef0a..0xceef0b
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xceeeeb..0xceeefa
+            - Range: 0xceef0b..0xceef1a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 120
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0xceef00..0xceefc5]
+      OutOfLinePCRanges: [0xceef20..0xceefe5]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 266 StructureType main.wideStruct
           Locations:
-            - Range: 0xceef00..0xceefb2
+            - Range: 0xceef20..0xceefd2
               Pieces: []
-            - Range: 0xceefb2..0xceefb3
+            - Range: 0xceefd2..0xceefd3
               Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
-            - Range: 0xceefb3..0xceefc5
+            - Range: 0xceefd3..0xceefe5
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 121
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0xceefe0..0xcef059]
+      OutOfLinePCRanges: [0xcef000..0xcef079]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xceefe0..0xcef04c
+            - Range: 0xcef000..0xcef06c
               Pieces: []
-            - Range: 0xcef04c..0xcef04d
+            - Range: 0xcef06c..0xcef06d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcef04d..0xcef059
+            - Range: 0xcef06d..0xcef079
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 14 BaseType float64
-          Locations: [{Range: 0xceefe0..0xcef059, Pieces: []}]
+          Locations: [{Range: 0xcef000..0xcef079, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0xceefe0..0xcef04c
+            - Range: 0xcef000..0xcef06c
               Pieces: []
-            - Range: 0xcef04c..0xcef04d
+            - Range: 0xcef06c..0xcef06d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcef04d..0xcef059
+            - Range: 0xcef06d..0xcef079
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 14 BaseType float64
-          Locations: [{Range: 0xceefe0..0xcef059, Pieces: []}]
+          Locations: [{Range: 0xcef000..0xcef079, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xceefe0..0xcef04c
+            - Range: 0xcef000..0xcef06c
               Pieces: []
-            - Range: 0xcef04c..0xcef04d
+            - Range: 0xcef06c..0xcef06d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcef04d..0xcef059
+            - Range: 0xcef06d..0xcef079
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 122
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0xcef060..0xcef0dc]
+      OutOfLinePCRanges: [0xcef080..0xcef0fc]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 267 StructureType main.structWithArray
           Locations:
-            - Range: 0xcef060..0xcef0cf
+            - Range: 0xcef080..0xcef0ef
               Pieces: []
-            - Range: 0xcef0cf..0xcef0d0
+            - Range: 0xcef0ef..0xcef0f0
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xcef0d0..0xcef0dc
+            - Range: 0xcef0f0..0xcef0fc
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 123
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0xcef0e0..0xcef13b]
+      OutOfLinePCRanges: [0xcef100..0xcef15b]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 14 BaseType float64
-          Locations: [{Range: 0xcef0e0..0xcef13b, Pieces: []}]
+          Locations: [{Range: 0xcef100..0xcef15b, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 124
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0xcef140..0xcef1a7]
+      OutOfLinePCRanges: [0xcef160..0xcef1c7]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float32
-          Locations: [{Range: 0xcef140..0xcef1a7, Pieces: []}]
+          Locations: [{Range: 0xcef160..0xcef1c7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 14 BaseType float64
-          Locations: [{Range: 0xcef140..0xcef1a7, Pieces: []}]
+          Locations: [{Range: 0xcef160..0xcef1c7, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 125
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0xcef1c0..0xcef21d]
+      OutOfLinePCRanges: [0xcef1e0..0xcef23d]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xcef1c0..0xcef210
+            - Range: 0xcef1e0..0xcef230
               Pieces: []
-            - Range: 0xcef210..0xcef211
+            - Range: 0xcef230..0xcef231
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcef211..0xcef21d
+            - Range: 0xcef231..0xcef23d
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 2 BaseType uintptr
           Locations:
-            - Range: 0xcef1c0..0xcef210
+            - Range: 0xcef1e0..0xcef230
               Pieces: []
-            - Range: 0xcef210..0xcef211
+            - Range: 0xcef230..0xcef231
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcef211..0xcef21d
+            - Range: 0xcef231..0xcef23d
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 126
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0xcef220..0xcef39d]
+      OutOfLinePCRanges: [0xcef240..0xcef3bd]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0xcef220..0xcef39d
+            - Range: 0xcef240..0xcef3bd
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0xcef220..0xcef38d
+            - Range: 0xcef240..0xcef3ad
               Pieces: []
-            - Range: 0xcef38d..0xcef38e
+            - Range: 0xcef3ad..0xcef3ae
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
-            - Range: 0xcef38e..0xcef39d
+            - Range: 0xcef3ae..0xcef3bd
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 127
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0xcef3a0..0xcef47a]
+      OutOfLinePCRanges: [0xcef3c0..0xcef49a]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 262 ArrayType [3]int
           Locations:
-            - Range: 0xcef3a0..0xcef47a
+            - Range: 0xcef3c0..0xcef49a
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 262 ArrayType [3]int
           Locations:
-            - Range: 0xcef3a0..0xcef46a
+            - Range: 0xcef3c0..0xcef48a
               Pieces: []
-            - Range: 0xcef46a..0xcef46b
+            - Range: 0xcef48a..0xcef48b
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xcef46b..0xcef47a
+            - Range: 0xcef48b..0xcef49a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 128
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0xcef480..0xcef6bb]
+      OutOfLinePCRanges: [0xcef4a0..0xcef6db]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0xcef480..0xcef6bb
+            - Range: 0xcef4a0..0xcef6db
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s2
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0xcef480..0xcef6bb
+            - Range: 0xcef4a0..0xcef6db
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0xcef480..0xcef6ab
+            - Range: 0xcef4a0..0xcef6cb
               Pieces: []
-            - Range: 0xcef6ab..0xcef6ac
+            - Range: 0xcef6cb..0xcef6cc
               Pieces: [{Size: 80, Op: {CfaOffset: 160}}]
-            - Range: 0xcef6ac..0xcef6bb
+            - Range: 0xcef6cc..0xcef6db
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 129
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0xcef6c0..0xcef96f]
+      OutOfLinePCRanges: [0xcef6e0..0xcef98f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcef6c0..0xcef787
+            - Range: 0xcef6e0..0xcef7a7
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcef787..0xcef96f
+            - Range: 0xcef7a7..0xcef98f
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcef6c0..0xcef787
+            - Range: 0xcef6e0..0xcef7a7
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcef787..0xcef96f
+            - Range: 0xcef7a7..0xcef98f
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcef6c0..0xcef72a
+            - Range: 0xcef6e0..0xcef74a
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcef72a..0xcef96f
+            - Range: 0xcef74a..0xcef98f
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcef6c0..0xcef787
+            - Range: 0xcef6e0..0xcef7a7
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcef787..0xcef96f
+            - Range: 0xcef7a7..0xcef98f
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcef6c0..0xcef787
+            - Range: 0xcef6e0..0xcef7a7
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcef787..0xcef96f
+            - Range: 0xcef7a7..0xcef98f
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcef6c0..0xcef787
+            - Range: 0xcef6e0..0xcef7a7
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcef787..0xcef96f
+            - Range: 0xcef7a7..0xcef98f
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcef6c0..0xcef787
+            - Range: 0xcef6e0..0xcef7a7
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcef787..0xcef96f
+            - Range: 0xcef7a7..0xcef98f
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcef6c0..0xcef787
+            - Range: 0xcef6e0..0xcef7a7
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcef787..0xcef96f
+            - Range: 0xcef7a7..0xcef98f
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcef6c0..0xcef787
+            - Range: 0xcef6e0..0xcef7a7
               Pieces: [{Size: 8, Op: {RegNo: 11, Shift: 0}}]
-            - Range: 0xcef787..0xcef96f
+            - Range: 0xcef7a7..0xcef98f
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 120 ArrayType [2]int
           Locations:
-            - Range: 0xcef6c0..0xcef902
+            - Range: 0xcef6e0..0xcef922
               Pieces: []
-            - Range: 0xcef902..0xcef903
+            - Range: 0xcef922..0xcef923
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xcef903..0xcef96f
+            - Range: 0xcef923..0xcef98f
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 130
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0xcef980..0xcefc45]
+      OutOfLinePCRanges: [0xcef9a0..0xcefc65]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcef980..0xcefa2a
+            - Range: 0xcef9a0..0xcefa4a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcefa2a..0xcefc45
+            - Range: 0xcefa4a..0xcefc65
               Pieces: [{Size: 8, Op: {CfaOffset: 96}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcef980..0xcefa2a
+            - Range: 0xcef9a0..0xcefa4a
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcefa2a..0xcefc45
+            - Range: 0xcefa4a..0xcefc65
               Pieces: [{Size: 8, Op: {CfaOffset: 104}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcef980..0xcef9e2
+            - Range: 0xcef9a0..0xcefa02
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcef9e2..0xcefc45
+            - Range: 0xcefa02..0xcefc65
               Pieces: [{Size: 8, Op: {CfaOffset: 112}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcef980..0xcefa2a
+            - Range: 0xcef9a0..0xcefa4a
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcefa2a..0xcefc45
+            - Range: 0xcefa4a..0xcefc65
               Pieces: [{Size: 8, Op: {CfaOffset: 120}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcef980..0xcefa2a
+            - Range: 0xcef9a0..0xcefa4a
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcefa2a..0xcefc45
+            - Range: 0xcefa4a..0xcefc65
               Pieces: [{Size: 8, Op: {CfaOffset: 128}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcef980..0xcefa2a
+            - Range: 0xcef9a0..0xcefa4a
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcefa2a..0xcefc45
+            - Range: 0xcefa4a..0xcefc65
               Pieces: [{Size: 8, Op: {CfaOffset: 136}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcef980..0xcefa2a
+            - Range: 0xcef9a0..0xcefa4a
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcefa2a..0xcefc45
+            - Range: 0xcefa4a..0xcefc65
               Pieces: [{Size: 8, Op: {CfaOffset: 144}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcef980..0xcefa2a
+            - Range: 0xcef9a0..0xcefa4a
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcefa2a..0xcefc45
+            - Range: 0xcefa4a..0xcefc65
               Pieces: [{Size: 8, Op: {CfaOffset: 152}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcef980..0xcefc45
+            - Range: 0xcef9a0..0xcefc65
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -9041,212 +9041,193 @@ Subprograms:
         - Name: ~r0
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0xcef980..0xcefbc2
+            - Range: 0xcef9a0..0xcefbe2
               Pieces: []
-            - Range: 0xcefbc2..0xcefbc3
+            - Range: 0xcefbe2..0xcefbe3
               Pieces: [{Size: 80, Op: {CfaOffset: 16}}]
-            - Range: 0xcefbc3..0xcefc45
+            - Range: 0xcefbe3..0xcefc65
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 131
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0xcefc60..0xcefcee]
+      OutOfLinePCRanges: [0xcefc80..0xcefd0e]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 172 ArrayType [5]int
           Locations:
-            - Range: 0xcefc60..0xcefcee
+            - Range: 0xcefc80..0xcefd0e
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcefc60..0xcefcde
+            - Range: 0xcefc80..0xcefcfe
               Pieces: []
-            - Range: 0xcefcde..0xcefcdf
+            - Range: 0xcefcfe..0xcefcff
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcefcdf..0xcefcee
+            - Range: 0xcefcff..0xcefd0e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcefc60..0xcefcde
+            - Range: 0xcefc80..0xcefcfe
               Pieces: []
-            - Range: 0xcefcde..0xcefcdf
+            - Range: 0xcefcfe..0xcefcff
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcefcdf..0xcefcee
+            - Range: 0xcefcff..0xcefd0e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcefc60..0xcefcde
+            - Range: 0xcefc80..0xcefcfe
               Pieces: []
-            - Range: 0xcefcde..0xcefcdf
+            - Range: 0xcefcfe..0xcefcff
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcefcdf..0xcefcee
+            - Range: 0xcefcff..0xcefd0e
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 132
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0xcefd00..0xcefded]
+      OutOfLinePCRanges: [0xcefd20..0xcefe0d]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 120 ArrayType [2]int
           Locations:
-            - Range: 0xcefd00..0xcefded
+            - Range: 0xcefd20..0xcefe0d
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 262 ArrayType [3]int
           Locations:
-            - Range: 0xcefd00..0xcefded
+            - Range: 0xcefd20..0xcefe0d
               Pieces: [{Size: 24, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcefd00..0xcefddd
+            - Range: 0xcefd20..0xcefdfd
               Pieces: []
-            - Range: 0xcefddd..0xcefdde
+            - Range: 0xcefdfd..0xcefdfe
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcefdde..0xcefded
+            - Range: 0xcefdfe..0xcefe0d
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 120 ArrayType [2]int
           Locations:
-            - Range: 0xcefd00..0xcefddd
+            - Range: 0xcefd20..0xcefdfd
               Pieces: []
-            - Range: 0xcefddd..0xcefdde
+            - Range: 0xcefdfd..0xcefdfe
               Pieces: [{Size: 16, Op: {CfaOffset: 40}}]
-            - Range: 0xcefdde..0xcefded
+            - Range: 0xcefdfe..0xcefe0d
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 133
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0xcefe00..0xcefed4]
+      OutOfLinePCRanges: [0xcefe20..0xcefef4]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 267 StructureType main.structWithArray
           Locations:
-            - Range: 0xcefe00..0xcefed4
+            - Range: 0xcefe20..0xcefef4
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcefe00..0xcefec4
+            - Range: 0xcefe20..0xcefee4
               Pieces: []
-            - Range: 0xcefec4..0xcefec5
+            - Range: 0xcefee4..0xcefee5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcefec5..0xcefed4
+            - Range: 0xcefee5..0xcefef4
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 267 StructureType main.structWithArray
           Locations:
-            - Range: 0xcefe00..0xcefec4
+            - Range: 0xcefe20..0xcefee4
               Pieces: []
-            - Range: 0xcefec4..0xcefec5
+            - Range: 0xcefee4..0xcefee5
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xcefec5..0xcefed4
+            - Range: 0xcefee5..0xcefef4
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcefe8e..0xcefed4
+            - Range: 0xcefeae..0xcefef4
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 134
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0xcefee0..0xceff86]
+      OutOfLinePCRanges: [0xceff00..0xceffa6]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 264 ArrayType [0]int
-          Locations: [{Range: 0xcefee0..0xceff86, Pieces: []}]
+          Locations: [{Range: 0xceff00..0xceffa6, Pieces: []}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcefee0..0xceff25
+            - Range: 0xceff00..0xceff45
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xceff25..0xceff47
+            - Range: 0xceff45..0xceff67
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xceff47..0xceff5a
+            - Range: 0xceff67..0xceff7a
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xceff5a..0xceff86
+            - Range: 0xceff7a..0xceffa6
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0xcefee0..0xceff6c
+            - Range: 0xceff00..0xceff8c
               Pieces: []
-            - Range: 0xceff6c..0xceff6d
+            - Range: 0xceff8c..0xceff8d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xceff6d..0xceff86
+            - Range: 0xceff8d..0xceffa6
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 264 ArrayType [0]int
           Locations:
-            - Range: 0xcefee0..0xceff6c
+            - Range: 0xceff00..0xceff8c
               Pieces: []
-            - Range: 0xceff6c..0xceff6d
+            - Range: 0xceff8c..0xceff8d
               Pieces: []
-            - Range: 0xceff6d..0xceff86
+            - Range: 0xceff8d..0xceffa6
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 135
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0xcf04e0..0xcf04e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 268 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcf04e0..0xcf04e1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 136
-      Name: main.testEmptySlice
       OutOfLinePCRanges: [0xcf0500..0xcf0501]
       InlinePCRanges: []
       Variables:
@@ -9264,13 +9245,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 137
-      Name: main.testSliceOfSlices
+    - ID: 136
+      Name: main.testEmptySlice
       OutOfLinePCRanges: [0xcf0520..0xcf0521]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 269 GoSliceHeaderType [][]uint
+          Type: 268 GoSliceHeaderType []uint
           Locations:
             - Range: 0xcf0520..0xcf0521
               Pieces:
@@ -9283,13 +9264,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 138
-      Name: main.testStructSlice
+    - ID: 137
+      Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0xcf0540..0xcf0541]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 271 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 269 GoSliceHeaderType [][]uint
           Locations:
             - Range: 0xcf0540..0xcf0541
               Pieces:
@@ -9301,16 +9282,9 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
           DictIndex: -1
-        - Name: a
-          Type: 8 BaseType int
-          Locations:
-            - Range: 0xcf0540..0xcf0541
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
       DictRegister: null
-    - ID: 139
-      Name: main.testEmptySliceOfStructs
+    - ID: 138
+      Name: main.testStructSlice
       OutOfLinePCRanges: [0xcf0560..0xcf0561]
       InlinePCRanges: []
       Variables:
@@ -9335,8 +9309,8 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 140
-      Name: main.testNilSliceOfStructs
+    - ID: 139
+      Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0xcf0580..0xcf0581]
       InlinePCRanges: []
       Variables:
@@ -9361,15 +9335,41 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 140
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0xcf05a0..0xcf05a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 271 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcf05a0..0xcf05a1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 8 BaseType int
+          Locations:
+            - Range: 0xcf05a0..0xcf05a1
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 141
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0xcf05a0..0xcf05a1]
+      OutOfLinePCRanges: [0xcf05c0..0xcf05c1]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 165 GoSliceHeaderType []string
           Locations:
-            - Range: 0xcf05a0..0xcf05a1
+            - Range: 0xcf05c0..0xcf05c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9382,20 +9382,20 @@ Subprograms:
       DictRegister: null
     - ID: 142
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xcf05c0..0xcf05c1]
+      OutOfLinePCRanges: [0xcf05e0..0xcf05e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 21 BaseType int8
           Locations:
-            - Range: 0xcf05c0..0xcf05c1
+            - Range: 0xcf05e0..0xcf05e1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 274 GoSliceHeaderType []bool
           Locations:
-            - Range: 0xcf05c0..0xcf05c1
+            - Range: 0xcf05e0..0xcf05e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9408,37 +9408,18 @@ Subprograms:
         - Name: x
           Type: 15 BaseType uint
           Locations:
-            - Range: 0xcf05c0..0xcf05c1
+            - Range: 0xcf05e0..0xcf05e1
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 143
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0xcf05e0..0xcf05e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 275 GoSliceHeaderType []uint16
-          Locations:
-            - Range: 0xcf05e0..0xcf05e1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 144
-      Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0xcf0600..0xcf0601]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 268 GoSliceHeaderType []uint
+          Type: 275 GoSliceHeaderType []uint16
           Locations:
             - Range: 0xcf0600..0xcf0601
               Pieces:
@@ -9451,13 +9432,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 145
-      Name: main.testSliceEmptyStructs
+    - ID: 144
+      Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0xcf0620..0xcf0621]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 276 GoSliceHeaderType []struct {}
+          Type: 268 GoSliceHeaderType []uint
           Locations:
             - Range: 0xcf0620..0xcf0621
               Pieces:
@@ -9470,15 +9451,34 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 145
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0xcf0640..0xcf0641]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 276 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0xcf0640..0xcf0641
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 146
       Name: main.testSubslices
-      OutOfLinePCRanges: [0xcf0640..0xcf0641]
+      OutOfLinePCRanges: [0xcf0660..0xcf0661]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 268 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcf0640..0xcf0641
+            - Range: 0xcf0660..0xcf0661
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9491,7 +9491,7 @@ Subprograms:
         - Name: bs
           Type: 268 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcf0640..0xcf0641
+            - Range: 0xcf0660..0xcf0661
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -9504,7 +9504,7 @@ Subprograms:
         - Name: cs
           Type: 268 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcf0640..0xcf0641
+            - Range: 0xcf0660..0xcf0661
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -9517,44 +9517,27 @@ Subprograms:
       DictRegister: null
     - ID: 147
       Name: main.stackC
-      OutOfLinePCRanges: [0xcf0da0..0xcf0df2]
+      OutOfLinePCRanges: [0xcf0dc0..0xcf0e12]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcf0da0..0xcf0de5
+            - Range: 0xcf0dc0..0xcf0e05
               Pieces: []
-            - Range: 0xcf0de5..0xcf0de6
+            - Range: 0xcf0e05..0xcf0e06
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf0de6..0xcf0df2
+            - Range: 0xcf0e06..0xcf0e12
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 148
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xcf0e00..0xcf0e01]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 10 GoStringHeaderType string
-          Locations:
-            - Range: 0xcf0e00..0xcf0e01
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 149
-      Name: main.testThreeStrings
       OutOfLinePCRanges: [0xcf0e20..0xcf0e21]
       InlinePCRanges: []
       Variables:
@@ -9569,10 +9552,27 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
           DictIndex: -1
+      DictRegister: null
+    - ID: 149
+      Name: main.testThreeStrings
+      OutOfLinePCRanges: [0xcf0e40..0xcf0e41]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0xcf0e40..0xcf0e41
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
         - Name: "y"
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcf0e20..0xcf0e21
+            - Range: 0xcf0e40..0xcf0e41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9583,7 +9583,7 @@ Subprograms:
         - Name: z
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcf0e20..0xcf0e21
+            - Range: 0xcf0e40..0xcf0e41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9594,13 +9594,13 @@ Subprograms:
       DictRegister: null
     - ID: 150
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xcf0e40..0xcf0e41]
+      OutOfLinePCRanges: [0xcf0e60..0xcf0e61]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 278 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xcf0e40..0xcf0e41
+            - Range: 0xcf0e60..0xcf0e61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9619,49 +9619,32 @@ Subprograms:
       DictRegister: null
     - ID: 151
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xcf0e60..0xcf0e61]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 279 PointerType *main.threeStringStruct
-          Locations:
-            - Range: 0xcf0e60..0xcf0e61
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 152
-      Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0xcf0e80..0xcf0e81]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 280 PointerType *main.oneStringStruct
+          Type: 279 PointerType *main.threeStringStruct
           Locations:
             - Range: 0xcf0e80..0xcf0e81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 153
-      Name: main.testMassiveString
+    - ID: 152
+      Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0xcf0ea0..0xcf0ea1]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 10 GoStringHeaderType string
+        - Name: a
+          Type: 280 PointerType *main.oneStringStruct
           Locations:
             - Range: 0xcf0ea0..0xcf0ea1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 154
-      Name: main.testUnitializedString
+    - ID: 153
+      Name: main.testMassiveString
       OutOfLinePCRanges: [0xcf0ec0..0xcf0ec1]
       InlinePCRanges: []
       Variables:
@@ -9677,8 +9660,8 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 155
-      Name: main.testEmptyString
+    - ID: 154
+      Name: main.testUnitializedString
       OutOfLinePCRanges: [0xcf0ee0..0xcf0ee1]
       InlinePCRanges: []
       Variables:
@@ -9694,12 +9677,12 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 156
-      Name: main.testSubstrings
+    - ID: 155
+      Name: main.testEmptyString
       OutOfLinePCRanges: [0xcf0f00..0xcf0f01]
       InlinePCRanges: []
       Variables:
-        - Name: a
+        - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
             - Range: 0xcf0f00..0xcf0f01
@@ -9710,10 +9693,27 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
           DictIndex: -1
+      DictRegister: null
+    - ID: 156
+      Name: main.testSubstrings
+      OutOfLinePCRanges: [0xcf0f20..0xcf0f21]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0xcf0f20..0xcf0f21
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
         - Name: b
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcf0f00..0xcf0f01
+            - Range: 0xcf0f20..0xcf0f21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9724,7 +9724,7 @@ Subprograms:
         - Name: c
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcf0f00..0xcf0f01
+            - Range: 0xcf0f20..0xcf0f21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9735,26 +9735,26 @@ Subprograms:
       DictRegister: null
     - ID: 157
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0xcf1080..0xcf1081]
+      OutOfLinePCRanges: [0xcf10a0..0xcf10a1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 282 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0xcf1080..0xcf1081
+            - Range: 0xcf10a0..0xcf10a1
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 158
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0xcf10a0..0xcf10a1]
+      OutOfLinePCRanges: [0xcf10c0..0xcf10c1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 295 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0xcf10a0..0xcf10a1
+            - Range: 0xcf10c0..0xcf10c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9773,13 +9773,13 @@ Subprograms:
       DictRegister: null
     - ID: 159
       Name: main.testStruct
-      OutOfLinePCRanges: [0xcf11e0..0xcf11e1]
+      OutOfLinePCRanges: [0xcf1200..0xcf1201]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 326 StructureType main.aStruct
           Locations:
-            - Range: 0xcf11e0..0xcf11e1
+            - Range: 0xcf1200..0xcf1201
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -9800,91 +9800,91 @@ Subprograms:
       DictRegister: null
     - ID: 160
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0xcf12a0..0xcf12a1]
+      OutOfLinePCRanges: [0xcf12c0..0xcf12c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 327 PointerType *main.anotherStruct
           Locations:
-            - Range: 0xcf12a0..0xcf12a1
+            - Range: 0xcf12c0..0xcf12c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 161
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0xcf12c0..0xcf12c1]
+      OutOfLinePCRanges: [0xcf12e0..0xcf12e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 329 StructureType main.tenStrings
           Locations:
-            - Range: 0xcf12c0..0xcf12c1
+            - Range: 0xcf12e0..0xcf12e1
               Pieces: [{Size: 160, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 162
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xcf1320..0xcf1321]
+      OutOfLinePCRanges: [0xcf1340..0xcf1341]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 330 StructureType main.emptyStruct
-          Locations: [{Range: 0xcf1320..0xcf1321, Pieces: []}]
+          Locations: [{Range: 0xcf1340..0xcf1341, Pieces: []}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 163
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xcf1340..0xcf1341]
+      OutOfLinePCRanges: [0xcf1360..0xcf1361]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 331 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xcf1340..0xcf1341
+            - Range: 0xcf1360..0xcf1361
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 164
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0xcf32a0..0xcf32a4]
+      OutOfLinePCRanges: [0xcf32c0..0xcf32c4]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0xcf32a0..0xcf32a4
+            - Range: 0xcf32c0..0xcf32c4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xcf32a0..0xcf32a3
+            - Range: 0xcf32c0..0xcf32c3
               Pieces: []
-            - Range: 0xcf32a3..0xcf32a4
+            - Range: 0xcf32c3..0xcf32c4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 165
       Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0xcf32c0..0xcf32cc]
+      OutOfLinePCRanges: [0xcf32e0..0xcf32ec]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf32c0..0xcf32cb
+            - Range: 0xcf32e0..0xcf32eb
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcf32cb..0xcf32cc
+            - Range: 0xcf32eb..0xcf32ec
               Pieces:
                 - Size: 8
                   Op: null
@@ -9895,9 +9895,9 @@ Subprograms:
         - Name: ~r0
           Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xcf32c0..0xcf32cb
+            - Range: 0xcf32e0..0xcf32eb
               Pieces: []
-            - Range: 0xcf32cb..0xcf32cc
+            - Range: 0xcf32eb..0xcf32ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9908,41 +9908,41 @@ Subprograms:
       DictRegister: 0
     - ID: 166
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0xcf32e0..0xcf32e4]
+      OutOfLinePCRanges: [0xcf3300..0xcf3304]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xcf32e0..0xcf32e4
+            - Range: 0xcf3300..0xcf3304
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0xcf32e0..0xcf32e3
+            - Range: 0xcf3300..0xcf3303
               Pieces: []
-            - Range: 0xcf32e3..0xcf32e4
+            - Range: 0xcf3303..0xcf3304
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 167
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0xcf3300..0xcf330c]
+      OutOfLinePCRanges: [0xcf3320..0xcf332c]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xcf3300..0xcf330b
+            - Range: 0xcf3320..0xcf332b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcf330b..0xcf330c
+            - Range: 0xcf332b..0xcf332c
               Pieces:
                 - Size: 8
                   Op: null
@@ -9953,9 +9953,9 @@ Subprograms:
         - Name: ~r0
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf3300..0xcf330b
+            - Range: 0xcf3320..0xcf332b
               Pieces: []
-            - Range: 0xcf330b..0xcf330c
+            - Range: 0xcf332b..0xcf332c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9966,13 +9966,13 @@ Subprograms:
       DictRegister: 0
     - ID: 168
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0xcf3380..0xcf3565]
+      OutOfLinePCRanges: [0xcf33a0..0xcf3585]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 336 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xcf3380..0xcf33be
+            - Range: 0xcf33a0..0xcf33de
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9980,7 +9980,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcf33be..0xcf33c9
+            - Range: 0xcf33de..0xcf33e9
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -9988,7 +9988,7 @@ Subprograms:
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: null
-            - Range: 0xcf33c9..0xcf3565
+            - Range: 0xcf33e9..0xcf3585
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -10001,18 +10001,18 @@ Subprograms:
         - Name: pred
           Type: 338 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0xcf3380..0xcf33c9
+            - Range: 0xcf33a0..0xcf33e9
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcf33c9..0xcf3565
+            - Range: 0xcf33e9..0xcf3585
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 336 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xcf3380..0xcf351a
+            - Range: 0xcf33a0..0xcf353a
               Pieces: []
-            - Range: 0xcf351a..0xcf351b
+            - Range: 0xcf353a..0xcf353b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10020,14 +10020,14 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcf351b..0xcf3565
+            - Range: 0xcf353b..0xcf3585
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
           Type: 336 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xcf33c9..0xcf33f6
+            - Range: 0xcf33e9..0xcf3416
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10035,7 +10035,7 @@ Subprograms:
                   Op: {CfaOffset: -88}
                 - Size: 8
                   Op: {CfaOffset: -80}
-            - Range: 0xcf33f6..0xcf33f6
+            - Range: 0xcf3416..0xcf3416
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10043,7 +10043,7 @@ Subprograms:
                   Op: {CfaOffset: -88}
                 - Size: 8
                   Op: {CfaOffset: -80}
-            - Range: 0xcf33f6..0xcf342c
+            - Range: 0xcf3416..0xcf344c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -10051,7 +10051,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0xcf342c..0xcf34e5
+            - Range: 0xcf344c..0xcf3505
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10059,7 +10059,7 @@ Subprograms:
                   Op: {CfaOffset: -88}
                 - Size: 8
                   Op: {CfaOffset: -80}
-            - Range: 0xcf34e5..0xcf34f6
+            - Range: 0xcf3505..0xcf3516
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -10067,7 +10067,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0xcf34f6..0xcf3508
+            - Range: 0xcf3516..0xcf3528
               Pieces:
                 - Size: 8
                   Op: null
@@ -10075,7 +10075,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0xcf3511..0xcf3517
+            - Range: 0xcf3531..0xcf3537
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10083,7 +10083,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0xcf3517..0xcf3565
+            - Range: 0xcf3537..0xcf3585
               Pieces:
                 - Size: 8
                   Op: null
@@ -10096,84 +10096,62 @@ Subprograms:
         - Name: item
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0xcf341f..0xcf342c
+            - Range: 0xcf343f..0xcf344c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf342c..0xcf34e5
+            - Range: 0xcf344c..0xcf3505
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
     - ID: 169
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xcf3580..0xcf35c4]
+      OutOfLinePCRanges: [0xcf35a0..0xcf35e4]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xcf3580..0xcf3599
+            - Range: 0xcf35a0..0xcf35b9
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
           Type: 339 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0xcf3580..0xcf3599
+            - Range: 0xcf35a0..0xcf35b9
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xcf3580..0xcf3599
+            - Range: 0xcf35a0..0xcf35b9
               Pieces: []
-            - Range: 0xcf3599..0xcf359a
+            - Range: 0xcf35b9..0xcf35ba
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf359a..0xcf35c4
+            - Range: 0xcf35ba..0xcf35e4
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
     - ID: 170
       Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0xcf3800..0xcf3804]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 337 PointerType *go.shape.int
-          Locations:
-            - Range: 0xcf3800..0xcf3804
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 337 PointerType *go.shape.int
-          Locations:
-            - Range: 0xcf3800..0xcf3803
-              Pieces: []
-            - Range: 0xcf3803..0xcf3804
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 171
-      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
       OutOfLinePCRanges: [0xcf3820..0xcf3824]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 340 PointerType *go.shape.struct { Name string }
+          Type: 337 PointerType *go.shape.int
           Locations:
             - Range: 0xcf3820..0xcf3824
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 340 PointerType *go.shape.struct { Name string }
+          Type: 337 PointerType *go.shape.int
           Locations:
             - Range: 0xcf3820..0xcf3823
               Pieces: []
@@ -10182,20 +10160,20 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 172
-      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
+    - ID: 171
+      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
       OutOfLinePCRanges: [0xcf3840..0xcf3844]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 342 PointerType *go.shape.struct { X int; Y int }
+          Type: 340 PointerType *go.shape.struct { Name string }
           Locations:
             - Range: 0xcf3840..0xcf3844
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 342 PointerType *go.shape.struct { X int; Y int }
+          Type: 340 PointerType *go.shape.struct { Name string }
           Locations:
             - Range: 0xcf3840..0xcf3843
               Pieces: []
@@ -10204,24 +10182,46 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
+    - ID: 172
+      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
+      OutOfLinePCRanges: [0xcf3860..0xcf3864]
+      InlinePCRanges: []
+      Variables:
+        - Name: p
+          Type: 342 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0xcf3860..0xcf3864
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 342 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0xcf3860..0xcf3863
+              Pieces: []
+            - Range: 0xcf3863..0xcf3864
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
     - ID: 173
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0xcf3860..0xcf3871]
+      OutOfLinePCRanges: [0xcf3880..0xcf3891]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 344 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0xcf3860..0xcf3871
+            - Range: 0xcf3880..0xcf3891
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf3860..0xcf3870
+            - Range: 0xcf3880..0xcf3890
               Pieces: []
-            - Range: 0xcf3870..0xcf3871
+            - Range: 0xcf3890..0xcf3891
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10232,69 +10232,69 @@ Subprograms:
       DictRegister: 0
     - ID: 174
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0xcf3940..0xcf3949]
+      OutOfLinePCRanges: [0xcf3960..0xcf3969]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 346 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0xcf3940..0xcf3949
+            - Range: 0xcf3960..0xcf3969
               Pieces: [{Size: 136, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0xcf3940..0xcf3948
+            - Range: 0xcf3960..0xcf3968
               Pieces: []
-            - Range: 0xcf3948..0xcf3949
+            - Range: 0xcf3968..0xcf3969
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 175
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0xcf3a00..0xcf3a08]
+      OutOfLinePCRanges: [0xcf3a20..0xcf3a28]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 347 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0xcf3a00..0xcf3a08
+            - Range: 0xcf3a20..0xcf3a28
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0xcf3a00..0xcf3a08
+            - Range: 0xcf3a20..0xcf3a28
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
           Type: 349 BaseType go.shape.bool
           Locations:
-            - Range: 0xcf3a00..0xcf3a08
+            - Range: 0xcf3a20..0xcf3a28
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
     - ID: 176
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0xcf3a80..0xcf3aee]
+      OutOfLinePCRanges: [0xcf3aa0..0xcf3b0e]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 350 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0xcf3a80..0xcf3aee
+            - Range: 0xcf3aa0..0xcf3b0e
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf3a80..0xcf3aee
+            - Range: 0xcf3aa0..0xcf3b0e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10305,20 +10305,20 @@ Subprograms:
         - Name: v
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0xcf3a80..0xcf3aee
+            - Range: 0xcf3aa0..0xcf3b0e
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
     - ID: 177
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0xcf3b60..0xcf3b68]
+      OutOfLinePCRanges: [0xcf3b80..0xcf3b88]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf3b60..0xcf3b68
+            - Range: 0xcf3b80..0xcf3b88
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10329,25 +10329,25 @@ Subprograms:
         - Name: b
           Type: 349 BaseType go.shape.bool
           Locations:
-            - Range: 0xcf3b60..0xcf3b68
+            - Range: 0xcf3b80..0xcf3b88
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 349 BaseType go.shape.bool
           Locations:
-            - Range: 0xcf3b60..0xcf3b67
+            - Range: 0xcf3b80..0xcf3b87
               Pieces: []
-            - Range: 0xcf3b67..0xcf3b68
+            - Range: 0xcf3b87..0xcf3b88
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf3b60..0xcf3b67
+            - Range: 0xcf3b80..0xcf3b87
               Pieces: []
-            - Range: 0xcf3b67..0xcf3b68
+            - Range: 0xcf3b87..0xcf3b88
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10358,26 +10358,26 @@ Subprograms:
       DictRegister: 0
     - ID: 178
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xcf3b80..0xcf3b8f]
+      OutOfLinePCRanges: [0xcf3ba0..0xcf3baf]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0xcf3b80..0xcf3b8e
+            - Range: 0xcf3ba0..0xcf3bae
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf3b80..0xcf3b8b
+            - Range: 0xcf3ba0..0xcf3bab
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcf3b8b..0xcf3b8f
+            - Range: 0xcf3bab..0xcf3baf
               Pieces:
                 - Size: 8
                   Op: null
@@ -10388,9 +10388,9 @@ Subprograms:
         - Name: ~r0
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf3b80..0xcf3b8e
+            - Range: 0xcf3ba0..0xcf3bae
               Pieces: []
-            - Range: 0xcf3b8e..0xcf3b8f
+            - Range: 0xcf3bae..0xcf3baf
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10401,56 +10401,56 @@ Subprograms:
         - Name: ~r1
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0xcf3b80..0xcf3b8e
+            - Range: 0xcf3ba0..0xcf3bae
               Pieces: []
-            - Range: 0xcf3b8e..0xcf3b8f
+            - Range: 0xcf3bae..0xcf3baf
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 179
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0xcf3ba0..0xcf3bda]
+      OutOfLinePCRanges: [0xcf3bc0..0xcf3bfa]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 352 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0xcf3ba0..0xcf3bb9
+            - Range: 0xcf3bc0..0xcf3bd9
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcf3ba0..0xcf3bb9
+            - Range: 0xcf3bc0..0xcf3bd9
               Pieces: []
-            - Range: 0xcf3bb9..0xcf3bba
+            - Range: 0xcf3bd9..0xcf3bda
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf3bba..0xcf3bda
+            - Range: 0xcf3bda..0xcf3bfa
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 180
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0xcf3be0..0xcf3c2d]
+      OutOfLinePCRanges: [0xcf3c00..0xcf3c4d]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 353 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0xcf3be0..0xcf3bff
+            - Range: 0xcf3c00..0xcf3c1f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcf3bff..0xcf3c02
+            - Range: 0xcf3c1f..0xcf3c22
               Pieces:
                 - Size: 8
                   Op: null
@@ -10461,37 +10461,37 @@ Subprograms:
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xcf3be0..0xcf3c02
+            - Range: 0xcf3c00..0xcf3c22
               Pieces: []
-            - Range: 0xcf3c02..0xcf3c03
+            - Range: 0xcf3c22..0xcf3c23
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf3c03..0xcf3c2d
+            - Range: 0xcf3c23..0xcf3c4d
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 181
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0xcf3c40..0xcf3c48]
+      OutOfLinePCRanges: [0xcf3c60..0xcf3c68]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 354 PointerType *go.shape.string
           Locations:
-            - Range: 0xcf3c40..0xcf3c47
+            - Range: 0xcf3c60..0xcf3c67
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf3c40..0xcf3c47
+            - Range: 0xcf3c60..0xcf3c67
               Pieces: []
-            - Range: 0xcf3c47..0xcf3c48
+            - Range: 0xcf3c67..0xcf3c68
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10502,22 +10502,22 @@ Subprograms:
       DictRegister: 0
     - ID: 182
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0xcf3c60..0xcf3cbb]
+      OutOfLinePCRanges: [0xcf3c80..0xcf3cdb]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 355 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xcf3c60..0xcf3ca1
+            - Range: 0xcf3c80..0xcf3cc1
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 356 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xcf3c60..0xcf3cb5
+            - Range: 0xcf3c80..0xcf3cd5
               Pieces: []
-            - Range: 0xcf3cb5..0xcf3cb6
+            - Range: 0xcf3cd5..0xcf3cd6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10531,20 +10531,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xcf3cb6..0xcf3cbb
+            - Range: 0xcf3cd6..0xcf3cdb
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 183
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0xcf3cc0..0xcf3ce4]
+      OutOfLinePCRanges: [0xcf3ce0..0xcf3d04]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 336 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xcf3cc0..0xcf3ce4
+            - Range: 0xcf3ce0..0xcf3d04
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10557,33 +10557,33 @@ Subprograms:
         - Name: needle
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0xcf3cc0..0xcf3ce4
+            - Range: 0xcf3ce0..0xcf3d04
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xcf3cc0..0xcf3ce0
+            - Range: 0xcf3ce0..0xcf3d00
               Pieces: []
-            - Range: 0xcf3ce0..0xcf3ce1
+            - Range: 0xcf3d00..0xcf3d01
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf3ce1..0xcf3ce3
+            - Range: 0xcf3d01..0xcf3d03
               Pieces: []
-            - Range: 0xcf3ce3..0xcf3ce4
+            - Range: 0xcf3d03..0xcf3d04
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 184
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0xcf3d00..0xcf3dbf]
+      OutOfLinePCRanges: [0xcf3d20..0xcf3ddf]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 357 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0xcf3d00..0xcf3d1d
+            - Range: 0xcf3d20..0xcf3d3d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10591,7 +10591,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcf3d1d..0xcf3d1f
+            - Range: 0xcf3d3d..0xcf3d3f
               Pieces:
                 - Size: 8
                   Op: null
@@ -10604,13 +10604,13 @@ Subprograms:
         - Name: needle
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf3d00..0xcf3d4c
+            - Range: 0xcf3d20..0xcf3d6c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xcf3d4c..0xcf3dbf
+            - Range: 0xcf3d6c..0xcf3ddf
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
@@ -10621,28 +10621,28 @@ Subprograms:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xcf3d00..0xcf3d6b
+            - Range: 0xcf3d20..0xcf3d8b
               Pieces: []
-            - Range: 0xcf3d6b..0xcf3d6c
+            - Range: 0xcf3d8b..0xcf3d8c
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf3d6c..0xcf3d73
+            - Range: 0xcf3d8c..0xcf3d93
               Pieces: []
-            - Range: 0xcf3d73..0xcf3d74
+            - Range: 0xcf3d93..0xcf3d94
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf3d74..0xcf3dbf
+            - Range: 0xcf3d94..0xcf3ddf
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf3d2f..0xcf3d41
+            - Range: 0xcf3d4f..0xcf3d61
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xcf3d41..0xcf3d4c
+            - Range: 0xcf3d61..0xcf3d6c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10653,54 +10653,54 @@ Subprograms:
       DictRegister: 0
     - ID: 185
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0xcf3dc0..0xcf3dc7]
+      OutOfLinePCRanges: [0xcf3de0..0xcf3de7]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 358 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0xcf3dc0..0xcf3dc6
+            - Range: 0xcf3de0..0xcf3de6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0xcf3dc0..0xcf3dc7
+            - Range: 0xcf3de0..0xcf3de7
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xcf3dc0..0xcf3dc6
+            - Range: 0xcf3de0..0xcf3de6
               Pieces: []
-            - Range: 0xcf3dc6..0xcf3dc7
+            - Range: 0xcf3de6..0xcf3de7
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 3
     - ID: 186
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0xcf3e20..0xcf3e8c]
+      OutOfLinePCRanges: [0xcf3e40..0xcf3eac]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 359 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0xcf3e20..0xcf3e40
+            - Range: 0xcf3e40..0xcf3e60
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf3e40..0xcf3e48
+            - Range: 0xcf3e60..0xcf3e68
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf3e48..0xcf3e4d
+            - Range: 0xcf3e68..0xcf3e6d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10711,7 +10711,7 @@ Subprograms:
         - Name: value
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf3e20..0xcf3e4d
+            - Range: 0xcf3e40..0xcf3e6d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -10722,11 +10722,11 @@ Subprograms:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0xcf3e20..0xcf3e4d
+            - Range: 0xcf3e40..0xcf3e6d
               Pieces: []
-            - Range: 0xcf3e4d..0xcf3e4e
+            - Range: 0xcf3e6d..0xcf3e6e
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf3e4e..0xcf3e8c
+            - Range: 0xcf3e6e..0xcf3eac
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10963,8 +10963,8 @@ Subprograms:
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0xceac20..0xceac86]
       InlinePCRanges:
-        - Ranges: [0xcf3f1a..0xcf3f48]
-          RootRanges: [0xcf3f00..0xcf3f65]
+        - Ranges: [0xcf3f3a..0xcf3f68]
+          RootRanges: [0xcf3f20..0xcf3f85]
       Variables:
         - Name: b
           Type: 364 StructureType main.firstBehavior
@@ -10997,8 +10997,8 @@ Subprograms:
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xceb4fd..0xceb504]
-          RootRanges: [0xceb460..0xceb54b]
+        - Ranges: [0xceb51d..0xceb524]
+          RootRanges: [0xceb480..0xceb56b]
         - Ranges: [0x53dae1..0x53dae9]
           RootRanges: [0x53dae0..0x53daea]
       Variables: []

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -13,11 +13,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1406 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0x8969e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x896a08", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1407 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0x896a1c", Frameless: false}]
+              InjectionPoints: [{PC: "0x896a3c", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -84,11 +84,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1377 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0x89545c", Frameless: false}]
+              InjectionPoints: [{PC: "0x89547c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1378 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0x8954f4", Frameless: false}]
+              InjectionPoints: [{PC: "0x895514", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -176,7 +176,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1257 EventRootType Probe[main.testArrayOfMaps]
-              InjectionPoints: [{PC: "0x891eb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x891ed0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -241,11 +241,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1279 EventRootType Probe[main.testAtomicAdd]
-              InjectionPoints: [{PC: "0x8935a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8935c0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1280 EventRootType Probe[main.testAtomicAdd]Return
-              InjectionPoints: [{PC: "0x8935dc", Frameless: true}]
+              InjectionPoints: [{PC: "0x8935fc", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -342,11 +342,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1425 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x896d40", Frameless: true}]
+              InjectionPoints: [{PC: "0x896d60", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1426 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0x896d5c", Frameless: true}]
+              InjectionPoints: [{PC: "0x896d7c", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -476,7 +476,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1276 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x893340", Frameless: true}]
+              InjectionPoints: [{PC: "0x893360", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -495,7 +495,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1277 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x893340", Frameless: true}]
+              InjectionPoints: [{PC: "0x893360", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -521,7 +521,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1433 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0x896df0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896e10", Frameless: true}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -557,7 +557,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1281 EventRootType Probe[main.testChannel]
-              InjectionPoints: [{PC: "0x8935e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x893600", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -587,7 +587,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1275 EventRootType Probe[main.testCombinedByte]
-              InjectionPoints: [{PC: "0x893320", Frameless: true}]
+              InjectionPoints: [{PC: "0x893340", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{w}, {x}, {y}'
@@ -616,11 +616,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1342 EventRootType Probe[main.testConflictingReturn]
-              InjectionPoints: [{PC: "0x894658", Frameless: false}]
+              InjectionPoints: [{PC: "0x894678", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1343 EventRootType Probe[main.testConflictingReturn]Return
-              InjectionPoints: [{PC: "0x894708", Frameless: false}]
+              InjectionPoints: [{PC: "0x894728", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -642,7 +642,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1289 EventRootType Probe[main.testCycle]
-              InjectionPoints: [{PC: "0x893890", Frameless: true}]
+              InjectionPoints: [{PC: "0x8938b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{t}'
@@ -796,7 +796,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1394 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0x896330", Frameless: true}]
+              InjectionPoints: [{PC: "0x896350", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -823,7 +823,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1397 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0x896360", Frameless: true}]
+              InjectionPoints: [{PC: "0x896380", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -851,7 +851,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1420 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0x896ac0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896ae0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -873,7 +873,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1434 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0x896e40", Frameless: true}]
+              InjectionPoints: [{PC: "0x896e60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -894,7 +894,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1435 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0x896e50", Frameless: true}]
+              InjectionPoints: [{PC: "0x896e70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1107,11 +1107,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1472 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0x8991b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8991d0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1473 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x8991b8", Frameless: true}]
+              InjectionPoints: [{PC: "0x8991d8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1125,11 +1125,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1474 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0x8991d0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8991f0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1475 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0x89920c", Frameless: false}]
+              InjectionPoints: [{PC: "0x89922c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1152,11 +1152,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1468 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0x899118", Frameless: false}]
+              InjectionPoints: [{PC: "0x899138", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1469 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0x899128", Frameless: false}]
+              InjectionPoints: [{PC: "0x899148", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1170,11 +1170,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1470 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0x899168", Frameless: false}]
+              InjectionPoints: [{PC: "0x899188", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1471 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0x899180", Frameless: false}]
+              InjectionPoints: [{PC: "0x8991a0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1197,14 +1197,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1476 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0x899220", Frameless: true}]
+              InjectionPoints: [{PC: "0x899240", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1477 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0x899248"
+                - PC: "0x899268"
                   Frameless: true
-                - PC: "0x899250"
+                - PC: "0x899270"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1219,14 +1219,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1478 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0x899278", Frameless: false}]
+              InjectionPoints: [{PC: "0x899298", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1479 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0x8992d8"
+                - PC: "0x8992f8"
                   Frameless: false
-                - PC: "0x8992e8"
+                - PC: "0x899308"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1253,7 +1253,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1480 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0x899224", Frameless: true}]
+              InjectionPoints: [{PC: "0x899244", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1265,7 +1265,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1481 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0x899288", Frameless: false}]
+              InjectionPoints: [{PC: "0x8992a8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1286,11 +1286,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1456 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0x898df0", Frameless: true}]
+              InjectionPoints: [{PC: "0x898e10", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1457 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0x898df8", Frameless: true}]
+              InjectionPoints: [{PC: "0x898e18", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1304,11 +1304,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1458 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0x898e80", Frameless: true}]
+              InjectionPoints: [{PC: "0x898ea0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1459 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0x898e84", Frameless: true}]
+              InjectionPoints: [{PC: "0x898ea4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1332,11 +1332,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1444 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0x898998", Frameless: false}]
+              InjectionPoints: [{PC: "0x8989b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1445 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x898a6c", Frameless: false}]
+              InjectionPoints: [{PC: "0x898a8c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1378,11 +1378,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1448 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x898ac8", Frameless: false}]
+              InjectionPoints: [{PC: "0x898ae8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1449 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x898ad8", Frameless: false}]
+              InjectionPoints: [{PC: "0x898af8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1405,11 +1405,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1482 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0x899330", Frameless: true}]
+              InjectionPoints: [{PC: "0x899350", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1483 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0x899338", Frameless: true}]
+              InjectionPoints: [{PC: "0x899358", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1423,11 +1423,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1484 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0x8993d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8993f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1485 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0x8993fc", Frameless: false}]
+              InjectionPoints: [{PC: "0x89941c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1450,11 +1450,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1440 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0x8988f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x898910", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1441 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x8988f4", Frameless: true}]
+              InjectionPoints: [{PC: "0x898914", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1468,11 +1468,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1442 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0x898900", Frameless: true}]
+              InjectionPoints: [{PC: "0x898920", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1443 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x89890c", Frameless: true}]
+              InjectionPoints: [{PC: "0x89892c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1495,11 +1495,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1460 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0x898f20", Frameless: true}]
+              InjectionPoints: [{PC: "0x898f40", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1461 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0x898f28", Frameless: true}]
+              InjectionPoints: [{PC: "0x898f48", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1513,11 +1513,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1462 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0x898fc8", Frameless: false}]
+              InjectionPoints: [{PC: "0x898fe8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1463 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0x898ff4", Frameless: false}]
+              InjectionPoints: [{PC: "0x899014", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1540,11 +1540,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1450 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0x898dc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x898de0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1451 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x898dc4", Frameless: true}]
+              InjectionPoints: [{PC: "0x898de4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1558,11 +1558,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1452 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0x898dd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x898df0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1453 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0x898dd4", Frameless: true}]
+              InjectionPoints: [{PC: "0x898df4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1576,11 +1576,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1454 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0x898de0", Frameless: true}]
+              InjectionPoints: [{PC: "0x898e00", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1455 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0x898de4", Frameless: true}]
+              InjectionPoints: [{PC: "0x898e04", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1603,11 +1603,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1464 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0x8990d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8990f0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1465 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0x8990d8", Frameless: true}]
+              InjectionPoints: [{PC: "0x8990f8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1621,11 +1621,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1466 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x8990e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x899100", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1467 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x8990f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x899110", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1648,11 +1648,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1436 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0x8988d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8988f0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1437 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x8988d4", Frameless: true}]
+              InjectionPoints: [{PC: "0x8988f4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1666,11 +1666,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1438 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0x8988e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x898900", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1439 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x8988ec", Frameless: true}]
+              InjectionPoints: [{PC: "0x89890c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1902,7 +1902,7 @@ Probes:
               InjectionPoints:
                 - PC: "0x12a824"
                   Frameless: true
-                - PC: "0x891df4"
+                - PC: "0x891e14"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2198,11 +2198,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1375 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0x895280", Frameless: false}]
+              InjectionPoints: [{PC: "0x8952a0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1376 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x8953d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8953f8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2224,7 +2224,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1283 EventRootType Probe[main.testLinkedList]
-              InjectionPoints: [{PC: "0x8937a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8937c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -2336,11 +2336,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1381 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0x89578c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8957ac", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1382 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0x8958fc", Frameless: false}]
+              InjectionPoints: [{PC: "0x89591c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2449,7 +2449,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1255 EventRootType Probe[main.testMapArrayToArray]
-              InjectionPoints: [{PC: "0x891e90", Frameless: true}]
+              InjectionPoints: [{PC: "0x891eb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2471,7 +2471,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1262 EventRootType Probe[main.testMapEmbeddedMaps]
-              InjectionPoints: [{PC: "0x891ef0", Frameless: true}]
+              InjectionPoints: [{PC: "0x891f10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2493,7 +2493,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1272 EventRootType Probe[main.testMapEmptyKey]
-              InjectionPoints: [{PC: "0x891f90", Frameless: true}]
+              InjectionPoints: [{PC: "0x891fb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2515,7 +2515,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1274 EventRootType Probe[main.testMapEmptyKeyAndValue]
-              InjectionPoints: [{PC: "0x891fb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x891fd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2537,7 +2537,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1273 EventRootType Probe[main.testMapEmptyValue]
-              InjectionPoints: [{PC: "0x891fa0", Frameless: true}]
+              InjectionPoints: [{PC: "0x891fc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2559,7 +2559,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1259 EventRootType Probe[main.testMapIntToInt]
-              InjectionPoints: [{PC: "0x891ed0", Frameless: true}]
+              InjectionPoints: [{PC: "0x891ef0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2581,7 +2581,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1271 EventRootType Probe[main.testMapLargeKeyLargeValue]
-              InjectionPoints: [{PC: "0x891f80", Frameless: true}]
+              InjectionPoints: [{PC: "0x891fa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2603,7 +2603,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1270 EventRootType Probe[main.testMapLargeKeySmallValue]
-              InjectionPoints: [{PC: "0x891f70", Frameless: true}]
+              InjectionPoints: [{PC: "0x891f90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2627,7 +2627,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1260 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x891ee0", Frameless: true}]
+              InjectionPoints: [{PC: "0x891f00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2651,7 +2651,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1261 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x891ee0", Frameless: true}]
+              InjectionPoints: [{PC: "0x891f00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2673,7 +2673,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1269 EventRootType Probe[main.testMapSmallKeyLargeValue]
-              InjectionPoints: [{PC: "0x891f60", Frameless: true}]
+              InjectionPoints: [{PC: "0x891f80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2695,7 +2695,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1268 EventRootType Probe[main.testMapSmallKeySmallValue]
-              InjectionPoints: [{PC: "0x891f50", Frameless: true}]
+              InjectionPoints: [{PC: "0x891f70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2717,7 +2717,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1253 EventRootType Probe[main.testMapStringToInt]
-              InjectionPoints: [{PC: "0x891e70", Frameless: true}]
+              InjectionPoints: [{PC: "0x891e90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2739,7 +2739,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1254 EventRootType Probe[main.testMapStringToSlice]
-              InjectionPoints: [{PC: "0x891e80", Frameless: true}]
+              InjectionPoints: [{PC: "0x891ea0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2761,7 +2761,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1252 EventRootType Probe[main.testMapStringToStruct]
-              InjectionPoints: [{PC: "0x891e60", Frameless: true}]
+              InjectionPoints: [{PC: "0x891e80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2783,7 +2783,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1263 EventRootType Probe[main.testMapWithLinkedList]
-              InjectionPoints: [{PC: "0x891f00", Frameless: true}]
+              InjectionPoints: [{PC: "0x891f20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2805,7 +2805,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1266 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-              InjectionPoints: [{PC: "0x891f30", Frameless: true}]
+              InjectionPoints: [{PC: "0x891f50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2827,7 +2827,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1267 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-              InjectionPoints: [{PC: "0x891f40", Frameless: true}]
+              InjectionPoints: [{PC: "0x891f60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2849,7 +2849,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1264 EventRootType Probe[main.testMapWithSmallValue]
-              InjectionPoints: [{PC: "0x891f10", Frameless: true}]
+              InjectionPoints: [{PC: "0x891f30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2873,7 +2873,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1265 EventRootType Probe[main.testMapWithSmallValueMassive]
-              InjectionPoints: [{PC: "0x891f20", Frameless: true}]
+              InjectionPoints: [{PC: "0x891f40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2895,7 +2895,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1417 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x896aa0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896ac0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2918,7 +2918,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1418 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x896aa0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896ac0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2965,11 +2965,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1383 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0x895980", Frameless: false}]
+              InjectionPoints: [{PC: "0x8959a0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1384 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0x895b30", Frameless: false}]
+              InjectionPoints: [{PC: "0x895b50", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -3035,11 +3035,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1387 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0x895c5c", Frameless: false}]
+              InjectionPoints: [{PC: "0x895c7c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1388 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0x895d00", Frameless: false}]
+              InjectionPoints: [{PC: "0x895d20", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3070,11 +3070,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1379 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0x895530", Frameless: false}]
+              InjectionPoints: [{PC: "0x895550", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1380 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0x895700", Frameless: false}]
+              InjectionPoints: [{PC: "0x895720", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3100,11 +3100,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1320 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8944b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8944d8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1321 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x894544", Frameless: false}]
+              InjectionPoints: [{PC: "0x894564", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3140,7 +3140,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1278 EventRootType Probe[main.testMultipleSimpleParams]
-              InjectionPoints: [{PC: "0x893400", Frameless: true}]
+              InjectionPoints: [{PC: "0x893420", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -3181,11 +3181,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1314 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x894418", Frameless: false}]
+              InjectionPoints: [{PC: "0x894438", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1315 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x894478", Frameless: false}]
+              InjectionPoints: [{PC: "0x894498", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3209,11 +3209,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1316 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x894418", Frameless: false}]
+              InjectionPoints: [{PC: "0x894438", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1317 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x894478", Frameless: false}]
+              InjectionPoints: [{PC: "0x894498", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
       version: 0
@@ -3232,11 +3232,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1322 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8944b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8944d8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1323 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x894544", Frameless: false}]
+              InjectionPoints: [{PC: "0x894564", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
       version: 0
@@ -3256,11 +3256,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1324 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8944b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8944d8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1325 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x894544", Frameless: false}]
+              InjectionPoints: [{PC: "0x894564", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r1={result} r2={result2}
@@ -3293,11 +3293,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1318 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x894418", Frameless: false}]
+              InjectionPoints: [{PC: "0x894438", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1319 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x894478", Frameless: false}]
+              InjectionPoints: [{PC: "0x894498", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Parameter {i} * 2 = result {result}
@@ -3325,7 +3325,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1429 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x896de0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896e00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3350,7 +3350,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1430 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x896de0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896e00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3381,7 +3381,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1431 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x896de0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896e00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3406,7 +3406,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1432 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x896de0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896e00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3433,7 +3433,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1288 EventRootType Probe[main.testNilPointer]
-              InjectionPoints: [{PC: "0x893870", Frameless: true}]
+              InjectionPoints: [{PC: "0x893890", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}, {a}'
@@ -3460,7 +3460,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1401 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0x8963a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8963c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3487,7 +3487,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1398 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0x896370", Frameless: true}]
+              InjectionPoints: [{PC: "0x896390", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3522,7 +3522,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1400 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0x896390", Frameless: true}]
+              InjectionPoints: [{PC: "0x8963b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3554,7 +3554,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1416 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0x896a90", Frameless: true}]
+              InjectionPoints: [{PC: "0x896ab0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3576,7 +3576,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1284 EventRootType Probe[main.testPointerLoop]
-              InjectionPoints: [{PC: "0x8937b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8937d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3598,7 +3598,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1258 EventRootType Probe[main.testPointerToMap]
-              InjectionPoints: [{PC: "0x891ec0", Frameless: true}]
+              InjectionPoints: [{PC: "0x891ee0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3620,7 +3620,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1282 EventRootType Probe[main.testPointerToSimpleStruct]
-              InjectionPoints: [{PC: "0x893790", Frameless: true}]
+              InjectionPoints: [{PC: "0x8937b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3644,11 +3644,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1290 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x893cb8", Frameless: false}]
+              InjectionPoints: [{PC: "0x893cd8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1291 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x893cfc", Frameless: false}]
+              InjectionPoints: [{PC: "0x893d1c", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
       version: 0
@@ -3668,11 +3668,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1334 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x894588", Frameless: false}]
+              InjectionPoints: [{PC: "0x8945a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1335 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x894614", Frameless: false}]
+              InjectionPoints: [{PC: "0x894634", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3715,11 +3715,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1300 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x893dd8", Frameless: false}]
+              InjectionPoints: [{PC: "0x893df8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1301 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x893e70", Frameless: false}]
+              InjectionPoints: [{PC: "0x893e90", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3759,11 +3759,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1292 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x893cb8", Frameless: false}]
+              InjectionPoints: [{PC: "0x893cd8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1293 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x893cfc", Frameless: false}]
+              InjectionPoints: [{PC: "0x893d1c", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3806,11 +3806,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1302 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x893dd8", Frameless: false}]
+              InjectionPoints: [{PC: "0x893df8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1303 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x893e70", Frameless: false}]
+              InjectionPoints: [{PC: "0x893e90", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3852,11 +3852,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1336 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x894588", Frameless: false}]
+              InjectionPoints: [{PC: "0x8945a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1337 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x894614", Frameless: false}]
+              InjectionPoints: [{PC: "0x894634", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
       version: 0
@@ -3873,11 +3873,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1338 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x894588", Frameless: false}]
+              InjectionPoints: [{PC: "0x8945a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1339 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x894614", Frameless: false}]
+              InjectionPoints: [{PC: "0x894634", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r0={@return.r0}
@@ -3899,11 +3899,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1294 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x893cb8", Frameless: false}]
+              InjectionPoints: [{PC: "0x893cd8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1295 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x893cfc", Frameless: false}]
+              InjectionPoints: [{PC: "0x893d1c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: result={@return}
@@ -3926,18 +3926,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1310 EventRootType Probe[main.testReturnsAny]
-              InjectionPoints: [{PC: "0x8940a8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8940c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1311 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
-                - PC: "0x894148"
+                - PC: "0x894168"
                   Frameless: false
-                - PC: "0x894190"
+                - PC: "0x8941b0"
                   Frameless: false
-                - PC: "0x894254"
+                - PC: "0x894274"
                   Frameless: false
-                - PC: "0x894268"
+                - PC: "0x894288"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3965,18 +3965,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1308 EventRootType Probe[main.testReturnsAnyAndError]
-              InjectionPoints: [{PC: "0x893f28", Frameless: false}]
+              InjectionPoints: [{PC: "0x893f48", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1309 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
-                - PC: "0x893f94"
+                - PC: "0x893fb4"
                   Frameless: false
-                - PC: "0x893fe0"
+                - PC: "0x894000"
                   Frameless: false
-                - PC: "0x894020"
+                - PC: "0x894040"
                   Frameless: false
-                - PC: "0x894060"
+                - PC: "0x894080"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4003,11 +4003,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1353 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0x894c8c", Frameless: false}]
+              InjectionPoints: [{PC: "0x894cac", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1354 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0x894ce0", Frameless: false}]
+              InjectionPoints: [{PC: "0x894d00", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -4024,11 +4024,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1355 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0x894d18", Frameless: false}]
+              InjectionPoints: [{PC: "0x894d38", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1356 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0x894d54", Frameless: false}]
+              InjectionPoints: [{PC: "0x894d74", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -4045,11 +4045,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1357 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0x894d88", Frameless: false}]
+              InjectionPoints: [{PC: "0x894da8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1358 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0x894dc0", Frameless: false}]
+              InjectionPoints: [{PC: "0x894de0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4066,11 +4066,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1361 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0x894e78", Frameless: false}]
+              InjectionPoints: [{PC: "0x894e98", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1362 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0x894edc", Frameless: false}]
+              InjectionPoints: [{PC: "0x894efc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4087,11 +4087,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1373 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0x895208", Frameless: false}]
+              InjectionPoints: [{PC: "0x895228", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1374 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0x895248", Frameless: false}]
+              InjectionPoints: [{PC: "0x895268", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4108,11 +4108,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1349 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0x894b38", Frameless: false}]
+              InjectionPoints: [{PC: "0x894b58", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1350 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0x894b84", Frameless: false}]
+              InjectionPoints: [{PC: "0x894ba4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4130,14 +4130,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1306 EventRootType Probe[main.testReturnsError]
-              InjectionPoints: [{PC: "0x893ea8", Frameless: false}]
+              InjectionPoints: [{PC: "0x893ec8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1307 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
-                - PC: "0x893ed8"
+                - PC: "0x893ef8"
                   Frameless: false
-                - PC: "0x893eec"
+                - PC: "0x893f0c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4159,11 +4159,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1296 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x893cb8", Frameless: false}]
+              InjectionPoints: [{PC: "0x893cd8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1297 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x893cfc", Frameless: false}]
+              InjectionPoints: [{PC: "0x893d1c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4184,11 +4184,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1304 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x893dd8", Frameless: false}]
+              InjectionPoints: [{PC: "0x893df8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1305 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x893e70", Frameless: false}]
+              InjectionPoints: [{PC: "0x893e90", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4209,11 +4209,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1298 EventRootType Probe[main.testReturnsIntPointer]
-              InjectionPoints: [{PC: "0x893d38", Frameless: false}]
+              InjectionPoints: [{PC: "0x893d58", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1299 EventRootType Probe[main.testReturnsIntPointer]Return
-              InjectionPoints: [{PC: "0x893d9c", Frameless: false}]
+              InjectionPoints: [{PC: "0x893dbc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4235,14 +4235,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1312 EventRootType Probe[main.testReturnsInterface]
-              InjectionPoints: [{PC: "0x8942a8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8942c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1313 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
-                - PC: "0x894378"
+                - PC: "0x894398"
                   Frameless: false
-                - PC: "0x89438c"
+                - PC: "0x8943ac"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4264,11 +4264,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1351 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0x894bc0", Frameless: false}]
+              InjectionPoints: [{PC: "0x894be0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1352 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0x894c54", Frameless: false}]
+              InjectionPoints: [{PC: "0x894c74", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4285,11 +4285,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1347 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0x894a78", Frameless: false}]
+              InjectionPoints: [{PC: "0x894a98", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1348 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0x894afc", Frameless: false}]
+              InjectionPoints: [{PC: "0x894b1c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4306,11 +4306,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1365 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0x894ff8", Frameless: false}]
+              InjectionPoints: [{PC: "0x895018", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1366 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0x895050", Frameless: false}]
+              InjectionPoints: [{PC: "0x895070", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4327,11 +4327,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1359 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0x894df8", Frameless: false}]
+              InjectionPoints: [{PC: "0x894e18", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1360 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0x894e40", Frameless: false}]
+              InjectionPoints: [{PC: "0x894e60", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4348,11 +4348,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1371 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0x895188", Frameless: false}]
+              InjectionPoints: [{PC: "0x8951a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1372 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0x8951cc", Frameless: false}]
+              InjectionPoints: [{PC: "0x8951ec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
@@ -4372,7 +4372,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1344 EventRootType Probe[main.testReturnsNamedDeferLine]Line
-              InjectionPoints: [{PC: "0x894808", Frameless: false}]
+              InjectionPoints: [{PC: "0x894828", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4393,11 +4393,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1369 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0x895118", Frameless: false}]
+              InjectionPoints: [{PC: "0x895138", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1370 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0x895158", Frameless: false}]
+              InjectionPoints: [{PC: "0x895178", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4414,11 +4414,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1345 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0x8949e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x894a08", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1346 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0x894a40", Frameless: false}]
+              InjectionPoints: [{PC: "0x894a60", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4435,11 +4435,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1367 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0x89508c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8950ac", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1368 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0x8950e0", Frameless: false}]
+              InjectionPoints: [{PC: "0x895100", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4456,11 +4456,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1363 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0x894f20", Frameless: false}]
+              InjectionPoints: [{PC: "0x894f40", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1364 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0x894fc4", Frameless: false}]
+              InjectionPoints: [{PC: "0x894fe4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4513,11 +4513,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1326 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8944b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8944d8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1327 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x894544", Frameless: false}]
+              InjectionPoints: [{PC: "0x894564", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -4792,7 +4792,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1408 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0x896a40", Frameless: true}]
+              InjectionPoints: [{PC: "0x896a60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4924,7 +4924,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1404 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0x8963c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8963e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -4946,7 +4946,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1395 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0x896340", Frameless: true}]
+              InjectionPoints: [{PC: "0x896360", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -4968,7 +4968,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1256 EventRootType Probe[main.testSmallMap]
-              InjectionPoints: [{PC: "0x891ea0", Frameless: true}]
+              InjectionPoints: [{PC: "0x891ec0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -4989,11 +4989,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1340 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x894588", Frameless: false}]
+              InjectionPoints: [{PC: "0x8945a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1341 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x894614", Frameless: false}]
+              InjectionPoints: [{PC: "0x894634", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -5014,11 +5014,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1385 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0x895bb8", Frameless: false}]
+              InjectionPoints: [{PC: "0x895bd8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1386 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0x895c1c", Frameless: false}]
+              InjectionPoints: [{PC: "0x895c3c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5062,7 +5062,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1287 EventRootType Probe[main.testStringPointer]
-              InjectionPoints: [{PC: "0x893850", Frameless: true}]
+              InjectionPoints: [{PC: "0x893870", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}'
@@ -5084,7 +5084,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1399 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0x896380", Frameless: true}]
+              InjectionPoints: [{PC: "0x8963a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5150,11 +5150,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1427 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x896d40", Frameless: true}]
+              InjectionPoints: [{PC: "0x896d60", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1428 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0x896d5c", Frameless: true}]
+              InjectionPoints: [{PC: "0x896d7c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5181,7 +5181,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1396 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0x896350", Frameless: true}]
+              InjectionPoints: [{PC: "0x896370", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5229,11 +5229,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1389 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0x895d3c", Frameless: false}]
+              InjectionPoints: [{PC: "0x895d5c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1390 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0x895dcc", Frameless: false}]
+              InjectionPoints: [{PC: "0x895dec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5255,11 +5255,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1423 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0x896c50", Frameless: true}]
+              InjectionPoints: [{PC: "0x896c70", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1424 EventRootType Probe[main.testStructWithCyclicMaps]Return
-              InjectionPoints: [{PC: "0x896c68", Frameless: true}]
+              InjectionPoints: [{PC: "0x896c88", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5280,7 +5280,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1422 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0x896c40", Frameless: true}]
+              InjectionPoints: [{PC: "0x896c60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5307,7 +5307,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1251 EventRootType Probe[main.testStructWithMap]
-              InjectionPoints: [{PC: "0x891e50", Frameless: true}]
+              InjectionPoints: [{PC: "0x891e70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s} {@duration}'
@@ -5340,7 +5340,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1405 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0x8963d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8963f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5380,7 +5380,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1421 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0x896ad0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896af0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5413,11 +5413,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1328 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8944b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8944d8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1329 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x894544", Frameless: false}]
+              InjectionPoints: [{PC: "0x894564", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{nonexistentVariable}'
@@ -5438,11 +5438,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1330 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8944b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8944d8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1331 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x894544", Frameless: false}]
+              InjectionPoints: [{PC: "0x894564", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{unsupportedExpression}'
@@ -5465,11 +5465,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1332 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8944b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8944d8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1333 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x894544", Frameless: false}]
+              InjectionPoints: [{PC: "0x894564", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -5501,7 +5501,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1409 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0x896a50", Frameless: true}]
+              InjectionPoints: [{PC: "0x896a70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5533,11 +5533,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1410 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x896a60", Frameless: true}]
+              InjectionPoints: [{PC: "0x896a80", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1411 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0x896a78", Frameless: true}]
+              InjectionPoints: [{PC: "0x896a98", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5567,11 +5567,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1412 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x896a60", Frameless: true}]
+              InjectionPoints: [{PC: "0x896a80", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1413 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0x896a78", Frameless: true}]
+              InjectionPoints: [{PC: "0x896a98", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5603,7 +5603,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1414 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x896a80", Frameless: true}]
+              InjectionPoints: [{PC: "0x896aa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5633,7 +5633,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1415 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x896a80", Frameless: true}]
+              InjectionPoints: [{PC: "0x896aa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5797,7 +5797,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1286 EventRootType Probe[main.testUintPointer]
-              InjectionPoints: [{PC: "0x8937e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x893800", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5819,7 +5819,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1393 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0x896320", Frameless: true}]
+              InjectionPoints: [{PC: "0x896340", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5841,7 +5841,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1419 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0x896ab0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896ad0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5863,7 +5863,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1285 EventRootType Probe[main.testUnsafePointer]
-              InjectionPoints: [{PC: "0x8937c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8937e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5907,7 +5907,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1402 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x8963b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8963d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5929,7 +5929,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1403 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x8963b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8963d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5954,7 +5954,7 @@ Probes:
               InjectionPoints:
                 - PC: "0x8915f8"
                   Frameless: false
-                - PC: "0x8994fc"
+                - PC: "0x89951c"
                   Frameless: false
               Condition: null
             - Kind: Return
@@ -5981,11 +5981,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1391 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0x895e08", Frameless: false}]
+              InjectionPoints: [{PC: "0x895e28", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1392 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x895e74", Frameless: false}]
+              InjectionPoints: [{PC: "0x895e94", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -7072,214 +7072,188 @@ Subprograms:
       DictRegister: null
     - ID: 63
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x891e50..0x891e60]
+      OutOfLinePCRanges: [0x891e70..0x891e80]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 165 StructureType main.structWithMap
-          Locations:
-            - Range: 0x891e50..0x891e60
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 64
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x891e60..0x891e70]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 171 GoMapType map[string]main.nestedStruct
-          Locations:
-            - Range: 0x891e60..0x891e70
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 65
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0x891e70..0x891e80]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 176 GoMapType map[string]int
           Locations:
             - Range: 0x891e70..0x891e80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 66
-      Name: main.testMapStringToSlice
+    - ID: 64
+      Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0x891e80..0x891e90]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 181 GoMapType map[string][]string
+          Type: 171 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0x891e80..0x891e90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 67
-      Name: main.testMapArrayToArray
+    - ID: 65
+      Name: main.testMapStringToInt
       OutOfLinePCRanges: [0x891e90..0x891ea0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 186 GoMapType map[[4]string][2]int
+          Type: 176 GoMapType map[string]int
           Locations:
             - Range: 0x891e90..0x891ea0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 68
-      Name: main.testSmallMap
+    - ID: 66
+      Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0x891ea0..0x891eb0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 176 GoMapType map[string]int
+          Type: 181 GoMapType map[string][]string
           Locations:
             - Range: 0x891ea0..0x891eb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 69
-      Name: main.testArrayOfMaps
+    - ID: 67
+      Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0x891eb0..0x891ec0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 191 ArrayType [2]map[string]int
+          Type: 186 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0x891eb0..0x891ec0
-              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 70
-      Name: main.testPointerToMap
+    - ID: 68
+      Name: main.testSmallMap
       OutOfLinePCRanges: [0x891ec0..0x891ed0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 192 PointerType *map[string]int
+          Type: 176 GoMapType map[string]int
           Locations:
             - Range: 0x891ec0..0x891ed0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 71
-      Name: main.testMapIntToInt
+    - ID: 69
+      Name: main.testArrayOfMaps
       OutOfLinePCRanges: [0x891ed0..0x891ee0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 166 GoMapType map[int]int
+          Type: 191 ArrayType [2]map[string]int
           Locations:
             - Range: 0x891ed0..0x891ee0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 72
-      Name: main.testMapMassive
+    - ID: 70
+      Name: main.testPointerToMap
       OutOfLinePCRanges: [0x891ee0..0x891ef0]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 193 GoMapType map[string][]main.structWithMap
+        - Name: m
+          Type: 192 PointerType *map[string]int
           Locations:
             - Range: 0x891ee0..0x891ef0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 73
-      Name: main.testMapEmbeddedMaps
+    - ID: 71
+      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0x891ef0..0x891f00]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 193 GoMapType map[string][]main.structWithMap
+          Type: 166 GoMapType map[int]int
           Locations:
             - Range: 0x891ef0..0x891f00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 74
-      Name: main.testMapWithLinkedList
+    - ID: 72
+      Name: main.testMapMassive
       OutOfLinePCRanges: [0x891f00..0x891f10]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 198 GoMapType map[bool]main.node
+        - Name: redactMyEntries
+          Type: 193 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x891f00..0x891f10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 75
-      Name: main.testMapWithSmallValue
+    - ID: 73
+      Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0x891f10..0x891f20]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 203 GoMapType map[int]uint8
+          Type: 193 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x891f10..0x891f20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 76
-      Name: main.testMapWithSmallValueMassive
+    - ID: 74
+      Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0x891f20..0x891f30]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 203 GoMapType map[int]uint8
+        - Name: m
+          Type: 198 GoMapType map[bool]main.node
           Locations:
             - Range: 0x891f20..0x891f30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 77
-      Name: main.testMapWithSmallKeyAndValue
+    - ID: 75
+      Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0x891f30..0x891f40]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 208 GoMapType map[uint8]uint8
+          Type: 203 GoMapType map[int]uint8
           Locations:
             - Range: 0x891f30..0x891f40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 78
-      Name: main.testMapWithSmallKeyAndValueMassive
+    - ID: 76
+      Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0x891f40..0x891f50]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 208 GoMapType map[uint8]uint8
+        - Name: redactMyEntries
+          Type: 203 GoMapType map[int]uint8
           Locations:
             - Range: 0x891f40..0x891f50
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 79
-      Name: main.testMapSmallKeySmallValue
+    - ID: 77
+      Name: main.testMapWithSmallKeyAndValue
       OutOfLinePCRanges: [0x891f50..0x891f60]
       InlinePCRanges: []
       Variables:
@@ -7291,113 +7265,112 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 80
-      Name: main.testMapSmallKeyLargeValue
+    - ID: 78
+      Name: main.testMapWithSmallKeyAndValueMassive
       OutOfLinePCRanges: [0x891f60..0x891f70]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 213 GoMapType map[uint8][4]int
+          Type: 208 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x891f60..0x891f70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 81
-      Name: main.testMapLargeKeySmallValue
+    - ID: 79
+      Name: main.testMapSmallKeySmallValue
       OutOfLinePCRanges: [0x891f70..0x891f80]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 218 GoMapType map[[4]int]uint8
+          Type: 208 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x891f70..0x891f80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 82
-      Name: main.testMapLargeKeyLargeValue
+    - ID: 80
+      Name: main.testMapSmallKeyLargeValue
       OutOfLinePCRanges: [0x891f80..0x891f90]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 223 GoMapType map[[4]int][4]int
+          Type: 213 GoMapType map[uint8][4]int
           Locations:
             - Range: 0x891f80..0x891f90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 83
-      Name: main.testMapEmptyKey
+    - ID: 81
+      Name: main.testMapLargeKeySmallValue
       OutOfLinePCRanges: [0x891f90..0x891fa0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 228 GoMapType map[struct {}]int
+          Type: 218 GoMapType map[[4]int]uint8
           Locations:
             - Range: 0x891f90..0x891fa0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 84
-      Name: main.testMapEmptyValue
+    - ID: 82
+      Name: main.testMapLargeKeyLargeValue
       OutOfLinePCRanges: [0x891fa0..0x891fb0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 233 GoMapType map[int]struct {}
+          Type: 223 GoMapType map[[4]int][4]int
           Locations:
             - Range: 0x891fa0..0x891fb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 85
-      Name: main.testMapEmptyKeyAndValue
+    - ID: 83
+      Name: main.testMapEmptyKey
       OutOfLinePCRanges: [0x891fb0..0x891fc0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 238 GoMapType map[struct {}]struct {}
+          Type: 228 GoMapType map[struct {}]int
           Locations:
             - Range: 0x891fb0..0x891fc0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 86
-      Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x893320..0x893330]
+    - ID: 84
+      Name: main.testMapEmptyValue
+      OutOfLinePCRanges: [0x891fc0..0x891fd0]
       InlinePCRanges: []
       Variables:
-        - Name: w
-          Type: 4 BaseType uint8
+        - Name: m
+          Type: 233 GoMapType map[int]struct {}
           Locations:
-            - Range: 0x893320..0x893330
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: x
-          Type: 4 BaseType uint8
-          Locations:
-            - Range: 0x893320..0x893330
-              Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: "y"
-          Type: 17 BaseType float32
-          Locations:
-            - Range: 0x893320..0x893330
-              Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
+            - Range: 0x891fc0..0x891fd0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 87
-      Name: main.testCombinedString
+    - ID: 85
+      Name: main.testMapEmptyKeyAndValue
+      OutOfLinePCRanges: [0x891fd0..0x891fe0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 238 GoMapType map[struct {}]struct {}
+          Locations:
+            - Range: 0x891fd0..0x891fe0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 86
+      Name: main.testCombinedByte
       OutOfLinePCRanges: [0x893340..0x893350]
       InlinePCRanges: []
       Variables:
@@ -7409,14 +7382,10 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
         - Name: x
-          Type: 12 GoStringHeaderType string
+          Type: 4 BaseType uint8
           Locations:
             - Range: 0x893340..0x893350
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
+              Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: "y"
@@ -7427,43 +7396,74 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 87
+      Name: main.testCombinedString
+      OutOfLinePCRanges: [0x893360..0x893370]
+      InlinePCRanges: []
+      Variables:
+        - Name: w
+          Type: 4 BaseType uint8
+          Locations:
+            - Range: 0x893360..0x893370
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: x
+          Type: 12 GoStringHeaderType string
+          Locations:
+            - Range: 0x893360..0x893370
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: "y"
+          Type: 17 BaseType float32
+          Locations:
+            - Range: 0x893360..0x893370
+              Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 88
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x893400..0x893410]
+      OutOfLinePCRanges: [0x893420..0x893430]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x893400..0x893410
+            - Range: 0x893420..0x893430
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x893400..0x893410
+            - Range: 0x893420..0x893430
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 14 BaseType int32
           Locations:
-            - Range: 0x893400..0x893410
+            - Range: 0x893420..0x893430
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 13 BaseType uint
           Locations:
-            - Range: 0x893400..0x893410
+            - Range: 0x893420..0x893430
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0x893400..0x893410
+            - Range: 0x893420..0x893430
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7474,63 +7474,63 @@ Subprograms:
       DictRegister: null
     - ID: 89
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0x8935a0..0x8935e0]
+      OutOfLinePCRanges: [0x8935c0..0x893600]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 BaseType uint64
           Locations:
-            - Range: 0x8935a0..0x8935dc
+            - Range: 0x8935c0..0x8935fc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 11 BaseType uint64
           Locations:
-            - Range: 0x8935a0..0x8935dc
+            - Range: 0x8935c0..0x8935fc
               Pieces: []
-            - Range: 0x8935dc..0x8935dd
+            - Range: 0x8935fc..0x8935fd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8935dd..0x8935e0
+            - Range: 0x8935fd..0x893600
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 90
       Name: main.testChannel
-      OutOfLinePCRanges: [0x8935e0..0x8935f0]
+      OutOfLinePCRanges: [0x893600..0x893610]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 243 GoChannelType chan bool
           Locations:
-            - Range: 0x8935e0..0x8935f0
+            - Range: 0x893600..0x893610
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 91
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x893790..0x8937a0]
+      OutOfLinePCRanges: [0x8937b0..0x8937c0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 244 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x893790..0x8937a0
+            - Range: 0x8937b0..0x8937c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 92
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x8937a0..0x8937b0]
+      OutOfLinePCRanges: [0x8937c0..0x8937d0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 246 StructureType main.node
           Locations:
-            - Range: 0x8937a0..0x8937b0
+            - Range: 0x8937c0..0x8937d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7541,273 +7541,273 @@ Subprograms:
       DictRegister: null
     - ID: 93
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x8937b0..0x8937c0]
+      OutOfLinePCRanges: [0x8937d0..0x8937e0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 247 PointerType *main.node
           Locations:
-            - Range: 0x8937b0..0x8937c0
+            - Range: 0x8937d0..0x8937e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 94
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x8937c0..0x8937d0]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 20 VoidPointerType unsafe.Pointer
-          Locations:
-            - Range: 0x8937c0..0x8937d0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 95
-      Name: main.testUintPointer
       OutOfLinePCRanges: [0x8937e0..0x8937f0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 101 PointerType *uint
+          Type: 20 VoidPointerType unsafe.Pointer
           Locations:
             - Range: 0x8937e0..0x8937f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 95
+      Name: main.testUintPointer
+      OutOfLinePCRanges: [0x893800..0x893810]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 101 PointerType *uint
+          Locations:
+            - Range: 0x893800..0x893810
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 96
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x893850..0x893860]
+      OutOfLinePCRanges: [0x893870..0x893880]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 89 PointerType *string
           Locations:
-            - Range: 0x893850..0x893860
+            - Range: 0x893870..0x893880
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 97
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x893870..0x893880]
+      OutOfLinePCRanges: [0x893890..0x8938a0]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 6 PointerType *bool
           Locations:
-            - Range: 0x893870..0x893880
+            - Range: 0x893890..0x8938a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 13 BaseType uint
           Locations:
-            - Range: 0x893870..0x893880
+            - Range: 0x893890..0x8938a0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 98
       Name: main.testCycle
-      OutOfLinePCRanges: [0x893890..0x8938a0]
+      OutOfLinePCRanges: [0x8938b0..0x8938c0]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 248 PointerType *main.t
           Locations:
-            - Range: 0x893890..0x8938a0
+            - Range: 0x8938b0..0x8938c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 99
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0x893ca0..0x893d20]
+      OutOfLinePCRanges: [0x893cc0..0x893d40]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 10 BaseType int
           Locations:
-            - Range: 0x893ca0..0x893cbc
+            - Range: 0x893cc0..0x893cdc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0x893ca0..0x893cfc
+            - Range: 0x893cc0..0x893d1c
               Pieces: []
-            - Range: 0x893cfc..0x893cfd
+            - Range: 0x893d1c..0x893d1d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893cfd..0x893d20
+            - Range: 0x893d1d..0x893d40
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result
           Type: 10 BaseType int
           Locations:
-            - Range: 0x893cbc..0x893cc8
+            - Range: 0x893cdc..0x893ce8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893cc8..0x893d20
+            - Range: 0x893ce8..0x893d40
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 100
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0x893d20..0x893dc0]
+      OutOfLinePCRanges: [0x893d40..0x893de0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 10 BaseType int
           Locations:
-            - Range: 0x893d20..0x893d44
+            - Range: 0x893d40..0x893d64
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893d44..0x893dc0
+            - Range: 0x893d64..0x893de0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 95 PointerType *int
           Locations:
-            - Range: 0x893d20..0x893d9c
+            - Range: 0x893d40..0x893dbc
               Pieces: []
-            - Range: 0x893d9c..0x893d9d
+            - Range: 0x893dbc..0x893dbd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893d9d..0x893dc0
+            - Range: 0x893dbd..0x893de0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: '&result'
           Type: 95 PointerType *int
           Locations:
-            - Range: 0x893d48..0x893d64
+            - Range: 0x893d68..0x893d84
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893d64..0x893dc0
+            - Range: 0x893d84..0x893de0
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 101
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0x893dc0..0x893e90]
+      OutOfLinePCRanges: [0x893de0..0x893eb0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 10 BaseType int
           Locations:
-            - Range: 0x893dc0..0x893e18
+            - Range: 0x893de0..0x893e38
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0x893dc0..0x893e70
+            - Range: 0x893de0..0x893e90
               Pieces: []
-            - Range: 0x893e70..0x893e71
+            - Range: 0x893e90..0x893e91
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893e71..0x893e90
+            - Range: 0x893e91..0x893eb0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0x893dc0..0x893e90, Pieces: []}]
+          Locations: [{Range: 0x893de0..0x893eb0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: resultInt
           Type: 10 BaseType int
           Locations:
-            - Range: 0x893ddc..0x893e1c
+            - Range: 0x893dfc..0x893e3c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x893e1c..0x893e90
+            - Range: 0x893e3c..0x893eb0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: -1
         - Name: resultFloat
           Type: 18 BaseType float64
           Locations:
-            - Range: 0x893dec..0x893e1c
+            - Range: 0x893e0c..0x893e3c
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-            - Range: 0x893e1c..0x893e90
+            - Range: 0x893e3c..0x893eb0
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 102
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0x893e90..0x893f10]
+      OutOfLinePCRanges: [0x893eb0..0x893f30]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x893e90..0x893eb4
+            - Range: 0x893eb0..0x893ed4
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 19 GoInterfaceType error
           Locations:
-            - Range: 0x893e90..0x893ed8
+            - Range: 0x893eb0..0x893ef8
               Pieces: []
-            - Range: 0x893ed8..0x893ed9
+            - Range: 0x893ef8..0x893ef9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x893ed9..0x893eec
+            - Range: 0x893ef9..0x893f0c
               Pieces: []
-            - Range: 0x893eec..0x893eed
+            - Range: 0x893f0c..0x893f0d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x893eed..0x893f10
+            - Range: 0x893f0d..0x893f30
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 103
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0x893f10..0x894090]
+      OutOfLinePCRanges: [0x893f30..0x8940b0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x893f10..0x893f68
+            - Range: 0x893f30..0x893f88
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x893f68..0x893f6c
+            - Range: 0x893f88..0x893f8c
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x893fc4..0x893fc8
+            - Range: 0x893fe4..0x893fe8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x893ff4..0x893ff8
+            - Range: 0x894014..0x894018
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x894034..0x894038
+            - Range: 0x894054..0x894058
               Pieces:
                 - Size: 8
                   Op: null
@@ -7818,117 +7818,117 @@ Subprograms:
         - Name: failed
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x893f10..0x893f64
+            - Range: 0x893f30..0x893f84
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x893f10..0x893f94
+            - Range: 0x893f30..0x893fb4
               Pieces: []
-            - Range: 0x893f94..0x893f95
+            - Range: 0x893fb4..0x893fb5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x893f95..0x893fe0
+            - Range: 0x893fb5..0x894000
               Pieces: []
-            - Range: 0x893fe0..0x893fe1
+            - Range: 0x894000..0x894001
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x893fe1..0x894020
+            - Range: 0x894001..0x894040
               Pieces: []
-            - Range: 0x894020..0x894021
+            - Range: 0x894040..0x894041
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x894021..0x894060
+            - Range: 0x894041..0x894080
               Pieces: []
-            - Range: 0x894060..0x894061
+            - Range: 0x894080..0x894081
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x894061..0x894090
+            - Range: 0x894081..0x8940b0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 19 GoInterfaceType error
           Locations:
-            - Range: 0x893f10..0x893f94
+            - Range: 0x893f30..0x893fb4
               Pieces: []
-            - Range: 0x893f94..0x893f95
+            - Range: 0x893fb4..0x893fb5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x893f95..0x893fe0
+            - Range: 0x893fb5..0x894000
               Pieces: []
-            - Range: 0x893fe0..0x893fe1
+            - Range: 0x894000..0x894001
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x893fe1..0x894020
+            - Range: 0x894001..0x894040
               Pieces: []
-            - Range: 0x894020..0x894021
+            - Range: 0x894040..0x894041
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x894021..0x894060
+            - Range: 0x894041..0x894080
               Pieces: []
-            - Range: 0x894060..0x894061
+            - Range: 0x894080..0x894081
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x894061..0x894090
+            - Range: 0x894081..0x8940b0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 10 BaseType int
           Locations:
-            - Range: 0x893fc4..0x893fcc
+            - Range: 0x893fe4..0x893fec
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 104
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0x894090..0x894290]
+      OutOfLinePCRanges: [0x8940b0..0x8942b0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x894090..0x8940ec
+            - Range: 0x8940b0..0x89410c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8940ec..0x8940f0
+            - Range: 0x89410c..0x894110
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8940f0..0x894290
+            - Range: 0x894110..0x8942b0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -7939,549 +7939,549 @@ Subprograms:
         - Name: ~r0
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x894090..0x894148
+            - Range: 0x8940b0..0x894168
               Pieces: []
-            - Range: 0x894148..0x894149
+            - Range: 0x894168..0x894169
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x894149..0x894190
+            - Range: 0x894169..0x8941b0
               Pieces: []
-            - Range: 0x894190..0x894191
+            - Range: 0x8941b0..0x8941b1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x894191..0x894254
+            - Range: 0x8941b1..0x894274
               Pieces: []
-            - Range: 0x894254..0x894255
+            - Range: 0x894274..0x894275
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x894255..0x894268
+            - Range: 0x894275..0x894288
               Pieces: []
-            - Range: 0x894268..0x894269
+            - Range: 0x894288..0x894289
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x894269..0x894290
+            - Range: 0x894289..0x8942b0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 10 BaseType int
           Locations:
-            - Range: 0x89417c..0x894184
+            - Range: 0x89419c..0x8941a4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: '&result'
           Type: 95 PointerType *int
           Locations:
-            - Range: 0x89412c..0x894148
+            - Range: 0x89414c..0x894168
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 105
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0x894290..0x894400]
+      OutOfLinePCRanges: [0x8942b0..0x894420]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x894290..0x8942cc
+            - Range: 0x8942b0..0x8942ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8942cc..0x89432c
+            - Range: 0x8942ec..0x89434c
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x89432c..0x894398
+            - Range: 0x89434c..0x8943b8
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x894398..0x8943c0
+            - Range: 0x8943b8..0x8943e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8943c0..0x8943c4
+            - Range: 0x8943e0..0x8943e4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8943c4..0x894400
+            - Range: 0x8943e4..0x894420
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 162 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x894290..0x894378
+            - Range: 0x8942b0..0x894398
               Pieces: []
-            - Range: 0x894378..0x894379
+            - Range: 0x894398..0x894399
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x894379..0x89438c
+            - Range: 0x894399..0x8943ac
               Pieces: []
-            - Range: 0x89438c..0x89438d
+            - Range: 0x8943ac..0x8943ad
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89438d..0x894400
+            - Range: 0x8943ad..0x894420
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 162 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x894290..0x8942cc
+            - Range: 0x8942b0..0x8942ec
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8942cc..0x89431c
+            - Range: 0x8942ec..0x89433c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x89431c..0x89432c
+            - Range: 0x89433c..0x89434c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -64}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x89432c..0x894384
+            - Range: 0x89434c..0x8943a4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -64}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x894384..0x894388
+            - Range: 0x8943a4..0x8943a8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x894388..0x89438c
+            - Range: 0x8943a8..0x8943ac
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x89438c..0x894400
+            - Range: 0x8943ac..0x894420
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 106
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0x894400..0x8944a0]
+      OutOfLinePCRanges: [0x894420..0x8944c0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 10 BaseType int
           Locations:
-            - Range: 0x894400..0x89441c
+            - Range: 0x894420..0x89443c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 10 BaseType int
           Locations:
-            - Range: 0x894400..0x894478
+            - Range: 0x894420..0x894498
               Pieces: []
-            - Range: 0x894478..0x894479
+            - Range: 0x894498..0x894499
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x894479..0x8944a0
+            - Range: 0x894499..0x8944c0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 107
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0x8944a0..0x894570]
+      OutOfLinePCRanges: [0x8944c0..0x894590]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 10 BaseType int
           Locations:
-            - Range: 0x8944a0..0x8944f0
+            - Range: 0x8944c0..0x894510
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 10 BaseType int
           Locations:
-            - Range: 0x8944a0..0x894544
+            - Range: 0x8944c0..0x894564
               Pieces: []
-            - Range: 0x894544..0x894545
+            - Range: 0x894564..0x894565
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x894545..0x894570
+            - Range: 0x894565..0x894590
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 10 BaseType int
           Locations:
-            - Range: 0x8944a0..0x894544
+            - Range: 0x8944c0..0x894564
               Pieces: []
-            - Range: 0x894544..0x894545
+            - Range: 0x894564..0x894565
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x894545..0x894570
+            - Range: 0x894565..0x894590
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 108
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0x894570..0x894640]
+      OutOfLinePCRanges: [0x894590..0x894660]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 10 BaseType int
           Locations:
-            - Range: 0x894570..0x8945b0
+            - Range: 0x894590..0x8945d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8945b0..0x894640
+            - Range: 0x8945d0..0x894660
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0x894570..0x894614
+            - Range: 0x894590..0x894634
               Pieces: []
-            - Range: 0x894614..0x894615
+            - Range: 0x894634..0x894635
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x894615..0x894640
+            - Range: 0x894635..0x894660
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 10 BaseType int
           Locations:
-            - Range: 0x894570..0x894614
+            - Range: 0x894590..0x894634
               Pieces: []
-            - Range: 0x894614..0x894615
+            - Range: 0x894634..0x894635
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x894615..0x894640
+            - Range: 0x894635..0x894660
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 10 BaseType int
           Locations:
-            - Range: 0x894570..0x894614
+            - Range: 0x894590..0x894634
               Pieces: []
-            - Range: 0x894614..0x894615
+            - Range: 0x894634..0x894635
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x894615..0x894640
+            - Range: 0x894635..0x894660
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 109
       Name: main.testConflictingReturn
-      OutOfLinePCRanges: [0x894640..0x894730]
+      OutOfLinePCRanges: [0x894660..0x894750]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 10 BaseType int
           Locations:
-            - Range: 0x894640..0x894680
+            - Range: 0x894660..0x8946a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x894680..0x894730
+            - Range: 0x8946a0..0x894750
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0x894640..0x894708
+            - Range: 0x894660..0x894728
               Pieces: []
-            - Range: 0x894708..0x894709
+            - Range: 0x894728..0x894729
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x894709..0x894730
+            - Range: 0x894729..0x894750
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: r0
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0x894640..0x894708
+            - Range: 0x894660..0x894728
               Pieces: []
-            - Range: 0x894708..0x894709
+            - Range: 0x894728..0x894729
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x894709..0x894730
+            - Range: 0x894729..0x894750
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 110
       Name: main.testReturnsNamedDeferLine
-      OutOfLinePCRanges: [0x894730..0x8948f0]
+      OutOfLinePCRanges: [0x894750..0x894910]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 10 BaseType int
           Locations:
-            - Range: 0x894730..0x894794
+            - Range: 0x894750..0x8947b4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x894794..0x8948f0
+            - Range: 0x8947b4..0x894910
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0x89475c..0x8948f0
+            - Range: 0x89477c..0x894910
               Pieces: [{Size: 16, Op: {CfaOffset: -120}}]
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0x894760..0x8948f0
+            - Range: 0x894780..0x894910
               Pieces: [{Size: 16, Op: {CfaOffset: -136}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 111
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0x8949d0..0x894a60]
+      OutOfLinePCRanges: [0x8949f0..0x894a80]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 16 BaseType int8
           Locations:
-            - Range: 0x8949d0..0x894a40
+            - Range: 0x8949f0..0x894a60
               Pieces: []
-            - Range: 0x894a40..0x894a41
+            - Range: 0x894a60..0x894a61
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x894a41..0x894a60
+            - Range: 0x894a61..0x894a80
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 90 BaseType int16
           Locations:
-            - Range: 0x8949d0..0x894a40
+            - Range: 0x8949f0..0x894a60
               Pieces: []
-            - Range: 0x894a40..0x894a41
+            - Range: 0x894a60..0x894a61
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x894a41..0x894a60
+            - Range: 0x894a61..0x894a80
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 14 BaseType int32
           Locations:
-            - Range: 0x8949d0..0x894a40
+            - Range: 0x8949f0..0x894a60
               Pieces: []
-            - Range: 0x894a40..0x894a41
+            - Range: 0x894a60..0x894a61
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x894a41..0x894a60
+            - Range: 0x894a61..0x894a80
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 15 BaseType int64
           Locations:
-            - Range: 0x8949d0..0x894a40
+            - Range: 0x8949f0..0x894a60
               Pieces: []
-            - Range: 0x894a40..0x894a41
+            - Range: 0x894a60..0x894a61
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x894a41..0x894a60
+            - Range: 0x894a61..0x894a80
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x8949d0..0x894a40
+            - Range: 0x8949f0..0x894a60
               Pieces: []
-            - Range: 0x894a40..0x894a41
+            - Range: 0x894a60..0x894a61
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x894a41..0x894a60
+            - Range: 0x894a61..0x894a80
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 8 BaseType uint16
           Locations:
-            - Range: 0x8949d0..0x894a40
+            - Range: 0x8949f0..0x894a60
               Pieces: []
-            - Range: 0x894a40..0x894a41
+            - Range: 0x894a60..0x894a61
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x894a41..0x894a60
+            - Range: 0x894a61..0x894a80
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 3 BaseType uint32
           Locations:
-            - Range: 0x8949d0..0x894a40
+            - Range: 0x8949f0..0x894a60
               Pieces: []
-            - Range: 0x894a40..0x894a41
+            - Range: 0x894a60..0x894a61
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x894a41..0x894a60
+            - Range: 0x894a61..0x894a80
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 11 BaseType uint64
           Locations:
-            - Range: 0x8949d0..0x894a40
+            - Range: 0x8949f0..0x894a60
               Pieces: []
-            - Range: 0x894a40..0x894a41
+            - Range: 0x894a60..0x894a61
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x894a41..0x894a60
+            - Range: 0x894a61..0x894a80
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 112
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0x894a60..0x894b20]
+      OutOfLinePCRanges: [0x894a80..0x894b40]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float64
-          Locations: [{Range: 0x894a60..0x894b20, Pieces: []}]
+          Locations: [{Range: 0x894a80..0x894b40, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0x894a60..0x894b20, Pieces: []}]
+          Locations: [{Range: 0x894a80..0x894b40, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 18 BaseType float64
-          Locations: [{Range: 0x894a60..0x894b20, Pieces: []}]
+          Locations: [{Range: 0x894a80..0x894b40, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 18 BaseType float64
-          Locations: [{Range: 0x894a60..0x894b20, Pieces: []}]
+          Locations: [{Range: 0x894a80..0x894b40, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 18 BaseType float64
-          Locations: [{Range: 0x894a60..0x894b20, Pieces: []}]
+          Locations: [{Range: 0x894a80..0x894b40, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 18 BaseType float64
-          Locations: [{Range: 0x894a60..0x894b20, Pieces: []}]
+          Locations: [{Range: 0x894a80..0x894b40, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 18 BaseType float64
-          Locations: [{Range: 0x894a60..0x894b20, Pieces: []}]
+          Locations: [{Range: 0x894a80..0x894b40, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 18 BaseType float64
-          Locations: [{Range: 0x894a60..0x894b20, Pieces: []}]
+          Locations: [{Range: 0x894a80..0x894b40, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 18 BaseType float64
-          Locations: [{Range: 0x894a60..0x894b20, Pieces: []}]
+          Locations: [{Range: 0x894a80..0x894b40, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r9
           Type: 18 BaseType float64
-          Locations: [{Range: 0x894a60..0x894b20, Pieces: []}]
+          Locations: [{Range: 0x894a80..0x894b40, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r10
           Type: 18 BaseType float64
-          Locations: [{Range: 0x894a60..0x894b20, Pieces: []}]
+          Locations: [{Range: 0x894a80..0x894b40, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r11
           Type: 18 BaseType float64
-          Locations: [{Range: 0x894a60..0x894b20, Pieces: []}]
+          Locations: [{Range: 0x894a80..0x894b40, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r12
           Type: 18 BaseType float64
-          Locations: [{Range: 0x894a60..0x894b20, Pieces: []}]
+          Locations: [{Range: 0x894a80..0x894b40, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r13
           Type: 18 BaseType float64
-          Locations: [{Range: 0x894a60..0x894b20, Pieces: []}]
+          Locations: [{Range: 0x894a80..0x894b40, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r14
           Type: 18 BaseType float64
-          Locations: [{Range: 0x894a60..0x894b20, Pieces: []}]
+          Locations: [{Range: 0x894a80..0x894b40, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: onlyOnAmd64_16
           Type: 18 BaseType float64
-          Locations: [{Range: 0x894a60..0x894b20, Pieces: []}]
+          Locations: [{Range: 0x894a80..0x894b40, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: bothArmAndAmd64
           Type: 18 BaseType float64
           Locations:
-            - Range: 0x894a60..0x894afc
+            - Range: 0x894a80..0x894b1c
               Pieces: []
-            - Range: 0x894afc..0x894afd
+            - Range: 0x894b1c..0x894b1d
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x894afd..0x894b20
+            - Range: 0x894b1d..0x894b40
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 113
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0x894b20..0x894ba0]
+      OutOfLinePCRanges: [0x894b40..0x894bc0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 91 BaseType complex64
-          Locations: [{Range: 0x894b20..0x894ba0, Pieces: []}]
+          Locations: [{Range: 0x894b40..0x894bc0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 92 BaseType complex128
-          Locations: [{Range: 0x894b20..0x894ba0, Pieces: []}]
+          Locations: [{Range: 0x894b40..0x894bc0, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 114
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0x894ba0..0x894c70]
+      OutOfLinePCRanges: [0x894bc0..0x894c90]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x894ba0..0x894c54
+            - Range: 0x894bc0..0x894c74
               Pieces: []
-            - Range: 0x894c54..0x894c55
+            - Range: 0x894c74..0x894c75
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8503,193 +8503,193 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x894c55..0x894c70
+            - Range: 0x894c75..0x894c90
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 115
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0x894c70..0x894d00]
+      OutOfLinePCRanges: [0x894c90..0x894d20]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0x894c70..0x894ce0
+            - Range: 0x894c90..0x894d00
               Pieces: []
-            - Range: 0x894ce0..0x894ce1
+            - Range: 0x894d00..0x894d01
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x894ce1..0x894d00
+            - Range: 0x894d01..0x894d20
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 116
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0x894d00..0x894d70]
+      OutOfLinePCRanges: [0x894d20..0x894d90]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 252 ArrayType [1]int
           Locations:
-            - Range: 0x894d00..0x894d54
+            - Range: 0x894d20..0x894d74
               Pieces: []
-            - Range: 0x894d54..0x894d55
+            - Range: 0x894d74..0x894d75
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x894d55..0x894d70
+            - Range: 0x894d75..0x894d90
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 117
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0x894d70..0x894de0]
+      OutOfLinePCRanges: [0x894d90..0x894e00]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 253 ArrayType [0]int
           Locations:
-            - Range: 0x894d70..0x894dc0
+            - Range: 0x894d90..0x894de0
               Pieces: []
-            - Range: 0x894dc0..0x894dc1
+            - Range: 0x894de0..0x894de1
               Pieces: []
-            - Range: 0x894dc1..0x894de0
+            - Range: 0x894de1..0x894e00
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 118
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0x894de0..0x894e60]
+      OutOfLinePCRanges: [0x894e00..0x894e80]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 254 StructureType main.mixedStruct
-          Locations: [{Range: 0x894de0..0x894e60, Pieces: []}]
+          Locations: [{Range: 0x894e00..0x894e80, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 119
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0x894e60..0x894f00]
+      OutOfLinePCRanges: [0x894e80..0x894f20]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0x894e60..0x894edc
+            - Range: 0x894e80..0x894efc
               Pieces: []
-            - Range: 0x894edc..0x894edd
+            - Range: 0x894efc..0x894efd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x894edd..0x894f00
+            - Range: 0x894efd..0x894f20
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 10 BaseType int
           Locations:
-            - Range: 0x894e60..0x894edc
+            - Range: 0x894e80..0x894efc
               Pieces: []
-            - Range: 0x894edc..0x894edd
+            - Range: 0x894efc..0x894efd
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x894edd..0x894f00
+            - Range: 0x894efd..0x894f20
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 10 BaseType int
           Locations:
-            - Range: 0x894e60..0x894edc
+            - Range: 0x894e80..0x894efc
               Pieces: []
-            - Range: 0x894edc..0x894edd
+            - Range: 0x894efc..0x894efd
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x894edd..0x894f00
+            - Range: 0x894efd..0x894f20
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 10 BaseType int
           Locations:
-            - Range: 0x894e60..0x894edc
+            - Range: 0x894e80..0x894efc
               Pieces: []
-            - Range: 0x894edc..0x894edd
+            - Range: 0x894efc..0x894efd
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x894edd..0x894f00
+            - Range: 0x894efd..0x894f20
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 10 BaseType int
           Locations:
-            - Range: 0x894e60..0x894edc
+            - Range: 0x894e80..0x894efc
               Pieces: []
-            - Range: 0x894edc..0x894edd
+            - Range: 0x894efc..0x894efd
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x894edd..0x894f00
+            - Range: 0x894efd..0x894f20
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 10 BaseType int
           Locations:
-            - Range: 0x894e60..0x894edc
+            - Range: 0x894e80..0x894efc
               Pieces: []
-            - Range: 0x894edc..0x894edd
+            - Range: 0x894efc..0x894efd
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x894edd..0x894f00
+            - Range: 0x894efd..0x894f20
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 10 BaseType int
           Locations:
-            - Range: 0x894e60..0x894edc
+            - Range: 0x894e80..0x894efc
               Pieces: []
-            - Range: 0x894edc..0x894edd
+            - Range: 0x894efc..0x894efd
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x894edd..0x894f00
+            - Range: 0x894efd..0x894f20
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 10 BaseType int
           Locations:
-            - Range: 0x894e60..0x894edc
+            - Range: 0x894e80..0x894efc
               Pieces: []
-            - Range: 0x894edc..0x894edd
+            - Range: 0x894efc..0x894efd
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x894edd..0x894f00
+            - Range: 0x894efd..0x894f20
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0x894e60..0x894edc
+            - Range: 0x894e80..0x894efc
               Pieces: []
-            - Range: 0x894edc..0x894edd
+            - Range: 0x894efc..0x894efd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x894edd..0x894f00
+            - Range: 0x894efd..0x894f20
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 120
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0x894f00..0x894fe0]
+      OutOfLinePCRanges: [0x894f20..0x895000]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 255 StructureType main.wideStruct
           Locations:
-            - Range: 0x894f00..0x894fc4
+            - Range: 0x894f20..0x894fe4
               Pieces: []
-            - Range: 0x894fc4..0x894fc5
+            - Range: 0x894fe4..0x894fe5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8713,145 +8713,145 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0x894fc5..0x894fe0
+            - Range: 0x894fe5..0x895000
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 121
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0x894fe0..0x895070]
+      OutOfLinePCRanges: [0x895000..0x895090]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0x894fe0..0x895050
+            - Range: 0x895000..0x895070
               Pieces: []
-            - Range: 0x895050..0x895051
+            - Range: 0x895070..0x895071
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x895051..0x895070
+            - Range: 0x895071..0x895090
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0x894fe0..0x895070, Pieces: []}]
+          Locations: [{Range: 0x895000..0x895090, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 10 BaseType int
           Locations:
-            - Range: 0x894fe0..0x895050
+            - Range: 0x895000..0x895070
               Pieces: []
-            - Range: 0x895050..0x895051
+            - Range: 0x895070..0x895071
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x895051..0x895070
+            - Range: 0x895071..0x895090
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 18 BaseType float64
-          Locations: [{Range: 0x894fe0..0x895070, Pieces: []}]
+          Locations: [{Range: 0x895000..0x895090, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0x894fe0..0x895050
+            - Range: 0x895000..0x895070
               Pieces: []
-            - Range: 0x895050..0x895051
+            - Range: 0x895070..0x895071
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x895051..0x895070
+            - Range: 0x895071..0x895090
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 122
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0x895070..0x895100]
+      OutOfLinePCRanges: [0x895090..0x895120]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 256 StructureType main.structWithArray
           Locations:
-            - Range: 0x895070..0x8950e0
+            - Range: 0x895090..0x895100
               Pieces: []
-            - Range: 0x8950e0..0x8950e1
+            - Range: 0x895100..0x895101
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x8950e1..0x895100
+            - Range: 0x895101..0x895120
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 123
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0x895100..0x895170]
+      OutOfLinePCRanges: [0x895120..0x895190]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float64
-          Locations: [{Range: 0x895100..0x895170, Pieces: []}]
+          Locations: [{Range: 0x895120..0x895190, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 124
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0x895170..0x8951f0]
+      OutOfLinePCRanges: [0x895190..0x895210]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float32
-          Locations: [{Range: 0x895170..0x8951f0, Pieces: []}]
+          Locations: [{Range: 0x895190..0x895210, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0x895170..0x8951f0, Pieces: []}]
+          Locations: [{Range: 0x895190..0x895210, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 125
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0x8951f0..0x895260]
+      OutOfLinePCRanges: [0x895210..0x895280]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x8951f0..0x895248
+            - Range: 0x895210..0x895268
               Pieces: []
-            - Range: 0x895248..0x895249
+            - Range: 0x895268..0x895269
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x895249..0x895260
+            - Range: 0x895269..0x895280
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 2 BaseType uintptr
           Locations:
-            - Range: 0x8951f0..0x895248
+            - Range: 0x895210..0x895268
               Pieces: []
-            - Range: 0x895248..0x895249
+            - Range: 0x895268..0x895269
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x895249..0x895260
+            - Range: 0x895269..0x895280
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 126
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0x895260..0x895440]
+      OutOfLinePCRanges: [0x895280..0x895460]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x895260..0x8952cc
+            - Range: 0x895280..0x8952ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8873,7 +8873,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8952cc..0x8952e0
+            - Range: 0x8952ec..0x895300
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8895,7 +8895,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8952e0..0x8952e4
+            - Range: 0x895300..0x895304
               Pieces:
                 - Size: 8
                   Op: null
@@ -8922,9 +8922,9 @@ Subprograms:
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x895260..0x8953d8
+            - Range: 0x895280..0x8953f8
               Pieces: []
-            - Range: 0x8953d8..0x8953d9
+            - Range: 0x8953f8..0x8953f9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8946,44 +8946,44 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8953d9..0x895440
+            - Range: 0x8953f9..0x895460
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 127
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0x895440..0x895510]
+      OutOfLinePCRanges: [0x895460..0x895530]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0x895440..0x895510
+            - Range: 0x895460..0x895530
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0x895440..0x8954f4
+            - Range: 0x895460..0x895514
               Pieces: []
-            - Range: 0x8954f4..0x8954f5
+            - Range: 0x895514..0x895515
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x8954f5..0x895510
+            - Range: 0x895515..0x895530
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 128
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0x895510..0x895770]
+      OutOfLinePCRanges: [0x895530..0x895790]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x895510..0x895580
+            - Range: 0x895530..0x8955a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9005,7 +9005,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x895580..0x895594
+            - Range: 0x8955a0..0x8955b4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9027,7 +9027,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x895594..0x895598
+            - Range: 0x8955b4..0x8955b8
               Pieces:
                 - Size: 8
                   Op: null
@@ -9054,16 +9054,16 @@ Subprograms:
         - Name: s2
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x895510..0x895770
+            - Range: 0x895530..0x895790
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x895510..0x895700
+            - Range: 0x895530..0x895720
               Pieces: []
-            - Range: 0x895700..0x895701
+            - Range: 0x895720..0x895721
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9085,196 +9085,196 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x895701..0x895770
+            - Range: 0x895721..0x895790
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 129
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0x895770..0x895960]
+      OutOfLinePCRanges: [0x895790..0x895980]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 10 BaseType int
           Locations:
-            - Range: 0x895770..0x8957e8
+            - Range: 0x895790..0x895808
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8957e8..0x895960
+            - Range: 0x895808..0x895980
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 10 BaseType int
           Locations:
-            - Range: 0x895770..0x8957e8
+            - Range: 0x895790..0x895808
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x8957e8..0x895960
+            - Range: 0x895808..0x895980
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 10 BaseType int
           Locations:
-            - Range: 0x895770..0x8957e8
+            - Range: 0x895790..0x895808
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x8957e8..0x895960
+            - Range: 0x895808..0x895980
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 10 BaseType int
           Locations:
-            - Range: 0x895770..0x8957e8
+            - Range: 0x895790..0x895808
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x8957e8..0x895960
+            - Range: 0x895808..0x895980
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 10 BaseType int
           Locations:
-            - Range: 0x895770..0x8957e8
+            - Range: 0x895790..0x895808
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x8957e8..0x895960
+            - Range: 0x895808..0x895980
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 10 BaseType int
           Locations:
-            - Range: 0x895770..0x8957e8
+            - Range: 0x895790..0x895808
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x8957e8..0x895960
+            - Range: 0x895808..0x895980
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 10 BaseType int
           Locations:
-            - Range: 0x895770..0x8957e8
+            - Range: 0x895790..0x895808
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x8957e8..0x895960
+            - Range: 0x895808..0x895980
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 10 BaseType int
           Locations:
-            - Range: 0x895770..0x8957e8
+            - Range: 0x895790..0x895808
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x8957e8..0x895960
+            - Range: 0x895808..0x895980
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: i
           Type: 10 BaseType int
           Locations:
-            - Range: 0x895770..0x8957e8
+            - Range: 0x895790..0x895808
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0x8957e8..0x895960
+            - Range: 0x895808..0x895980
               Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 107 ArrayType [2]int
           Locations:
-            - Range: 0x895770..0x8958fc
+            - Range: 0x895790..0x89591c
               Pieces: []
-            - Range: 0x8958fc..0x8958fd
+            - Range: 0x89591c..0x89591d
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-            - Range: 0x8958fd..0x895960
+            - Range: 0x89591d..0x895980
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 130
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0x895960..0x895ba0]
+      OutOfLinePCRanges: [0x895980..0x895bc0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 10 BaseType int
           Locations:
-            - Range: 0x895960..0x8959e8
+            - Range: 0x895980..0x895a08
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8959e8..0x895ba0
+            - Range: 0x895a08..0x895bc0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 10 BaseType int
           Locations:
-            - Range: 0x895960..0x8959e8
+            - Range: 0x895980..0x895a08
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x8959e8..0x895ba0
+            - Range: 0x895a08..0x895bc0
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 10 BaseType int
           Locations:
-            - Range: 0x895960..0x8959e8
+            - Range: 0x895980..0x895a08
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x8959e8..0x895ba0
+            - Range: 0x895a08..0x895bc0
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 10 BaseType int
           Locations:
-            - Range: 0x895960..0x8959e8
+            - Range: 0x895980..0x895a08
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x8959e8..0x895ba0
+            - Range: 0x895a08..0x895bc0
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 10 BaseType int
           Locations:
-            - Range: 0x895960..0x8959e8
+            - Range: 0x895980..0x895a08
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x8959e8..0x895ba0
+            - Range: 0x895a08..0x895bc0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 10 BaseType int
           Locations:
-            - Range: 0x895960..0x8959e8
+            - Range: 0x895980..0x895a08
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x8959e8..0x895ba0
+            - Range: 0x895a08..0x895bc0
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 10 BaseType int
           Locations:
-            - Range: 0x895960..0x8959e8
+            - Range: 0x895980..0x895a08
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x8959e8..0x895ba0
+            - Range: 0x895a08..0x895bc0
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 10 BaseType int
           Locations:
-            - Range: 0x895960..0x8959e8
+            - Range: 0x895980..0x895a08
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x8959e8..0x895ba0
+            - Range: 0x895a08..0x895bc0
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0x895960..0x8959e8
+            - Range: 0x895980..0x895a08
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8959e8..0x895ba0
+            - Range: 0x895a08..0x895bc0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 72}
@@ -9285,9 +9285,9 @@ Subprograms:
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x895960..0x895b30
+            - Range: 0x895980..0x895b50
               Pieces: []
-            - Range: 0x895b30..0x895b31
+            - Range: 0x895b50..0x895b51
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9309,232 +9309,194 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x895b31..0x895ba0
+            - Range: 0x895b51..0x895bc0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 131
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0x895ba0..0x895c40]
+      OutOfLinePCRanges: [0x895bc0..0x895c60]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 161 ArrayType [5]int
           Locations:
-            - Range: 0x895ba0..0x895c40
+            - Range: 0x895bc0..0x895c60
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0x895ba0..0x895c1c
+            - Range: 0x895bc0..0x895c3c
               Pieces: []
-            - Range: 0x895c1c..0x895c1d
+            - Range: 0x895c3c..0x895c3d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x895c1d..0x895c40
+            - Range: 0x895c3d..0x895c60
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 10 BaseType int
           Locations:
-            - Range: 0x895ba0..0x895c1c
+            - Range: 0x895bc0..0x895c3c
               Pieces: []
-            - Range: 0x895c1c..0x895c1d
+            - Range: 0x895c3c..0x895c3d
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x895c1d..0x895c40
+            - Range: 0x895c3d..0x895c60
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 10 BaseType int
           Locations:
-            - Range: 0x895ba0..0x895c1c
+            - Range: 0x895bc0..0x895c3c
               Pieces: []
-            - Range: 0x895c1c..0x895c1d
+            - Range: 0x895c3c..0x895c3d
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x895c1d..0x895c40
+            - Range: 0x895c3d..0x895c60
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 132
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0x895c40..0x895d20]
+      OutOfLinePCRanges: [0x895c60..0x895d40]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 107 ArrayType [2]int
           Locations:
-            - Range: 0x895c40..0x895d20
+            - Range: 0x895c60..0x895d40
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0x895c40..0x895d20
+            - Range: 0x895c60..0x895d40
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0x895c40..0x895d00
+            - Range: 0x895c60..0x895d20
               Pieces: []
-            - Range: 0x895d00..0x895d01
+            - Range: 0x895d20..0x895d21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x895d01..0x895d20
+            - Range: 0x895d21..0x895d40
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 107 ArrayType [2]int
           Locations:
-            - Range: 0x895c40..0x895d00
+            - Range: 0x895c60..0x895d20
               Pieces: []
-            - Range: 0x895d00..0x895d01
+            - Range: 0x895d20..0x895d21
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
-            - Range: 0x895d01..0x895d20
+            - Range: 0x895d21..0x895d40
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 133
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0x895d20..0x895df0]
+      OutOfLinePCRanges: [0x895d40..0x895e10]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 256 StructureType main.structWithArray
           Locations:
-            - Range: 0x895d20..0x895df0
+            - Range: 0x895d40..0x895e10
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0x895d20..0x895dcc
+            - Range: 0x895d40..0x895dec
               Pieces: []
-            - Range: 0x895dcc..0x895dcd
+            - Range: 0x895dec..0x895ded
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x895dcd..0x895df0
+            - Range: 0x895ded..0x895e10
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 256 StructureType main.structWithArray
           Locations:
-            - Range: 0x895d20..0x895dcc
+            - Range: 0x895d40..0x895dec
               Pieces: []
-            - Range: 0x895dcc..0x895dcd
+            - Range: 0x895dec..0x895ded
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x895dcd..0x895df0
+            - Range: 0x895ded..0x895e10
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 10 BaseType int
           Locations:
-            - Range: 0x895da0..0x895df0
+            - Range: 0x895dc0..0x895e10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 134
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0x895df0..0x895ea0]
+      OutOfLinePCRanges: [0x895e10..0x895ec0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 253 ArrayType [0]int
-          Locations: [{Range: 0x895df0..0x895ea0, Pieces: []}]
+          Locations: [{Range: 0x895e10..0x895ec0, Pieces: []}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 10 BaseType int
           Locations:
-            - Range: 0x895df0..0x895e30
+            - Range: 0x895e10..0x895e50
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x895e30..0x895e4c
+            - Range: 0x895e50..0x895e6c
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x895e4c..0x895e68
+            - Range: 0x895e6c..0x895e88
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x895e68..0x895ea0
+            - Range: 0x895e88..0x895ec0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType int
           Locations:
-            - Range: 0x895df0..0x895e74
+            - Range: 0x895e10..0x895e94
               Pieces: []
-            - Range: 0x895e74..0x895e75
+            - Range: 0x895e94..0x895e95
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x895e75..0x895ea0
+            - Range: 0x895e95..0x895ec0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 253 ArrayType [0]int
           Locations:
-            - Range: 0x895df0..0x895e74
+            - Range: 0x895e10..0x895e94
               Pieces: []
-            - Range: 0x895e74..0x895e75
+            - Range: 0x895e94..0x895e95
               Pieces: []
-            - Range: 0x895e75..0x895ea0
+            - Range: 0x895e95..0x895ec0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 135
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0x896320..0x896330]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 257 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x896320..0x896330
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 136
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x896330..0x896340]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 257 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x896330..0x896340
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 137
-      Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0x896340..0x896350]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 258 GoSliceHeaderType [][]uint
+          Type: 257 GoSliceHeaderType []uint
           Locations:
             - Range: 0x896340..0x896350
               Pieces:
@@ -9547,13 +9509,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 138
-      Name: main.testStructSlice
+    - ID: 136
+      Name: main.testEmptySlice
       OutOfLinePCRanges: [0x896350..0x896360]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 260 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 257 GoSliceHeaderType []uint
           Locations:
             - Range: 0x896350..0x896360
               Pieces:
@@ -9565,21 +9527,14 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
           DictIndex: -1
-        - Name: a
-          Type: 10 BaseType int
-          Locations:
-            - Range: 0x896350..0x896360
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
       DictRegister: null
-    - ID: 139
-      Name: main.testEmptySliceOfStructs
+    - ID: 137
+      Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0x896360..0x896370]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 260 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 258 GoSliceHeaderType [][]uint
           Locations:
             - Range: 0x896360..0x896370
               Pieces:
@@ -9591,16 +9546,9 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
           DictIndex: -1
-        - Name: a
-          Type: 10 BaseType int
-          Locations:
-            - Range: 0x896360..0x896370
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
       DictRegister: null
-    - ID: 140
-      Name: main.testNilSliceOfStructs
+    - ID: 138
+      Name: main.testStructSlice
       OutOfLinePCRanges: [0x896370..0x896380]
       InlinePCRanges: []
       Variables:
@@ -9625,13 +9573,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 141
-      Name: main.testStringSlice
+    - ID: 139
+      Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0x896380..0x896390]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 154 GoSliceHeaderType []string
+        - Name: xs
+          Type: 260 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0x896380..0x896390
               Pieces:
@@ -9643,47 +9591,47 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
           DictIndex: -1
+        - Name: a
+          Type: 10 BaseType int
+          Locations:
+            - Range: 0x896380..0x896390
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
       DictRegister: null
-    - ID: 142
-      Name: main.testNilSliceWithOtherParams
+    - ID: 140
+      Name: main.testNilSliceOfStructs
       OutOfLinePCRanges: [0x896390..0x8963a0]
       InlinePCRanges: []
       Variables:
-        - Name: a
-          Type: 16 BaseType int8
-          Locations:
-            - Range: 0x896390..0x8963a0
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: s
-          Type: 263 GoSliceHeaderType []bool
+        - Name: xs
+          Type: 260 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0x896390..0x8963a0
               Pieces:
                 - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
           Role: Parameter
           DictIndex: -1
-        - Name: x
-          Type: 13 BaseType uint
+        - Name: a
+          Type: 10 BaseType int
           Locations:
             - Range: 0x896390..0x8963a0
-              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 143
-      Name: main.testNilSlice
+    - ID: 141
+      Name: main.testStringSlice
       OutOfLinePCRanges: [0x8963a0..0x8963b0]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 264 GoSliceHeaderType []uint16
+        - Name: s
+          Type: 154 GoSliceHeaderType []string
           Locations:
             - Range: 0x8963a0..0x8963b0
               Pieces:
@@ -9696,32 +9644,46 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 144
-      Name: main.testVeryLargeSlice
+    - ID: 142
+      Name: main.testNilSliceWithOtherParams
       OutOfLinePCRanges: [0x8963b0..0x8963c0]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 257 GoSliceHeaderType []uint
+        - Name: a
+          Type: 16 BaseType int8
+          Locations:
+            - Range: 0x8963b0..0x8963c0
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: s
+          Type: 263 GoSliceHeaderType []bool
           Locations:
             - Range: 0x8963b0..0x8963c0
               Pieces:
                 - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: x
+          Type: 13 BaseType uint
+          Locations:
+            - Range: 0x8963b0..0x8963c0
+              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 145
-      Name: main.testSliceEmptyStructs
+    - ID: 143
+      Name: main.testNilSlice
       OutOfLinePCRanges: [0x8963c0..0x8963d0]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 265 GoSliceHeaderType []struct {}
+          Type: 264 GoSliceHeaderType []uint16
           Locations:
             - Range: 0x8963c0..0x8963d0
               Pieces:
@@ -9734,15 +9696,53 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 144
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0x8963d0..0x8963e0]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 257 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0x8963d0..0x8963e0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 145
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0x8963e0..0x8963f0]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 265 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0x8963e0..0x8963f0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 146
       Name: main.testSubslices
-      OutOfLinePCRanges: [0x8963d0..0x8963e0]
+      OutOfLinePCRanges: [0x8963f0..0x896400]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8963d0..0x8963e0
+            - Range: 0x8963f0..0x896400
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9755,7 +9755,7 @@ Subprograms:
         - Name: bs
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8963d0..0x8963e0
+            - Range: 0x8963f0..0x896400
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9768,7 +9768,7 @@ Subprograms:
         - Name: cs
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8963d0..0x8963e0
+            - Range: 0x8963f0..0x896400
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -9781,34 +9781,34 @@ Subprograms:
       DictRegister: null
     - ID: 147
       Name: main.stackC
-      OutOfLinePCRanges: [0x8969d0..0x896a40]
+      OutOfLinePCRanges: [0x8969f0..0x896a60]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0x8969d0..0x896a1c
+            - Range: 0x8969f0..0x896a3c
               Pieces: []
-            - Range: 0x896a1c..0x896a1d
+            - Range: 0x896a3c..0x896a3d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x896a1d..0x896a40
+            - Range: 0x896a3d..0x896a60
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 148
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x896a40..0x896a50]
+      OutOfLinePCRanges: [0x896a60..0x896a70]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0x896a40..0x896a50
+            - Range: 0x896a60..0x896a70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9819,13 +9819,13 @@ Subprograms:
       DictRegister: null
     - ID: 149
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x896a50..0x896a60]
+      OutOfLinePCRanges: [0x896a70..0x896a80]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0x896a50..0x896a60
+            - Range: 0x896a70..0x896a80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9836,7 +9836,7 @@ Subprograms:
         - Name: "y"
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0x896a50..0x896a60
+            - Range: 0x896a70..0x896a80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9847,7 +9847,7 @@ Subprograms:
         - Name: z
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0x896a50..0x896a60
+            - Range: 0x896a70..0x896a80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9858,13 +9858,13 @@ Subprograms:
       DictRegister: null
     - ID: 150
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x896a60..0x896a80]
+      OutOfLinePCRanges: [0x896a80..0x896aa0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 267 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x896a60..0x896a80
+            - Range: 0x896a80..0x896aa0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9883,66 +9883,32 @@ Subprograms:
       DictRegister: null
     - ID: 151
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x896a80..0x896a90]
+      OutOfLinePCRanges: [0x896aa0..0x896ab0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 268 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x896a80..0x896a90
+            - Range: 0x896aa0..0x896ab0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 152
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x896a90..0x896aa0]
+      OutOfLinePCRanges: [0x896ab0..0x896ac0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 269 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x896a90..0x896aa0
+            - Range: 0x896ab0..0x896ac0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 153
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0x896aa0..0x896ab0]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 12 GoStringHeaderType string
-          Locations:
-            - Range: 0x896aa0..0x896ab0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 154
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x896ab0..0x896ac0]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 12 GoStringHeaderType string
-          Locations:
-            - Range: 0x896ab0..0x896ac0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 155
-      Name: main.testEmptyString
       OutOfLinePCRanges: [0x896ac0..0x896ad0]
       InlinePCRanges: []
       Variables:
@@ -9958,12 +9924,12 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 156
-      Name: main.testSubstrings
+    - ID: 154
+      Name: main.testUnitializedString
       OutOfLinePCRanges: [0x896ad0..0x896ae0]
       InlinePCRanges: []
       Variables:
-        - Name: a
+        - Name: x
           Type: 12 GoStringHeaderType string
           Locations:
             - Range: 0x896ad0..0x896ae0
@@ -9974,10 +9940,44 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
           DictIndex: -1
+      DictRegister: null
+    - ID: 155
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0x896ae0..0x896af0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 12 GoStringHeaderType string
+          Locations:
+            - Range: 0x896ae0..0x896af0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 156
+      Name: main.testSubstrings
+      OutOfLinePCRanges: [0x896af0..0x896b00]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 12 GoStringHeaderType string
+          Locations:
+            - Range: 0x896af0..0x896b00
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
         - Name: b
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0x896ad0..0x896ae0
+            - Range: 0x896af0..0x896b00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9988,7 +9988,7 @@ Subprograms:
         - Name: c
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0x896ad0..0x896ae0
+            - Range: 0x896af0..0x896b00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9999,26 +9999,26 @@ Subprograms:
       DictRegister: null
     - ID: 157
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x896c40..0x896c50]
+      OutOfLinePCRanges: [0x896c60..0x896c70]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 271 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x896c40..0x896c50
+            - Range: 0x896c60..0x896c70
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 158
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x896c50..0x896c70]
+      OutOfLinePCRanges: [0x896c70..0x896c90]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 284 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x896c50..0x896c70
+            - Range: 0x896c70..0x896c90
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10037,13 +10037,13 @@ Subprograms:
       DictRegister: null
     - ID: 159
       Name: main.testStruct
-      OutOfLinePCRanges: [0x896d40..0x896d60]
+      OutOfLinePCRanges: [0x896d60..0x896d80]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 315 StructureType main.aStruct
           Locations:
-            - Range: 0x896d40..0x896d60
+            - Range: 0x896d60..0x896d80
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -10064,130 +10064,68 @@ Subprograms:
       DictRegister: null
     - ID: 160
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0x896de0..0x896df0]
+      OutOfLinePCRanges: [0x896e00..0x896e10]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 316 PointerType *main.anotherStruct
           Locations:
-            - Range: 0x896de0..0x896df0
+            - Range: 0x896e00..0x896e10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 161
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0x896df0..0x896e00]
+      OutOfLinePCRanges: [0x896e10..0x896e20]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 318 StructureType main.tenStrings
           Locations:
-            - Range: 0x896df0..0x896e00
+            - Range: 0x896e10..0x896e20
               Pieces: [{Size: 160, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 162
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x896e40..0x896e50]
+      OutOfLinePCRanges: [0x896e60..0x896e70]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 319 StructureType main.emptyStruct
-          Locations: [{Range: 0x896e40..0x896e50, Pieces: []}]
+          Locations: [{Range: 0x896e60..0x896e70, Pieces: []}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 163
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x896e50..0x896e60]
+      OutOfLinePCRanges: [0x896e70..0x896e80]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 320 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x896e50..0x896e60
+            - Range: 0x896e70..0x896e80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 164
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0x8988d0..0x8988e0]
+      OutOfLinePCRanges: [0x8988f0..0x898900]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 321 BaseType go.shape.int
-          Locations:
-            - Range: 0x8988d0..0x8988e0
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 322 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
-          Locations:
-            - Range: 0x8988d0..0x8988d4
-              Pieces: []
-            - Range: 0x8988d4..0x8988d5
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8988d5..0x8988e0
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 165
-      Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0x8988e0..0x8988f0]
-      InlinePCRanges: []
-      Variables:
-        - Name: val
-          Type: 323 GoStringHeaderType go.shape.string
-          Locations:
-            - Range: 0x8988e0..0x8988ec
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0x8988ec..0x8988f0
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 324 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
-          Locations:
-            - Range: 0x8988e0..0x8988ec
-              Pieces: []
-            - Range: 0x8988ec..0x8988ed
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8988ed..0x8988f0
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 166
-      Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0x8988f0..0x898900]
-      InlinePCRanges: []
-      Variables:
-        - Name: box
-          Type: 322 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
             - Range: 0x8988f0..0x898900
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 321 BaseType go.shape.int
+          Type: 322 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
             - Range: 0x8988f0..0x8988f4
               Pieces: []
@@ -10198,13 +10136,13 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 167
-      Name: main.nestedGeneric[go.shape.string]
+    - ID: 165
+      Name: main.wrapBox[go.shape.string]
       OutOfLinePCRanges: [0x898900..0x898910]
       InlinePCRanges: []
       Variables:
-        - Name: box
-          Type: 324 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+        - Name: val
+          Type: 323 GoStringHeaderType go.shape.string
           Locations:
             - Range: 0x898900..0x89890c
               Pieces:
@@ -10221,7 +10159,7 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 323 GoStringHeaderType go.shape.string
+          Type: 324 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
             - Range: 0x898900..0x89890c
               Pieces: []
@@ -10236,15 +10174,77 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
+    - ID: 166
+      Name: main.nestedGeneric[go.shape.int]
+      OutOfLinePCRanges: [0x898910..0x898920]
+      InlinePCRanges: []
+      Variables:
+        - Name: box
+          Type: 322 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+          Locations:
+            - Range: 0x898910..0x898920
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 321 BaseType go.shape.int
+          Locations:
+            - Range: 0x898910..0x898914
+              Pieces: []
+            - Range: 0x898914..0x898915
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x898915..0x898920
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 167
+      Name: main.nestedGeneric[go.shape.string]
+      OutOfLinePCRanges: [0x898920..0x898930]
+      InlinePCRanges: []
+      Variables:
+        - Name: box
+          Type: 324 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+          Locations:
+            - Range: 0x898920..0x89892c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x89892c..0x898930
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 323 GoStringHeaderType go.shape.string
+          Locations:
+            - Range: 0x898920..0x89892c
+              Pieces: []
+            - Range: 0x89892c..0x89892d
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x89892d..0x898930
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
     - ID: 168
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0x898980..0x898ab0]
+      OutOfLinePCRanges: [0x8989a0..0x898ad0]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 325 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x898980..0x8989ac
+            - Range: 0x8989a0..0x8989cc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10252,7 +10252,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8989ac..0x8989bc
+            - Range: 0x8989cc..0x8989dc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10260,7 +10260,7 @@ Subprograms:
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: null
-            - Range: 0x8989bc..0x898ab0
+            - Range: 0x8989dc..0x898ad0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10273,18 +10273,18 @@ Subprograms:
         - Name: pred
           Type: 327 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0x898980..0x8989bc
+            - Range: 0x8989a0..0x8989dc
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x8989bc..0x898ab0
+            - Range: 0x8989dc..0x898ad0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 325 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x898980..0x898a6c
+            - Range: 0x8989a0..0x898a8c
               Pieces: []
-            - Range: 0x898a6c..0x898a6d
+            - Range: 0x898a8c..0x898a8d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10292,14 +10292,14 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x898a6d..0x898ab0
+            - Range: 0x898a8d..0x898ad0
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
           Type: 325 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x8989bc..0x8989d8
+            - Range: 0x8989dc..0x8989f8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10307,7 +10307,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x8989d8..0x8989dc
+            - Range: 0x8989f8..0x8989fc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10315,7 +10315,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x8989dc..0x8989e0
+            - Range: 0x8989fc..0x898a00
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10323,7 +10323,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x8989e0..0x8989e0
+            - Range: 0x898a00..0x898a00
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10331,7 +10331,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x8989e0..0x898a0c
+            - Range: 0x898a00..0x898a2c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10339,7 +10339,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x898a0c..0x898a60
+            - Range: 0x898a2c..0x898a80
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10347,7 +10347,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x898a60..0x898ab0
+            - Range: 0x898a80..0x898ad0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10360,110 +10360,62 @@ Subprograms:
         - Name: item
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0x8989fc..0x898a0c
+            - Range: 0x898a1c..0x898a2c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x898a0c..0x898a60
+            - Range: 0x898a2c..0x898a80
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
     - ID: 169
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x898ab0..0x898b10]
+      OutOfLinePCRanges: [0x898ad0..0x898b30]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 322 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x898ab0..0x898ad8
+            - Range: 0x898ad0..0x898af8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
           Type: 328 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0x898ab0..0x898ad8
+            - Range: 0x898ad0..0x898af8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 324 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x898ab0..0x898ad8
+            - Range: 0x898ad0..0x898af8
               Pieces: []
-            - Range: 0x898ad8..0x898ad9
+            - Range: 0x898af8..0x898af9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x898ad9..0x898b10
+            - Range: 0x898af9..0x898b30
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
     - ID: 170
       Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0x898dc0..0x898dd0]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 326 PointerType *go.shape.int
-          Locations:
-            - Range: 0x898dc0..0x898dd0
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 326 PointerType *go.shape.int
-          Locations:
-            - Range: 0x898dc0..0x898dc4
-              Pieces: []
-            - Range: 0x898dc4..0x898dc5
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x898dc5..0x898dd0
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 171
-      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0x898dd0..0x898de0]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 329 PointerType *go.shape.struct { Name string }
-          Locations:
-            - Range: 0x898dd0..0x898de0
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 329 PointerType *go.shape.struct { Name string }
-          Locations:
-            - Range: 0x898dd0..0x898dd4
-              Pieces: []
-            - Range: 0x898dd4..0x898dd5
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x898dd5..0x898de0
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 172
-      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
       OutOfLinePCRanges: [0x898de0..0x898df0]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 331 PointerType *go.shape.struct { X int; Y int }
+          Type: 326 PointerType *go.shape.int
           Locations:
             - Range: 0x898de0..0x898df0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 331 PointerType *go.shape.struct { X int; Y int }
+          Type: 326 PointerType *go.shape.int
           Locations:
             - Range: 0x898de0..0x898de4
               Pieces: []
@@ -10474,101 +10426,149 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
+    - ID: 171
+      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
+      OutOfLinePCRanges: [0x898df0..0x898e00]
+      InlinePCRanges: []
+      Variables:
+        - Name: p
+          Type: 329 PointerType *go.shape.struct { Name string }
+          Locations:
+            - Range: 0x898df0..0x898e00
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 329 PointerType *go.shape.struct { Name string }
+          Locations:
+            - Range: 0x898df0..0x898df4
+              Pieces: []
+            - Range: 0x898df4..0x898df5
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x898df5..0x898e00
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 172
+      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
+      OutOfLinePCRanges: [0x898e00..0x898e10]
+      InlinePCRanges: []
+      Variables:
+        - Name: p
+          Type: 331 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0x898e00..0x898e10
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 331 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0x898e00..0x898e04
+              Pieces: []
+            - Range: 0x898e04..0x898e05
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x898e05..0x898e10
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
     - ID: 173
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0x898df0..0x898e00]
+      OutOfLinePCRanges: [0x898e10..0x898e20]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 333 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0x898df0..0x898e00
+            - Range: 0x898e10..0x898e20
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x898df0..0x898df8
+            - Range: 0x898e10..0x898e18
               Pieces: []
-            - Range: 0x898df8..0x898df9
+            - Range: 0x898e18..0x898e19
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x898df9..0x898e00
+            - Range: 0x898e19..0x898e20
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 174
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0x898e80..0x898e90]
+      OutOfLinePCRanges: [0x898ea0..0x898eb0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 335 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0x898e80..0x898e90
+            - Range: 0x898ea0..0x898eb0
               Pieces: [{Size: 136, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0x898e80..0x898e84
+            - Range: 0x898ea0..0x898ea4
               Pieces: []
-            - Range: 0x898e84..0x898e85
+            - Range: 0x898ea4..0x898ea5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x898e85..0x898e90
+            - Range: 0x898ea5..0x898eb0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 175
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0x898f20..0x898f30]
+      OutOfLinePCRanges: [0x898f40..0x898f50]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 336 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0x898f20..0x898f30
+            - Range: 0x898f40..0x898f50
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0x898f20..0x898f30
+            - Range: 0x898f40..0x898f50
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
           Type: 338 BaseType go.shape.bool
           Locations:
-            - Range: 0x898f20..0x898f30
+            - Range: 0x898f40..0x898f50
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
     - ID: 176
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0x898fb0..0x899040]
+      OutOfLinePCRanges: [0x898fd0..0x899060]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 339 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0x898fb0..0x899040
+            - Range: 0x898fd0..0x899060
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x898fb0..0x899040
+            - Range: 0x898fd0..0x899060
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10579,20 +10579,20 @@ Subprograms:
         - Name: v
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0x898fb0..0x899040
+            - Range: 0x898fd0..0x899060
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
     - ID: 177
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0x8990d0..0x8990e0]
+      OutOfLinePCRanges: [0x8990f0..0x899100]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8990d0..0x8990e0
+            - Range: 0x8990f0..0x899100
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10603,59 +10603,59 @@ Subprograms:
         - Name: b
           Type: 338 BaseType go.shape.bool
           Locations:
-            - Range: 0x8990d0..0x8990e0
+            - Range: 0x8990f0..0x899100
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 338 BaseType go.shape.bool
           Locations:
-            - Range: 0x8990d0..0x8990d8
+            - Range: 0x8990f0..0x8990f8
               Pieces: []
-            - Range: 0x8990d8..0x8990d9
+            - Range: 0x8990f8..0x8990f9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8990d9..0x8990e0
+            - Range: 0x8990f9..0x899100
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8990d0..0x8990d8
+            - Range: 0x8990f0..0x8990f8
               Pieces: []
-            - Range: 0x8990d8..0x8990d9
+            - Range: 0x8990f8..0x8990f9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x8990d9..0x8990e0
+            - Range: 0x8990f9..0x899100
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 178
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x8990e0..0x899100]
+      OutOfLinePCRanges: [0x899100..0x899120]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0x8990e0..0x8990f0
+            - Range: 0x899100..0x899110
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8990e0..0x8990ec
+            - Range: 0x899100..0x89910c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8990ec..0x899100
+            - Range: 0x89910c..0x899120
               Pieces:
                 - Size: 8
                   Op: null
@@ -10666,73 +10666,73 @@ Subprograms:
         - Name: ~r0
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8990e0..0x8990f0
+            - Range: 0x899100..0x899110
               Pieces: []
-            - Range: 0x8990f0..0x8990f1
+            - Range: 0x899110..0x899111
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8990f1..0x899100
+            - Range: 0x899111..0x899120
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0x8990e0..0x8990f0
+            - Range: 0x899100..0x899110
               Pieces: []
-            - Range: 0x8990f0..0x8990f1
+            - Range: 0x899110..0x899111
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x8990f1..0x899100
+            - Range: 0x899111..0x899120
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 179
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0x899100..0x899150]
+      OutOfLinePCRanges: [0x899120..0x899170]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 341 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0x899100..0x899128
+            - Range: 0x899120..0x899148
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0x899100..0x899128
+            - Range: 0x899120..0x899148
               Pieces: []
-            - Range: 0x899128..0x899129
+            - Range: 0x899148..0x899149
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x899129..0x899150
+            - Range: 0x899149..0x899170
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 180
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0x899150..0x8991b0]
+      OutOfLinePCRanges: [0x899170..0x8991d0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 342 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0x899150..0x89917c
+            - Range: 0x899170..0x89919c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x89917c..0x899180
+            - Range: 0x89919c..0x8991a0
               Pieces:
                 - Size: 8
                   Op: null
@@ -10743,65 +10743,65 @@ Subprograms:
         - Name: ~r0
           Type: 12 GoStringHeaderType string
           Locations:
-            - Range: 0x899150..0x899180
+            - Range: 0x899170..0x8991a0
               Pieces: []
-            - Range: 0x899180..0x899181
+            - Range: 0x8991a0..0x8991a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x899181..0x8991b0
+            - Range: 0x8991a1..0x8991d0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 181
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0x8991b0..0x8991c0]
+      OutOfLinePCRanges: [0x8991d0..0x8991e0]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 343 PointerType *go.shape.string
           Locations:
-            - Range: 0x8991b0..0x8991b8
+            - Range: 0x8991d0..0x8991d8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8991b0..0x8991b8
+            - Range: 0x8991d0..0x8991d8
               Pieces: []
-            - Range: 0x8991b8..0x8991b9
+            - Range: 0x8991d8..0x8991d9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8991b9..0x8991c0
+            - Range: 0x8991d9..0x8991e0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 182
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0x8991c0..0x899220]
+      OutOfLinePCRanges: [0x8991e0..0x899240]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 344 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x8991c0..0x8991fc
+            - Range: 0x8991e0..0x89921c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 345 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x8991c0..0x89920c
+            - Range: 0x8991e0..0x89922c
               Pieces: []
-            - Range: 0x89920c..0x89920d
+            - Range: 0x89922c..0x89922d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10815,20 +10815,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x89920d..0x899220
+            - Range: 0x89922d..0x899240
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 183
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0x899220..0x899260]
+      OutOfLinePCRanges: [0x899240..0x899280]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 325 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x899220..0x89922c
+            - Range: 0x899240..0x89924c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10836,7 +10836,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x89922c..0x899260
+            - Range: 0x89924c..0x899280
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10849,42 +10849,42 @@ Subprograms:
         - Name: needle
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0x899220..0x899260
+            - Range: 0x899240..0x899280
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x899220..0x899248
+            - Range: 0x899240..0x899268
               Pieces: []
-            - Range: 0x899248..0x899249
+            - Range: 0x899268..0x899269
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x899249..0x899250
+            - Range: 0x899269..0x899270
               Pieces: []
-            - Range: 0x899250..0x899251
+            - Range: 0x899270..0x899271
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x899251..0x899260
+            - Range: 0x899271..0x899280
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0x89923c..0x89924c
+            - Range: 0x89925c..0x89926c
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Local
           DictIndex: 1
       DictRegister: 0
     - ID: 184
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0x899260..0x899330]
+      OutOfLinePCRanges: [0x899280..0x899350]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 346 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0x899260..0x899284
+            - Range: 0x899280..0x8992a4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10892,7 +10892,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x899284..0x899288
+            - Range: 0x8992a4..0x8992a8
               Pieces:
                 - Size: 8
                   Op: null
@@ -10905,13 +10905,13 @@ Subprograms:
         - Name: needle
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x899260..0x8992bc
+            - Range: 0x899280..0x8992dc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x8992bc..0x899330
+            - Range: 0x8992dc..0x899350
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 40}
@@ -10922,28 +10922,28 @@ Subprograms:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x899260..0x8992d8
+            - Range: 0x899280..0x8992f8
               Pieces: []
-            - Range: 0x8992d8..0x8992d9
+            - Range: 0x8992f8..0x8992f9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8992d9..0x8992e8
+            - Range: 0x8992f9..0x899308
               Pieces: []
-            - Range: 0x8992e8..0x8992e9
+            - Range: 0x899308..0x899309
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8992e9..0x899330
+            - Range: 0x899309..0x899350
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x89929c..0x8992b0
+            - Range: 0x8992bc..0x8992d0
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8992b0..0x8992bc
+            - Range: 0x8992d0..0x8992dc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10954,56 +10954,56 @@ Subprograms:
       DictRegister: 0
     - ID: 185
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0x899330..0x899340]
+      OutOfLinePCRanges: [0x899350..0x899360]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 347 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0x899330..0x899338
+            - Range: 0x899350..0x899358
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
           Type: 321 BaseType go.shape.int
           Locations:
-            - Range: 0x899330..0x899340
+            - Range: 0x899350..0x899360
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x899330..0x899338
+            - Range: 0x899350..0x899358
               Pieces: []
-            - Range: 0x899338..0x899339
+            - Range: 0x899358..0x899359
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x899339..0x899340
+            - Range: 0x899359..0x899360
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 1
     - ID: 186
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0x8993c0..0x899440]
+      OutOfLinePCRanges: [0x8993e0..0x899460]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 348 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0x8993c0..0x8993ec
+            - Range: 0x8993e0..0x89940c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8993ec..0x8993f8
+            - Range: 0x89940c..0x899418
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8993f8..0x8993fc
+            - Range: 0x899418..0x89941c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11014,7 +11014,7 @@ Subprograms:
         - Name: value
           Type: 323 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8993c0..0x8993fc
+            - Range: 0x8993e0..0x89941c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -11025,11 +11025,11 @@ Subprograms:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x8993c0..0x8993fc
+            - Range: 0x8993e0..0x89941c
               Pieces: []
-            - Range: 0x8993fc..0x8993fd
+            - Range: 0x89941c..0x89941d
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8993fd..0x899440
+            - Range: 0x89941d..0x899460
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11258,8 +11258,8 @@ Subprograms:
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0x8915e0..0x891660]
       InlinePCRanges:
-        - Ranges: [0x8994fc..0x899530]
-          RootRanges: [0x8994d0..0x899580]
+        - Ranges: [0x89951c..0x899550]
+          RootRanges: [0x8994f0..0x8995a0]
       Variables:
         - Name: b
           Type: 353 StructureType main.firstBehavior
@@ -11298,8 +11298,8 @@ Subprograms:
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x891df4..0x891e00, 0x891e04..0x891e0c]
-          RootRanges: [0x891d60..0x891e50]
+        - Ranges: [0x891e14..0x891e20, 0x891e24..0x891e2c]
+          RootRanges: [0x891d80..0x891e70]
         - Ranges: [0x12a824..0x12a828, 0x12a82c..0x12a834]
           RootRanges: [0x12a810..0x12a840]
       Variables: []

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -13,11 +13,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1581 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0x853f38", Frameless: false}]
+              InjectionPoints: [{PC: "0x853f58", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1582 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0x853f6c", Frameless: false}]
+              InjectionPoints: [{PC: "0x853f8c", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -84,11 +84,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1552 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0x852a5c", Frameless: false}]
+              InjectionPoints: [{PC: "0x852a7c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1553 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0x852af4", Frameless: false}]
+              InjectionPoints: [{PC: "0x852b14", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -176,7 +176,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1432 EventRootType Probe[main.testArrayOfMaps]
-              InjectionPoints: [{PC: "0x84f510", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f530", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -241,11 +241,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1454 EventRootType Probe[main.testAtomicAdd]
-              InjectionPoints: [{PC: "0x850cb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x850cd0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1455 EventRootType Probe[main.testAtomicAdd]Return
-              InjectionPoints: [{PC: "0x850cec", Frameless: true}]
+              InjectionPoints: [{PC: "0x850d0c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -342,11 +342,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1600 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x854290", Frameless: true}]
+              InjectionPoints: [{PC: "0x8542b0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1601 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0x8542ac", Frameless: true}]
+              InjectionPoints: [{PC: "0x8542cc", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -476,7 +476,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1451 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x850a50", Frameless: true}]
+              InjectionPoints: [{PC: "0x850a70", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -495,7 +495,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1452 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x850a50", Frameless: true}]
+              InjectionPoints: [{PC: "0x850a70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -521,7 +521,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1608 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0x854340", Frameless: true}]
+              InjectionPoints: [{PC: "0x854360", Frameless: true}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -557,7 +557,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1456 EventRootType Probe[main.testChannel]
-              InjectionPoints: [{PC: "0x850cf0", Frameless: true}]
+              InjectionPoints: [{PC: "0x850d10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -587,7 +587,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1450 EventRootType Probe[main.testCombinedByte]
-              InjectionPoints: [{PC: "0x850a30", Frameless: true}]
+              InjectionPoints: [{PC: "0x850a50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{w}, {x}, {y}'
@@ -616,11 +616,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1517 EventRootType Probe[main.testConflictingReturn]
-              InjectionPoints: [{PC: "0x851c78", Frameless: false}]
+              InjectionPoints: [{PC: "0x851c98", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1518 EventRootType Probe[main.testConflictingReturn]Return
-              InjectionPoints: [{PC: "0x851d24", Frameless: false}]
+              InjectionPoints: [{PC: "0x851d44", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -642,7 +642,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1464 EventRootType Probe[main.testCycle]
-              InjectionPoints: [{PC: "0x850fa0", Frameless: true}]
+              InjectionPoints: [{PC: "0x850fc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{t}'
@@ -796,7 +796,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1569 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0x853890", Frameless: true}]
+              InjectionPoints: [{PC: "0x8538b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -823,7 +823,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1572 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0x8538c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8538e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -851,7 +851,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1595 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0x854010", Frameless: true}]
+              InjectionPoints: [{PC: "0x854030", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -873,7 +873,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1609 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0x854390", Frameless: true}]
+              InjectionPoints: [{PC: "0x8543b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -894,7 +894,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1610 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0x8543a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8543c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1107,11 +1107,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1647 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0x856500", Frameless: true}]
+              InjectionPoints: [{PC: "0x856520", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1648 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x856508", Frameless: true}]
+              InjectionPoints: [{PC: "0x856528", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1125,11 +1125,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1649 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0x856520", Frameless: false}]
+              InjectionPoints: [{PC: "0x856540", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1650 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0x85655c", Frameless: false}]
+              InjectionPoints: [{PC: "0x85657c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1152,11 +1152,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1643 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0x856468", Frameless: false}]
+              InjectionPoints: [{PC: "0x856488", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1644 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0x856478", Frameless: false}]
+              InjectionPoints: [{PC: "0x856498", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1170,11 +1170,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1645 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0x8564b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8564d8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1646 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0x8564d0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8564f0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1197,14 +1197,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1651 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0x856570", Frameless: true}]
+              InjectionPoints: [{PC: "0x856590", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1652 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0x856598"
+                - PC: "0x8565b8"
                   Frameless: true
-                - PC: "0x8565a0"
+                - PC: "0x8565c0"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1219,14 +1219,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1653 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0x8565c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8565e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1654 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0x856628"
+                - PC: "0x856648"
                   Frameless: false
-                - PC: "0x856638"
+                - PC: "0x856658"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1253,7 +1253,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1655 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0x856574", Frameless: true}]
+              InjectionPoints: [{PC: "0x856594", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1265,7 +1265,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1656 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0x8565d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8565f8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1286,11 +1286,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1631 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0x856160", Frameless: true}]
+              InjectionPoints: [{PC: "0x856180", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1632 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0x856168", Frameless: true}]
+              InjectionPoints: [{PC: "0x856188", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1304,11 +1304,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1633 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0x8561f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x856210", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1634 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0x8561f4", Frameless: true}]
+              InjectionPoints: [{PC: "0x856214", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1332,11 +1332,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1619 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0x855d68", Frameless: false}]
+              InjectionPoints: [{PC: "0x855d88", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1620 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x855e3c", Frameless: false}]
+              InjectionPoints: [{PC: "0x855e5c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1378,11 +1378,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1623 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x855e88", Frameless: false}]
+              InjectionPoints: [{PC: "0x855ea8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1624 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x855e98", Frameless: false}]
+              InjectionPoints: [{PC: "0x855eb8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1405,11 +1405,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1657 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0x856670", Frameless: true}]
+              InjectionPoints: [{PC: "0x856690", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1658 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0x856678", Frameless: true}]
+              InjectionPoints: [{PC: "0x856698", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1423,11 +1423,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1659 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0x856708", Frameless: false}]
+              InjectionPoints: [{PC: "0x856728", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1660 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0x85672c", Frameless: false}]
+              InjectionPoints: [{PC: "0x85674c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1450,11 +1450,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1615 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0x855cd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x855cf0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1616 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x855cd4", Frameless: true}]
+              InjectionPoints: [{PC: "0x855cf4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1468,11 +1468,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1617 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0x855ce0", Frameless: true}]
+              InjectionPoints: [{PC: "0x855d00", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1618 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x855cec", Frameless: true}]
+              InjectionPoints: [{PC: "0x855d0c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1495,11 +1495,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1635 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0x856290", Frameless: true}]
+              InjectionPoints: [{PC: "0x8562b0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1636 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0x856298", Frameless: true}]
+              InjectionPoints: [{PC: "0x8562b8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1513,11 +1513,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1637 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0x856338", Frameless: false}]
+              InjectionPoints: [{PC: "0x856358", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1638 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0x856364", Frameless: false}]
+              InjectionPoints: [{PC: "0x856384", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1540,11 +1540,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1625 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0x856130", Frameless: true}]
+              InjectionPoints: [{PC: "0x856150", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1626 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x856134", Frameless: true}]
+              InjectionPoints: [{PC: "0x856154", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1558,11 +1558,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1627 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0x856140", Frameless: true}]
+              InjectionPoints: [{PC: "0x856160", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1628 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0x856144", Frameless: true}]
+              InjectionPoints: [{PC: "0x856164", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1576,11 +1576,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1629 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0x856150", Frameless: true}]
+              InjectionPoints: [{PC: "0x856170", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1630 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0x856154", Frameless: true}]
+              InjectionPoints: [{PC: "0x856174", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1603,11 +1603,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1639 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0x856420", Frameless: true}]
+              InjectionPoints: [{PC: "0x856440", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1640 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0x856428", Frameless: true}]
+              InjectionPoints: [{PC: "0x856448", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1621,11 +1621,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1641 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x856430", Frameless: true}]
+              InjectionPoints: [{PC: "0x856450", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1642 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x856440", Frameless: true}]
+              InjectionPoints: [{PC: "0x856460", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1648,11 +1648,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1611 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0x855cb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x855cd0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1612 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x855cb4", Frameless: true}]
+              InjectionPoints: [{PC: "0x855cd4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1666,11 +1666,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1613 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0x855cc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x855ce0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1614 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x855ccc", Frameless: true}]
+              InjectionPoints: [{PC: "0x855cec", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1902,7 +1902,7 @@ Probes:
               InjectionPoints:
                 - PC: "0x129ba8"
                   Frameless: true
-                - PC: "0x84f454"
+                - PC: "0x84f474"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2198,11 +2198,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1550 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0x8528a0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8528c0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1551 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x8529f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x852a18", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2224,7 +2224,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1458 EventRootType Probe[main.testLinkedList]
-              InjectionPoints: [{PC: "0x850eb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x850ed0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -2336,11 +2336,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1556 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0x852d5c", Frameless: false}]
+              InjectionPoints: [{PC: "0x852d7c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1557 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0x852ec8", Frameless: false}]
+              InjectionPoints: [{PC: "0x852ee8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2449,7 +2449,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1430 EventRootType Probe[main.testMapArrayToArray]
-              InjectionPoints: [{PC: "0x84f4f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f510", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2471,7 +2471,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1437 EventRootType Probe[main.testMapEmbeddedMaps]
-              InjectionPoints: [{PC: "0x84f550", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f570", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2493,7 +2493,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1447 EventRootType Probe[main.testMapEmptyKey]
-              InjectionPoints: [{PC: "0x84f5f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f610", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2515,7 +2515,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1449 EventRootType Probe[main.testMapEmptyKeyAndValue]
-              InjectionPoints: [{PC: "0x84f610", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f630", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2537,7 +2537,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1448 EventRootType Probe[main.testMapEmptyValue]
-              InjectionPoints: [{PC: "0x84f600", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f620", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2559,7 +2559,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1434 EventRootType Probe[main.testMapIntToInt]
-              InjectionPoints: [{PC: "0x84f530", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f550", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2581,7 +2581,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1446 EventRootType Probe[main.testMapLargeKeyLargeValue]
-              InjectionPoints: [{PC: "0x84f5e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f600", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2603,7 +2603,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1445 EventRootType Probe[main.testMapLargeKeySmallValue]
-              InjectionPoints: [{PC: "0x84f5d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f5f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2627,7 +2627,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1435 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x84f540", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f560", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2651,7 +2651,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1436 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x84f540", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f560", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2673,7 +2673,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1444 EventRootType Probe[main.testMapSmallKeyLargeValue]
-              InjectionPoints: [{PC: "0x84f5c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f5e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2695,7 +2695,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1443 EventRootType Probe[main.testMapSmallKeySmallValue]
-              InjectionPoints: [{PC: "0x84f5b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f5d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2717,7 +2717,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1428 EventRootType Probe[main.testMapStringToInt]
-              InjectionPoints: [{PC: "0x84f4d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f4f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2739,7 +2739,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1429 EventRootType Probe[main.testMapStringToSlice]
-              InjectionPoints: [{PC: "0x84f4e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f500", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2761,7 +2761,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1427 EventRootType Probe[main.testMapStringToStruct]
-              InjectionPoints: [{PC: "0x84f4c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f4e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2783,7 +2783,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1438 EventRootType Probe[main.testMapWithLinkedList]
-              InjectionPoints: [{PC: "0x84f560", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f580", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2805,7 +2805,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1441 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-              InjectionPoints: [{PC: "0x84f590", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f5b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2827,7 +2827,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1442 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-              InjectionPoints: [{PC: "0x84f5a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f5c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2849,7 +2849,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1439 EventRootType Probe[main.testMapWithSmallValue]
-              InjectionPoints: [{PC: "0x84f570", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f590", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2873,7 +2873,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1440 EventRootType Probe[main.testMapWithSmallValueMassive]
-              InjectionPoints: [{PC: "0x84f580", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f5a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2895,7 +2895,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1592 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x853ff0", Frameless: true}]
+              InjectionPoints: [{PC: "0x854010", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2918,7 +2918,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1593 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x853ff0", Frameless: true}]
+              InjectionPoints: [{PC: "0x854010", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2965,11 +2965,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1558 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0x852f30", Frameless: false}]
+              InjectionPoints: [{PC: "0x852f50", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1559 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0x8530dc", Frameless: false}]
+              InjectionPoints: [{PC: "0x8530fc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -3035,11 +3035,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1562 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0x8531dc", Frameless: false}]
+              InjectionPoints: [{PC: "0x8531fc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1563 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0x853284", Frameless: false}]
+              InjectionPoints: [{PC: "0x8532a4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3070,11 +3070,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1554 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0x852b30", Frameless: false}]
+              InjectionPoints: [{PC: "0x852b50", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1555 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0x852d00", Frameless: false}]
+              InjectionPoints: [{PC: "0x852d20", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3100,11 +3100,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1495 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x851ae8", Frameless: false}]
+              InjectionPoints: [{PC: "0x851b08", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1496 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x851b74", Frameless: false}]
+              InjectionPoints: [{PC: "0x851b94", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3140,7 +3140,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1453 EventRootType Probe[main.testMultipleSimpleParams]
-              InjectionPoints: [{PC: "0x850b10", Frameless: true}]
+              InjectionPoints: [{PC: "0x850b30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -3181,11 +3181,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1489 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x851a48", Frameless: false}]
+              InjectionPoints: [{PC: "0x851a68", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1490 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x851aa8", Frameless: false}]
+              InjectionPoints: [{PC: "0x851ac8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3209,11 +3209,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1491 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x851a48", Frameless: false}]
+              InjectionPoints: [{PC: "0x851a68", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1492 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x851aa8", Frameless: false}]
+              InjectionPoints: [{PC: "0x851ac8", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
       version: 0
@@ -3232,11 +3232,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1497 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x851ae8", Frameless: false}]
+              InjectionPoints: [{PC: "0x851b08", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1498 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x851b74", Frameless: false}]
+              InjectionPoints: [{PC: "0x851b94", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
       version: 0
@@ -3256,11 +3256,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1499 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x851ae8", Frameless: false}]
+              InjectionPoints: [{PC: "0x851b08", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1500 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x851b74", Frameless: false}]
+              InjectionPoints: [{PC: "0x851b94", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r1={result} r2={result2}
@@ -3293,11 +3293,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1493 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x851a48", Frameless: false}]
+              InjectionPoints: [{PC: "0x851a68", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1494 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x851aa8", Frameless: false}]
+              InjectionPoints: [{PC: "0x851ac8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Parameter {i} * 2 = result {result}
@@ -3325,7 +3325,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1604 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x854330", Frameless: true}]
+              InjectionPoints: [{PC: "0x854350", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3350,7 +3350,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1605 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x854330", Frameless: true}]
+              InjectionPoints: [{PC: "0x854350", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3381,7 +3381,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1606 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x854330", Frameless: true}]
+              InjectionPoints: [{PC: "0x854350", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3406,7 +3406,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1607 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x854330", Frameless: true}]
+              InjectionPoints: [{PC: "0x854350", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3433,7 +3433,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1463 EventRootType Probe[main.testNilPointer]
-              InjectionPoints: [{PC: "0x850f80", Frameless: true}]
+              InjectionPoints: [{PC: "0x850fa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}, {a}'
@@ -3460,7 +3460,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1576 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0x853900", Frameless: true}]
+              InjectionPoints: [{PC: "0x853920", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3487,7 +3487,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1573 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0x8538d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8538f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3522,7 +3522,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1575 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0x8538f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x853910", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3554,7 +3554,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1591 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0x853fe0", Frameless: true}]
+              InjectionPoints: [{PC: "0x854000", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3576,7 +3576,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1459 EventRootType Probe[main.testPointerLoop]
-              InjectionPoints: [{PC: "0x850ec0", Frameless: true}]
+              InjectionPoints: [{PC: "0x850ee0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3598,7 +3598,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1433 EventRootType Probe[main.testPointerToMap]
-              InjectionPoints: [{PC: "0x84f520", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f540", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3620,7 +3620,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1457 EventRootType Probe[main.testPointerToSimpleStruct]
-              InjectionPoints: [{PC: "0x850ea0", Frameless: true}]
+              InjectionPoints: [{PC: "0x850ec0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3644,11 +3644,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1465 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x8512f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x851318", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1466 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x85133c", Frameless: false}]
+              InjectionPoints: [{PC: "0x85135c", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
       version: 0
@@ -3668,11 +3668,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1509 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x851bb8", Frameless: false}]
+              InjectionPoints: [{PC: "0x851bd8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1510 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x851c40", Frameless: false}]
+              InjectionPoints: [{PC: "0x851c60", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3715,11 +3715,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1475 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x851418", Frameless: false}]
+              InjectionPoints: [{PC: "0x851438", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1476 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x8514b0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8514d0", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3759,11 +3759,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1467 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x8512f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x851318", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1468 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x85133c", Frameless: false}]
+              InjectionPoints: [{PC: "0x85135c", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3806,11 +3806,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1477 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x851418", Frameless: false}]
+              InjectionPoints: [{PC: "0x851438", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1478 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x8514b0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8514d0", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3852,11 +3852,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1511 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x851bb8", Frameless: false}]
+              InjectionPoints: [{PC: "0x851bd8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1512 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x851c40", Frameless: false}]
+              InjectionPoints: [{PC: "0x851c60", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
       version: 0
@@ -3873,11 +3873,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1513 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x851bb8", Frameless: false}]
+              InjectionPoints: [{PC: "0x851bd8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1514 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x851c40", Frameless: false}]
+              InjectionPoints: [{PC: "0x851c60", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r0={@return.r0}
@@ -3899,11 +3899,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1469 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x8512f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x851318", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1470 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x85133c", Frameless: false}]
+              InjectionPoints: [{PC: "0x85135c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: result={@return}
@@ -3926,18 +3926,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1485 EventRootType Probe[main.testReturnsAny]
-              InjectionPoints: [{PC: "0x8516e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x851708", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1486 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
-                - PC: "0x851784"
+                - PC: "0x8517a4"
                   Frameless: false
-                - PC: "0x8517cc"
+                - PC: "0x8517ec"
                   Frameless: false
-                - PC: "0x851890"
+                - PC: "0x8518b0"
                   Frameless: false
-                - PC: "0x8518a4"
+                - PC: "0x8518c4"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3965,18 +3965,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1483 EventRootType Probe[main.testReturnsAnyAndError]
-              InjectionPoints: [{PC: "0x851568", Frameless: false}]
+              InjectionPoints: [{PC: "0x851588", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1484 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
-                - PC: "0x8515bc"
+                - PC: "0x8515dc"
                   Frameless: false
-                - PC: "0x851620"
+                - PC: "0x851640"
                   Frameless: false
-                - PC: "0x851660"
+                - PC: "0x851680"
                   Frameless: false
-                - PC: "0x8516a0"
+                - PC: "0x8516c0"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4003,11 +4003,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1528 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0x8522ac", Frameless: false}]
+              InjectionPoints: [{PC: "0x8522cc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1529 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0x852300", Frameless: false}]
+              InjectionPoints: [{PC: "0x852320", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -4024,11 +4024,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1530 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0x852338", Frameless: false}]
+              InjectionPoints: [{PC: "0x852358", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1531 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0x852374", Frameless: false}]
+              InjectionPoints: [{PC: "0x852394", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -4045,11 +4045,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1532 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0x8523a8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8523c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1533 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0x8523e0", Frameless: false}]
+              InjectionPoints: [{PC: "0x852400", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4066,11 +4066,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1536 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0x852498", Frameless: false}]
+              InjectionPoints: [{PC: "0x8524b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1537 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0x8524fc", Frameless: false}]
+              InjectionPoints: [{PC: "0x85251c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4087,11 +4087,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1548 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0x852828", Frameless: false}]
+              InjectionPoints: [{PC: "0x852848", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1549 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0x852868", Frameless: false}]
+              InjectionPoints: [{PC: "0x852888", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4108,11 +4108,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1524 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0x852158", Frameless: false}]
+              InjectionPoints: [{PC: "0x852178", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1525 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0x8521a4", Frameless: false}]
+              InjectionPoints: [{PC: "0x8521c4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4130,14 +4130,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1481 EventRootType Probe[main.testReturnsError]
-              InjectionPoints: [{PC: "0x8514e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x851508", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1482 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
-                - PC: "0x851518"
+                - PC: "0x851538"
                   Frameless: false
-                - PC: "0x85152c"
+                - PC: "0x85154c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4159,11 +4159,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1471 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x8512f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x851318", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1472 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x85133c", Frameless: false}]
+              InjectionPoints: [{PC: "0x85135c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4184,11 +4184,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1479 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x851418", Frameless: false}]
+              InjectionPoints: [{PC: "0x851438", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1480 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x8514b0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8514d0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4209,11 +4209,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1473 EventRootType Probe[main.testReturnsIntPointer]
-              InjectionPoints: [{PC: "0x851378", Frameless: false}]
+              InjectionPoints: [{PC: "0x851398", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1474 EventRootType Probe[main.testReturnsIntPointer]Return
-              InjectionPoints: [{PC: "0x8513d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8513f8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4235,14 +4235,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1487 EventRootType Probe[main.testReturnsInterface]
-              InjectionPoints: [{PC: "0x8518e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x851908", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1488 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
-                - PC: "0x8519b4"
+                - PC: "0x8519d4"
                   Frameless: false
-                - PC: "0x8519c8"
+                - PC: "0x8519e8"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4264,11 +4264,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1526 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0x8521e0", Frameless: false}]
+              InjectionPoints: [{PC: "0x852200", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1527 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0x852274", Frameless: false}]
+              InjectionPoints: [{PC: "0x852294", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4285,11 +4285,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1522 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0x852098", Frameless: false}]
+              InjectionPoints: [{PC: "0x8520b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1523 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0x85211c", Frameless: false}]
+              InjectionPoints: [{PC: "0x85213c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4306,11 +4306,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1540 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0x852618", Frameless: false}]
+              InjectionPoints: [{PC: "0x852638", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1541 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0x852670", Frameless: false}]
+              InjectionPoints: [{PC: "0x852690", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4327,11 +4327,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1534 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0x852418", Frameless: false}]
+              InjectionPoints: [{PC: "0x852438", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1535 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0x852460", Frameless: false}]
+              InjectionPoints: [{PC: "0x852480", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4348,11 +4348,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1546 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0x8527a8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8527c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1547 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0x8527ec", Frameless: false}]
+              InjectionPoints: [{PC: "0x85280c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
@@ -4372,7 +4372,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1519 EventRootType Probe[main.testReturnsNamedDeferLine]Line
-              InjectionPoints: [{PC: "0x851e28", Frameless: false}]
+              InjectionPoints: [{PC: "0x851e48", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4393,11 +4393,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1544 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0x852738", Frameless: false}]
+              InjectionPoints: [{PC: "0x852758", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1545 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0x852778", Frameless: false}]
+              InjectionPoints: [{PC: "0x852798", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4414,11 +4414,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1520 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0x852008", Frameless: false}]
+              InjectionPoints: [{PC: "0x852028", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1521 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0x852060", Frameless: false}]
+              InjectionPoints: [{PC: "0x852080", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4435,11 +4435,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1542 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0x8526ac", Frameless: false}]
+              InjectionPoints: [{PC: "0x8526cc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1543 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0x852700", Frameless: false}]
+              InjectionPoints: [{PC: "0x852720", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4456,11 +4456,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1538 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0x852540", Frameless: false}]
+              InjectionPoints: [{PC: "0x852560", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1539 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0x8525e4", Frameless: false}]
+              InjectionPoints: [{PC: "0x852604", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4513,11 +4513,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1501 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x851ae8", Frameless: false}]
+              InjectionPoints: [{PC: "0x851b08", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1502 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x851b74", Frameless: false}]
+              InjectionPoints: [{PC: "0x851b94", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -4792,7 +4792,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1583 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0x853f90", Frameless: true}]
+              InjectionPoints: [{PC: "0x853fb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4924,7 +4924,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1579 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0x853920", Frameless: true}]
+              InjectionPoints: [{PC: "0x853940", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -4946,7 +4946,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1570 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0x8538a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8538c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -4968,7 +4968,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1431 EventRootType Probe[main.testSmallMap]
-              InjectionPoints: [{PC: "0x84f500", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f520", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -4989,11 +4989,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1515 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x851bb8", Frameless: false}]
+              InjectionPoints: [{PC: "0x851bd8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1516 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x851c40", Frameless: false}]
+              InjectionPoints: [{PC: "0x851c60", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -5014,11 +5014,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1560 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0x853138", Frameless: false}]
+              InjectionPoints: [{PC: "0x853158", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1561 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0x85319c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8531bc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5062,7 +5062,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1462 EventRootType Probe[main.testStringPointer]
-              InjectionPoints: [{PC: "0x850f60", Frameless: true}]
+              InjectionPoints: [{PC: "0x850f80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}'
@@ -5084,7 +5084,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1574 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0x8538e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x853900", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5150,11 +5150,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1602 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x854290", Frameless: true}]
+              InjectionPoints: [{PC: "0x8542b0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1603 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0x8542ac", Frameless: true}]
+              InjectionPoints: [{PC: "0x8542cc", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5181,7 +5181,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1571 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0x8538b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8538d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5229,11 +5229,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1564 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0x8532bc", Frameless: false}]
+              InjectionPoints: [{PC: "0x8532dc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1565 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0x85334c", Frameless: false}]
+              InjectionPoints: [{PC: "0x85336c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5255,11 +5255,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1598 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0x8541a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8541c0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1599 EventRootType Probe[main.testStructWithCyclicMaps]Return
-              InjectionPoints: [{PC: "0x8541b8", Frameless: true}]
+              InjectionPoints: [{PC: "0x8541d8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5280,7 +5280,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1597 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0x854190", Frameless: true}]
+              InjectionPoints: [{PC: "0x8541b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5307,7 +5307,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1426 EventRootType Probe[main.testStructWithMap]
-              InjectionPoints: [{PC: "0x84f4b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84f4d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s} {@duration}'
@@ -5340,7 +5340,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1580 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0x853930", Frameless: true}]
+              InjectionPoints: [{PC: "0x853950", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5380,7 +5380,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1596 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0x854020", Frameless: true}]
+              InjectionPoints: [{PC: "0x854040", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5413,11 +5413,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1503 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x851ae8", Frameless: false}]
+              InjectionPoints: [{PC: "0x851b08", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1504 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x851b74", Frameless: false}]
+              InjectionPoints: [{PC: "0x851b94", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{nonexistentVariable}'
@@ -5438,11 +5438,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1505 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x851ae8", Frameless: false}]
+              InjectionPoints: [{PC: "0x851b08", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1506 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x851b74", Frameless: false}]
+              InjectionPoints: [{PC: "0x851b94", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{unsupportedExpression}'
@@ -5465,11 +5465,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1507 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x851ae8", Frameless: false}]
+              InjectionPoints: [{PC: "0x851b08", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1508 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x851b74", Frameless: false}]
+              InjectionPoints: [{PC: "0x851b94", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -5501,7 +5501,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1584 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0x853fa0", Frameless: true}]
+              InjectionPoints: [{PC: "0x853fc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5533,11 +5533,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1585 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x853fb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x853fd0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1586 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0x853fc8", Frameless: true}]
+              InjectionPoints: [{PC: "0x853fe8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5567,11 +5567,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1587 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x853fb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x853fd0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1588 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0x853fc8", Frameless: true}]
+              InjectionPoints: [{PC: "0x853fe8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5603,7 +5603,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1589 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x853fd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x853ff0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5633,7 +5633,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1590 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x853fd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x853ff0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5797,7 +5797,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1461 EventRootType Probe[main.testUintPointer]
-              InjectionPoints: [{PC: "0x850ef0", Frameless: true}]
+              InjectionPoints: [{PC: "0x850f10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5819,7 +5819,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1568 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0x853880", Frameless: true}]
+              InjectionPoints: [{PC: "0x8538a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5841,7 +5841,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1594 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0x854000", Frameless: true}]
+              InjectionPoints: [{PC: "0x854020", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5863,7 +5863,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1460 EventRootType Probe[main.testUnsafePointer]
-              InjectionPoints: [{PC: "0x850ed0", Frameless: true}]
+              InjectionPoints: [{PC: "0x850ef0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5907,7 +5907,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1577 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x853910", Frameless: true}]
+              InjectionPoints: [{PC: "0x853930", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5929,7 +5929,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1578 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x853910", Frameless: true}]
+              InjectionPoints: [{PC: "0x853930", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5954,7 +5954,7 @@ Probes:
               InjectionPoints:
                 - PC: "0x84ec68"
                   Frameless: false
-                - PC: "0x85680c"
+                - PC: "0x85682c"
                   Frameless: false
               Condition: null
             - Kind: Return
@@ -5981,11 +5981,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1566 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0x853388", Frameless: false}]
+              InjectionPoints: [{PC: "0x8533a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1567 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x8533f0", Frameless: false}]
+              InjectionPoints: [{PC: "0x853410", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -7072,214 +7072,188 @@ Subprograms:
       DictRegister: null
     - ID: 63
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x84f4b0..0x84f4c0]
+      OutOfLinePCRanges: [0x84f4d0..0x84f4e0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 168 StructureType main.structWithMap
-          Locations:
-            - Range: 0x84f4b0..0x84f4c0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 64
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x84f4c0..0x84f4d0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 174 GoMapType map[string]main.nestedStruct
-          Locations:
-            - Range: 0x84f4c0..0x84f4d0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 65
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0x84f4d0..0x84f4e0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 179 GoMapType map[string]int
           Locations:
             - Range: 0x84f4d0..0x84f4e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 66
-      Name: main.testMapStringToSlice
+    - ID: 64
+      Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0x84f4e0..0x84f4f0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 184 GoMapType map[string][]string
+          Type: 174 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0x84f4e0..0x84f4f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 67
-      Name: main.testMapArrayToArray
+    - ID: 65
+      Name: main.testMapStringToInt
       OutOfLinePCRanges: [0x84f4f0..0x84f500]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 189 GoMapType map[[4]string][2]int
+          Type: 179 GoMapType map[string]int
           Locations:
             - Range: 0x84f4f0..0x84f500
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 68
-      Name: main.testSmallMap
+    - ID: 66
+      Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0x84f500..0x84f510]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 179 GoMapType map[string]int
+          Type: 184 GoMapType map[string][]string
           Locations:
             - Range: 0x84f500..0x84f510
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 69
-      Name: main.testArrayOfMaps
+    - ID: 67
+      Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0x84f510..0x84f520]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 194 ArrayType [2]map[string]int
+          Type: 189 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0x84f510..0x84f520
-              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 70
-      Name: main.testPointerToMap
+    - ID: 68
+      Name: main.testSmallMap
       OutOfLinePCRanges: [0x84f520..0x84f530]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 195 PointerType *map[string]int
+          Type: 179 GoMapType map[string]int
           Locations:
             - Range: 0x84f520..0x84f530
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 71
-      Name: main.testMapIntToInt
+    - ID: 69
+      Name: main.testArrayOfMaps
       OutOfLinePCRanges: [0x84f530..0x84f540]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 169 GoMapType map[int]int
+          Type: 194 ArrayType [2]map[string]int
           Locations:
             - Range: 0x84f530..0x84f540
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 72
-      Name: main.testMapMassive
+    - ID: 70
+      Name: main.testPointerToMap
       OutOfLinePCRanges: [0x84f540..0x84f550]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 196 GoMapType map[string][]main.structWithMap
+        - Name: m
+          Type: 195 PointerType *map[string]int
           Locations:
             - Range: 0x84f540..0x84f550
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 73
-      Name: main.testMapEmbeddedMaps
+    - ID: 71
+      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0x84f550..0x84f560]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 196 GoMapType map[string][]main.structWithMap
+          Type: 169 GoMapType map[int]int
           Locations:
             - Range: 0x84f550..0x84f560
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 74
-      Name: main.testMapWithLinkedList
+    - ID: 72
+      Name: main.testMapMassive
       OutOfLinePCRanges: [0x84f560..0x84f570]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 201 GoMapType map[bool]main.node
+        - Name: redactMyEntries
+          Type: 196 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x84f560..0x84f570
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 75
-      Name: main.testMapWithSmallValue
+    - ID: 73
+      Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0x84f570..0x84f580]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 206 GoMapType map[int]uint8
+          Type: 196 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x84f570..0x84f580
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 76
-      Name: main.testMapWithSmallValueMassive
+    - ID: 74
+      Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0x84f580..0x84f590]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 206 GoMapType map[int]uint8
+        - Name: m
+          Type: 201 GoMapType map[bool]main.node
           Locations:
             - Range: 0x84f580..0x84f590
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 77
-      Name: main.testMapWithSmallKeyAndValue
+    - ID: 75
+      Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0x84f590..0x84f5a0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 211 GoMapType map[uint8]uint8
+          Type: 206 GoMapType map[int]uint8
           Locations:
             - Range: 0x84f590..0x84f5a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 78
-      Name: main.testMapWithSmallKeyAndValueMassive
+    - ID: 76
+      Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0x84f5a0..0x84f5b0]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 211 GoMapType map[uint8]uint8
+        - Name: redactMyEntries
+          Type: 206 GoMapType map[int]uint8
           Locations:
             - Range: 0x84f5a0..0x84f5b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 79
-      Name: main.testMapSmallKeySmallValue
+    - ID: 77
+      Name: main.testMapWithSmallKeyAndValue
       OutOfLinePCRanges: [0x84f5b0..0x84f5c0]
       InlinePCRanges: []
       Variables:
@@ -7291,113 +7265,112 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 80
-      Name: main.testMapSmallKeyLargeValue
+    - ID: 78
+      Name: main.testMapWithSmallKeyAndValueMassive
       OutOfLinePCRanges: [0x84f5c0..0x84f5d0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 216 GoMapType map[uint8][4]int
+          Type: 211 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x84f5c0..0x84f5d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 81
-      Name: main.testMapLargeKeySmallValue
+    - ID: 79
+      Name: main.testMapSmallKeySmallValue
       OutOfLinePCRanges: [0x84f5d0..0x84f5e0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 221 GoMapType map[[4]int]uint8
+          Type: 211 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x84f5d0..0x84f5e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 82
-      Name: main.testMapLargeKeyLargeValue
+    - ID: 80
+      Name: main.testMapSmallKeyLargeValue
       OutOfLinePCRanges: [0x84f5e0..0x84f5f0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 226 GoMapType map[[4]int][4]int
+          Type: 216 GoMapType map[uint8][4]int
           Locations:
             - Range: 0x84f5e0..0x84f5f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 83
-      Name: main.testMapEmptyKey
+    - ID: 81
+      Name: main.testMapLargeKeySmallValue
       OutOfLinePCRanges: [0x84f5f0..0x84f600]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 231 GoMapType map[struct {}]int
+          Type: 221 GoMapType map[[4]int]uint8
           Locations:
             - Range: 0x84f5f0..0x84f600
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 84
-      Name: main.testMapEmptyValue
+    - ID: 82
+      Name: main.testMapLargeKeyLargeValue
       OutOfLinePCRanges: [0x84f600..0x84f610]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 236 GoMapType map[int]struct {}
+          Type: 226 GoMapType map[[4]int][4]int
           Locations:
             - Range: 0x84f600..0x84f610
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 85
-      Name: main.testMapEmptyKeyAndValue
+    - ID: 83
+      Name: main.testMapEmptyKey
       OutOfLinePCRanges: [0x84f610..0x84f620]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 241 GoMapType map[struct {}]struct {}
+          Type: 231 GoMapType map[struct {}]int
           Locations:
             - Range: 0x84f610..0x84f620
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 86
-      Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x850a30..0x850a40]
+    - ID: 84
+      Name: main.testMapEmptyValue
+      OutOfLinePCRanges: [0x84f620..0x84f630]
       InlinePCRanges: []
       Variables:
-        - Name: w
-          Type: 4 BaseType uint8
+        - Name: m
+          Type: 236 GoMapType map[int]struct {}
           Locations:
-            - Range: 0x850a30..0x850a40
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: x
-          Type: 4 BaseType uint8
-          Locations:
-            - Range: 0x850a30..0x850a40
-              Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: "y"
-          Type: 18 BaseType float32
-          Locations:
-            - Range: 0x850a30..0x850a40
-              Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
+            - Range: 0x84f620..0x84f630
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 87
-      Name: main.testCombinedString
+    - ID: 85
+      Name: main.testMapEmptyKeyAndValue
+      OutOfLinePCRanges: [0x84f630..0x84f640]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 241 GoMapType map[struct {}]struct {}
+          Locations:
+            - Range: 0x84f630..0x84f640
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 86
+      Name: main.testCombinedByte
       OutOfLinePCRanges: [0x850a50..0x850a60]
       InlinePCRanges: []
       Variables:
@@ -7409,14 +7382,10 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
         - Name: x
-          Type: 10 GoStringHeaderType string
+          Type: 4 BaseType uint8
           Locations:
             - Range: 0x850a50..0x850a60
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
+              Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: "y"
@@ -7427,43 +7396,74 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 87
+      Name: main.testCombinedString
+      OutOfLinePCRanges: [0x850a70..0x850a80]
+      InlinePCRanges: []
+      Variables:
+        - Name: w
+          Type: 4 BaseType uint8
+          Locations:
+            - Range: 0x850a70..0x850a80
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: x
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0x850a70..0x850a80
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: "y"
+          Type: 18 BaseType float32
+          Locations:
+            - Range: 0x850a70..0x850a80
+              Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 88
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x850b10..0x850b20]
+      OutOfLinePCRanges: [0x850b30..0x850b40]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x850b10..0x850b20
+            - Range: 0x850b30..0x850b40
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x850b10..0x850b20
+            - Range: 0x850b30..0x850b40
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x850b10..0x850b20
+            - Range: 0x850b30..0x850b40
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 11 BaseType uint
           Locations:
-            - Range: 0x850b10..0x850b20
+            - Range: 0x850b30..0x850b40
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x850b10..0x850b20
+            - Range: 0x850b30..0x850b40
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7474,63 +7474,63 @@ Subprograms:
       DictRegister: null
     - ID: 89
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0x850cb0..0x850cf0]
+      OutOfLinePCRanges: [0x850cd0..0x850d10]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0x850cb0..0x850cec
+            - Range: 0x850cd0..0x850d0c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0x850cb0..0x850cec
+            - Range: 0x850cd0..0x850d0c
               Pieces: []
-            - Range: 0x850cec..0x850ced
+            - Range: 0x850d0c..0x850d0d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x850ced..0x850cf0
+            - Range: 0x850d0d..0x850d10
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 90
       Name: main.testChannel
-      OutOfLinePCRanges: [0x850cf0..0x850d00]
+      OutOfLinePCRanges: [0x850d10..0x850d20]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 246 GoChannelType chan bool
           Locations:
-            - Range: 0x850cf0..0x850d00
+            - Range: 0x850d10..0x850d20
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 91
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x850ea0..0x850eb0]
+      OutOfLinePCRanges: [0x850ec0..0x850ed0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 247 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x850ea0..0x850eb0
+            - Range: 0x850ec0..0x850ed0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 92
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x850eb0..0x850ec0]
+      OutOfLinePCRanges: [0x850ed0..0x850ee0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 249 StructureType main.node
           Locations:
-            - Range: 0x850eb0..0x850ec0
+            - Range: 0x850ed0..0x850ee0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7541,273 +7541,273 @@ Subprograms:
       DictRegister: null
     - ID: 93
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x850ec0..0x850ed0]
+      OutOfLinePCRanges: [0x850ee0..0x850ef0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 250 PointerType *main.node
           Locations:
-            - Range: 0x850ec0..0x850ed0
+            - Range: 0x850ee0..0x850ef0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 94
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x850ed0..0x850ee0]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 16 VoidPointerType unsafe.Pointer
-          Locations:
-            - Range: 0x850ed0..0x850ee0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 95
-      Name: main.testUintPointer
       OutOfLinePCRanges: [0x850ef0..0x850f00]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 106 PointerType *uint
+          Type: 16 VoidPointerType unsafe.Pointer
           Locations:
             - Range: 0x850ef0..0x850f00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 95
+      Name: main.testUintPointer
+      OutOfLinePCRanges: [0x850f10..0x850f20]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 106 PointerType *uint
+          Locations:
+            - Range: 0x850f10..0x850f20
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 96
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x850f60..0x850f70]
+      OutOfLinePCRanges: [0x850f80..0x850f90]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 94 PointerType *string
           Locations:
-            - Range: 0x850f60..0x850f70
+            - Range: 0x850f80..0x850f90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 97
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x850f80..0x850f90]
+      OutOfLinePCRanges: [0x850fa0..0x850fb0]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 12 PointerType *bool
           Locations:
-            - Range: 0x850f80..0x850f90
+            - Range: 0x850fa0..0x850fb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 11 BaseType uint
           Locations:
-            - Range: 0x850f80..0x850f90
+            - Range: 0x850fa0..0x850fb0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 98
       Name: main.testCycle
-      OutOfLinePCRanges: [0x850fa0..0x850fb0]
+      OutOfLinePCRanges: [0x850fc0..0x850fd0]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 251 PointerType *main.t
           Locations:
-            - Range: 0x850fa0..0x850fb0
+            - Range: 0x850fc0..0x850fd0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 99
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0x8512e0..0x851360]
+      OutOfLinePCRanges: [0x851300..0x851380]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x8512e0..0x8512fc
+            - Range: 0x851300..0x85131c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x8512e0..0x85133c
+            - Range: 0x851300..0x85135c
               Pieces: []
-            - Range: 0x85133c..0x85133d
+            - Range: 0x85135c..0x85135d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x85133d..0x851360
+            - Range: 0x85135d..0x851380
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result
           Type: 8 BaseType int
           Locations:
-            - Range: 0x8512fc..0x851308
+            - Range: 0x85131c..0x851328
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x851308..0x851360
+            - Range: 0x851328..0x851380
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 100
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0x851360..0x851400]
+      OutOfLinePCRanges: [0x851380..0x851420]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x851360..0x851384
+            - Range: 0x851380..0x8513a4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x851384..0x851400
+            - Range: 0x8513a4..0x851420
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 100 PointerType *int
           Locations:
-            - Range: 0x851360..0x8513d8
+            - Range: 0x851380..0x8513f8
               Pieces: []
-            - Range: 0x8513d8..0x8513d9
+            - Range: 0x8513f8..0x8513f9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8513d9..0x851400
+            - Range: 0x8513f9..0x851420
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: '&result'
           Type: 100 PointerType *int
           Locations:
-            - Range: 0x851388..0x8513a0
+            - Range: 0x8513a8..0x8513c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8513a0..0x851400
+            - Range: 0x8513c0..0x851420
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 101
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0x851400..0x8514d0]
+      OutOfLinePCRanges: [0x851420..0x8514f0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x851400..0x851458
+            - Range: 0x851420..0x851478
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x851400..0x8514b0
+            - Range: 0x851420..0x8514d0
               Pieces: []
-            - Range: 0x8514b0..0x8514b1
+            - Range: 0x8514d0..0x8514d1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8514b1..0x8514d0
+            - Range: 0x8514d1..0x8514f0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 19 BaseType float64
-          Locations: [{Range: 0x851400..0x8514d0, Pieces: []}]
+          Locations: [{Range: 0x851420..0x8514f0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: resultInt
           Type: 8 BaseType int
           Locations:
-            - Range: 0x85141c..0x85145c
+            - Range: 0x85143c..0x85147c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x85145c..0x8514d0
+            - Range: 0x85147c..0x8514f0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: -1
         - Name: resultFloat
           Type: 19 BaseType float64
           Locations:
-            - Range: 0x85142c..0x85145c
+            - Range: 0x85144c..0x85147c
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-            - Range: 0x85145c..0x8514d0
+            - Range: 0x85147c..0x8514f0
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 102
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0x8514d0..0x851550]
+      OutOfLinePCRanges: [0x8514f0..0x851570]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x8514d0..0x8514f4
+            - Range: 0x8514f0..0x851514
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0x8514d0..0x851518
+            - Range: 0x8514f0..0x851538
               Pieces: []
-            - Range: 0x851518..0x851519
+            - Range: 0x851538..0x851539
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x851519..0x85152c
+            - Range: 0x851539..0x85154c
               Pieces: []
-            - Range: 0x85152c..0x85152d
+            - Range: 0x85154c..0x85154d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x85152d..0x851550
+            - Range: 0x85154d..0x851570
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 103
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0x851550..0x8516d0]
+      OutOfLinePCRanges: [0x851570..0x8516f0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 160 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x851550..0x8515a0
+            - Range: 0x851570..0x8515c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8515a0..0x8515a4
+            - Range: 0x8515c0..0x8515c4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x8515f4..0x8515f8
+            - Range: 0x851614..0x851618
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x851634..0x851638
+            - Range: 0x851654..0x851658
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x851674..0x851678
+            - Range: 0x851694..0x851698
               Pieces:
                 - Size: 8
                   Op: null
@@ -7818,117 +7818,117 @@ Subprograms:
         - Name: failed
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x851550..0x851594
+            - Range: 0x851570..0x8515b4
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 160 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x851550..0x8515bc
+            - Range: 0x851570..0x8515dc
               Pieces: []
-            - Range: 0x8515bc..0x8515bd
+            - Range: 0x8515dc..0x8515dd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8515bd..0x851620
+            - Range: 0x8515dd..0x851640
               Pieces: []
-            - Range: 0x851620..0x851621
+            - Range: 0x851640..0x851641
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x851621..0x851660
+            - Range: 0x851641..0x851680
               Pieces: []
-            - Range: 0x851660..0x851661
+            - Range: 0x851680..0x851681
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x851661..0x8516a0
+            - Range: 0x851681..0x8516c0
               Pieces: []
-            - Range: 0x8516a0..0x8516a1
+            - Range: 0x8516c0..0x8516c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8516a1..0x8516d0
+            - Range: 0x8516c1..0x8516f0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0x851550..0x8515bc
+            - Range: 0x851570..0x8515dc
               Pieces: []
-            - Range: 0x8515bc..0x8515bd
+            - Range: 0x8515dc..0x8515dd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8515bd..0x851620
+            - Range: 0x8515dd..0x851640
               Pieces: []
-            - Range: 0x851620..0x851621
+            - Range: 0x851640..0x851641
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x851621..0x851660
+            - Range: 0x851641..0x851680
               Pieces: []
-            - Range: 0x851660..0x851661
+            - Range: 0x851680..0x851681
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x851661..0x8516a0
+            - Range: 0x851681..0x8516c0
               Pieces: []
-            - Range: 0x8516a0..0x8516a1
+            - Range: 0x8516c0..0x8516c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8516a1..0x8516d0
+            - Range: 0x8516c1..0x8516f0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 8 BaseType int
           Locations:
-            - Range: 0x8515a0..0x8515a8
+            - Range: 0x8515c0..0x8515c8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 104
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0x8516d0..0x8518d0]
+      OutOfLinePCRanges: [0x8516f0..0x8518f0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 160 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x8516d0..0x851718
+            - Range: 0x8516f0..0x851738
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x851718..0x851720
+            - Range: 0x851738..0x851740
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x851720..0x8518d0
+            - Range: 0x851740..0x8518f0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -7939,549 +7939,549 @@ Subprograms:
         - Name: ~r0
           Type: 160 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x8516d0..0x851784
+            - Range: 0x8516f0..0x8517a4
               Pieces: []
-            - Range: 0x851784..0x851785
+            - Range: 0x8517a4..0x8517a5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x851785..0x8517cc
+            - Range: 0x8517a5..0x8517ec
               Pieces: []
-            - Range: 0x8517cc..0x8517cd
+            - Range: 0x8517ec..0x8517ed
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8517cd..0x851890
+            - Range: 0x8517ed..0x8518b0
               Pieces: []
-            - Range: 0x851890..0x851891
+            - Range: 0x8518b0..0x8518b1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x851891..0x8518a4
+            - Range: 0x8518b1..0x8518c4
               Pieces: []
-            - Range: 0x8518a4..0x8518a5
+            - Range: 0x8518c4..0x8518c5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8518a5..0x8518d0
+            - Range: 0x8518c5..0x8518f0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 8 BaseType int
           Locations:
-            - Range: 0x8517b8..0x8517c0
+            - Range: 0x8517d8..0x8517e0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: '&result'
           Type: 100 PointerType *int
           Locations:
-            - Range: 0x851768..0x851784
+            - Range: 0x851788..0x8517a4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 105
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0x8518d0..0x851a30]
+      OutOfLinePCRanges: [0x8518f0..0x851a50]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 160 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x8518d0..0x85190c
+            - Range: 0x8518f0..0x85192c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x85190c..0x851954
+            - Range: 0x85192c..0x851974
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x851954..0x8519d4
+            - Range: 0x851974..0x8519f4
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x8519d4..0x8519fc
+            - Range: 0x8519f4..0x851a1c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8519fc..0x851a00
+            - Range: 0x851a1c..0x851a20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x851a00..0x851a30
+            - Range: 0x851a20..0x851a50
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 165 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x8518d0..0x8519b4
+            - Range: 0x8518f0..0x8519d4
               Pieces: []
-            - Range: 0x8519b4..0x8519b5
+            - Range: 0x8519d4..0x8519d5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8519b5..0x8519c8
+            - Range: 0x8519d5..0x8519e8
               Pieces: []
-            - Range: 0x8519c8..0x8519c9
+            - Range: 0x8519e8..0x8519e9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8519c9..0x851a30
+            - Range: 0x8519e9..0x851a50
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 165 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x8518d0..0x85190c
+            - Range: 0x8518f0..0x85192c
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x85190c..0x851954
+            - Range: 0x85192c..0x851974
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x851954..0x85195c
+            - Range: 0x851974..0x85197c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -64}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x85195c..0x8519c0
+            - Range: 0x85197c..0x8519e0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -64}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8519c0..0x8519c4
+            - Range: 0x8519e0..0x8519e4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8519c4..0x8519c8
+            - Range: 0x8519e4..0x8519e8
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x8519c8..0x851a30
+            - Range: 0x8519e8..0x851a50
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 106
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0x851a30..0x851ad0]
+      OutOfLinePCRanges: [0x851a50..0x851af0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x851a30..0x851a4c
+            - Range: 0x851a50..0x851a6c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 8 BaseType int
           Locations:
-            - Range: 0x851a30..0x851aa8
+            - Range: 0x851a50..0x851ac8
               Pieces: []
-            - Range: 0x851aa8..0x851aa9
+            - Range: 0x851ac8..0x851ac9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x851aa9..0x851ad0
+            - Range: 0x851ac9..0x851af0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 107
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0x851ad0..0x851ba0]
+      OutOfLinePCRanges: [0x851af0..0x851bc0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x851ad0..0x851b20
+            - Range: 0x851af0..0x851b40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 8 BaseType int
           Locations:
-            - Range: 0x851ad0..0x851b74
+            - Range: 0x851af0..0x851b94
               Pieces: []
-            - Range: 0x851b74..0x851b75
+            - Range: 0x851b94..0x851b95
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x851b75..0x851ba0
+            - Range: 0x851b95..0x851bc0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 8 BaseType int
           Locations:
-            - Range: 0x851ad0..0x851b74
+            - Range: 0x851af0..0x851b94
               Pieces: []
-            - Range: 0x851b74..0x851b75
+            - Range: 0x851b94..0x851b95
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x851b75..0x851ba0
+            - Range: 0x851b95..0x851bc0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 108
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0x851ba0..0x851c60]
+      OutOfLinePCRanges: [0x851bc0..0x851c80]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x851ba0..0x851be0
+            - Range: 0x851bc0..0x851c00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x851be0..0x851c60
+            - Range: 0x851c00..0x851c80
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x851ba0..0x851c40
+            - Range: 0x851bc0..0x851c60
               Pieces: []
-            - Range: 0x851c40..0x851c41
+            - Range: 0x851c60..0x851c61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x851c41..0x851c60
+            - Range: 0x851c61..0x851c80
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 8 BaseType int
           Locations:
-            - Range: 0x851ba0..0x851c40
+            - Range: 0x851bc0..0x851c60
               Pieces: []
-            - Range: 0x851c40..0x851c41
+            - Range: 0x851c60..0x851c61
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x851c41..0x851c60
+            - Range: 0x851c61..0x851c80
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0x851ba0..0x851c40
+            - Range: 0x851bc0..0x851c60
               Pieces: []
-            - Range: 0x851c40..0x851c41
+            - Range: 0x851c60..0x851c61
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x851c41..0x851c60
+            - Range: 0x851c61..0x851c80
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 109
       Name: main.testConflictingReturn
-      OutOfLinePCRanges: [0x851c60..0x851d50]
+      OutOfLinePCRanges: [0x851c80..0x851d70]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x851c60..0x851ca0
+            - Range: 0x851c80..0x851cc0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x851ca0..0x851d50
+            - Range: 0x851cc0..0x851d70
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x851c60..0x851d24
+            - Range: 0x851c80..0x851d44
               Pieces: []
-            - Range: 0x851d24..0x851d25
+            - Range: 0x851d44..0x851d45
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x851d25..0x851d50
+            - Range: 0x851d45..0x851d70
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x851c60..0x851d24
+            - Range: 0x851c80..0x851d44
               Pieces: []
-            - Range: 0x851d24..0x851d25
+            - Range: 0x851d44..0x851d45
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x851d25..0x851d50
+            - Range: 0x851d45..0x851d70
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 110
       Name: main.testReturnsNamedDeferLine
-      OutOfLinePCRanges: [0x851d50..0x851f10]
+      OutOfLinePCRanges: [0x851d70..0x851f30]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x851d50..0x851db4
+            - Range: 0x851d70..0x851dd4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x851db4..0x851f10
+            - Range: 0x851dd4..0x851f30
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x851d7c..0x851f10
+            - Range: 0x851d9c..0x851f30
               Pieces: [{Size: 16, Op: {CfaOffset: -120}}]
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x851d80..0x851f10
+            - Range: 0x851da0..0x851f30
               Pieces: [{Size: 16, Op: {CfaOffset: -136}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 111
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0x851ff0..0x852080]
+      OutOfLinePCRanges: [0x852010..0x8520a0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType int8
           Locations:
-            - Range: 0x851ff0..0x852060
+            - Range: 0x852010..0x852080
               Pieces: []
-            - Range: 0x852060..0x852061
+            - Range: 0x852080..0x852081
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x852061..0x852080
+            - Range: 0x852081..0x8520a0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 95 BaseType int16
           Locations:
-            - Range: 0x851ff0..0x852060
+            - Range: 0x852010..0x852080
               Pieces: []
-            - Range: 0x852060..0x852061
+            - Range: 0x852080..0x852081
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x852061..0x852080
+            - Range: 0x852081..0x8520a0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x851ff0..0x852060
+            - Range: 0x852010..0x852080
               Pieces: []
-            - Range: 0x852060..0x852061
+            - Range: 0x852080..0x852081
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x852061..0x852080
+            - Range: 0x852081..0x8520a0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 14 BaseType int64
           Locations:
-            - Range: 0x851ff0..0x852060
+            - Range: 0x852010..0x852080
               Pieces: []
-            - Range: 0x852060..0x852061
+            - Range: 0x852080..0x852081
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x852061..0x852080
+            - Range: 0x852081..0x8520a0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x851ff0..0x852060
+            - Range: 0x852010..0x852080
               Pieces: []
-            - Range: 0x852060..0x852061
+            - Range: 0x852080..0x852081
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x852061..0x852080
+            - Range: 0x852081..0x8520a0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 7 BaseType uint16
           Locations:
-            - Range: 0x851ff0..0x852060
+            - Range: 0x852010..0x852080
               Pieces: []
-            - Range: 0x852060..0x852061
+            - Range: 0x852080..0x852081
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x852061..0x852080
+            - Range: 0x852081..0x8520a0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 3 BaseType uint32
           Locations:
-            - Range: 0x851ff0..0x852060
+            - Range: 0x852010..0x852080
               Pieces: []
-            - Range: 0x852060..0x852061
+            - Range: 0x852080..0x852081
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x852061..0x852080
+            - Range: 0x852081..0x8520a0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0x851ff0..0x852060
+            - Range: 0x852010..0x852080
               Pieces: []
-            - Range: 0x852060..0x852061
+            - Range: 0x852080..0x852081
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x852061..0x852080
+            - Range: 0x852081..0x8520a0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 112
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0x852080..0x852140]
+      OutOfLinePCRanges: [0x8520a0..0x852160]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 19 BaseType float64
-          Locations: [{Range: 0x852080..0x852140, Pieces: []}]
+          Locations: [{Range: 0x8520a0..0x852160, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 19 BaseType float64
-          Locations: [{Range: 0x852080..0x852140, Pieces: []}]
+          Locations: [{Range: 0x8520a0..0x852160, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 19 BaseType float64
-          Locations: [{Range: 0x852080..0x852140, Pieces: []}]
+          Locations: [{Range: 0x8520a0..0x852160, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 19 BaseType float64
-          Locations: [{Range: 0x852080..0x852140, Pieces: []}]
+          Locations: [{Range: 0x8520a0..0x852160, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 19 BaseType float64
-          Locations: [{Range: 0x852080..0x852140, Pieces: []}]
+          Locations: [{Range: 0x8520a0..0x852160, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 19 BaseType float64
-          Locations: [{Range: 0x852080..0x852140, Pieces: []}]
+          Locations: [{Range: 0x8520a0..0x852160, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 19 BaseType float64
-          Locations: [{Range: 0x852080..0x852140, Pieces: []}]
+          Locations: [{Range: 0x8520a0..0x852160, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 19 BaseType float64
-          Locations: [{Range: 0x852080..0x852140, Pieces: []}]
+          Locations: [{Range: 0x8520a0..0x852160, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 19 BaseType float64
-          Locations: [{Range: 0x852080..0x852140, Pieces: []}]
+          Locations: [{Range: 0x8520a0..0x852160, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r9
           Type: 19 BaseType float64
-          Locations: [{Range: 0x852080..0x852140, Pieces: []}]
+          Locations: [{Range: 0x8520a0..0x852160, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r10
           Type: 19 BaseType float64
-          Locations: [{Range: 0x852080..0x852140, Pieces: []}]
+          Locations: [{Range: 0x8520a0..0x852160, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r11
           Type: 19 BaseType float64
-          Locations: [{Range: 0x852080..0x852140, Pieces: []}]
+          Locations: [{Range: 0x8520a0..0x852160, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r12
           Type: 19 BaseType float64
-          Locations: [{Range: 0x852080..0x852140, Pieces: []}]
+          Locations: [{Range: 0x8520a0..0x852160, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r13
           Type: 19 BaseType float64
-          Locations: [{Range: 0x852080..0x852140, Pieces: []}]
+          Locations: [{Range: 0x8520a0..0x852160, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r14
           Type: 19 BaseType float64
-          Locations: [{Range: 0x852080..0x852140, Pieces: []}]
+          Locations: [{Range: 0x8520a0..0x852160, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: onlyOnAmd64_16
           Type: 19 BaseType float64
-          Locations: [{Range: 0x852080..0x852140, Pieces: []}]
+          Locations: [{Range: 0x8520a0..0x852160, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: bothArmAndAmd64
           Type: 19 BaseType float64
           Locations:
-            - Range: 0x852080..0x85211c
+            - Range: 0x8520a0..0x85213c
               Pieces: []
-            - Range: 0x85211c..0x85211d
+            - Range: 0x85213c..0x85213d
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x85211d..0x852140
+            - Range: 0x85213d..0x852160
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 113
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0x852140..0x8521c0]
+      OutOfLinePCRanges: [0x852160..0x8521e0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 96 BaseType complex64
-          Locations: [{Range: 0x852140..0x8521c0, Pieces: []}]
+          Locations: [{Range: 0x852160..0x8521e0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 97 BaseType complex128
-          Locations: [{Range: 0x852140..0x8521c0, Pieces: []}]
+          Locations: [{Range: 0x852160..0x8521e0, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 114
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0x8521c0..0x852290]
+      OutOfLinePCRanges: [0x8521e0..0x8522b0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 253 StructureType main.largeStruct
           Locations:
-            - Range: 0x8521c0..0x852274
+            - Range: 0x8521e0..0x852294
               Pieces: []
-            - Range: 0x852274..0x852275
+            - Range: 0x852294..0x852295
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8503,193 +8503,193 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x852275..0x852290
+            - Range: 0x852295..0x8522b0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 115
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0x852290..0x852320]
+      OutOfLinePCRanges: [0x8522b0..0x852340]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 254 ArrayType [3]int
           Locations:
-            - Range: 0x852290..0x852300
+            - Range: 0x8522b0..0x852320
               Pieces: []
-            - Range: 0x852300..0x852301
+            - Range: 0x852320..0x852321
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x852301..0x852320
+            - Range: 0x852321..0x852340
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 116
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0x852320..0x852390]
+      OutOfLinePCRanges: [0x852340..0x8523b0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 255 ArrayType [1]int
           Locations:
-            - Range: 0x852320..0x852374
+            - Range: 0x852340..0x852394
               Pieces: []
-            - Range: 0x852374..0x852375
+            - Range: 0x852394..0x852395
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x852375..0x852390
+            - Range: 0x852395..0x8523b0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 117
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0x852390..0x852400]
+      OutOfLinePCRanges: [0x8523b0..0x852420]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 256 ArrayType [0]int
           Locations:
-            - Range: 0x852390..0x8523e0
+            - Range: 0x8523b0..0x852400
               Pieces: []
-            - Range: 0x8523e0..0x8523e1
+            - Range: 0x852400..0x852401
               Pieces: []
-            - Range: 0x8523e1..0x852400
+            - Range: 0x852401..0x852420
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 118
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0x852400..0x852480]
+      OutOfLinePCRanges: [0x852420..0x8524a0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 257 StructureType main.mixedStruct
-          Locations: [{Range: 0x852400..0x852480, Pieces: []}]
+          Locations: [{Range: 0x852420..0x8524a0, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 119
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0x852480..0x852520]
+      OutOfLinePCRanges: [0x8524a0..0x852540]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852480..0x8524fc
+            - Range: 0x8524a0..0x85251c
               Pieces: []
-            - Range: 0x8524fc..0x8524fd
+            - Range: 0x85251c..0x85251d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8524fd..0x852520
+            - Range: 0x85251d..0x852540
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852480..0x8524fc
+            - Range: 0x8524a0..0x85251c
               Pieces: []
-            - Range: 0x8524fc..0x8524fd
+            - Range: 0x85251c..0x85251d
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x8524fd..0x852520
+            - Range: 0x85251d..0x852540
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852480..0x8524fc
+            - Range: 0x8524a0..0x85251c
               Pieces: []
-            - Range: 0x8524fc..0x8524fd
+            - Range: 0x85251c..0x85251d
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x8524fd..0x852520
+            - Range: 0x85251d..0x852540
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852480..0x8524fc
+            - Range: 0x8524a0..0x85251c
               Pieces: []
-            - Range: 0x8524fc..0x8524fd
+            - Range: 0x85251c..0x85251d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x8524fd..0x852520
+            - Range: 0x85251d..0x852540
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852480..0x8524fc
+            - Range: 0x8524a0..0x85251c
               Pieces: []
-            - Range: 0x8524fc..0x8524fd
+            - Range: 0x85251c..0x85251d
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x8524fd..0x852520
+            - Range: 0x85251d..0x852540
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852480..0x8524fc
+            - Range: 0x8524a0..0x85251c
               Pieces: []
-            - Range: 0x8524fc..0x8524fd
+            - Range: 0x85251c..0x85251d
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x8524fd..0x852520
+            - Range: 0x85251d..0x852540
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852480..0x8524fc
+            - Range: 0x8524a0..0x85251c
               Pieces: []
-            - Range: 0x8524fc..0x8524fd
+            - Range: 0x85251c..0x85251d
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x8524fd..0x852520
+            - Range: 0x85251d..0x852540
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852480..0x8524fc
+            - Range: 0x8524a0..0x85251c
               Pieces: []
-            - Range: 0x8524fc..0x8524fd
+            - Range: 0x85251c..0x85251d
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x8524fd..0x852520
+            - Range: 0x85251d..0x852540
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x852480..0x8524fc
+            - Range: 0x8524a0..0x85251c
               Pieces: []
-            - Range: 0x8524fc..0x8524fd
+            - Range: 0x85251c..0x85251d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8524fd..0x852520
+            - Range: 0x85251d..0x852540
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 120
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0x852520..0x852600]
+      OutOfLinePCRanges: [0x852540..0x852620]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 258 StructureType main.wideStruct
           Locations:
-            - Range: 0x852520..0x8525e4
+            - Range: 0x852540..0x852604
               Pieces: []
-            - Range: 0x8525e4..0x8525e5
+            - Range: 0x852604..0x852605
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8713,145 +8713,145 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0x8525e5..0x852600
+            - Range: 0x852605..0x852620
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 121
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0x852600..0x852690]
+      OutOfLinePCRanges: [0x852620..0x8526b0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852600..0x852670
+            - Range: 0x852620..0x852690
               Pieces: []
-            - Range: 0x852670..0x852671
+            - Range: 0x852690..0x852691
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x852671..0x852690
+            - Range: 0x852691..0x8526b0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 19 BaseType float64
-          Locations: [{Range: 0x852600..0x852690, Pieces: []}]
+          Locations: [{Range: 0x852620..0x8526b0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852600..0x852670
+            - Range: 0x852620..0x852690
               Pieces: []
-            - Range: 0x852670..0x852671
+            - Range: 0x852690..0x852691
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x852671..0x852690
+            - Range: 0x852691..0x8526b0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 19 BaseType float64
-          Locations: [{Range: 0x852600..0x852690, Pieces: []}]
+          Locations: [{Range: 0x852620..0x8526b0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x852600..0x852670
+            - Range: 0x852620..0x852690
               Pieces: []
-            - Range: 0x852670..0x852671
+            - Range: 0x852690..0x852691
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x852671..0x852690
+            - Range: 0x852691..0x8526b0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 122
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0x852690..0x852720]
+      OutOfLinePCRanges: [0x8526b0..0x852740]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 259 StructureType main.structWithArray
           Locations:
-            - Range: 0x852690..0x852700
+            - Range: 0x8526b0..0x852720
               Pieces: []
-            - Range: 0x852700..0x852701
+            - Range: 0x852720..0x852721
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x852701..0x852720
+            - Range: 0x852721..0x852740
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 123
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0x852720..0x852790]
+      OutOfLinePCRanges: [0x852740..0x8527b0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 19 BaseType float64
-          Locations: [{Range: 0x852720..0x852790, Pieces: []}]
+          Locations: [{Range: 0x852740..0x8527b0, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 124
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0x852790..0x852810]
+      OutOfLinePCRanges: [0x8527b0..0x852830]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float32
-          Locations: [{Range: 0x852790..0x852810, Pieces: []}]
+          Locations: [{Range: 0x8527b0..0x852830, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 19 BaseType float64
-          Locations: [{Range: 0x852790..0x852810, Pieces: []}]
+          Locations: [{Range: 0x8527b0..0x852830, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 125
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0x852810..0x852880]
+      OutOfLinePCRanges: [0x852830..0x8528a0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x852810..0x852868
+            - Range: 0x852830..0x852888
               Pieces: []
-            - Range: 0x852868..0x852869
+            - Range: 0x852888..0x852889
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x852869..0x852880
+            - Range: 0x852889..0x8528a0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 2 BaseType uintptr
           Locations:
-            - Range: 0x852810..0x852868
+            - Range: 0x852830..0x852888
               Pieces: []
-            - Range: 0x852868..0x852869
+            - Range: 0x852888..0x852889
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x852869..0x852880
+            - Range: 0x852889..0x8528a0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 126
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0x852880..0x852a40]
+      OutOfLinePCRanges: [0x8528a0..0x852a60]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 253 StructureType main.largeStruct
           Locations:
-            - Range: 0x852880..0x8528ec
+            - Range: 0x8528a0..0x85290c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8873,7 +8873,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8528ec..0x852900
+            - Range: 0x85290c..0x852920
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8895,7 +8895,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x852900..0x852904
+            - Range: 0x852920..0x852924
               Pieces:
                 - Size: 8
                   Op: null
@@ -8922,9 +8922,9 @@ Subprograms:
         - Name: ~r0
           Type: 253 StructureType main.largeStruct
           Locations:
-            - Range: 0x852880..0x8529f8
+            - Range: 0x8528a0..0x852a18
               Pieces: []
-            - Range: 0x8529f8..0x8529f9
+            - Range: 0x852a18..0x852a19
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8946,44 +8946,44 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8529f9..0x852a40
+            - Range: 0x852a19..0x852a60
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 127
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0x852a40..0x852b10]
+      OutOfLinePCRanges: [0x852a60..0x852b30]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 254 ArrayType [3]int
           Locations:
-            - Range: 0x852a40..0x852b10
+            - Range: 0x852a60..0x852b30
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 254 ArrayType [3]int
           Locations:
-            - Range: 0x852a40..0x852af4
+            - Range: 0x852a60..0x852b14
               Pieces: []
-            - Range: 0x852af4..0x852af5
+            - Range: 0x852b14..0x852b15
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x852af5..0x852b10
+            - Range: 0x852b15..0x852b30
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 128
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0x852b10..0x852d40]
+      OutOfLinePCRanges: [0x852b30..0x852d60]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 253 StructureType main.largeStruct
           Locations:
-            - Range: 0x852b10..0x852b80
+            - Range: 0x852b30..0x852ba0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9005,7 +9005,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x852b80..0x852b94
+            - Range: 0x852ba0..0x852bb4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9027,7 +9027,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x852b94..0x852b98
+            - Range: 0x852bb4..0x852bb8
               Pieces:
                 - Size: 8
                   Op: null
@@ -9054,16 +9054,16 @@ Subprograms:
         - Name: s2
           Type: 253 StructureType main.largeStruct
           Locations:
-            - Range: 0x852b10..0x852d40
+            - Range: 0x852b30..0x852d60
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 253 StructureType main.largeStruct
           Locations:
-            - Range: 0x852b10..0x852d00
+            - Range: 0x852b30..0x852d20
               Pieces: []
-            - Range: 0x852d00..0x852d01
+            - Range: 0x852d20..0x852d21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9085,196 +9085,196 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x852d01..0x852d40
+            - Range: 0x852d21..0x852d60
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 129
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0x852d40..0x852f10]
+      OutOfLinePCRanges: [0x852d60..0x852f30]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852d40..0x852db8
+            - Range: 0x852d60..0x852dd8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x852db8..0x852f10
+            - Range: 0x852dd8..0x852f30
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852d40..0x852da4
+            - Range: 0x852d60..0x852dc4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x852da4..0x852f10
+            - Range: 0x852dc4..0x852f30
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852d40..0x852db8
+            - Range: 0x852d60..0x852dd8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x852db8..0x852f10
+            - Range: 0x852dd8..0x852f30
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852d40..0x852db8
+            - Range: 0x852d60..0x852dd8
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x852db8..0x852f10
+            - Range: 0x852dd8..0x852f30
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852d40..0x852db8
+            - Range: 0x852d60..0x852dd8
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x852db8..0x852f10
+            - Range: 0x852dd8..0x852f30
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852d40..0x852db8
+            - Range: 0x852d60..0x852dd8
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x852db8..0x852f10
+            - Range: 0x852dd8..0x852f30
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852d40..0x852db8
+            - Range: 0x852d60..0x852dd8
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x852db8..0x852f10
+            - Range: 0x852dd8..0x852f30
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852d40..0x852db8
+            - Range: 0x852d60..0x852dd8
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x852db8..0x852f10
+            - Range: 0x852dd8..0x852f30
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852d40..0x852db8
+            - Range: 0x852d60..0x852dd8
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0x852db8..0x852f10
+            - Range: 0x852dd8..0x852f30
               Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 112 ArrayType [2]int
           Locations:
-            - Range: 0x852d40..0x852ec8
+            - Range: 0x852d60..0x852ee8
               Pieces: []
-            - Range: 0x852ec8..0x852ec9
+            - Range: 0x852ee8..0x852ee9
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-            - Range: 0x852ec9..0x852f10
+            - Range: 0x852ee9..0x852f30
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 130
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0x852f10..0x853120]
+      OutOfLinePCRanges: [0x852f30..0x853140]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852f10..0x852f98
+            - Range: 0x852f30..0x852fb8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x852f98..0x853120
+            - Range: 0x852fb8..0x853140
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852f10..0x852f84
+            - Range: 0x852f30..0x852fa4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x852f84..0x853120
+            - Range: 0x852fa4..0x853140
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852f10..0x852f98
+            - Range: 0x852f30..0x852fb8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x852f98..0x853120
+            - Range: 0x852fb8..0x853140
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852f10..0x852f98
+            - Range: 0x852f30..0x852fb8
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x852f98..0x853120
+            - Range: 0x852fb8..0x853140
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852f10..0x852f98
+            - Range: 0x852f30..0x852fb8
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x852f98..0x853120
+            - Range: 0x852fb8..0x853140
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852f10..0x852f98
+            - Range: 0x852f30..0x852fb8
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x852f98..0x853120
+            - Range: 0x852fb8..0x853140
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852f10..0x852f98
+            - Range: 0x852f30..0x852fb8
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x852f98..0x853120
+            - Range: 0x852fb8..0x853140
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 8 BaseType int
           Locations:
-            - Range: 0x852f10..0x852f98
+            - Range: 0x852f30..0x852fb8
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x852f98..0x853120
+            - Range: 0x852fb8..0x853140
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x852f10..0x852f98
+            - Range: 0x852f30..0x852fb8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x852f98..0x853120
+            - Range: 0x852fb8..0x853140
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 72}
@@ -9285,9 +9285,9 @@ Subprograms:
         - Name: ~r0
           Type: 253 StructureType main.largeStruct
           Locations:
-            - Range: 0x852f10..0x8530dc
+            - Range: 0x852f30..0x8530fc
               Pieces: []
-            - Range: 0x8530dc..0x8530dd
+            - Range: 0x8530fc..0x8530fd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9309,232 +9309,194 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8530dd..0x853120
+            - Range: 0x8530fd..0x853140
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 131
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0x853120..0x8531c0]
+      OutOfLinePCRanges: [0x853140..0x8531e0]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 164 ArrayType [5]int
           Locations:
-            - Range: 0x853120..0x8531c0
+            - Range: 0x853140..0x8531e0
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x853120..0x85319c
+            - Range: 0x853140..0x8531bc
               Pieces: []
-            - Range: 0x85319c..0x85319d
+            - Range: 0x8531bc..0x8531bd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x85319d..0x8531c0
+            - Range: 0x8531bd..0x8531e0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 8 BaseType int
           Locations:
-            - Range: 0x853120..0x85319c
+            - Range: 0x853140..0x8531bc
               Pieces: []
-            - Range: 0x85319c..0x85319d
+            - Range: 0x8531bc..0x8531bd
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x85319d..0x8531c0
+            - Range: 0x8531bd..0x8531e0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0x853120..0x85319c
+            - Range: 0x853140..0x8531bc
               Pieces: []
-            - Range: 0x85319c..0x85319d
+            - Range: 0x8531bc..0x8531bd
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x85319d..0x8531c0
+            - Range: 0x8531bd..0x8531e0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 132
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0x8531c0..0x8532a0]
+      OutOfLinePCRanges: [0x8531e0..0x8532c0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 112 ArrayType [2]int
           Locations:
-            - Range: 0x8531c0..0x8532a0
+            - Range: 0x8531e0..0x8532c0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 254 ArrayType [3]int
           Locations:
-            - Range: 0x8531c0..0x8532a0
+            - Range: 0x8531e0..0x8532c0
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x8531c0..0x853284
+            - Range: 0x8531e0..0x8532a4
               Pieces: []
-            - Range: 0x853284..0x853285
+            - Range: 0x8532a4..0x8532a5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x853285..0x8532a0
+            - Range: 0x8532a5..0x8532c0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 112 ArrayType [2]int
           Locations:
-            - Range: 0x8531c0..0x853284
+            - Range: 0x8531e0..0x8532a4
               Pieces: []
-            - Range: 0x853284..0x853285
+            - Range: 0x8532a4..0x8532a5
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
-            - Range: 0x853285..0x8532a0
+            - Range: 0x8532a5..0x8532c0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 133
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0x8532a0..0x853370]
+      OutOfLinePCRanges: [0x8532c0..0x853390]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 259 StructureType main.structWithArray
           Locations:
-            - Range: 0x8532a0..0x853370
+            - Range: 0x8532c0..0x853390
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x8532a0..0x85334c
+            - Range: 0x8532c0..0x85336c
               Pieces: []
-            - Range: 0x85334c..0x85334d
+            - Range: 0x85336c..0x85336d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x85334d..0x853370
+            - Range: 0x85336d..0x853390
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 259 StructureType main.structWithArray
           Locations:
-            - Range: 0x8532a0..0x85334c
+            - Range: 0x8532c0..0x85336c
               Pieces: []
-            - Range: 0x85334c..0x85334d
+            - Range: 0x85336c..0x85336d
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x85334d..0x853370
+            - Range: 0x85336d..0x853390
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0x853320..0x853370
+            - Range: 0x853340..0x853390
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 134
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0x853370..0x853410]
+      OutOfLinePCRanges: [0x853390..0x853430]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 256 ArrayType [0]int
-          Locations: [{Range: 0x853370..0x853410, Pieces: []}]
+          Locations: [{Range: 0x853390..0x853430, Pieces: []}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0x853370..0x8533b0
+            - Range: 0x853390..0x8533d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8533b0..0x8533cc
+            - Range: 0x8533d0..0x8533ec
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x8533cc..0x8533d4
+            - Range: 0x8533ec..0x8533f4
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x8533d4..0x853410
+            - Range: 0x8533f4..0x853430
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x853370..0x8533f0
+            - Range: 0x853390..0x853410
               Pieces: []
-            - Range: 0x8533f0..0x8533f1
+            - Range: 0x853410..0x853411
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8533f1..0x853410
+            - Range: 0x853411..0x853430
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 256 ArrayType [0]int
           Locations:
-            - Range: 0x853370..0x8533f0
+            - Range: 0x853390..0x853410
               Pieces: []
-            - Range: 0x8533f0..0x8533f1
+            - Range: 0x853410..0x853411
               Pieces: []
-            - Range: 0x8533f1..0x853410
+            - Range: 0x853411..0x853430
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 135
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0x853880..0x853890]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 260 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x853880..0x853890
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 136
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x853890..0x8538a0]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 260 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x853890..0x8538a0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 137
-      Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0x8538a0..0x8538b0]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 261 GoSliceHeaderType [][]uint
+          Type: 260 GoSliceHeaderType []uint
           Locations:
             - Range: 0x8538a0..0x8538b0
               Pieces:
@@ -9547,13 +9509,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 138
-      Name: main.testStructSlice
+    - ID: 136
+      Name: main.testEmptySlice
       OutOfLinePCRanges: [0x8538b0..0x8538c0]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 263 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 260 GoSliceHeaderType []uint
           Locations:
             - Range: 0x8538b0..0x8538c0
               Pieces:
@@ -9565,21 +9527,14 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
           DictIndex: -1
-        - Name: a
-          Type: 8 BaseType int
-          Locations:
-            - Range: 0x8538b0..0x8538c0
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
       DictRegister: null
-    - ID: 139
-      Name: main.testEmptySliceOfStructs
+    - ID: 137
+      Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0x8538c0..0x8538d0]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 263 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 261 GoSliceHeaderType [][]uint
           Locations:
             - Range: 0x8538c0..0x8538d0
               Pieces:
@@ -9591,16 +9546,9 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
           DictIndex: -1
-        - Name: a
-          Type: 8 BaseType int
-          Locations:
-            - Range: 0x8538c0..0x8538d0
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
       DictRegister: null
-    - ID: 140
-      Name: main.testNilSliceOfStructs
+    - ID: 138
+      Name: main.testStructSlice
       OutOfLinePCRanges: [0x8538d0..0x8538e0]
       InlinePCRanges: []
       Variables:
@@ -9625,13 +9573,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 141
-      Name: main.testStringSlice
+    - ID: 139
+      Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0x8538e0..0x8538f0]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 157 GoSliceHeaderType []string
+        - Name: xs
+          Type: 263 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0x8538e0..0x8538f0
               Pieces:
@@ -9643,47 +9591,47 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
           DictIndex: -1
+        - Name: a
+          Type: 8 BaseType int
+          Locations:
+            - Range: 0x8538e0..0x8538f0
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
       DictRegister: null
-    - ID: 142
-      Name: main.testNilSliceWithOtherParams
+    - ID: 140
+      Name: main.testNilSliceOfStructs
       OutOfLinePCRanges: [0x8538f0..0x853900]
       InlinePCRanges: []
       Variables:
-        - Name: a
-          Type: 17 BaseType int8
-          Locations:
-            - Range: 0x8538f0..0x853900
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: s
-          Type: 266 GoSliceHeaderType []bool
+        - Name: xs
+          Type: 263 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0x8538f0..0x853900
               Pieces:
                 - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
           Role: Parameter
           DictIndex: -1
-        - Name: x
-          Type: 11 BaseType uint
+        - Name: a
+          Type: 8 BaseType int
           Locations:
             - Range: 0x8538f0..0x853900
-              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 143
-      Name: main.testNilSlice
+    - ID: 141
+      Name: main.testStringSlice
       OutOfLinePCRanges: [0x853900..0x853910]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 267 GoSliceHeaderType []uint16
+        - Name: s
+          Type: 157 GoSliceHeaderType []string
           Locations:
             - Range: 0x853900..0x853910
               Pieces:
@@ -9696,32 +9644,46 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 144
-      Name: main.testVeryLargeSlice
+    - ID: 142
+      Name: main.testNilSliceWithOtherParams
       OutOfLinePCRanges: [0x853910..0x853920]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 260 GoSliceHeaderType []uint
+        - Name: a
+          Type: 17 BaseType int8
+          Locations:
+            - Range: 0x853910..0x853920
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: s
+          Type: 266 GoSliceHeaderType []bool
           Locations:
             - Range: 0x853910..0x853920
               Pieces:
                 - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: x
+          Type: 11 BaseType uint
+          Locations:
+            - Range: 0x853910..0x853920
+              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 145
-      Name: main.testSliceEmptyStructs
+    - ID: 143
+      Name: main.testNilSlice
       OutOfLinePCRanges: [0x853920..0x853930]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 268 GoSliceHeaderType []struct {}
+          Type: 267 GoSliceHeaderType []uint16
           Locations:
             - Range: 0x853920..0x853930
               Pieces:
@@ -9734,15 +9696,53 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 144
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0x853930..0x853940]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 260 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0x853930..0x853940
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 145
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0x853940..0x853950]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 268 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0x853940..0x853950
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 146
       Name: main.testSubslices
-      OutOfLinePCRanges: [0x853930..0x853940]
+      OutOfLinePCRanges: [0x853950..0x853960]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 260 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x853930..0x853940
+            - Range: 0x853950..0x853960
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9755,7 +9755,7 @@ Subprograms:
         - Name: bs
           Type: 260 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x853930..0x853940
+            - Range: 0x853950..0x853960
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9768,7 +9768,7 @@ Subprograms:
         - Name: cs
           Type: 260 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x853930..0x853940
+            - Range: 0x853950..0x853960
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -9781,34 +9781,34 @@ Subprograms:
       DictRegister: null
     - ID: 147
       Name: main.stackC
-      OutOfLinePCRanges: [0x853f20..0x853f90]
+      OutOfLinePCRanges: [0x853f40..0x853fb0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x853f20..0x853f6c
+            - Range: 0x853f40..0x853f8c
               Pieces: []
-            - Range: 0x853f6c..0x853f6d
+            - Range: 0x853f8c..0x853f8d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x853f6d..0x853f90
+            - Range: 0x853f8d..0x853fb0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 148
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x853f90..0x853fa0]
+      OutOfLinePCRanges: [0x853fb0..0x853fc0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x853f90..0x853fa0
+            - Range: 0x853fb0..0x853fc0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9819,13 +9819,13 @@ Subprograms:
       DictRegister: null
     - ID: 149
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x853fa0..0x853fb0]
+      OutOfLinePCRanges: [0x853fc0..0x853fd0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x853fa0..0x853fb0
+            - Range: 0x853fc0..0x853fd0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9836,7 +9836,7 @@ Subprograms:
         - Name: "y"
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x853fa0..0x853fb0
+            - Range: 0x853fc0..0x853fd0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9847,7 +9847,7 @@ Subprograms:
         - Name: z
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x853fa0..0x853fb0
+            - Range: 0x853fc0..0x853fd0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9858,13 +9858,13 @@ Subprograms:
       DictRegister: null
     - ID: 150
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x853fb0..0x853fd0]
+      OutOfLinePCRanges: [0x853fd0..0x853ff0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 270 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x853fb0..0x853fd0
+            - Range: 0x853fd0..0x853ff0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9883,66 +9883,32 @@ Subprograms:
       DictRegister: null
     - ID: 151
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x853fd0..0x853fe0]
+      OutOfLinePCRanges: [0x853ff0..0x854000]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 271 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x853fd0..0x853fe0
+            - Range: 0x853ff0..0x854000
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 152
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x853fe0..0x853ff0]
+      OutOfLinePCRanges: [0x854000..0x854010]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 272 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x853fe0..0x853ff0
+            - Range: 0x854000..0x854010
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 153
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0x853ff0..0x854000]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 10 GoStringHeaderType string
-          Locations:
-            - Range: 0x853ff0..0x854000
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 154
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x854000..0x854010]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 10 GoStringHeaderType string
-          Locations:
-            - Range: 0x854000..0x854010
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 155
-      Name: main.testEmptyString
       OutOfLinePCRanges: [0x854010..0x854020]
       InlinePCRanges: []
       Variables:
@@ -9958,12 +9924,12 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 156
-      Name: main.testSubstrings
+    - ID: 154
+      Name: main.testUnitializedString
       OutOfLinePCRanges: [0x854020..0x854030]
       InlinePCRanges: []
       Variables:
-        - Name: a
+        - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
             - Range: 0x854020..0x854030
@@ -9974,10 +9940,44 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
           DictIndex: -1
+      DictRegister: null
+    - ID: 155
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0x854030..0x854040]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0x854030..0x854040
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 156
+      Name: main.testSubstrings
+      OutOfLinePCRanges: [0x854040..0x854050]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0x854040..0x854050
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
         - Name: b
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x854020..0x854030
+            - Range: 0x854040..0x854050
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9988,7 +9988,7 @@ Subprograms:
         - Name: c
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x854020..0x854030
+            - Range: 0x854040..0x854050
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9999,26 +9999,26 @@ Subprograms:
       DictRegister: null
     - ID: 157
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x854190..0x8541a0]
+      OutOfLinePCRanges: [0x8541b0..0x8541c0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 274 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x854190..0x8541a0
+            - Range: 0x8541b0..0x8541c0
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 158
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x8541a0..0x8541c0]
+      OutOfLinePCRanges: [0x8541c0..0x8541e0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 287 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x8541a0..0x8541c0
+            - Range: 0x8541c0..0x8541e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10037,13 +10037,13 @@ Subprograms:
       DictRegister: null
     - ID: 159
       Name: main.testStruct
-      OutOfLinePCRanges: [0x854290..0x8542b0]
+      OutOfLinePCRanges: [0x8542b0..0x8542d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 318 StructureType main.aStruct
           Locations:
-            - Range: 0x854290..0x8542b0
+            - Range: 0x8542b0..0x8542d0
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -10064,130 +10064,68 @@ Subprograms:
       DictRegister: null
     - ID: 160
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0x854330..0x854340]
+      OutOfLinePCRanges: [0x854350..0x854360]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 319 PointerType *main.anotherStruct
           Locations:
-            - Range: 0x854330..0x854340
+            - Range: 0x854350..0x854360
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 161
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0x854340..0x854350]
+      OutOfLinePCRanges: [0x854360..0x854370]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 321 StructureType main.tenStrings
           Locations:
-            - Range: 0x854340..0x854350
+            - Range: 0x854360..0x854370
               Pieces: [{Size: 160, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 162
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x854390..0x8543a0]
+      OutOfLinePCRanges: [0x8543b0..0x8543c0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 322 StructureType main.emptyStruct
-          Locations: [{Range: 0x854390..0x8543a0, Pieces: []}]
+          Locations: [{Range: 0x8543b0..0x8543c0, Pieces: []}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 163
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x8543a0..0x8543b0]
+      OutOfLinePCRanges: [0x8543c0..0x8543d0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 323 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x8543a0..0x8543b0
+            - Range: 0x8543c0..0x8543d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 164
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0x855cb0..0x855cc0]
+      OutOfLinePCRanges: [0x855cd0..0x855ce0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 324 BaseType go.shape.int
-          Locations:
-            - Range: 0x855cb0..0x855cc0
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 325 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
-          Locations:
-            - Range: 0x855cb0..0x855cb4
-              Pieces: []
-            - Range: 0x855cb4..0x855cb5
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x855cb5..0x855cc0
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 165
-      Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0x855cc0..0x855cd0]
-      InlinePCRanges: []
-      Variables:
-        - Name: val
-          Type: 326 GoStringHeaderType go.shape.string
-          Locations:
-            - Range: 0x855cc0..0x855ccc
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0x855ccc..0x855cd0
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
-          Locations:
-            - Range: 0x855cc0..0x855ccc
-              Pieces: []
-            - Range: 0x855ccc..0x855ccd
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x855ccd..0x855cd0
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 166
-      Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0x855cd0..0x855ce0]
-      InlinePCRanges: []
-      Variables:
-        - Name: box
-          Type: 325 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
             - Range: 0x855cd0..0x855ce0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 324 BaseType go.shape.int
+          Type: 325 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
             - Range: 0x855cd0..0x855cd4
               Pieces: []
@@ -10198,13 +10136,13 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 167
-      Name: main.nestedGeneric[go.shape.string]
+    - ID: 165
+      Name: main.wrapBox[go.shape.string]
       OutOfLinePCRanges: [0x855ce0..0x855cf0]
       InlinePCRanges: []
       Variables:
-        - Name: box
-          Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+        - Name: val
+          Type: 326 GoStringHeaderType go.shape.string
           Locations:
             - Range: 0x855ce0..0x855cec
               Pieces:
@@ -10221,7 +10159,7 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 326 GoStringHeaderType go.shape.string
+          Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
             - Range: 0x855ce0..0x855cec
               Pieces: []
@@ -10236,15 +10174,77 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
+    - ID: 166
+      Name: main.nestedGeneric[go.shape.int]
+      OutOfLinePCRanges: [0x855cf0..0x855d00]
+      InlinePCRanges: []
+      Variables:
+        - Name: box
+          Type: 325 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+          Locations:
+            - Range: 0x855cf0..0x855d00
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 324 BaseType go.shape.int
+          Locations:
+            - Range: 0x855cf0..0x855cf4
+              Pieces: []
+            - Range: 0x855cf4..0x855cf5
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x855cf5..0x855d00
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 167
+      Name: main.nestedGeneric[go.shape.string]
+      OutOfLinePCRanges: [0x855d00..0x855d10]
+      InlinePCRanges: []
+      Variables:
+        - Name: box
+          Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+          Locations:
+            - Range: 0x855d00..0x855d0c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x855d0c..0x855d10
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 326 GoStringHeaderType go.shape.string
+          Locations:
+            - Range: 0x855d00..0x855d0c
+              Pieces: []
+            - Range: 0x855d0c..0x855d0d
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x855d0d..0x855d10
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
     - ID: 168
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0x855d50..0x855e70]
+      OutOfLinePCRanges: [0x855d70..0x855e90]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 328 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x855d50..0x855d7c
+            - Range: 0x855d70..0x855d9c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10252,7 +10252,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x855d7c..0x855d8c
+            - Range: 0x855d9c..0x855dac
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10260,7 +10260,7 @@ Subprograms:
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: null
-            - Range: 0x855d8c..0x855e70
+            - Range: 0x855dac..0x855e90
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10273,18 +10273,18 @@ Subprograms:
         - Name: pred
           Type: 330 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0x855d50..0x855d8c
+            - Range: 0x855d70..0x855dac
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x855d8c..0x855e70
+            - Range: 0x855dac..0x855e90
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 328 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x855d50..0x855e3c
+            - Range: 0x855d70..0x855e5c
               Pieces: []
-            - Range: 0x855e3c..0x855e3d
+            - Range: 0x855e5c..0x855e5d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10292,14 +10292,14 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x855e3d..0x855e70
+            - Range: 0x855e5d..0x855e90
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
           Type: 328 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x855d8c..0x855da8
+            - Range: 0x855dac..0x855dc8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10307,7 +10307,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x855da8..0x855dac
+            - Range: 0x855dc8..0x855dcc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10315,7 +10315,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x855dac..0x855db0
+            - Range: 0x855dcc..0x855dd0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10323,7 +10323,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x855db0..0x855db0
+            - Range: 0x855dd0..0x855dd0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10331,7 +10331,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x855db0..0x855ddc
+            - Range: 0x855dd0..0x855dfc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10339,7 +10339,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x855ddc..0x855e30
+            - Range: 0x855dfc..0x855e50
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10347,7 +10347,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x855e30..0x855e70
+            - Range: 0x855e50..0x855e90
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10360,110 +10360,62 @@ Subprograms:
         - Name: item
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0x855dcc..0x855ddc
+            - Range: 0x855dec..0x855dfc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x855ddc..0x855e30
+            - Range: 0x855dfc..0x855e50
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
     - ID: 169
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x855e70..0x855ec0]
+      OutOfLinePCRanges: [0x855e90..0x855ee0]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 325 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x855e70..0x855e98
+            - Range: 0x855e90..0x855eb8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
           Type: 331 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0x855e70..0x855e98
+            - Range: 0x855e90..0x855eb8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x855e70..0x855e98
+            - Range: 0x855e90..0x855eb8
               Pieces: []
-            - Range: 0x855e98..0x855e99
+            - Range: 0x855eb8..0x855eb9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x855e99..0x855ec0
+            - Range: 0x855eb9..0x855ee0
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
     - ID: 170
       Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0x856130..0x856140]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 329 PointerType *go.shape.int
-          Locations:
-            - Range: 0x856130..0x856140
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 329 PointerType *go.shape.int
-          Locations:
-            - Range: 0x856130..0x856134
-              Pieces: []
-            - Range: 0x856134..0x856135
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x856135..0x856140
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 171
-      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0x856140..0x856150]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 332 PointerType *go.shape.struct { Name string }
-          Locations:
-            - Range: 0x856140..0x856150
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 332 PointerType *go.shape.struct { Name string }
-          Locations:
-            - Range: 0x856140..0x856144
-              Pieces: []
-            - Range: 0x856144..0x856145
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x856145..0x856150
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 172
-      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
       OutOfLinePCRanges: [0x856150..0x856160]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 334 PointerType *go.shape.struct { X int; Y int }
+          Type: 329 PointerType *go.shape.int
           Locations:
             - Range: 0x856150..0x856160
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 334 PointerType *go.shape.struct { X int; Y int }
+          Type: 329 PointerType *go.shape.int
           Locations:
             - Range: 0x856150..0x856154
               Pieces: []
@@ -10474,101 +10426,149 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
+    - ID: 171
+      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
+      OutOfLinePCRanges: [0x856160..0x856170]
+      InlinePCRanges: []
+      Variables:
+        - Name: p
+          Type: 332 PointerType *go.shape.struct { Name string }
+          Locations:
+            - Range: 0x856160..0x856170
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 332 PointerType *go.shape.struct { Name string }
+          Locations:
+            - Range: 0x856160..0x856164
+              Pieces: []
+            - Range: 0x856164..0x856165
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x856165..0x856170
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 172
+      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
+      OutOfLinePCRanges: [0x856170..0x856180]
+      InlinePCRanges: []
+      Variables:
+        - Name: p
+          Type: 334 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0x856170..0x856180
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 334 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0x856170..0x856174
+              Pieces: []
+            - Range: 0x856174..0x856175
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x856175..0x856180
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
     - ID: 173
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0x856160..0x856170]
+      OutOfLinePCRanges: [0x856180..0x856190]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 336 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0x856160..0x856170
+            - Range: 0x856180..0x856190
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x856160..0x856168
+            - Range: 0x856180..0x856188
               Pieces: []
-            - Range: 0x856168..0x856169
+            - Range: 0x856188..0x856189
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x856169..0x856170
+            - Range: 0x856189..0x856190
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 174
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0x8561f0..0x856200]
+      OutOfLinePCRanges: [0x856210..0x856220]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 338 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0x8561f0..0x856200
+            - Range: 0x856210..0x856220
               Pieces: [{Size: 136, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0x8561f0..0x8561f4
+            - Range: 0x856210..0x856214
               Pieces: []
-            - Range: 0x8561f4..0x8561f5
+            - Range: 0x856214..0x856215
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8561f5..0x856200
+            - Range: 0x856215..0x856220
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 175
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0x856290..0x8562a0]
+      OutOfLinePCRanges: [0x8562b0..0x8562c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 339 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0x856290..0x8562a0
+            - Range: 0x8562b0..0x8562c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0x856290..0x8562a0
+            - Range: 0x8562b0..0x8562c0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
           Type: 341 BaseType go.shape.bool
           Locations:
-            - Range: 0x856290..0x8562a0
+            - Range: 0x8562b0..0x8562c0
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
     - ID: 176
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0x856320..0x8563a0]
+      OutOfLinePCRanges: [0x856340..0x8563c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 342 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0x856320..0x8563a0
+            - Range: 0x856340..0x8563c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x856320..0x8563a0
+            - Range: 0x856340..0x8563c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10579,20 +10579,20 @@ Subprograms:
         - Name: v
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0x856320..0x8563a0
+            - Range: 0x856340..0x8563c0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
     - ID: 177
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0x856420..0x856430]
+      OutOfLinePCRanges: [0x856440..0x856450]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x856420..0x856430
+            - Range: 0x856440..0x856450
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10603,59 +10603,59 @@ Subprograms:
         - Name: b
           Type: 341 BaseType go.shape.bool
           Locations:
-            - Range: 0x856420..0x856430
+            - Range: 0x856440..0x856450
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 341 BaseType go.shape.bool
           Locations:
-            - Range: 0x856420..0x856428
+            - Range: 0x856440..0x856448
               Pieces: []
-            - Range: 0x856428..0x856429
+            - Range: 0x856448..0x856449
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x856429..0x856430
+            - Range: 0x856449..0x856450
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x856420..0x856428
+            - Range: 0x856440..0x856448
               Pieces: []
-            - Range: 0x856428..0x856429
+            - Range: 0x856448..0x856449
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x856429..0x856430
+            - Range: 0x856449..0x856450
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 178
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x856430..0x856450]
+      OutOfLinePCRanges: [0x856450..0x856470]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0x856430..0x856440
+            - Range: 0x856450..0x856460
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x856430..0x85643c
+            - Range: 0x856450..0x85645c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x85643c..0x856450
+            - Range: 0x85645c..0x856470
               Pieces:
                 - Size: 8
                   Op: null
@@ -10666,73 +10666,73 @@ Subprograms:
         - Name: ~r0
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x856430..0x856440
+            - Range: 0x856450..0x856460
               Pieces: []
-            - Range: 0x856440..0x856441
+            - Range: 0x856460..0x856461
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x856441..0x856450
+            - Range: 0x856461..0x856470
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0x856430..0x856440
+            - Range: 0x856450..0x856460
               Pieces: []
-            - Range: 0x856440..0x856441
+            - Range: 0x856460..0x856461
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x856441..0x856450
+            - Range: 0x856461..0x856470
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 179
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0x856450..0x8564a0]
+      OutOfLinePCRanges: [0x856470..0x8564c0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 344 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0x856450..0x856478
+            - Range: 0x856470..0x856498
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x856450..0x856478
+            - Range: 0x856470..0x856498
               Pieces: []
-            - Range: 0x856478..0x856479
+            - Range: 0x856498..0x856499
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x856479..0x8564a0
+            - Range: 0x856499..0x8564c0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 180
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0x8564a0..0x856500]
+      OutOfLinePCRanges: [0x8564c0..0x856520]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 345 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0x8564a0..0x8564cc
+            - Range: 0x8564c0..0x8564ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x8564cc..0x8564d0
+            - Range: 0x8564ec..0x8564f0
               Pieces:
                 - Size: 8
                   Op: null
@@ -10743,65 +10743,65 @@ Subprograms:
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x8564a0..0x8564d0
+            - Range: 0x8564c0..0x8564f0
               Pieces: []
-            - Range: 0x8564d0..0x8564d1
+            - Range: 0x8564f0..0x8564f1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8564d1..0x856500
+            - Range: 0x8564f1..0x856520
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 181
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0x856500..0x856510]
+      OutOfLinePCRanges: [0x856520..0x856530]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 346 PointerType *go.shape.string
           Locations:
-            - Range: 0x856500..0x856508
+            - Range: 0x856520..0x856528
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x856500..0x856508
+            - Range: 0x856520..0x856528
               Pieces: []
-            - Range: 0x856508..0x856509
+            - Range: 0x856528..0x856529
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x856509..0x856510
+            - Range: 0x856529..0x856530
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 182
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0x856510..0x856570]
+      OutOfLinePCRanges: [0x856530..0x856590]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 347 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x856510..0x85654c
+            - Range: 0x856530..0x85656c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 348 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x856510..0x85655c
+            - Range: 0x856530..0x85657c
               Pieces: []
-            - Range: 0x85655c..0x85655d
+            - Range: 0x85657c..0x85657d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10815,20 +10815,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x85655d..0x856570
+            - Range: 0x85657d..0x856590
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 183
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0x856570..0x8565b0]
+      OutOfLinePCRanges: [0x856590..0x8565d0]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 328 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x856570..0x85657c
+            - Range: 0x856590..0x85659c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10836,7 +10836,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x85657c..0x8565b0
+            - Range: 0x85659c..0x8565d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10849,42 +10849,42 @@ Subprograms:
         - Name: needle
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0x856570..0x8565b0
+            - Range: 0x856590..0x8565d0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x856570..0x856598
+            - Range: 0x856590..0x8565b8
               Pieces: []
-            - Range: 0x856598..0x856599
+            - Range: 0x8565b8..0x8565b9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x856599..0x8565a0
+            - Range: 0x8565b9..0x8565c0
               Pieces: []
-            - Range: 0x8565a0..0x8565a1
+            - Range: 0x8565c0..0x8565c1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8565a1..0x8565b0
+            - Range: 0x8565c1..0x8565d0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0x85658c..0x85659c
+            - Range: 0x8565ac..0x8565bc
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Local
           DictIndex: 1
       DictRegister: 0
     - ID: 184
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0x8565b0..0x856670]
+      OutOfLinePCRanges: [0x8565d0..0x856690]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 349 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0x8565b0..0x8565d4
+            - Range: 0x8565d0..0x8565f4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10892,7 +10892,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8565d4..0x8565d8
+            - Range: 0x8565f4..0x8565f8
               Pieces:
                 - Size: 8
                   Op: null
@@ -10905,13 +10905,13 @@ Subprograms:
         - Name: needle
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8565b0..0x85660c
+            - Range: 0x8565d0..0x85662c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x85660c..0x856670
+            - Range: 0x85662c..0x856690
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 40}
@@ -10922,28 +10922,28 @@ Subprograms:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x8565b0..0x856628
+            - Range: 0x8565d0..0x856648
               Pieces: []
-            - Range: 0x856628..0x856629
+            - Range: 0x856648..0x856649
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x856629..0x856638
+            - Range: 0x856649..0x856658
               Pieces: []
-            - Range: 0x856638..0x856639
+            - Range: 0x856658..0x856659
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x856639..0x856670
+            - Range: 0x856659..0x856690
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8565ec..0x856600
+            - Range: 0x85660c..0x856620
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x856600..0x85660c
+            - Range: 0x856620..0x85662c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10954,56 +10954,56 @@ Subprograms:
       DictRegister: 0
     - ID: 185
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0x856670..0x856680]
+      OutOfLinePCRanges: [0x856690..0x8566a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 350 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0x856670..0x856678
+            - Range: 0x856690..0x856698
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
           Type: 324 BaseType go.shape.int
           Locations:
-            - Range: 0x856670..0x856680
+            - Range: 0x856690..0x8566a0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x856670..0x856678
+            - Range: 0x856690..0x856698
               Pieces: []
-            - Range: 0x856678..0x856679
+            - Range: 0x856698..0x856699
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x856679..0x856680
+            - Range: 0x856699..0x8566a0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 1
     - ID: 186
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0x8566f0..0x856760]
+      OutOfLinePCRanges: [0x856710..0x856780]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 351 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0x8566f0..0x85671c
+            - Range: 0x856710..0x85673c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x85671c..0x856728
+            - Range: 0x85673c..0x856748
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x856728..0x85672c
+            - Range: 0x856748..0x85674c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11014,7 +11014,7 @@ Subprograms:
         - Name: value
           Type: 326 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8566f0..0x85672c
+            - Range: 0x856710..0x85674c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -11025,11 +11025,11 @@ Subprograms:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x8566f0..0x85672c
+            - Range: 0x856710..0x85674c
               Pieces: []
-            - Range: 0x85672c..0x85672d
+            - Range: 0x85674c..0x85674d
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x85672d..0x856760
+            - Range: 0x85674d..0x856780
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11258,8 +11258,8 @@ Subprograms:
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0x84ec50..0x84ecc0]
       InlinePCRanges:
-        - Ranges: [0x85680c..0x856840]
-          RootRanges: [0x8567e0..0x856890]
+        - Ranges: [0x85682c..0x856860]
+          RootRanges: [0x856800..0x8568b0]
       Variables:
         - Name: b
           Type: 356 StructureType main.firstBehavior
@@ -11298,8 +11298,8 @@ Subprograms:
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x84f454..0x84f460, 0x84f464..0x84f46c]
-          RootRanges: [0x84f3c0..0x84f4b0]
+        - Ranges: [0x84f474..0x84f480, 0x84f484..0x84f48c]
+          RootRanges: [0x84f3e0..0x84f4d0]
         - Ranges: [0x129ba8..0x129bac, 0x129bb0..0x129bb8]
           RootRanges: [0x129ba0..0x129bc0]
       Variables: []

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -13,11 +13,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1600 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0x8102e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x810308", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1601 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0x810318", Frameless: false}]
+              InjectionPoints: [{PC: "0x810338", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -84,11 +84,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1571 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0x80ef1c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ef3c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1572 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0x80efa8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80efc8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -176,7 +176,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1451 EventRootType Probe[main.testArrayOfMaps]
-              InjectionPoints: [{PC: "0x80bbb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bbd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -241,11 +241,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1473 EventRootType Probe[main.testAtomicAdd]
-              InjectionPoints: [{PC: "0x80d300", Frameless: true}]
+              InjectionPoints: [{PC: "0x80d320", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1474 EventRootType Probe[main.testAtomicAdd]Return
-              InjectionPoints: [{PC: "0x80d33c", Frameless: true}]
+              InjectionPoints: [{PC: "0x80d35c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -342,11 +342,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1619 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x8105d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8105f0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1620 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0x8105e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x810600", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -476,7 +476,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1470 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x80d0a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80d0c0", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -495,7 +495,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1471 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x80d0a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80d0c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -521,7 +521,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1627 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0x810670", Frameless: true}]
+              InjectionPoints: [{PC: "0x810690", Frameless: true}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -557,7 +557,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1475 EventRootType Probe[main.testChannel]
-              InjectionPoints: [{PC: "0x80d340", Frameless: true}]
+              InjectionPoints: [{PC: "0x80d360", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -587,7 +587,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1469 EventRootType Probe[main.testCombinedByte]
-              InjectionPoints: [{PC: "0x80d080", Frameless: true}]
+              InjectionPoints: [{PC: "0x80d0a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{w}, {x}, {y}'
@@ -616,11 +616,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1536 EventRootType Probe[main.testConflictingReturn]
-              InjectionPoints: [{PC: "0x80e218", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e238", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1537 EventRootType Probe[main.testConflictingReturn]Return
-              InjectionPoints: [{PC: "0x80e2b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e2d8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -642,7 +642,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1483 EventRootType Probe[main.testCycle]
-              InjectionPoints: [{PC: "0x80d5d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80d5f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{t}'
@@ -796,7 +796,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1588 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0x80fc70", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fc90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -823,7 +823,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1591 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0x80fca0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fcc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -851,7 +851,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1614 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0x8103a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8103c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -873,7 +873,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1628 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0x8106a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8106c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -894,7 +894,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1629 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0x8106b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8106d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1107,11 +1107,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1666 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0x8126c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8126e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1667 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x8126c4", Frameless: true}]
+              InjectionPoints: [{PC: "0x8126e4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1125,11 +1125,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1668 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0x8126e0", Frameless: false}]
+              InjectionPoints: [{PC: "0x812700", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1669 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0x812710", Frameless: false}]
+              InjectionPoints: [{PC: "0x812730", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1152,11 +1152,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1662 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0x812628", Frameless: false}]
+              InjectionPoints: [{PC: "0x812648", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1663 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0x812638", Frameless: false}]
+              InjectionPoints: [{PC: "0x812658", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1170,11 +1170,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1664 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0x812678", Frameless: false}]
+              InjectionPoints: [{PC: "0x812698", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1665 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0x812690", Frameless: false}]
+              InjectionPoints: [{PC: "0x8126b0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1197,14 +1197,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1670 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0x812720", Frameless: true}]
+              InjectionPoints: [{PC: "0x812740", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1671 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0x812748"
+                - PC: "0x812768"
                   Frameless: true
-                - PC: "0x812750"
+                - PC: "0x812770"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1219,14 +1219,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1672 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0x812778", Frameless: false}]
+              InjectionPoints: [{PC: "0x812798", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1673 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0x8127d4"
+                - PC: "0x8127f4"
                   Frameless: false
-                - PC: "0x8127e4"
+                - PC: "0x812804"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1253,7 +1253,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1674 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0x812724", Frameless: true}]
+              InjectionPoints: [{PC: "0x812744", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1265,7 +1265,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1675 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0x812788", Frameless: false}]
+              InjectionPoints: [{PC: "0x8127a8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1286,11 +1286,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1650 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0x812330", Frameless: true}]
+              InjectionPoints: [{PC: "0x812350", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1651 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0x812334", Frameless: true}]
+              InjectionPoints: [{PC: "0x812354", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1304,11 +1304,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1652 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0x8123c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8123e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1653 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0x8123c4", Frameless: true}]
+              InjectionPoints: [{PC: "0x8123e4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1332,11 +1332,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1638 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0x811f38", Frameless: false}]
+              InjectionPoints: [{PC: "0x811f58", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1639 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x81200c", Frameless: false}]
+              InjectionPoints: [{PC: "0x81202c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1378,11 +1378,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1642 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x812058", Frameless: false}]
+              InjectionPoints: [{PC: "0x812078", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1643 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x812068", Frameless: false}]
+              InjectionPoints: [{PC: "0x812088", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1405,11 +1405,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1676 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0x812820", Frameless: true}]
+              InjectionPoints: [{PC: "0x812840", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1677 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0x812828", Frameless: true}]
+              InjectionPoints: [{PC: "0x812848", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1423,11 +1423,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1678 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0x8128b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8128d8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1679 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0x8128dc", Frameless: false}]
+              InjectionPoints: [{PC: "0x8128fc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1450,11 +1450,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1634 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0x811ea0", Frameless: true}]
+              InjectionPoints: [{PC: "0x811ec0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1635 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x811ea4", Frameless: true}]
+              InjectionPoints: [{PC: "0x811ec4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1468,11 +1468,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1636 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0x811eb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x811ed0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1637 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x811ebc", Frameless: true}]
+              InjectionPoints: [{PC: "0x811edc", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1495,11 +1495,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1654 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0x812460", Frameless: true}]
+              InjectionPoints: [{PC: "0x812480", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1655 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0x812468", Frameless: true}]
+              InjectionPoints: [{PC: "0x812488", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1513,11 +1513,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1656 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0x812508", Frameless: false}]
+              InjectionPoints: [{PC: "0x812528", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1657 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0x812530", Frameless: false}]
+              InjectionPoints: [{PC: "0x812550", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1540,11 +1540,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1644 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0x812300", Frameless: true}]
+              InjectionPoints: [{PC: "0x812320", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1645 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x812304", Frameless: true}]
+              InjectionPoints: [{PC: "0x812324", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1558,11 +1558,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1646 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0x812310", Frameless: true}]
+              InjectionPoints: [{PC: "0x812330", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1647 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0x812314", Frameless: true}]
+              InjectionPoints: [{PC: "0x812334", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1576,11 +1576,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1648 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0x812320", Frameless: true}]
+              InjectionPoints: [{PC: "0x812340", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1649 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0x812324", Frameless: true}]
+              InjectionPoints: [{PC: "0x812344", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1603,11 +1603,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1658 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0x8125e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x812600", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1659 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0x8125e8", Frameless: true}]
+              InjectionPoints: [{PC: "0x812608", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1621,11 +1621,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1660 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x8125f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x812610", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1661 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x812600", Frameless: true}]
+              InjectionPoints: [{PC: "0x812620", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1648,11 +1648,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1630 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0x811e80", Frameless: true}]
+              InjectionPoints: [{PC: "0x811ea0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1631 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x811e84", Frameless: true}]
+              InjectionPoints: [{PC: "0x811ea4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1666,11 +1666,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1632 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0x811e90", Frameless: true}]
+              InjectionPoints: [{PC: "0x811eb0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1633 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x811e9c", Frameless: true}]
+              InjectionPoints: [{PC: "0x811ebc", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1902,7 +1902,7 @@ Probes:
               InjectionPoints:
                 - PC: "0x12c238"
                   Frameless: true
-                - PC: "0x80baf0"
+                - PC: "0x80bb10"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2198,11 +2198,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1569 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0x80ed90", Frameless: false}]
+              InjectionPoints: [{PC: "0x80edb0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1570 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x80eeb8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80eed8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2224,7 +2224,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1477 EventRootType Probe[main.testLinkedList]
-              InjectionPoints: [{PC: "0x80d4e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80d500", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -2336,11 +2336,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1575 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0x80f1ec", Frameless: false}]
+              InjectionPoints: [{PC: "0x80f20c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1576 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0x80f32c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80f34c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2449,7 +2449,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1449 EventRootType Probe[main.testMapArrayToArray]
-              InjectionPoints: [{PC: "0x80bb90", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bbb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2471,7 +2471,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1456 EventRootType Probe[main.testMapEmbeddedMaps]
-              InjectionPoints: [{PC: "0x80bbf0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bc10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2493,7 +2493,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1466 EventRootType Probe[main.testMapEmptyKey]
-              InjectionPoints: [{PC: "0x80bc90", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bcb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2515,7 +2515,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1468 EventRootType Probe[main.testMapEmptyKeyAndValue]
-              InjectionPoints: [{PC: "0x80bcb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bcd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2537,7 +2537,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1467 EventRootType Probe[main.testMapEmptyValue]
-              InjectionPoints: [{PC: "0x80bca0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bcc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2559,7 +2559,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1453 EventRootType Probe[main.testMapIntToInt]
-              InjectionPoints: [{PC: "0x80bbd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bbf0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2581,7 +2581,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1465 EventRootType Probe[main.testMapLargeKeyLargeValue]
-              InjectionPoints: [{PC: "0x80bc80", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bca0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2603,7 +2603,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1464 EventRootType Probe[main.testMapLargeKeySmallValue]
-              InjectionPoints: [{PC: "0x80bc70", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bc90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2627,7 +2627,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1454 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x80bbe0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bc00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2651,7 +2651,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1455 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x80bbe0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bc00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2673,7 +2673,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1463 EventRootType Probe[main.testMapSmallKeyLargeValue]
-              InjectionPoints: [{PC: "0x80bc60", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bc80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2695,7 +2695,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1462 EventRootType Probe[main.testMapSmallKeySmallValue]
-              InjectionPoints: [{PC: "0x80bc50", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bc70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2717,7 +2717,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1447 EventRootType Probe[main.testMapStringToInt]
-              InjectionPoints: [{PC: "0x80bb70", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bb90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2739,7 +2739,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1448 EventRootType Probe[main.testMapStringToSlice]
-              InjectionPoints: [{PC: "0x80bb80", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bba0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2761,7 +2761,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1446 EventRootType Probe[main.testMapStringToStruct]
-              InjectionPoints: [{PC: "0x80bb60", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bb80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2783,7 +2783,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1457 EventRootType Probe[main.testMapWithLinkedList]
-              InjectionPoints: [{PC: "0x80bc00", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bc20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2805,7 +2805,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1460 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-              InjectionPoints: [{PC: "0x80bc30", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bc50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2827,7 +2827,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1461 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-              InjectionPoints: [{PC: "0x80bc40", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bc60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2849,7 +2849,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1458 EventRootType Probe[main.testMapWithSmallValue]
-              InjectionPoints: [{PC: "0x80bc10", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bc30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2873,7 +2873,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1459 EventRootType Probe[main.testMapWithSmallValueMassive]
-              InjectionPoints: [{PC: "0x80bc20", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bc40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2895,7 +2895,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1611 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x810380", Frameless: true}]
+              InjectionPoints: [{PC: "0x8103a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2918,7 +2918,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1612 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x810380", Frameless: true}]
+              InjectionPoints: [{PC: "0x8103a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2965,11 +2965,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1577 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0x80f390", Frameless: false}]
+              InjectionPoints: [{PC: "0x80f3b0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1578 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0x80f518", Frameless: false}]
+              InjectionPoints: [{PC: "0x80f538", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -3035,11 +3035,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1581 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0x80f60c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80f62c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1582 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0x80f6a4", Frameless: false}]
+              InjectionPoints: [{PC: "0x80f6c4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3070,11 +3070,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1573 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0x80efe0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80f000", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1574 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0x80f184", Frameless: false}]
+              InjectionPoints: [{PC: "0x80f1a4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3100,11 +3100,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1514 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80e098", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e0b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1515 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80e118", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e138", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3140,7 +3140,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1472 EventRootType Probe[main.testMultipleSimpleParams]
-              InjectionPoints: [{PC: "0x80d160", Frameless: true}]
+              InjectionPoints: [{PC: "0x80d180", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -3181,11 +3181,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1508 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x80e008", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e028", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1509 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x80e060", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e080", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3209,11 +3209,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1510 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x80e008", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e028", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1511 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x80e060", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e080", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
       version: 0
@@ -3232,11 +3232,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1516 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80e098", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e0b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1517 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80e118", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e138", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
       version: 0
@@ -3256,11 +3256,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1518 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80e098", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e0b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1519 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80e118", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e138", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r1={result} r2={result2}
@@ -3293,11 +3293,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1512 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x80e008", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e028", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1513 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x80e060", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e080", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Parameter {i} * 2 = result {result}
@@ -3325,7 +3325,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1623 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x810660", Frameless: true}]
+              InjectionPoints: [{PC: "0x810680", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3350,7 +3350,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1624 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x810660", Frameless: true}]
+              InjectionPoints: [{PC: "0x810680", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3381,7 +3381,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1625 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x810660", Frameless: true}]
+              InjectionPoints: [{PC: "0x810680", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3406,7 +3406,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1626 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x810660", Frameless: true}]
+              InjectionPoints: [{PC: "0x810680", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3433,7 +3433,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1482 EventRootType Probe[main.testNilPointer]
-              InjectionPoints: [{PC: "0x80d5b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80d5d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}, {a}'
@@ -3460,7 +3460,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1595 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0x80fce0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fd00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3487,7 +3487,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1592 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0x80fcb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fcd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3522,7 +3522,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1594 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0x80fcd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fcf0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3554,7 +3554,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1610 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0x810370", Frameless: true}]
+              InjectionPoints: [{PC: "0x810390", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3576,7 +3576,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1478 EventRootType Probe[main.testPointerLoop]
-              InjectionPoints: [{PC: "0x80d4f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80d510", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3598,7 +3598,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1452 EventRootType Probe[main.testPointerToMap]
-              InjectionPoints: [{PC: "0x80bbc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bbe0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3620,7 +3620,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1476 EventRootType Probe[main.testPointerToSimpleStruct]
-              InjectionPoints: [{PC: "0x80d4d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80d4f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3644,11 +3644,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1484 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x80d8f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d918", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1485 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x80d938", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d958", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
       version: 0
@@ -3668,11 +3668,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1528 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x80e158", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e178", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1529 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x80e1dc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e1fc", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3715,11 +3715,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1494 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x80da18", Frameless: false}]
+              InjectionPoints: [{PC: "0x80da38", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1495 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x80daa4", Frameless: false}]
+              InjectionPoints: [{PC: "0x80dac4", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3759,11 +3759,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1486 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x80d8f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d918", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1487 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x80d938", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d958", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3806,11 +3806,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1496 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x80da18", Frameless: false}]
+              InjectionPoints: [{PC: "0x80da38", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1497 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x80daa4", Frameless: false}]
+              InjectionPoints: [{PC: "0x80dac4", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3852,11 +3852,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1530 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x80e158", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e178", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1531 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x80e1dc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e1fc", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
       version: 0
@@ -3873,11 +3873,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1532 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x80e158", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e178", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1533 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x80e1dc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e1fc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r0={@return.r0}
@@ -3899,11 +3899,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1488 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x80d8f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d918", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1489 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x80d938", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d958", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: result={@return}
@@ -3926,18 +3926,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1504 EventRootType Probe[main.testReturnsAny]
-              InjectionPoints: [{PC: "0x80dcd8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80dcf8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1505 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
-                - PC: "0x80dd60"
+                - PC: "0x80dd80"
                   Frameless: false
-                - PC: "0x80ddb4"
+                - PC: "0x80ddd4"
                   Frameless: false
-                - PC: "0x80de64"
+                - PC: "0x80de84"
                   Frameless: false
-                - PC: "0x80de78"
+                - PC: "0x80de98"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3965,18 +3965,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1502 EventRootType Probe[main.testReturnsAnyAndError]
-              InjectionPoints: [{PC: "0x80db68", Frameless: false}]
+              InjectionPoints: [{PC: "0x80db88", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1503 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
-                - PC: "0x80dbbc"
+                - PC: "0x80dbdc"
                   Frameless: false
-                - PC: "0x80dc18"
+                - PC: "0x80dc38"
                   Frameless: false
-                - PC: "0x80dc58"
+                - PC: "0x80dc78"
                   Frameless: false
-                - PC: "0x80dc94"
+                - PC: "0x80dcb4"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4003,11 +4003,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1547 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0x80e7ec", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e80c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1548 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0x80e838", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e858", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -4024,11 +4024,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1549 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0x80e868", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e888", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1550 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0x80e8a0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e8c0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -4045,11 +4045,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1551 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0x80e8d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e8f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1552 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0x80e90c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e92c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4066,11 +4066,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1555 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0x80e9c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e9e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1556 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0x80ea28", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ea48", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4087,11 +4087,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1567 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0x80ed18", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ed38", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1568 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0x80ed54", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ed74", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4108,11 +4108,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1543 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0x80e6a8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e6c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1544 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0x80e6f0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e710", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4130,14 +4130,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1500 EventRootType Probe[main.testReturnsError]
-              InjectionPoints: [{PC: "0x80dae8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80db08", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1501 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
-                - PC: "0x80db14"
+                - PC: "0x80db34"
                   Frameless: false
-                - PC: "0x80db28"
+                - PC: "0x80db48"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4159,11 +4159,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1490 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x80d8f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d918", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1491 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x80d938", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d958", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4184,11 +4184,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1498 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x80da18", Frameless: false}]
+              InjectionPoints: [{PC: "0x80da38", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1499 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x80daa4", Frameless: false}]
+              InjectionPoints: [{PC: "0x80dac4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4209,11 +4209,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1492 EventRootType Probe[main.testReturnsIntPointer]
-              InjectionPoints: [{PC: "0x80d978", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d998", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1493 EventRootType Probe[main.testReturnsIntPointer]Return
-              InjectionPoints: [{PC: "0x80d9d4", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d9f4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4235,14 +4235,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1506 EventRootType Probe[main.testReturnsInterface]
-              InjectionPoints: [{PC: "0x80deb8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ded8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1507 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
-                - PC: "0x80df70"
+                - PC: "0x80df90"
                   Frameless: false
-                - PC: "0x80df84"
+                - PC: "0x80dfa4"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4264,11 +4264,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1545 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0x80e730", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e750", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1546 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0x80e7ac", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e7cc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4285,11 +4285,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1541 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0x80e5f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e618", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1542 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0x80e678", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e698", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4306,11 +4306,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1559 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0x80eb28", Frameless: false}]
+              InjectionPoints: [{PC: "0x80eb48", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1560 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0x80eb7c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80eb9c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4327,11 +4327,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1553 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0x80e948", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e968", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1554 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0x80e98c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e9ac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4348,11 +4348,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1565 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0x80eca8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ecc8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1566 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0x80ece8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ed08", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
@@ -4372,7 +4372,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1538 EventRootType Probe[main.testReturnsNamedDeferLine]Line
-              InjectionPoints: [{PC: "0x80e3c0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e3e0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4393,11 +4393,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1563 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0x80ec38", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ec58", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1564 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0x80ec74", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ec94", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4414,11 +4414,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1539 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0x80e568", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e588", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1540 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0x80e5bc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e5dc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4435,11 +4435,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1561 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0x80ebbc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ebdc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1562 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0x80ec08", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ec28", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4456,11 +4456,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1557 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0x80ea60", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ea80", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1558 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0x80eaec", Frameless: false}]
+              InjectionPoints: [{PC: "0x80eb0c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4513,11 +4513,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1520 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80e098", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e0b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1521 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80e118", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e138", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -4792,7 +4792,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1602 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0x810330", Frameless: true}]
+              InjectionPoints: [{PC: "0x810350", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4924,7 +4924,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1598 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0x80fd00", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fd20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -4946,7 +4946,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1589 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0x80fc80", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fca0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -4968,7 +4968,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1450 EventRootType Probe[main.testSmallMap]
-              InjectionPoints: [{PC: "0x80bba0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bbc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -4989,11 +4989,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1534 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x80e158", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e178", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1535 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x80e1dc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e1fc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -5014,11 +5014,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1579 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0x80f578", Frameless: false}]
+              InjectionPoints: [{PC: "0x80f598", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1580 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0x80f5d0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80f5f0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5062,7 +5062,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1481 EventRootType Probe[main.testStringPointer]
-              InjectionPoints: [{PC: "0x80d590", Frameless: true}]
+              InjectionPoints: [{PC: "0x80d5b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}'
@@ -5084,7 +5084,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1593 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0x80fcc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fce0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5150,11 +5150,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1621 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x8105d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8105f0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1622 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0x8105e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x810600", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5181,7 +5181,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1590 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0x80fc90", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fcb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5229,11 +5229,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1583 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0x80f6dc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80f6fc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1584 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0x80f760", Frameless: false}]
+              InjectionPoints: [{PC: "0x80f780", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5255,11 +5255,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1617 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0x810520", Frameless: true}]
+              InjectionPoints: [{PC: "0x810540", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1618 EventRootType Probe[main.testStructWithCyclicMaps]Return
-              InjectionPoints: [{PC: "0x81052c", Frameless: true}]
+              InjectionPoints: [{PC: "0x81054c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5280,7 +5280,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1616 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0x810510", Frameless: true}]
+              InjectionPoints: [{PC: "0x810530", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5307,7 +5307,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1445 EventRootType Probe[main.testStructWithMap]
-              InjectionPoints: [{PC: "0x80bb50", Frameless: true}]
+              InjectionPoints: [{PC: "0x80bb70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s} {@duration}'
@@ -5340,7 +5340,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1599 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0x80fd10", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fd30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5380,7 +5380,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1615 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0x8103b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8103d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5413,11 +5413,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1522 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80e098", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e0b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1523 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80e118", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e138", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{nonexistentVariable}'
@@ -5438,11 +5438,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1524 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80e098", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e0b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1525 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80e118", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e138", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{unsupportedExpression}'
@@ -5465,11 +5465,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1526 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80e098", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e0b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1527 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80e118", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e138", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -5501,7 +5501,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1603 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0x810340", Frameless: true}]
+              InjectionPoints: [{PC: "0x810360", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5533,11 +5533,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1604 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x810350", Frameless: true}]
+              InjectionPoints: [{PC: "0x810370", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1605 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0x81035c", Frameless: true}]
+              InjectionPoints: [{PC: "0x81037c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5567,11 +5567,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1606 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x810350", Frameless: true}]
+              InjectionPoints: [{PC: "0x810370", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1607 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0x81035c", Frameless: true}]
+              InjectionPoints: [{PC: "0x81037c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5603,7 +5603,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1608 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x810360", Frameless: true}]
+              InjectionPoints: [{PC: "0x810380", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5633,7 +5633,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1609 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x810360", Frameless: true}]
+              InjectionPoints: [{PC: "0x810380", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5797,7 +5797,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1480 EventRootType Probe[main.testUintPointer]
-              InjectionPoints: [{PC: "0x80d520", Frameless: true}]
+              InjectionPoints: [{PC: "0x80d540", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5819,7 +5819,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1587 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0x80fc60", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fc80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5841,7 +5841,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1613 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0x810390", Frameless: true}]
+              InjectionPoints: [{PC: "0x8103b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5863,7 +5863,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1479 EventRootType Probe[main.testUnsafePointer]
-              InjectionPoints: [{PC: "0x80d500", Frameless: true}]
+              InjectionPoints: [{PC: "0x80d520", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5907,7 +5907,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1596 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x80fcf0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fd10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5929,7 +5929,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1597 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x80fcf0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fd10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5954,7 +5954,7 @@ Probes:
               InjectionPoints:
                 - PC: "0x80b398"
                   Frameless: false
-                - PC: "0x8129b8"
+                - PC: "0x8129d8"
                   Frameless: false
               Condition: null
             - Kind: Return
@@ -5981,11 +5981,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1585 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0x80f798", Frameless: false}]
+              InjectionPoints: [{PC: "0x80f7b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1586 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x80f7f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80f818", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -7066,214 +7066,188 @@ Subprograms:
       DictRegister: null
     - ID: 63
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x80bb50..0x80bb60]
+      OutOfLinePCRanges: [0x80bb70..0x80bb80]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 170 StructureType main.structWithMap
-          Locations:
-            - Range: 0x80bb50..0x80bb60
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 64
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x80bb60..0x80bb70]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 176 GoMapType map[string]main.nestedStruct
-          Locations:
-            - Range: 0x80bb60..0x80bb70
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 65
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0x80bb70..0x80bb80]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 181 GoMapType map[string]int
           Locations:
             - Range: 0x80bb70..0x80bb80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 66
-      Name: main.testMapStringToSlice
+    - ID: 64
+      Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0x80bb80..0x80bb90]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 186 GoMapType map[string][]string
+          Type: 176 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0x80bb80..0x80bb90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 67
-      Name: main.testMapArrayToArray
+    - ID: 65
+      Name: main.testMapStringToInt
       OutOfLinePCRanges: [0x80bb90..0x80bba0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 191 GoMapType map[[4]string][2]int
+          Type: 181 GoMapType map[string]int
           Locations:
             - Range: 0x80bb90..0x80bba0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 68
-      Name: main.testSmallMap
+    - ID: 66
+      Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0x80bba0..0x80bbb0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 181 GoMapType map[string]int
+          Type: 186 GoMapType map[string][]string
           Locations:
             - Range: 0x80bba0..0x80bbb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 69
-      Name: main.testArrayOfMaps
+    - ID: 67
+      Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0x80bbb0..0x80bbc0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 196 ArrayType [2]map[string]int
+          Type: 191 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0x80bbb0..0x80bbc0
-              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 70
-      Name: main.testPointerToMap
+    - ID: 68
+      Name: main.testSmallMap
       OutOfLinePCRanges: [0x80bbc0..0x80bbd0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 197 PointerType *map[string]int
+          Type: 181 GoMapType map[string]int
           Locations:
             - Range: 0x80bbc0..0x80bbd0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 71
-      Name: main.testMapIntToInt
+    - ID: 69
+      Name: main.testArrayOfMaps
       OutOfLinePCRanges: [0x80bbd0..0x80bbe0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 171 GoMapType map[int]int
+          Type: 196 ArrayType [2]map[string]int
           Locations:
             - Range: 0x80bbd0..0x80bbe0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 72
-      Name: main.testMapMassive
+    - ID: 70
+      Name: main.testPointerToMap
       OutOfLinePCRanges: [0x80bbe0..0x80bbf0]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 198 GoMapType map[string][]main.structWithMap
+        - Name: m
+          Type: 197 PointerType *map[string]int
           Locations:
             - Range: 0x80bbe0..0x80bbf0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 73
-      Name: main.testMapEmbeddedMaps
+    - ID: 71
+      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0x80bbf0..0x80bc00]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 198 GoMapType map[string][]main.structWithMap
+          Type: 171 GoMapType map[int]int
           Locations:
             - Range: 0x80bbf0..0x80bc00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 74
-      Name: main.testMapWithLinkedList
+    - ID: 72
+      Name: main.testMapMassive
       OutOfLinePCRanges: [0x80bc00..0x80bc10]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 203 GoMapType map[bool]main.node
+        - Name: redactMyEntries
+          Type: 198 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x80bc00..0x80bc10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 75
-      Name: main.testMapWithSmallValue
+    - ID: 73
+      Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0x80bc10..0x80bc20]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 208 GoMapType map[int]uint8
+          Type: 198 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x80bc10..0x80bc20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 76
-      Name: main.testMapWithSmallValueMassive
+    - ID: 74
+      Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0x80bc20..0x80bc30]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 208 GoMapType map[int]uint8
+        - Name: m
+          Type: 203 GoMapType map[bool]main.node
           Locations:
             - Range: 0x80bc20..0x80bc30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 77
-      Name: main.testMapWithSmallKeyAndValue
+    - ID: 75
+      Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0x80bc30..0x80bc40]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 213 GoMapType map[uint8]uint8
+          Type: 208 GoMapType map[int]uint8
           Locations:
             - Range: 0x80bc30..0x80bc40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 78
-      Name: main.testMapWithSmallKeyAndValueMassive
+    - ID: 76
+      Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0x80bc40..0x80bc50]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 213 GoMapType map[uint8]uint8
+        - Name: redactMyEntries
+          Type: 208 GoMapType map[int]uint8
           Locations:
             - Range: 0x80bc40..0x80bc50
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 79
-      Name: main.testMapSmallKeySmallValue
+    - ID: 77
+      Name: main.testMapWithSmallKeyAndValue
       OutOfLinePCRanges: [0x80bc50..0x80bc60]
       InlinePCRanges: []
       Variables:
@@ -7285,113 +7259,112 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 80
-      Name: main.testMapSmallKeyLargeValue
+    - ID: 78
+      Name: main.testMapWithSmallKeyAndValueMassive
       OutOfLinePCRanges: [0x80bc60..0x80bc70]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 218 GoMapType map[uint8][4]int
+          Type: 213 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x80bc60..0x80bc70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 81
-      Name: main.testMapLargeKeySmallValue
+    - ID: 79
+      Name: main.testMapSmallKeySmallValue
       OutOfLinePCRanges: [0x80bc70..0x80bc80]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 223 GoMapType map[[4]int]uint8
+          Type: 213 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x80bc70..0x80bc80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 82
-      Name: main.testMapLargeKeyLargeValue
+    - ID: 80
+      Name: main.testMapSmallKeyLargeValue
       OutOfLinePCRanges: [0x80bc80..0x80bc90]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 228 GoMapType map[[4]int][4]int
+          Type: 218 GoMapType map[uint8][4]int
           Locations:
             - Range: 0x80bc80..0x80bc90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 83
-      Name: main.testMapEmptyKey
+    - ID: 81
+      Name: main.testMapLargeKeySmallValue
       OutOfLinePCRanges: [0x80bc90..0x80bca0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 233 GoMapType map[struct {}]int
+          Type: 223 GoMapType map[[4]int]uint8
           Locations:
             - Range: 0x80bc90..0x80bca0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 84
-      Name: main.testMapEmptyValue
+    - ID: 82
+      Name: main.testMapLargeKeyLargeValue
       OutOfLinePCRanges: [0x80bca0..0x80bcb0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 238 GoMapType map[int]struct {}
+          Type: 228 GoMapType map[[4]int][4]int
           Locations:
             - Range: 0x80bca0..0x80bcb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 85
-      Name: main.testMapEmptyKeyAndValue
+    - ID: 83
+      Name: main.testMapEmptyKey
       OutOfLinePCRanges: [0x80bcb0..0x80bcc0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 243 GoMapType map[struct {}]struct {}
+          Type: 233 GoMapType map[struct {}]int
           Locations:
             - Range: 0x80bcb0..0x80bcc0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 86
-      Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x80d080..0x80d090]
+    - ID: 84
+      Name: main.testMapEmptyValue
+      OutOfLinePCRanges: [0x80bcc0..0x80bcd0]
       InlinePCRanges: []
       Variables:
-        - Name: w
-          Type: 4 BaseType uint8
+        - Name: m
+          Type: 238 GoMapType map[int]struct {}
           Locations:
-            - Range: 0x80d080..0x80d090
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: x
-          Type: 4 BaseType uint8
-          Locations:
-            - Range: 0x80d080..0x80d090
-              Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: "y"
-          Type: 19 BaseType float32
-          Locations:
-            - Range: 0x80d080..0x80d090
-              Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
+            - Range: 0x80bcc0..0x80bcd0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 87
-      Name: main.testCombinedString
+    - ID: 85
+      Name: main.testMapEmptyKeyAndValue
+      OutOfLinePCRanges: [0x80bcd0..0x80bce0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 243 GoMapType map[struct {}]struct {}
+          Locations:
+            - Range: 0x80bcd0..0x80bce0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 86
+      Name: main.testCombinedByte
       OutOfLinePCRanges: [0x80d0a0..0x80d0b0]
       InlinePCRanges: []
       Variables:
@@ -7403,14 +7376,10 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
         - Name: x
-          Type: 10 GoStringHeaderType string
+          Type: 4 BaseType uint8
           Locations:
             - Range: 0x80d0a0..0x80d0b0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
+              Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: "y"
@@ -7421,43 +7390,74 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 87
+      Name: main.testCombinedString
+      OutOfLinePCRanges: [0x80d0c0..0x80d0d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: w
+          Type: 4 BaseType uint8
+          Locations:
+            - Range: 0x80d0c0..0x80d0d0
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: x
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0x80d0c0..0x80d0d0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: "y"
+          Type: 19 BaseType float32
+          Locations:
+            - Range: 0x80d0c0..0x80d0d0
+              Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 88
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x80d160..0x80d170]
+      OutOfLinePCRanges: [0x80d180..0x80d190]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x80d160..0x80d170
+            - Range: 0x80d180..0x80d190
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x80d160..0x80d170
+            - Range: 0x80d180..0x80d190
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x80d160..0x80d170
+            - Range: 0x80d180..0x80d190
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 11 BaseType uint
           Locations:
-            - Range: 0x80d160..0x80d170
+            - Range: 0x80d180..0x80d190
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80d160..0x80d170
+            - Range: 0x80d180..0x80d190
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7468,63 +7468,63 @@ Subprograms:
       DictRegister: null
     - ID: 89
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0x80d300..0x80d340]
+      OutOfLinePCRanges: [0x80d320..0x80d360]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0x80d300..0x80d33c
+            - Range: 0x80d320..0x80d35c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0x80d300..0x80d33c
+            - Range: 0x80d320..0x80d35c
               Pieces: []
-            - Range: 0x80d33c..0x80d33d
+            - Range: 0x80d35c..0x80d35d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d33d..0x80d340
+            - Range: 0x80d35d..0x80d360
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 90
       Name: main.testChannel
-      OutOfLinePCRanges: [0x80d340..0x80d350]
+      OutOfLinePCRanges: [0x80d360..0x80d370]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 248 GoChannelType chan bool
           Locations:
-            - Range: 0x80d340..0x80d350
+            - Range: 0x80d360..0x80d370
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 91
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x80d4d0..0x80d4e0]
+      OutOfLinePCRanges: [0x80d4f0..0x80d500]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 249 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x80d4d0..0x80d4e0
+            - Range: 0x80d4f0..0x80d500
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 92
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x80d4e0..0x80d4f0]
+      OutOfLinePCRanges: [0x80d500..0x80d510]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 251 StructureType main.node
           Locations:
-            - Range: 0x80d4e0..0x80d4f0
+            - Range: 0x80d500..0x80d510
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7535,267 +7535,267 @@ Subprograms:
       DictRegister: null
     - ID: 93
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x80d4f0..0x80d500]
+      OutOfLinePCRanges: [0x80d510..0x80d520]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 252 PointerType *main.node
           Locations:
-            - Range: 0x80d4f0..0x80d500
+            - Range: 0x80d510..0x80d520
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 94
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x80d500..0x80d510]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 16 VoidPointerType unsafe.Pointer
-          Locations:
-            - Range: 0x80d500..0x80d510
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 95
-      Name: main.testUintPointer
       OutOfLinePCRanges: [0x80d520..0x80d530]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 108 PointerType *uint
+          Type: 16 VoidPointerType unsafe.Pointer
           Locations:
             - Range: 0x80d520..0x80d530
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 95
+      Name: main.testUintPointer
+      OutOfLinePCRanges: [0x80d540..0x80d550]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 108 PointerType *uint
+          Locations:
+            - Range: 0x80d540..0x80d550
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 96
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x80d590..0x80d5a0]
+      OutOfLinePCRanges: [0x80d5b0..0x80d5c0]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 96 PointerType *string
           Locations:
-            - Range: 0x80d590..0x80d5a0
+            - Range: 0x80d5b0..0x80d5c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 97
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x80d5b0..0x80d5c0]
+      OutOfLinePCRanges: [0x80d5d0..0x80d5e0]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 12 PointerType *bool
           Locations:
-            - Range: 0x80d5b0..0x80d5c0
+            - Range: 0x80d5d0..0x80d5e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 11 BaseType uint
           Locations:
-            - Range: 0x80d5b0..0x80d5c0
+            - Range: 0x80d5d0..0x80d5e0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 98
       Name: main.testCycle
-      OutOfLinePCRanges: [0x80d5d0..0x80d5e0]
+      OutOfLinePCRanges: [0x80d5f0..0x80d600]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 253 PointerType *main.t
           Locations:
-            - Range: 0x80d5d0..0x80d5e0
+            - Range: 0x80d5f0..0x80d600
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 99
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0x80d8e0..0x80d960]
+      OutOfLinePCRanges: [0x80d900..0x80d980]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80d8e0..0x80d8fc
+            - Range: 0x80d900..0x80d91c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80d8e0..0x80d938
+            - Range: 0x80d900..0x80d958
               Pieces: []
-            - Range: 0x80d938..0x80d939
+            - Range: 0x80d958..0x80d959
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d939..0x80d960
+            - Range: 0x80d959..0x80d980
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80d8fc..0x80d908
+            - Range: 0x80d91c..0x80d928
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d908..0x80d960
+            - Range: 0x80d928..0x80d980
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 100
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0x80d960..0x80da00]
+      OutOfLinePCRanges: [0x80d980..0x80da20]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80d960..0x80d984
+            - Range: 0x80d980..0x80d9a4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d984..0x80da00
+            - Range: 0x80d9a4..0x80da20
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 101 PointerType *int
           Locations:
-            - Range: 0x80d960..0x80d9d4
+            - Range: 0x80d980..0x80d9f4
               Pieces: []
-            - Range: 0x80d9d4..0x80d9d5
+            - Range: 0x80d9f4..0x80d9f5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d9d5..0x80da00
+            - Range: 0x80d9f5..0x80da20
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: '&result'
           Type: 101 PointerType *int
           Locations:
-            - Range: 0x80d988..0x80d9a0
+            - Range: 0x80d9a8..0x80d9c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d9a0..0x80da00
+            - Range: 0x80d9c0..0x80da20
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 101
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0x80da00..0x80dad0]
+      OutOfLinePCRanges: [0x80da20..0x80daf0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80da00..0x80da54
+            - Range: 0x80da20..0x80da74
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80da00..0x80daa4
+            - Range: 0x80da20..0x80dac4
               Pieces: []
-            - Range: 0x80daa4..0x80daa5
+            - Range: 0x80dac4..0x80dac5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80daa5..0x80dad0
+            - Range: 0x80dac5..0x80daf0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80da00..0x80dad0, Pieces: []}]
+          Locations: [{Range: 0x80da20..0x80daf0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: resultInt
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80da1c..0x80da58
+            - Range: 0x80da3c..0x80da78
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80da58..0x80dad0
+            - Range: 0x80da78..0x80daf0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: -1
         - Name: resultFloat
           Type: 17 BaseType float64
           Locations:
-            - Range: 0x80da2c..0x80da58
+            - Range: 0x80da4c..0x80da78
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-            - Range: 0x80da58..0x80dad0
+            - Range: 0x80da78..0x80daf0
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 102
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0x80dad0..0x80db50]
+      OutOfLinePCRanges: [0x80daf0..0x80db70]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x80dad0..0x80daf4
+            - Range: 0x80daf0..0x80db14
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0x80dad0..0x80db14
+            - Range: 0x80daf0..0x80db34
               Pieces: []
-            - Range: 0x80db14..0x80db15
+            - Range: 0x80db34..0x80db35
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80db15..0x80db28
+            - Range: 0x80db35..0x80db48
               Pieces: []
-            - Range: 0x80db28..0x80db29
+            - Range: 0x80db48..0x80db49
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80db29..0x80db50
+            - Range: 0x80db49..0x80db70
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 103
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0x80db50..0x80dcc0]
+      OutOfLinePCRanges: [0x80db70..0x80dce0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 162 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80db50..0x80dba0
+            - Range: 0x80db70..0x80dbc0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80dba0..0x80dba4
+            - Range: 0x80dbc0..0x80dbc4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x80dc2c..0x80dc30
+            - Range: 0x80dc4c..0x80dc50
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80dc6c..0x80dc70
+            - Range: 0x80dc8c..0x80dc90
               Pieces:
                 - Size: 8
                   Op: null
@@ -7806,117 +7806,117 @@ Subprograms:
         - Name: failed
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x80db50..0x80db94
+            - Range: 0x80db70..0x80dbb4
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 162 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80db50..0x80dbbc
+            - Range: 0x80db70..0x80dbdc
               Pieces: []
-            - Range: 0x80dbbc..0x80dbbd
+            - Range: 0x80dbdc..0x80dbdd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80dbbd..0x80dc18
+            - Range: 0x80dbdd..0x80dc38
               Pieces: []
-            - Range: 0x80dc18..0x80dc19
+            - Range: 0x80dc38..0x80dc39
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80dc19..0x80dc58
+            - Range: 0x80dc39..0x80dc78
               Pieces: []
-            - Range: 0x80dc58..0x80dc59
+            - Range: 0x80dc78..0x80dc79
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80dc59..0x80dc94
+            - Range: 0x80dc79..0x80dcb4
               Pieces: []
-            - Range: 0x80dc94..0x80dc95
+            - Range: 0x80dcb4..0x80dcb5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80dc95..0x80dcc0
+            - Range: 0x80dcb5..0x80dce0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0x80db50..0x80dbbc
+            - Range: 0x80db70..0x80dbdc
               Pieces: []
-            - Range: 0x80dbbc..0x80dbbd
+            - Range: 0x80dbdc..0x80dbdd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80dbbd..0x80dc18
+            - Range: 0x80dbdd..0x80dc38
               Pieces: []
-            - Range: 0x80dc18..0x80dc19
+            - Range: 0x80dc38..0x80dc39
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80dc19..0x80dc58
+            - Range: 0x80dc39..0x80dc78
               Pieces: []
-            - Range: 0x80dc58..0x80dc59
+            - Range: 0x80dc78..0x80dc79
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80dc59..0x80dc94
+            - Range: 0x80dc79..0x80dcb4
               Pieces: []
-            - Range: 0x80dc94..0x80dc95
+            - Range: 0x80dcb4..0x80dcb5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80dc95..0x80dcc0
+            - Range: 0x80dcb5..0x80dce0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80dba0..0x80dba8
+            - Range: 0x80dbc0..0x80dbc8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 104
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0x80dcc0..0x80dea0]
+      OutOfLinePCRanges: [0x80dce0..0x80dec0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 162 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80dcc0..0x80dd00
+            - Range: 0x80dce0..0x80dd20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80dd00..0x80dd08
+            - Range: 0x80dd20..0x80dd28
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80dd08..0x80dea0
+            - Range: 0x80dd28..0x80dec0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -7927,549 +7927,549 @@ Subprograms:
         - Name: ~r0
           Type: 162 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80dcc0..0x80dd60
+            - Range: 0x80dce0..0x80dd80
               Pieces: []
-            - Range: 0x80dd60..0x80dd61
+            - Range: 0x80dd80..0x80dd81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80dd61..0x80ddb4
+            - Range: 0x80dd81..0x80ddd4
               Pieces: []
-            - Range: 0x80ddb4..0x80ddb5
+            - Range: 0x80ddd4..0x80ddd5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80ddb5..0x80de64
+            - Range: 0x80ddd5..0x80de84
               Pieces: []
-            - Range: 0x80de64..0x80de65
+            - Range: 0x80de84..0x80de85
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80de65..0x80de78
+            - Range: 0x80de85..0x80de98
               Pieces: []
-            - Range: 0x80de78..0x80de79
+            - Range: 0x80de98..0x80de99
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80de79..0x80dea0
+            - Range: 0x80de99..0x80dec0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80dd4c..0x80dd54
+            - Range: 0x80dd6c..0x80dd74
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: '&result'
           Type: 101 PointerType *int
           Locations:
-            - Range: 0x80dd98..0x80ddb4
+            - Range: 0x80ddb8..0x80ddd4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 105
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0x80dea0..0x80dff0]
+      OutOfLinePCRanges: [0x80dec0..0x80e010]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 162 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80dea0..0x80dedc
+            - Range: 0x80dec0..0x80defc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80dedc..0x80df1c
+            - Range: 0x80defc..0x80df3c
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x80df1c..0x80df90
+            - Range: 0x80df3c..0x80dfb0
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x80df90..0x80dfb8
+            - Range: 0x80dfb0..0x80dfd8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80dfb8..0x80dfbc
+            - Range: 0x80dfd8..0x80dfdc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80dfbc..0x80dff0
+            - Range: 0x80dfdc..0x80e010
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 167 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x80dea0..0x80df70
+            - Range: 0x80dec0..0x80df90
               Pieces: []
-            - Range: 0x80df70..0x80df71
+            - Range: 0x80df90..0x80df91
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80df71..0x80df84
+            - Range: 0x80df91..0x80dfa4
               Pieces: []
-            - Range: 0x80df84..0x80df85
+            - Range: 0x80dfa4..0x80dfa5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80df85..0x80dff0
+            - Range: 0x80dfa5..0x80e010
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 167 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x80dea0..0x80dedc
+            - Range: 0x80dec0..0x80defc
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80dedc..0x80df1c
+            - Range: 0x80defc..0x80df3c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80df1c..0x80df24
+            - Range: 0x80df3c..0x80df44
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80df24..0x80df7c
+            - Range: 0x80df44..0x80df9c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80df7c..0x80df80
+            - Range: 0x80df9c..0x80dfa0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80df80..0x80df84
+            - Range: 0x80dfa0..0x80dfa4
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x80df84..0x80dff0
+            - Range: 0x80dfa4..0x80e010
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 106
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0x80dff0..0x80e080]
+      OutOfLinePCRanges: [0x80e010..0x80e0a0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80dff0..0x80e00c
+            - Range: 0x80e010..0x80e02c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80dff0..0x80e060
+            - Range: 0x80e010..0x80e080
               Pieces: []
-            - Range: 0x80e060..0x80e061
+            - Range: 0x80e080..0x80e081
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e061..0x80e080
+            - Range: 0x80e081..0x80e0a0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 107
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0x80e080..0x80e140]
+      OutOfLinePCRanges: [0x80e0a0..0x80e160]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80e080..0x80e0cc
+            - Range: 0x80e0a0..0x80e0ec
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80e080..0x80e118
+            - Range: 0x80e0a0..0x80e138
               Pieces: []
-            - Range: 0x80e118..0x80e119
+            - Range: 0x80e138..0x80e139
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e119..0x80e140
+            - Range: 0x80e139..0x80e160
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80e080..0x80e118
+            - Range: 0x80e0a0..0x80e138
               Pieces: []
-            - Range: 0x80e118..0x80e119
+            - Range: 0x80e138..0x80e139
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80e119..0x80e140
+            - Range: 0x80e139..0x80e160
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 108
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0x80e140..0x80e200]
+      OutOfLinePCRanges: [0x80e160..0x80e220]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80e140..0x80e17c
+            - Range: 0x80e160..0x80e19c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e17c..0x80e200
+            - Range: 0x80e19c..0x80e220
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80e140..0x80e1dc
+            - Range: 0x80e160..0x80e1fc
               Pieces: []
-            - Range: 0x80e1dc..0x80e1dd
+            - Range: 0x80e1fc..0x80e1fd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e1dd..0x80e200
+            - Range: 0x80e1fd..0x80e220
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80e140..0x80e1dc
+            - Range: 0x80e160..0x80e1fc
               Pieces: []
-            - Range: 0x80e1dc..0x80e1dd
+            - Range: 0x80e1fc..0x80e1fd
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80e1dd..0x80e200
+            - Range: 0x80e1fd..0x80e220
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80e140..0x80e1dc
+            - Range: 0x80e160..0x80e1fc
               Pieces: []
-            - Range: 0x80e1dc..0x80e1dd
+            - Range: 0x80e1fc..0x80e1fd
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80e1dd..0x80e200
+            - Range: 0x80e1fd..0x80e220
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 109
       Name: main.testConflictingReturn
-      OutOfLinePCRanges: [0x80e200..0x80e2e0]
+      OutOfLinePCRanges: [0x80e220..0x80e300]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80e200..0x80e23c
+            - Range: 0x80e220..0x80e25c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e23c..0x80e2e0
+            - Range: 0x80e25c..0x80e300
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80e200..0x80e2b8
+            - Range: 0x80e220..0x80e2d8
               Pieces: []
-            - Range: 0x80e2b8..0x80e2b9
+            - Range: 0x80e2d8..0x80e2d9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e2b9..0x80e2e0
+            - Range: 0x80e2d9..0x80e300
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80e200..0x80e2b8
+            - Range: 0x80e220..0x80e2d8
               Pieces: []
-            - Range: 0x80e2b8..0x80e2b9
+            - Range: 0x80e2d8..0x80e2d9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80e2b9..0x80e2e0
+            - Range: 0x80e2d9..0x80e300
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 110
       Name: main.testReturnsNamedDeferLine
-      OutOfLinePCRanges: [0x80e2e0..0x80e490]
+      OutOfLinePCRanges: [0x80e300..0x80e4b0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80e2e0..0x80e348
+            - Range: 0x80e300..0x80e368
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e348..0x80e490
+            - Range: 0x80e368..0x80e4b0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80e30c..0x80e490
+            - Range: 0x80e32c..0x80e4b0
               Pieces: [{Size: 16, Op: {CfaOffset: -120}}]
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80e310..0x80e490
+            - Range: 0x80e330..0x80e4b0
               Pieces: [{Size: 16, Op: {CfaOffset: -136}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 111
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0x80e550..0x80e5e0]
+      OutOfLinePCRanges: [0x80e570..0x80e600]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType int8
           Locations:
-            - Range: 0x80e550..0x80e5bc
+            - Range: 0x80e570..0x80e5dc
               Pieces: []
-            - Range: 0x80e5bc..0x80e5bd
+            - Range: 0x80e5dc..0x80e5dd
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e5bd..0x80e5e0
+            - Range: 0x80e5dd..0x80e600
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 97 BaseType int16
           Locations:
-            - Range: 0x80e550..0x80e5bc
+            - Range: 0x80e570..0x80e5dc
               Pieces: []
-            - Range: 0x80e5bc..0x80e5bd
+            - Range: 0x80e5dc..0x80e5dd
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80e5bd..0x80e5e0
+            - Range: 0x80e5dd..0x80e600
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x80e550..0x80e5bc
+            - Range: 0x80e570..0x80e5dc
               Pieces: []
-            - Range: 0x80e5bc..0x80e5bd
+            - Range: 0x80e5dc..0x80e5dd
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80e5bd..0x80e5e0
+            - Range: 0x80e5dd..0x80e600
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 14 BaseType int64
           Locations:
-            - Range: 0x80e550..0x80e5bc
+            - Range: 0x80e570..0x80e5dc
               Pieces: []
-            - Range: 0x80e5bc..0x80e5bd
+            - Range: 0x80e5dc..0x80e5dd
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80e5bd..0x80e5e0
+            - Range: 0x80e5dd..0x80e600
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x80e550..0x80e5bc
+            - Range: 0x80e570..0x80e5dc
               Pieces: []
-            - Range: 0x80e5bc..0x80e5bd
+            - Range: 0x80e5dc..0x80e5dd
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80e5bd..0x80e5e0
+            - Range: 0x80e5dd..0x80e600
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 7 BaseType uint16
           Locations:
-            - Range: 0x80e550..0x80e5bc
+            - Range: 0x80e570..0x80e5dc
               Pieces: []
-            - Range: 0x80e5bc..0x80e5bd
+            - Range: 0x80e5dc..0x80e5dd
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80e5bd..0x80e5e0
+            - Range: 0x80e5dd..0x80e600
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 3 BaseType uint32
           Locations:
-            - Range: 0x80e550..0x80e5bc
+            - Range: 0x80e570..0x80e5dc
               Pieces: []
-            - Range: 0x80e5bc..0x80e5bd
+            - Range: 0x80e5dc..0x80e5dd
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80e5bd..0x80e5e0
+            - Range: 0x80e5dd..0x80e600
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0x80e550..0x80e5bc
+            - Range: 0x80e570..0x80e5dc
               Pieces: []
-            - Range: 0x80e5bc..0x80e5bd
+            - Range: 0x80e5dc..0x80e5dd
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80e5bd..0x80e5e0
+            - Range: 0x80e5dd..0x80e600
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 112
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0x80e5e0..0x80e690]
+      OutOfLinePCRanges: [0x80e600..0x80e6b0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80e5e0..0x80e690, Pieces: []}]
+          Locations: [{Range: 0x80e600..0x80e6b0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80e5e0..0x80e690, Pieces: []}]
+          Locations: [{Range: 0x80e600..0x80e6b0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80e5e0..0x80e690, Pieces: []}]
+          Locations: [{Range: 0x80e600..0x80e6b0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80e5e0..0x80e690, Pieces: []}]
+          Locations: [{Range: 0x80e600..0x80e6b0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80e5e0..0x80e690, Pieces: []}]
+          Locations: [{Range: 0x80e600..0x80e6b0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80e5e0..0x80e690, Pieces: []}]
+          Locations: [{Range: 0x80e600..0x80e6b0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80e5e0..0x80e690, Pieces: []}]
+          Locations: [{Range: 0x80e600..0x80e6b0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80e5e0..0x80e690, Pieces: []}]
+          Locations: [{Range: 0x80e600..0x80e6b0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80e5e0..0x80e690, Pieces: []}]
+          Locations: [{Range: 0x80e600..0x80e6b0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r9
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80e5e0..0x80e690, Pieces: []}]
+          Locations: [{Range: 0x80e600..0x80e6b0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r10
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80e5e0..0x80e690, Pieces: []}]
+          Locations: [{Range: 0x80e600..0x80e6b0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r11
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80e5e0..0x80e690, Pieces: []}]
+          Locations: [{Range: 0x80e600..0x80e6b0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r12
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80e5e0..0x80e690, Pieces: []}]
+          Locations: [{Range: 0x80e600..0x80e6b0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r13
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80e5e0..0x80e690, Pieces: []}]
+          Locations: [{Range: 0x80e600..0x80e6b0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r14
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80e5e0..0x80e690, Pieces: []}]
+          Locations: [{Range: 0x80e600..0x80e6b0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: onlyOnAmd64_16
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80e5e0..0x80e690, Pieces: []}]
+          Locations: [{Range: 0x80e600..0x80e6b0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: bothArmAndAmd64
           Type: 17 BaseType float64
           Locations:
-            - Range: 0x80e5e0..0x80e678
+            - Range: 0x80e600..0x80e698
               Pieces: []
-            - Range: 0x80e678..0x80e679
+            - Range: 0x80e698..0x80e699
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x80e679..0x80e690
+            - Range: 0x80e699..0x80e6b0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 113
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0x80e690..0x80e710]
+      OutOfLinePCRanges: [0x80e6b0..0x80e730]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 98 BaseType complex64
-          Locations: [{Range: 0x80e690..0x80e710, Pieces: []}]
+          Locations: [{Range: 0x80e6b0..0x80e730, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 99 BaseType complex128
-          Locations: [{Range: 0x80e690..0x80e710, Pieces: []}]
+          Locations: [{Range: 0x80e6b0..0x80e730, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 114
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0x80e710..0x80e7d0]
+      OutOfLinePCRanges: [0x80e730..0x80e7f0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 255 StructureType main.largeStruct
           Locations:
-            - Range: 0x80e710..0x80e7ac
+            - Range: 0x80e730..0x80e7cc
               Pieces: []
-            - Range: 0x80e7ac..0x80e7ad
+            - Range: 0x80e7cc..0x80e7cd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8491,193 +8491,193 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80e7ad..0x80e7d0
+            - Range: 0x80e7cd..0x80e7f0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 115
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0x80e7d0..0x80e850]
+      OutOfLinePCRanges: [0x80e7f0..0x80e870]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 256 ArrayType [3]int
           Locations:
-            - Range: 0x80e7d0..0x80e838
+            - Range: 0x80e7f0..0x80e858
               Pieces: []
-            - Range: 0x80e838..0x80e839
+            - Range: 0x80e858..0x80e859
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x80e839..0x80e850
+            - Range: 0x80e859..0x80e870
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 116
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0x80e850..0x80e8c0]
+      OutOfLinePCRanges: [0x80e870..0x80e8e0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 257 ArrayType [1]int
           Locations:
-            - Range: 0x80e850..0x80e8a0
+            - Range: 0x80e870..0x80e8c0
               Pieces: []
-            - Range: 0x80e8a0..0x80e8a1
+            - Range: 0x80e8c0..0x80e8c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e8a1..0x80e8c0
+            - Range: 0x80e8c1..0x80e8e0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 117
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0x80e8c0..0x80e930]
+      OutOfLinePCRanges: [0x80e8e0..0x80e950]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 258 ArrayType [0]int
           Locations:
-            - Range: 0x80e8c0..0x80e90c
+            - Range: 0x80e8e0..0x80e92c
               Pieces: []
-            - Range: 0x80e90c..0x80e90d
+            - Range: 0x80e92c..0x80e92d
               Pieces: []
-            - Range: 0x80e90d..0x80e930
+            - Range: 0x80e92d..0x80e950
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 118
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0x80e930..0x80e9b0]
+      OutOfLinePCRanges: [0x80e950..0x80e9d0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 259 StructureType main.mixedStruct
-          Locations: [{Range: 0x80e930..0x80e9b0, Pieces: []}]
+          Locations: [{Range: 0x80e950..0x80e9d0, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 119
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0x80e9b0..0x80ea40]
+      OutOfLinePCRanges: [0x80e9d0..0x80ea60]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80e9b0..0x80ea28
+            - Range: 0x80e9d0..0x80ea48
               Pieces: []
-            - Range: 0x80ea28..0x80ea29
+            - Range: 0x80ea48..0x80ea49
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ea29..0x80ea40
+            - Range: 0x80ea49..0x80ea60
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80e9b0..0x80ea28
+            - Range: 0x80e9d0..0x80ea48
               Pieces: []
-            - Range: 0x80ea28..0x80ea29
+            - Range: 0x80ea48..0x80ea49
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80ea29..0x80ea40
+            - Range: 0x80ea49..0x80ea60
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80e9b0..0x80ea28
+            - Range: 0x80e9d0..0x80ea48
               Pieces: []
-            - Range: 0x80ea28..0x80ea29
+            - Range: 0x80ea48..0x80ea49
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80ea29..0x80ea40
+            - Range: 0x80ea49..0x80ea60
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80e9b0..0x80ea28
+            - Range: 0x80e9d0..0x80ea48
               Pieces: []
-            - Range: 0x80ea28..0x80ea29
+            - Range: 0x80ea48..0x80ea49
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80ea29..0x80ea40
+            - Range: 0x80ea49..0x80ea60
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80e9b0..0x80ea28
+            - Range: 0x80e9d0..0x80ea48
               Pieces: []
-            - Range: 0x80ea28..0x80ea29
+            - Range: 0x80ea48..0x80ea49
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80ea29..0x80ea40
+            - Range: 0x80ea49..0x80ea60
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80e9b0..0x80ea28
+            - Range: 0x80e9d0..0x80ea48
               Pieces: []
-            - Range: 0x80ea28..0x80ea29
+            - Range: 0x80ea48..0x80ea49
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80ea29..0x80ea40
+            - Range: 0x80ea49..0x80ea60
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80e9b0..0x80ea28
+            - Range: 0x80e9d0..0x80ea48
               Pieces: []
-            - Range: 0x80ea28..0x80ea29
+            - Range: 0x80ea48..0x80ea49
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80ea29..0x80ea40
+            - Range: 0x80ea49..0x80ea60
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80e9b0..0x80ea28
+            - Range: 0x80e9d0..0x80ea48
               Pieces: []
-            - Range: 0x80ea28..0x80ea29
+            - Range: 0x80ea48..0x80ea49
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80ea29..0x80ea40
+            - Range: 0x80ea49..0x80ea60
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80e9b0..0x80ea28
+            - Range: 0x80e9d0..0x80ea48
               Pieces: []
-            - Range: 0x80ea28..0x80ea29
+            - Range: 0x80ea48..0x80ea49
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80ea29..0x80ea40
+            - Range: 0x80ea49..0x80ea60
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 120
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0x80ea40..0x80eb10]
+      OutOfLinePCRanges: [0x80ea60..0x80eb30]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 260 StructureType main.wideStruct
           Locations:
-            - Range: 0x80ea40..0x80eaec
+            - Range: 0x80ea60..0x80eb0c
               Pieces: []
-            - Range: 0x80eaec..0x80eaed
+            - Range: 0x80eb0c..0x80eb0d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8701,145 +8701,145 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0x80eaed..0x80eb10
+            - Range: 0x80eb0d..0x80eb30
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 121
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0x80eb10..0x80eba0]
+      OutOfLinePCRanges: [0x80eb30..0x80ebc0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80eb10..0x80eb7c
+            - Range: 0x80eb30..0x80eb9c
               Pieces: []
-            - Range: 0x80eb7c..0x80eb7d
+            - Range: 0x80eb9c..0x80eb9d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80eb7d..0x80eba0
+            - Range: 0x80eb9d..0x80ebc0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80eb10..0x80eba0, Pieces: []}]
+          Locations: [{Range: 0x80eb30..0x80ebc0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80eb10..0x80eb7c
+            - Range: 0x80eb30..0x80eb9c
               Pieces: []
-            - Range: 0x80eb7c..0x80eb7d
+            - Range: 0x80eb9c..0x80eb9d
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80eb7d..0x80eba0
+            - Range: 0x80eb9d..0x80ebc0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80eb10..0x80eba0, Pieces: []}]
+          Locations: [{Range: 0x80eb30..0x80ebc0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80eb10..0x80eb7c
+            - Range: 0x80eb30..0x80eb9c
               Pieces: []
-            - Range: 0x80eb7c..0x80eb7d
+            - Range: 0x80eb9c..0x80eb9d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80eb7d..0x80eba0
+            - Range: 0x80eb9d..0x80ebc0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 122
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0x80eba0..0x80ec20]
+      OutOfLinePCRanges: [0x80ebc0..0x80ec40]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 261 StructureType main.structWithArray
           Locations:
-            - Range: 0x80eba0..0x80ec08
+            - Range: 0x80ebc0..0x80ec28
               Pieces: []
-            - Range: 0x80ec08..0x80ec09
+            - Range: 0x80ec28..0x80ec29
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x80ec09..0x80ec20
+            - Range: 0x80ec29..0x80ec40
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 123
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0x80ec20..0x80ec90]
+      OutOfLinePCRanges: [0x80ec40..0x80ecb0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80ec20..0x80ec90, Pieces: []}]
+          Locations: [{Range: 0x80ec40..0x80ecb0, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 124
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0x80ec90..0x80ed00]
+      OutOfLinePCRanges: [0x80ecb0..0x80ed20]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 19 BaseType float32
-          Locations: [{Range: 0x80ec90..0x80ed00, Pieces: []}]
+          Locations: [{Range: 0x80ecb0..0x80ed20, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0x80ec90..0x80ed00, Pieces: []}]
+          Locations: [{Range: 0x80ecb0..0x80ed20, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 125
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0x80ed00..0x80ed70]
+      OutOfLinePCRanges: [0x80ed20..0x80ed90]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x80ed00..0x80ed54
+            - Range: 0x80ed20..0x80ed74
               Pieces: []
-            - Range: 0x80ed54..0x80ed55
+            - Range: 0x80ed74..0x80ed75
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ed55..0x80ed70
+            - Range: 0x80ed75..0x80ed90
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 2 BaseType uintptr
           Locations:
-            - Range: 0x80ed00..0x80ed54
+            - Range: 0x80ed20..0x80ed74
               Pieces: []
-            - Range: 0x80ed54..0x80ed55
+            - Range: 0x80ed74..0x80ed75
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80ed55..0x80ed70
+            - Range: 0x80ed75..0x80ed90
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 126
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0x80ed70..0x80ef00]
+      OutOfLinePCRanges: [0x80ed90..0x80ef20]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 255 StructureType main.largeStruct
           Locations:
-            - Range: 0x80ed70..0x80edc8
+            - Range: 0x80ed90..0x80ede8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8861,7 +8861,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80edc8..0x80edd0
+            - Range: 0x80ede8..0x80edf0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8883,7 +8883,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80edd0..0x80edd8
+            - Range: 0x80edf0..0x80edf8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8905,7 +8905,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80edd8..0x80eddc
+            - Range: 0x80edf8..0x80edfc
               Pieces:
                 - Size: 8
                   Op: null
@@ -8932,9 +8932,9 @@ Subprograms:
         - Name: ~r0
           Type: 255 StructureType main.largeStruct
           Locations:
-            - Range: 0x80ed70..0x80eeb8
+            - Range: 0x80ed90..0x80eed8
               Pieces: []
-            - Range: 0x80eeb8..0x80eeb9
+            - Range: 0x80eed8..0x80eed9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8956,44 +8956,44 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80eeb9..0x80ef00
+            - Range: 0x80eed9..0x80ef20
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 127
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0x80ef00..0x80efc0]
+      OutOfLinePCRanges: [0x80ef20..0x80efe0]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 256 ArrayType [3]int
           Locations:
-            - Range: 0x80ef00..0x80efc0
+            - Range: 0x80ef20..0x80efe0
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 256 ArrayType [3]int
           Locations:
-            - Range: 0x80ef00..0x80efa8
+            - Range: 0x80ef20..0x80efc8
               Pieces: []
-            - Range: 0x80efa8..0x80efa9
+            - Range: 0x80efc8..0x80efc9
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x80efa9..0x80efc0
+            - Range: 0x80efc9..0x80efe0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 128
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0x80efc0..0x80f1d0]
+      OutOfLinePCRanges: [0x80efe0..0x80f1f0]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 255 StructureType main.largeStruct
           Locations:
-            - Range: 0x80efc0..0x80f01c
+            - Range: 0x80efe0..0x80f03c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9015,7 +9015,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80f01c..0x80f024
+            - Range: 0x80f03c..0x80f044
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9037,7 +9037,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80f024..0x80f02c
+            - Range: 0x80f044..0x80f04c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9059,7 +9059,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80f02c..0x80f030
+            - Range: 0x80f04c..0x80f050
               Pieces:
                 - Size: 8
                   Op: null
@@ -9086,16 +9086,16 @@ Subprograms:
         - Name: s2
           Type: 255 StructureType main.largeStruct
           Locations:
-            - Range: 0x80efc0..0x80f1d0
+            - Range: 0x80efe0..0x80f1f0
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 255 StructureType main.largeStruct
           Locations:
-            - Range: 0x80efc0..0x80f184
+            - Range: 0x80efe0..0x80f1a4
               Pieces: []
-            - Range: 0x80f184..0x80f185
+            - Range: 0x80f1a4..0x80f1a5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9117,196 +9117,196 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80f185..0x80f1d0
+            - Range: 0x80f1a5..0x80f1f0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 129
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0x80f1d0..0x80f370]
+      OutOfLinePCRanges: [0x80f1f0..0x80f390]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f1d0..0x80f244
+            - Range: 0x80f1f0..0x80f264
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80f244..0x80f370
+            - Range: 0x80f264..0x80f390
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f1d0..0x80f234
+            - Range: 0x80f1f0..0x80f254
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80f234..0x80f370
+            - Range: 0x80f254..0x80f390
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f1d0..0x80f23c
+            - Range: 0x80f1f0..0x80f25c
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80f23c..0x80f370
+            - Range: 0x80f25c..0x80f390
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f1d0..0x80f244
+            - Range: 0x80f1f0..0x80f264
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80f244..0x80f370
+            - Range: 0x80f264..0x80f390
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f1d0..0x80f244
+            - Range: 0x80f1f0..0x80f264
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80f244..0x80f370
+            - Range: 0x80f264..0x80f390
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f1d0..0x80f244
+            - Range: 0x80f1f0..0x80f264
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80f244..0x80f370
+            - Range: 0x80f264..0x80f390
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f1d0..0x80f244
+            - Range: 0x80f1f0..0x80f264
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80f244..0x80f370
+            - Range: 0x80f264..0x80f390
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f1d0..0x80f244
+            - Range: 0x80f1f0..0x80f264
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80f244..0x80f370
+            - Range: 0x80f264..0x80f390
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f1d0..0x80f244
+            - Range: 0x80f1f0..0x80f264
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0x80f244..0x80f370
+            - Range: 0x80f264..0x80f390
               Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 114 ArrayType [2]int
           Locations:
-            - Range: 0x80f1d0..0x80f32c
+            - Range: 0x80f1f0..0x80f34c
               Pieces: []
-            - Range: 0x80f32c..0x80f32d
+            - Range: 0x80f34c..0x80f34d
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-            - Range: 0x80f32d..0x80f370
+            - Range: 0x80f34d..0x80f390
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 130
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0x80f370..0x80f560]
+      OutOfLinePCRanges: [0x80f390..0x80f580]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f370..0x80f3f4
+            - Range: 0x80f390..0x80f414
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80f3f4..0x80f560
+            - Range: 0x80f414..0x80f580
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f370..0x80f3e4
+            - Range: 0x80f390..0x80f404
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80f3e4..0x80f560
+            - Range: 0x80f404..0x80f580
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f370..0x80f3ec
+            - Range: 0x80f390..0x80f40c
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80f3ec..0x80f560
+            - Range: 0x80f40c..0x80f580
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f370..0x80f3f4
+            - Range: 0x80f390..0x80f414
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80f3f4..0x80f560
+            - Range: 0x80f414..0x80f580
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f370..0x80f3f4
+            - Range: 0x80f390..0x80f414
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80f3f4..0x80f560
+            - Range: 0x80f414..0x80f580
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f370..0x80f3f4
+            - Range: 0x80f390..0x80f414
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80f3f4..0x80f560
+            - Range: 0x80f414..0x80f580
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f370..0x80f3f4
+            - Range: 0x80f390..0x80f414
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80f3f4..0x80f560
+            - Range: 0x80f414..0x80f580
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f370..0x80f3f4
+            - Range: 0x80f390..0x80f414
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80f3f4..0x80f560
+            - Range: 0x80f414..0x80f580
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80f370..0x80f3f4
+            - Range: 0x80f390..0x80f414
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80f3f4..0x80f560
+            - Range: 0x80f414..0x80f580
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 72}
@@ -9317,9 +9317,9 @@ Subprograms:
         - Name: ~r0
           Type: 255 StructureType main.largeStruct
           Locations:
-            - Range: 0x80f370..0x80f518
+            - Range: 0x80f390..0x80f538
               Pieces: []
-            - Range: 0x80f518..0x80f519
+            - Range: 0x80f538..0x80f539
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9341,232 +9341,194 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80f519..0x80f560
+            - Range: 0x80f539..0x80f580
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 131
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0x80f560..0x80f5f0]
+      OutOfLinePCRanges: [0x80f580..0x80f610]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 166 ArrayType [5]int
           Locations:
-            - Range: 0x80f560..0x80f5f0
+            - Range: 0x80f580..0x80f610
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f560..0x80f5d0
+            - Range: 0x80f580..0x80f5f0
               Pieces: []
-            - Range: 0x80f5d0..0x80f5d1
+            - Range: 0x80f5f0..0x80f5f1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80f5d1..0x80f5f0
+            - Range: 0x80f5f1..0x80f610
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f560..0x80f5d0
+            - Range: 0x80f580..0x80f5f0
               Pieces: []
-            - Range: 0x80f5d0..0x80f5d1
+            - Range: 0x80f5f0..0x80f5f1
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80f5d1..0x80f5f0
+            - Range: 0x80f5f1..0x80f610
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f560..0x80f5d0
+            - Range: 0x80f580..0x80f5f0
               Pieces: []
-            - Range: 0x80f5d0..0x80f5d1
+            - Range: 0x80f5f0..0x80f5f1
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80f5d1..0x80f5f0
+            - Range: 0x80f5f1..0x80f610
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 132
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0x80f5f0..0x80f6c0]
+      OutOfLinePCRanges: [0x80f610..0x80f6e0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 114 ArrayType [2]int
           Locations:
-            - Range: 0x80f5f0..0x80f6c0
+            - Range: 0x80f610..0x80f6e0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 256 ArrayType [3]int
           Locations:
-            - Range: 0x80f5f0..0x80f6c0
+            - Range: 0x80f610..0x80f6e0
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f5f0..0x80f6a4
+            - Range: 0x80f610..0x80f6c4
               Pieces: []
-            - Range: 0x80f6a4..0x80f6a5
+            - Range: 0x80f6c4..0x80f6c5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80f6a5..0x80f6c0
+            - Range: 0x80f6c5..0x80f6e0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 114 ArrayType [2]int
           Locations:
-            - Range: 0x80f5f0..0x80f6a4
+            - Range: 0x80f610..0x80f6c4
               Pieces: []
-            - Range: 0x80f6a4..0x80f6a5
+            - Range: 0x80f6c4..0x80f6c5
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
-            - Range: 0x80f6a5..0x80f6c0
+            - Range: 0x80f6c5..0x80f6e0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 133
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0x80f6c0..0x80f780]
+      OutOfLinePCRanges: [0x80f6e0..0x80f7a0]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 261 StructureType main.structWithArray
           Locations:
-            - Range: 0x80f6c0..0x80f780
+            - Range: 0x80f6e0..0x80f7a0
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f6c0..0x80f760
+            - Range: 0x80f6e0..0x80f780
               Pieces: []
-            - Range: 0x80f760..0x80f761
+            - Range: 0x80f780..0x80f781
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80f761..0x80f780
+            - Range: 0x80f781..0x80f7a0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 261 StructureType main.structWithArray
           Locations:
-            - Range: 0x80f6c0..0x80f760
+            - Range: 0x80f6e0..0x80f780
               Pieces: []
-            - Range: 0x80f760..0x80f761
+            - Range: 0x80f780..0x80f781
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x80f761..0x80f780
+            - Range: 0x80f781..0x80f7a0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f738..0x80f780
+            - Range: 0x80f758..0x80f7a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 134
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0x80f780..0x80f820]
+      OutOfLinePCRanges: [0x80f7a0..0x80f840]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 258 ArrayType [0]int
-          Locations: [{Range: 0x80f780..0x80f820, Pieces: []}]
+          Locations: [{Range: 0x80f7a0..0x80f840, Pieces: []}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f780..0x80f7bc
+            - Range: 0x80f7a0..0x80f7dc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80f7bc..0x80f7d4
+            - Range: 0x80f7dc..0x80f7f4
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x80f7d4..0x80f7dc
+            - Range: 0x80f7f4..0x80f7fc
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x80f7dc..0x80f820
+            - Range: 0x80f7fc..0x80f840
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80f780..0x80f7f8
+            - Range: 0x80f7a0..0x80f818
               Pieces: []
-            - Range: 0x80f7f8..0x80f7f9
+            - Range: 0x80f818..0x80f819
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80f7f9..0x80f820
+            - Range: 0x80f819..0x80f840
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 258 ArrayType [0]int
           Locations:
-            - Range: 0x80f780..0x80f7f8
+            - Range: 0x80f7a0..0x80f818
               Pieces: []
-            - Range: 0x80f7f8..0x80f7f9
+            - Range: 0x80f818..0x80f819
               Pieces: []
-            - Range: 0x80f7f9..0x80f820
+            - Range: 0x80f819..0x80f840
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 135
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0x80fc60..0x80fc70]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 262 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x80fc60..0x80fc70
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 136
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x80fc70..0x80fc80]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 262 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x80fc70..0x80fc80
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 137
-      Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0x80fc80..0x80fc90]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 263 GoSliceHeaderType [][]uint
+          Type: 262 GoSliceHeaderType []uint
           Locations:
             - Range: 0x80fc80..0x80fc90
               Pieces:
@@ -9579,13 +9541,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 138
-      Name: main.testStructSlice
+    - ID: 136
+      Name: main.testEmptySlice
       OutOfLinePCRanges: [0x80fc90..0x80fca0]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 265 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 262 GoSliceHeaderType []uint
           Locations:
             - Range: 0x80fc90..0x80fca0
               Pieces:
@@ -9597,21 +9559,14 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
           DictIndex: -1
-        - Name: a
-          Type: 8 BaseType int
-          Locations:
-            - Range: 0x80fc90..0x80fca0
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
       DictRegister: null
-    - ID: 139
-      Name: main.testEmptySliceOfStructs
+    - ID: 137
+      Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0x80fca0..0x80fcb0]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 265 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 263 GoSliceHeaderType [][]uint
           Locations:
             - Range: 0x80fca0..0x80fcb0
               Pieces:
@@ -9623,16 +9578,9 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
           DictIndex: -1
-        - Name: a
-          Type: 8 BaseType int
-          Locations:
-            - Range: 0x80fca0..0x80fcb0
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
       DictRegister: null
-    - ID: 140
-      Name: main.testNilSliceOfStructs
+    - ID: 138
+      Name: main.testStructSlice
       OutOfLinePCRanges: [0x80fcb0..0x80fcc0]
       InlinePCRanges: []
       Variables:
@@ -9657,13 +9605,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 141
-      Name: main.testStringSlice
+    - ID: 139
+      Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0x80fcc0..0x80fcd0]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 159 GoSliceHeaderType []string
+        - Name: xs
+          Type: 265 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0x80fcc0..0x80fcd0
               Pieces:
@@ -9675,47 +9623,47 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
           DictIndex: -1
+        - Name: a
+          Type: 8 BaseType int
+          Locations:
+            - Range: 0x80fcc0..0x80fcd0
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
       DictRegister: null
-    - ID: 142
-      Name: main.testNilSliceWithOtherParams
+    - ID: 140
+      Name: main.testNilSliceOfStructs
       OutOfLinePCRanges: [0x80fcd0..0x80fce0]
       InlinePCRanges: []
       Variables:
-        - Name: a
-          Type: 18 BaseType int8
-          Locations:
-            - Range: 0x80fcd0..0x80fce0
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: s
-          Type: 268 GoSliceHeaderType []bool
+        - Name: xs
+          Type: 265 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0x80fcd0..0x80fce0
               Pieces:
                 - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
           Role: Parameter
           DictIndex: -1
-        - Name: x
-          Type: 11 BaseType uint
+        - Name: a
+          Type: 8 BaseType int
           Locations:
             - Range: 0x80fcd0..0x80fce0
-              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 143
-      Name: main.testNilSlice
+    - ID: 141
+      Name: main.testStringSlice
       OutOfLinePCRanges: [0x80fce0..0x80fcf0]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 269 GoSliceHeaderType []uint16
+        - Name: s
+          Type: 159 GoSliceHeaderType []string
           Locations:
             - Range: 0x80fce0..0x80fcf0
               Pieces:
@@ -9728,32 +9676,46 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 144
-      Name: main.testVeryLargeSlice
+    - ID: 142
+      Name: main.testNilSliceWithOtherParams
       OutOfLinePCRanges: [0x80fcf0..0x80fd00]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 262 GoSliceHeaderType []uint
+        - Name: a
+          Type: 18 BaseType int8
+          Locations:
+            - Range: 0x80fcf0..0x80fd00
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: s
+          Type: 268 GoSliceHeaderType []bool
           Locations:
             - Range: 0x80fcf0..0x80fd00
               Pieces:
                 - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: x
+          Type: 11 BaseType uint
+          Locations:
+            - Range: 0x80fcf0..0x80fd00
+              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 145
-      Name: main.testSliceEmptyStructs
+    - ID: 143
+      Name: main.testNilSlice
       OutOfLinePCRanges: [0x80fd00..0x80fd10]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 270 GoSliceHeaderType []struct {}
+          Type: 269 GoSliceHeaderType []uint16
           Locations:
             - Range: 0x80fd00..0x80fd10
               Pieces:
@@ -9766,15 +9728,53 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 144
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0x80fd10..0x80fd20]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 262 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0x80fd10..0x80fd20
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 145
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0x80fd20..0x80fd30]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 270 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0x80fd20..0x80fd30
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 146
       Name: main.testSubslices
-      OutOfLinePCRanges: [0x80fd10..0x80fd20]
+      OutOfLinePCRanges: [0x80fd30..0x80fd40]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 262 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80fd10..0x80fd20
+            - Range: 0x80fd30..0x80fd40
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9787,7 +9787,7 @@ Subprograms:
         - Name: bs
           Type: 262 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80fd10..0x80fd20
+            - Range: 0x80fd30..0x80fd40
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9800,7 +9800,7 @@ Subprograms:
         - Name: cs
           Type: 262 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80fd10..0x80fd20
+            - Range: 0x80fd30..0x80fd40
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -9813,34 +9813,34 @@ Subprograms:
       DictRegister: null
     - ID: 147
       Name: main.stackC
-      OutOfLinePCRanges: [0x8102d0..0x810330]
+      OutOfLinePCRanges: [0x8102f0..0x810350]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x8102d0..0x810318
+            - Range: 0x8102f0..0x810338
               Pieces: []
-            - Range: 0x810318..0x810319
+            - Range: 0x810338..0x810339
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x810319..0x810330
+            - Range: 0x810339..0x810350
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 148
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x810330..0x810340]
+      OutOfLinePCRanges: [0x810350..0x810360]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x810330..0x810340
+            - Range: 0x810350..0x810360
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9851,13 +9851,13 @@ Subprograms:
       DictRegister: null
     - ID: 149
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x810340..0x810350]
+      OutOfLinePCRanges: [0x810360..0x810370]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x810340..0x810350
+            - Range: 0x810360..0x810370
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9868,7 +9868,7 @@ Subprograms:
         - Name: "y"
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x810340..0x810350
+            - Range: 0x810360..0x810370
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9879,7 +9879,7 @@ Subprograms:
         - Name: z
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x810340..0x810350
+            - Range: 0x810360..0x810370
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9890,13 +9890,13 @@ Subprograms:
       DictRegister: null
     - ID: 150
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x810350..0x810360]
+      OutOfLinePCRanges: [0x810370..0x810380]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 272 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x810350..0x810360
+            - Range: 0x810370..0x810380
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9915,66 +9915,32 @@ Subprograms:
       DictRegister: null
     - ID: 151
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x810360..0x810370]
+      OutOfLinePCRanges: [0x810380..0x810390]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 273 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x810360..0x810370
+            - Range: 0x810380..0x810390
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 152
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x810370..0x810380]
+      OutOfLinePCRanges: [0x810390..0x8103a0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 274 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x810370..0x810380
+            - Range: 0x810390..0x8103a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 153
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0x810380..0x810390]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 10 GoStringHeaderType string
-          Locations:
-            - Range: 0x810380..0x810390
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 154
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x810390..0x8103a0]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 10 GoStringHeaderType string
-          Locations:
-            - Range: 0x810390..0x8103a0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 155
-      Name: main.testEmptyString
       OutOfLinePCRanges: [0x8103a0..0x8103b0]
       InlinePCRanges: []
       Variables:
@@ -9990,12 +9956,12 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 156
-      Name: main.testSubstrings
+    - ID: 154
+      Name: main.testUnitializedString
       OutOfLinePCRanges: [0x8103b0..0x8103c0]
       InlinePCRanges: []
       Variables:
-        - Name: a
+        - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
             - Range: 0x8103b0..0x8103c0
@@ -10006,10 +9972,44 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
           DictIndex: -1
+      DictRegister: null
+    - ID: 155
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0x8103c0..0x8103d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0x8103c0..0x8103d0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 156
+      Name: main.testSubstrings
+      OutOfLinePCRanges: [0x8103d0..0x8103e0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0x8103d0..0x8103e0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
         - Name: b
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x8103b0..0x8103c0
+            - Range: 0x8103d0..0x8103e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10020,7 +10020,7 @@ Subprograms:
         - Name: c
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x8103b0..0x8103c0
+            - Range: 0x8103d0..0x8103e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -10031,26 +10031,26 @@ Subprograms:
       DictRegister: null
     - ID: 157
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x810510..0x810520]
+      OutOfLinePCRanges: [0x810530..0x810540]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 276 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x810510..0x810520
+            - Range: 0x810530..0x810540
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 158
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x810520..0x810530]
+      OutOfLinePCRanges: [0x810540..0x810550]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 289 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x810520..0x810530
+            - Range: 0x810540..0x810550
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10069,13 +10069,13 @@ Subprograms:
       DictRegister: null
     - ID: 159
       Name: main.testStruct
-      OutOfLinePCRanges: [0x8105d0..0x8105f0]
+      OutOfLinePCRanges: [0x8105f0..0x810610]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 320 StructureType main.aStruct
           Locations:
-            - Range: 0x8105d0..0x8105f0
+            - Range: 0x8105f0..0x810610
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -10096,130 +10096,68 @@ Subprograms:
       DictRegister: null
     - ID: 160
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0x810660..0x810670]
+      OutOfLinePCRanges: [0x810680..0x810690]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 321 PointerType *main.anotherStruct
           Locations:
-            - Range: 0x810660..0x810670
+            - Range: 0x810680..0x810690
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 161
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0x810670..0x810680]
+      OutOfLinePCRanges: [0x810690..0x8106a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 323 StructureType main.tenStrings
           Locations:
-            - Range: 0x810670..0x810680
+            - Range: 0x810690..0x8106a0
               Pieces: [{Size: 160, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 162
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x8106a0..0x8106b0]
+      OutOfLinePCRanges: [0x8106c0..0x8106d0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 324 StructureType main.emptyStruct
-          Locations: [{Range: 0x8106a0..0x8106b0, Pieces: []}]
+          Locations: [{Range: 0x8106c0..0x8106d0, Pieces: []}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 163
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x8106b0..0x8106c0]
+      OutOfLinePCRanges: [0x8106d0..0x8106e0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 325 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x8106b0..0x8106c0
+            - Range: 0x8106d0..0x8106e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 164
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0x811e80..0x811e90]
+      OutOfLinePCRanges: [0x811ea0..0x811eb0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 326 BaseType go.shape.int
-          Locations:
-            - Range: 0x811e80..0x811e90
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
-          Locations:
-            - Range: 0x811e80..0x811e84
-              Pieces: []
-            - Range: 0x811e84..0x811e85
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x811e85..0x811e90
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 165
-      Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0x811e90..0x811ea0]
-      InlinePCRanges: []
-      Variables:
-        - Name: val
-          Type: 328 GoStringHeaderType go.shape.string
-          Locations:
-            - Range: 0x811e90..0x811e9c
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0x811e9c..0x811ea0
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
-          Locations:
-            - Range: 0x811e90..0x811e9c
-              Pieces: []
-            - Range: 0x811e9c..0x811e9d
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x811e9d..0x811ea0
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 166
-      Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0x811ea0..0x811eb0]
-      InlinePCRanges: []
-      Variables:
-        - Name: box
-          Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
             - Range: 0x811ea0..0x811eb0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 326 BaseType go.shape.int
+          Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
             - Range: 0x811ea0..0x811ea4
               Pieces: []
@@ -10230,13 +10168,13 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 167
-      Name: main.nestedGeneric[go.shape.string]
+    - ID: 165
+      Name: main.wrapBox[go.shape.string]
       OutOfLinePCRanges: [0x811eb0..0x811ec0]
       InlinePCRanges: []
       Variables:
-        - Name: box
-          Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+        - Name: val
+          Type: 328 GoStringHeaderType go.shape.string
           Locations:
             - Range: 0x811eb0..0x811ebc
               Pieces:
@@ -10253,7 +10191,7 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 328 GoStringHeaderType go.shape.string
+          Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
             - Range: 0x811eb0..0x811ebc
               Pieces: []
@@ -10268,15 +10206,77 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
+    - ID: 166
+      Name: main.nestedGeneric[go.shape.int]
+      OutOfLinePCRanges: [0x811ec0..0x811ed0]
+      InlinePCRanges: []
+      Variables:
+        - Name: box
+          Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+          Locations:
+            - Range: 0x811ec0..0x811ed0
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 326 BaseType go.shape.int
+          Locations:
+            - Range: 0x811ec0..0x811ec4
+              Pieces: []
+            - Range: 0x811ec4..0x811ec5
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x811ec5..0x811ed0
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 167
+      Name: main.nestedGeneric[go.shape.string]
+      OutOfLinePCRanges: [0x811ed0..0x811ee0]
+      InlinePCRanges: []
+      Variables:
+        - Name: box
+          Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+          Locations:
+            - Range: 0x811ed0..0x811edc
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x811edc..0x811ee0
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 328 GoStringHeaderType go.shape.string
+          Locations:
+            - Range: 0x811ed0..0x811edc
+              Pieces: []
+            - Range: 0x811edc..0x811edd
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x811edd..0x811ee0
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
     - ID: 168
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0x811f20..0x812040]
+      OutOfLinePCRanges: [0x811f40..0x812060]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 330 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x811f20..0x811f4c
+            - Range: 0x811f40..0x811f6c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10284,7 +10284,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x811f4c..0x811f5c
+            - Range: 0x811f6c..0x811f7c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10292,7 +10292,7 @@ Subprograms:
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: null
-            - Range: 0x811f5c..0x812040
+            - Range: 0x811f7c..0x812060
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10305,18 +10305,18 @@ Subprograms:
         - Name: pred
           Type: 332 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0x811f20..0x811f5c
+            - Range: 0x811f40..0x811f7c
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x811f5c..0x812040
+            - Range: 0x811f7c..0x812060
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 330 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x811f20..0x81200c
+            - Range: 0x811f40..0x81202c
               Pieces: []
-            - Range: 0x81200c..0x81200d
+            - Range: 0x81202c..0x81202d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10324,14 +10324,14 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x81200d..0x812040
+            - Range: 0x81202d..0x812060
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
           Type: 330 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x811f4c..0x811f5c
+            - Range: 0x811f6c..0x811f7c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10339,7 +10339,7 @@ Subprograms:
                   Op: null
                 - Size: 8
                   Op: null
-            - Range: 0x811f5c..0x811f78
+            - Range: 0x811f7c..0x811f98
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10347,7 +10347,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x811f78..0x811f7c
+            - Range: 0x811f98..0x811f9c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10355,7 +10355,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x811f7c..0x811f80
+            - Range: 0x811f9c..0x811fa0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10363,7 +10363,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x811f80..0x811f80
+            - Range: 0x811fa0..0x811fa0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10371,7 +10371,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x811f80..0x811fac
+            - Range: 0x811fa0..0x811fcc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10379,7 +10379,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x811fac..0x812000
+            - Range: 0x811fcc..0x812020
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10387,7 +10387,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x812000..0x812040
+            - Range: 0x812020..0x812060
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10400,110 +10400,62 @@ Subprograms:
         - Name: item
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0x811f9c..0x811fac
+            - Range: 0x811fbc..0x811fcc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x811fac..0x812000
+            - Range: 0x811fcc..0x812020
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
     - ID: 169
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x812040..0x812090]
+      OutOfLinePCRanges: [0x812060..0x8120b0]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x812040..0x812068
+            - Range: 0x812060..0x812088
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
           Type: 333 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0x812040..0x812068
+            - Range: 0x812060..0x812088
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x812040..0x812068
+            - Range: 0x812060..0x812088
               Pieces: []
-            - Range: 0x812068..0x812069
+            - Range: 0x812088..0x812089
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x812069..0x812090
+            - Range: 0x812089..0x8120b0
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
     - ID: 170
       Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0x812300..0x812310]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 331 PointerType *go.shape.int
-          Locations:
-            - Range: 0x812300..0x812310
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 331 PointerType *go.shape.int
-          Locations:
-            - Range: 0x812300..0x812304
-              Pieces: []
-            - Range: 0x812304..0x812305
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x812305..0x812310
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 171
-      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0x812310..0x812320]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 334 PointerType *go.shape.struct { Name string }
-          Locations:
-            - Range: 0x812310..0x812320
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 334 PointerType *go.shape.struct { Name string }
-          Locations:
-            - Range: 0x812310..0x812314
-              Pieces: []
-            - Range: 0x812314..0x812315
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x812315..0x812320
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 172
-      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
       OutOfLinePCRanges: [0x812320..0x812330]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 336 PointerType *go.shape.struct { X int; Y int }
+          Type: 331 PointerType *go.shape.int
           Locations:
             - Range: 0x812320..0x812330
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 336 PointerType *go.shape.struct { X int; Y int }
+          Type: 331 PointerType *go.shape.int
           Locations:
             - Range: 0x812320..0x812324
               Pieces: []
@@ -10514,101 +10466,149 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
+    - ID: 171
+      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
+      OutOfLinePCRanges: [0x812330..0x812340]
+      InlinePCRanges: []
+      Variables:
+        - Name: p
+          Type: 334 PointerType *go.shape.struct { Name string }
+          Locations:
+            - Range: 0x812330..0x812340
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 334 PointerType *go.shape.struct { Name string }
+          Locations:
+            - Range: 0x812330..0x812334
+              Pieces: []
+            - Range: 0x812334..0x812335
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x812335..0x812340
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 172
+      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
+      OutOfLinePCRanges: [0x812340..0x812350]
+      InlinePCRanges: []
+      Variables:
+        - Name: p
+          Type: 336 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0x812340..0x812350
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 336 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0x812340..0x812344
+              Pieces: []
+            - Range: 0x812344..0x812345
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x812345..0x812350
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
     - ID: 173
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0x812330..0x812340]
+      OutOfLinePCRanges: [0x812350..0x812360]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 338 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0x812330..0x812340
+            - Range: 0x812350..0x812360
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x812330..0x812334
+            - Range: 0x812350..0x812354
               Pieces: []
-            - Range: 0x812334..0x812335
+            - Range: 0x812354..0x812355
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x812335..0x812340
+            - Range: 0x812355..0x812360
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 174
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0x8123c0..0x8123d0]
+      OutOfLinePCRanges: [0x8123e0..0x8123f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 340 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0x8123c0..0x8123d0
+            - Range: 0x8123e0..0x8123f0
               Pieces: [{Size: 136, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0x8123c0..0x8123c4
+            - Range: 0x8123e0..0x8123e4
               Pieces: []
-            - Range: 0x8123c4..0x8123c5
+            - Range: 0x8123e4..0x8123e5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8123c5..0x8123d0
+            - Range: 0x8123e5..0x8123f0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 175
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0x812460..0x812470]
+      OutOfLinePCRanges: [0x812480..0x812490]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 341 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0x812460..0x812470
+            - Range: 0x812480..0x812490
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0x812460..0x812470
+            - Range: 0x812480..0x812490
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
           Type: 343 BaseType go.shape.bool
           Locations:
-            - Range: 0x812460..0x812470
+            - Range: 0x812480..0x812490
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
     - ID: 176
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0x8124f0..0x812560]
+      OutOfLinePCRanges: [0x812510..0x812580]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 344 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0x8124f0..0x812560
+            - Range: 0x812510..0x812580
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8124f0..0x812560
+            - Range: 0x812510..0x812580
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10619,20 +10619,20 @@ Subprograms:
         - Name: v
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0x8124f0..0x812560
+            - Range: 0x812510..0x812580
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
     - ID: 177
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0x8125e0..0x8125f0]
+      OutOfLinePCRanges: [0x812600..0x812610]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8125e0..0x8125f0
+            - Range: 0x812600..0x812610
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10643,59 +10643,59 @@ Subprograms:
         - Name: b
           Type: 343 BaseType go.shape.bool
           Locations:
-            - Range: 0x8125e0..0x8125f0
+            - Range: 0x812600..0x812610
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 343 BaseType go.shape.bool
           Locations:
-            - Range: 0x8125e0..0x8125e8
+            - Range: 0x812600..0x812608
               Pieces: []
-            - Range: 0x8125e8..0x8125e9
+            - Range: 0x812608..0x812609
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8125e9..0x8125f0
+            - Range: 0x812609..0x812610
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8125e0..0x8125e8
+            - Range: 0x812600..0x812608
               Pieces: []
-            - Range: 0x8125e8..0x8125e9
+            - Range: 0x812608..0x812609
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x8125e9..0x8125f0
+            - Range: 0x812609..0x812610
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 178
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x8125f0..0x812610]
+      OutOfLinePCRanges: [0x812610..0x812630]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0x8125f0..0x812600
+            - Range: 0x812610..0x812620
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8125f0..0x8125fc
+            - Range: 0x812610..0x81261c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8125fc..0x812610
+            - Range: 0x81261c..0x812630
               Pieces:
                 - Size: 8
                   Op: null
@@ -10706,73 +10706,73 @@ Subprograms:
         - Name: ~r0
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8125f0..0x812600
+            - Range: 0x812610..0x812620
               Pieces: []
-            - Range: 0x812600..0x812601
+            - Range: 0x812620..0x812621
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x812601..0x812610
+            - Range: 0x812621..0x812630
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0x8125f0..0x812600
+            - Range: 0x812610..0x812620
               Pieces: []
-            - Range: 0x812600..0x812601
+            - Range: 0x812620..0x812621
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x812601..0x812610
+            - Range: 0x812621..0x812630
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 179
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0x812610..0x812660]
+      OutOfLinePCRanges: [0x812630..0x812680]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 346 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0x812610..0x812638
+            - Range: 0x812630..0x812658
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x812610..0x812638
+            - Range: 0x812630..0x812658
               Pieces: []
-            - Range: 0x812638..0x812639
+            - Range: 0x812658..0x812659
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x812639..0x812660
+            - Range: 0x812659..0x812680
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 180
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0x812660..0x8126c0]
+      OutOfLinePCRanges: [0x812680..0x8126e0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 347 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0x812660..0x81268c
+            - Range: 0x812680..0x8126ac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x81268c..0x812690
+            - Range: 0x8126ac..0x8126b0
               Pieces:
                 - Size: 8
                   Op: null
@@ -10783,65 +10783,65 @@ Subprograms:
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x812660..0x812690
+            - Range: 0x812680..0x8126b0
               Pieces: []
-            - Range: 0x812690..0x812691
+            - Range: 0x8126b0..0x8126b1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x812691..0x8126c0
+            - Range: 0x8126b1..0x8126e0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 181
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0x8126c0..0x8126d0]
+      OutOfLinePCRanges: [0x8126e0..0x8126f0]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 348 PointerType *go.shape.string
           Locations:
-            - Range: 0x8126c0..0x8126c4
+            - Range: 0x8126e0..0x8126e4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8126c0..0x8126c4
+            - Range: 0x8126e0..0x8126e4
               Pieces: []
-            - Range: 0x8126c4..0x8126c5
+            - Range: 0x8126e4..0x8126e5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8126c5..0x8126d0
+            - Range: 0x8126e5..0x8126f0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 182
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0x8126d0..0x812720]
+      OutOfLinePCRanges: [0x8126f0..0x812740]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 349 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x8126d0..0x81270c
+            - Range: 0x8126f0..0x81272c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 350 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x8126d0..0x812710
+            - Range: 0x8126f0..0x812730
               Pieces: []
-            - Range: 0x812710..0x812711
+            - Range: 0x812730..0x812731
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10855,20 +10855,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x812711..0x812720
+            - Range: 0x812731..0x812740
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 183
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0x812720..0x812760]
+      OutOfLinePCRanges: [0x812740..0x812780]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 330 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x812720..0x81272c
+            - Range: 0x812740..0x81274c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10876,7 +10876,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x81272c..0x812760
+            - Range: 0x81274c..0x812780
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10889,42 +10889,42 @@ Subprograms:
         - Name: needle
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0x812720..0x812760
+            - Range: 0x812740..0x812780
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x812720..0x812748
+            - Range: 0x812740..0x812768
               Pieces: []
-            - Range: 0x812748..0x812749
+            - Range: 0x812768..0x812769
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x812749..0x812750
+            - Range: 0x812769..0x812770
               Pieces: []
-            - Range: 0x812750..0x812751
+            - Range: 0x812770..0x812771
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x812751..0x812760
+            - Range: 0x812771..0x812780
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0x81273c..0x81274c
+            - Range: 0x81275c..0x81276c
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Local
           DictIndex: 1
       DictRegister: 0
     - ID: 184
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0x812760..0x812820]
+      OutOfLinePCRanges: [0x812780..0x812840]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 351 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0x812760..0x812784
+            - Range: 0x812780..0x8127a4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10932,7 +10932,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x812784..0x812788
+            - Range: 0x8127a4..0x8127a8
               Pieces:
                 - Size: 8
                   Op: null
@@ -10945,13 +10945,13 @@ Subprograms:
         - Name: needle
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x812760..0x8127b8
+            - Range: 0x812780..0x8127d8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x8127b8..0x812820
+            - Range: 0x8127d8..0x812840
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 40}
@@ -10962,22 +10962,22 @@ Subprograms:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x812760..0x8127d4
+            - Range: 0x812780..0x8127f4
               Pieces: []
-            - Range: 0x8127d4..0x8127d5
+            - Range: 0x8127f4..0x8127f5
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8127d5..0x8127e4
+            - Range: 0x8127f5..0x812804
               Pieces: []
-            - Range: 0x8127e4..0x8127e5
+            - Range: 0x812804..0x812805
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8127e5..0x812820
+            - Range: 0x812805..0x812840
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8127a0..0x8127b8
+            - Range: 0x8127c0..0x8127d8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10988,56 +10988,56 @@ Subprograms:
       DictRegister: 0
     - ID: 185
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0x812820..0x812830]
+      OutOfLinePCRanges: [0x812840..0x812850]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 352 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0x812820..0x812828
+            - Range: 0x812840..0x812848
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
           Type: 326 BaseType go.shape.int
           Locations:
-            - Range: 0x812820..0x812830
+            - Range: 0x812840..0x812850
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x812820..0x812828
+            - Range: 0x812840..0x812848
               Pieces: []
-            - Range: 0x812828..0x812829
+            - Range: 0x812848..0x812849
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x812829..0x812830
+            - Range: 0x812849..0x812850
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 1
     - ID: 186
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0x8128a0..0x812910]
+      OutOfLinePCRanges: [0x8128c0..0x812930]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 353 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0x8128a0..0x8128cc
+            - Range: 0x8128c0..0x8128ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8128cc..0x8128d8
+            - Range: 0x8128ec..0x8128f8
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8128d8..0x8128dc
+            - Range: 0x8128f8..0x8128fc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11048,7 +11048,7 @@ Subprograms:
         - Name: value
           Type: 328 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8128a0..0x8128dc
+            - Range: 0x8128c0..0x8128fc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -11059,11 +11059,11 @@ Subprograms:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x8128a0..0x8128dc
+            - Range: 0x8128c0..0x8128fc
               Pieces: []
-            - Range: 0x8128dc..0x8128dd
+            - Range: 0x8128fc..0x8128fd
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8128dd..0x812910
+            - Range: 0x8128fd..0x812930
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11300,8 +11300,8 @@ Subprograms:
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0x80b380..0x80b3e0]
       InlinePCRanges:
-        - Ranges: [0x8129b8..0x8129dc]
-          RootRanges: [0x812990..0x812a20]
+        - Ranges: [0x8129d8..0x8129fc]
+          RootRanges: [0x8129b0..0x812a40]
       Variables:
         - Name: b
           Type: 358 StructureType main.firstBehavior
@@ -11334,8 +11334,8 @@ Subprograms:
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x80baf0..0x80bafc, 0x80bb00..0x80bb08]
-          RootRanges: [0x80ba60..0x80bb50]
+        - Ranges: [0x80bb10..0x80bb1c, 0x80bb20..0x80bb28]
+          RootRanges: [0x80ba80..0x80bb70]
         - Ranges: [0x12c238..0x12c23c, 0x12c240..0x12c248]
           RootRanges: [0x12c230..0x12c250]
       Variables: []

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
@@ -13,11 +13,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1600 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0x80cb58", Frameless: false}]
+              InjectionPoints: [{PC: "0x80cb78", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1601 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0x80cb88", Frameless: false}]
+              InjectionPoints: [{PC: "0x80cba8", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -84,11 +84,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1571 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0x80b78c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b7ac", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1572 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0x80b820", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b840", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -176,7 +176,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1451 EventRootType Probe[main.testArrayOfMaps]
-              InjectionPoints: [{PC: "0x808480", Frameless: true}]
+              InjectionPoints: [{PC: "0x8084a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -241,11 +241,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1473 EventRootType Probe[main.testAtomicAdd]
-              InjectionPoints: [{PC: "0x809b70", Frameless: true}]
+              InjectionPoints: [{PC: "0x809b90", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1474 EventRootType Probe[main.testAtomicAdd]Return
-              InjectionPoints: [{PC: "0x809bac", Frameless: true}]
+              InjectionPoints: [{PC: "0x809bcc", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -338,7 +338,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1616 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x80ce20", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ce40", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -468,7 +468,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1470 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x809910", Frameless: true}]
+              InjectionPoints: [{PC: "0x809930", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -487,7 +487,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1471 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x809910", Frameless: true}]
+              InjectionPoints: [{PC: "0x809930", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -513,7 +513,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1622 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0x80ce90", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ceb0", Frameless: true}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -549,7 +549,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1475 EventRootType Probe[main.testChannel]
-              InjectionPoints: [{PC: "0x809bb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x809bd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -579,7 +579,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1469 EventRootType Probe[main.testCombinedByte]
-              InjectionPoints: [{PC: "0x8098f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x809910", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{w}, {x}, {y}'
@@ -608,11 +608,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1536 EventRootType Probe[main.testConflictingReturn]
-              InjectionPoints: [{PC: "0x80aa88", Frameless: false}]
+              InjectionPoints: [{PC: "0x80aaa8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1537 EventRootType Probe[main.testConflictingReturn]Return
-              InjectionPoints: [{PC: "0x80ab2c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ab4c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -634,7 +634,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1483 EventRootType Probe[main.testCycle]
-              InjectionPoints: [{PC: "0x809e30", Frameless: true}]
+              InjectionPoints: [{PC: "0x809e50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{t}'
@@ -788,7 +788,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1588 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0x80c510", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c530", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -815,7 +815,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1591 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0x80c540", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c560", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -843,7 +843,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1612 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0x80cc10", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cc30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -865,7 +865,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1623 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0x80cec0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cee0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -886,7 +886,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1624 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0x80ced0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cef0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1099,11 +1099,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1661 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0x80eca0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ecc0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1662 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x80eca4", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ecc4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1117,11 +1117,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1663 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0x80ecc0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ece0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1664 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0x80ecf4", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ed14", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1144,11 +1144,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1657 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0x80ec08", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ec28", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1658 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0x80ec18", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ec38", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1162,11 +1162,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1659 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0x80ec58", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ec78", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1660 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0x80ec70", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ec90", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1189,14 +1189,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1665 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0x80ed00", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ed20", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1666 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0x80ed28"
+                - PC: "0x80ed48"
                   Frameless: true
-                - PC: "0x80ed30"
+                - PC: "0x80ed50"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1211,14 +1211,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1667 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0x80ed58", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ed78", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1668 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0x80edb8"
+                - PC: "0x80edd8"
                   Frameless: false
-                - PC: "0x80edc8"
+                - PC: "0x80ede8"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1245,7 +1245,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1669 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0x80ed04", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ed24", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1257,7 +1257,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1670 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0x80ed68", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ed88", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1278,11 +1278,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1645 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0x80e980", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e9a0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1646 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0x80e984", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e9a4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1296,11 +1296,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1647 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0x80ea00", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ea20", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1648 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0x80ea04", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ea24", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1324,11 +1324,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1633 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0x80e58c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e5ac", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1634 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x80e6d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e6f8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1370,11 +1370,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1637 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x80e728", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e748", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1638 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x80e738", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e758", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1397,11 +1397,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1671 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0x80ee00", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ee20", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1672 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0x80ee08", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ee28", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1415,11 +1415,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1673 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0x80ee78", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ee98", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1674 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0x80ee9c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80eebc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1442,11 +1442,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1629 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0x80e4f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e510", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1630 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x80e4f4", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e514", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1460,11 +1460,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1631 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0x80e500", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e520", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1632 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x80e50c", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e52c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1487,11 +1487,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1649 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0x80ea80", Frameless: true}]
+              InjectionPoints: [{PC: "0x80eaa0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1650 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0x80ea88", Frameless: true}]
+              InjectionPoints: [{PC: "0x80eaa8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1505,11 +1505,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1651 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0x80eb08", Frameless: false}]
+              InjectionPoints: [{PC: "0x80eb28", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1652 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0x80eb30", Frameless: false}]
+              InjectionPoints: [{PC: "0x80eb50", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1532,11 +1532,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1639 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0x80e950", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e970", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1640 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x80e954", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e974", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1550,11 +1550,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1641 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0x80e960", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e980", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1642 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0x80e964", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e984", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1568,11 +1568,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1643 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0x80e970", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e990", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1644 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0x80e974", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e994", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1595,11 +1595,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1653 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0x80ebc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ebe0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1654 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0x80ebc8", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ebe8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1613,11 +1613,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1655 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x80ebd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ebf0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1656 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x80ebe0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ec00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1640,11 +1640,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1625 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0x80e4d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e4f0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1626 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x80e4d4", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e4f4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1658,11 +1658,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1627 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0x80e4e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e500", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 1628 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x80e4ec", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e50c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1894,7 +1894,7 @@ Probes:
               InjectionPoints:
                 - PC: "0x139638"
                   Frameless: true
-                - PC: "0x8083c0"
+                - PC: "0x8083e0"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2190,11 +2190,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1569 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0x80b600", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b620", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1570 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x80b730", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b750", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2216,7 +2216,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1477 EventRootType Probe[main.testLinkedList]
-              InjectionPoints: [{PC: "0x809d40", Frameless: true}]
+              InjectionPoints: [{PC: "0x809d60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -2328,11 +2328,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1575 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0x80ba6c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ba8c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1576 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0x80bbc0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80bbe0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2441,7 +2441,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1449 EventRootType Probe[main.testMapArrayToArray]
-              InjectionPoints: [{PC: "0x808460", Frameless: true}]
+              InjectionPoints: [{PC: "0x808480", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2463,7 +2463,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1456 EventRootType Probe[main.testMapEmbeddedMaps]
-              InjectionPoints: [{PC: "0x8084c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8084e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2485,7 +2485,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1466 EventRootType Probe[main.testMapEmptyKey]
-              InjectionPoints: [{PC: "0x808560", Frameless: true}]
+              InjectionPoints: [{PC: "0x808580", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2507,7 +2507,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1468 EventRootType Probe[main.testMapEmptyKeyAndValue]
-              InjectionPoints: [{PC: "0x808580", Frameless: true}]
+              InjectionPoints: [{PC: "0x8085a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2529,7 +2529,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1467 EventRootType Probe[main.testMapEmptyValue]
-              InjectionPoints: [{PC: "0x808570", Frameless: true}]
+              InjectionPoints: [{PC: "0x808590", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2551,7 +2551,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1453 EventRootType Probe[main.testMapIntToInt]
-              InjectionPoints: [{PC: "0x8084a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8084c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2573,7 +2573,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1465 EventRootType Probe[main.testMapLargeKeyLargeValue]
-              InjectionPoints: [{PC: "0x808550", Frameless: true}]
+              InjectionPoints: [{PC: "0x808570", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2595,7 +2595,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1464 EventRootType Probe[main.testMapLargeKeySmallValue]
-              InjectionPoints: [{PC: "0x808540", Frameless: true}]
+              InjectionPoints: [{PC: "0x808560", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2619,7 +2619,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1454 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x8084b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8084d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2643,7 +2643,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1455 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x8084b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8084d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2665,7 +2665,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1463 EventRootType Probe[main.testMapSmallKeyLargeValue]
-              InjectionPoints: [{PC: "0x808530", Frameless: true}]
+              InjectionPoints: [{PC: "0x808550", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2687,7 +2687,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1462 EventRootType Probe[main.testMapSmallKeySmallValue]
-              InjectionPoints: [{PC: "0x808520", Frameless: true}]
+              InjectionPoints: [{PC: "0x808540", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2709,7 +2709,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1447 EventRootType Probe[main.testMapStringToInt]
-              InjectionPoints: [{PC: "0x808440", Frameless: true}]
+              InjectionPoints: [{PC: "0x808460", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2731,7 +2731,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1448 EventRootType Probe[main.testMapStringToSlice]
-              InjectionPoints: [{PC: "0x808450", Frameless: true}]
+              InjectionPoints: [{PC: "0x808470", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2753,7 +2753,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1446 EventRootType Probe[main.testMapStringToStruct]
-              InjectionPoints: [{PC: "0x808430", Frameless: true}]
+              InjectionPoints: [{PC: "0x808450", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2775,7 +2775,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1457 EventRootType Probe[main.testMapWithLinkedList]
-              InjectionPoints: [{PC: "0x8084d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8084f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2797,7 +2797,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1460 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-              InjectionPoints: [{PC: "0x808500", Frameless: true}]
+              InjectionPoints: [{PC: "0x808520", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2819,7 +2819,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1461 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-              InjectionPoints: [{PC: "0x808510", Frameless: true}]
+              InjectionPoints: [{PC: "0x808530", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2841,7 +2841,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1458 EventRootType Probe[main.testMapWithSmallValue]
-              InjectionPoints: [{PC: "0x8084e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x808500", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2865,7 +2865,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1459 EventRootType Probe[main.testMapWithSmallValueMassive]
-              InjectionPoints: [{PC: "0x8084f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x808510", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2887,7 +2887,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1609 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x80cbf0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cc10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2910,7 +2910,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1610 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x80cbf0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cc10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2957,11 +2957,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1577 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0x80bc20", Frameless: false}]
+              InjectionPoints: [{PC: "0x80bc40", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1578 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0x80bdac", Frameless: false}]
+              InjectionPoints: [{PC: "0x80bdcc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -3027,11 +3027,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1581 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0x80be9c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80bebc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1582 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0x80bf38", Frameless: false}]
+              InjectionPoints: [{PC: "0x80bf58", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3062,11 +3062,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1573 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0x80b860", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b880", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1574 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0x80ba08", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ba28", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3092,11 +3092,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1514 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80a908", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a928", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1515 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80a98c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a9ac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3132,7 +3132,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1472 EventRootType Probe[main.testMultipleSimpleParams]
-              InjectionPoints: [{PC: "0x8099d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8099f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -3173,11 +3173,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1508 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x80a868", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a888", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1509 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x80a8c4", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a8e4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3201,11 +3201,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1510 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x80a868", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a888", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1511 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x80a8c4", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a8e4", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
       version: 0
@@ -3224,11 +3224,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1516 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80a908", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a928", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1517 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80a98c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a9ac", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
       version: 0
@@ -3248,11 +3248,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1518 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80a908", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a928", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1519 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80a98c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a9ac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r1={result} r2={result2}
@@ -3285,11 +3285,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1512 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x80a868", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a888", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1513 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x80a8c4", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a8e4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Parameter {i} * 2 = result {result}
@@ -3317,7 +3317,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1618 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80ce80", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cea0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3342,7 +3342,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1619 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80ce80", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cea0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3373,7 +3373,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1620 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80ce80", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cea0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3398,7 +3398,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1621 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80ce80", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cea0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3425,7 +3425,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1482 EventRootType Probe[main.testNilPointer]
-              InjectionPoints: [{PC: "0x809e10", Frameless: true}]
+              InjectionPoints: [{PC: "0x809e30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}, {a}'
@@ -3452,7 +3452,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1595 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0x80c580", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c5a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3479,7 +3479,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1592 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0x80c550", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c570", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3514,7 +3514,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1594 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0x80c570", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c590", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3546,7 +3546,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1608 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0x80cbe0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cc00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3568,7 +3568,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1478 EventRootType Probe[main.testPointerLoop]
-              InjectionPoints: [{PC: "0x809d50", Frameless: true}]
+              InjectionPoints: [{PC: "0x809d70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3590,7 +3590,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1452 EventRootType Probe[main.testPointerToMap]
-              InjectionPoints: [{PC: "0x808490", Frameless: true}]
+              InjectionPoints: [{PC: "0x8084b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3612,7 +3612,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1476 EventRootType Probe[main.testPointerToSimpleStruct]
-              InjectionPoints: [{PC: "0x809d30", Frameless: true}]
+              InjectionPoints: [{PC: "0x809d50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3636,11 +3636,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1484 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x80a148", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a168", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1485 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x80a188", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a1a8", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
       version: 0
@@ -3660,11 +3660,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1528 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x80a9c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a9e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1529 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x80aa50", Frameless: false}]
+              InjectionPoints: [{PC: "0x80aa70", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3707,11 +3707,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1494 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x80a268", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a288", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1495 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x80a2f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a318", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3751,11 +3751,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1486 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x80a148", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a168", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1487 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x80a188", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a1a8", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3798,11 +3798,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1496 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x80a268", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a288", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1497 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x80a2f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a318", Frameless: false}]
               Condition:
                 Type: 5 BaseType bool
                 Operations:
@@ -3844,11 +3844,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1530 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x80a9c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a9e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1531 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x80aa50", Frameless: false}]
+              InjectionPoints: [{PC: "0x80aa70", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
       version: 0
@@ -3865,11 +3865,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1532 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x80a9c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a9e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1533 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x80aa50", Frameless: false}]
+              InjectionPoints: [{PC: "0x80aa70", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r0={@return.r0}
@@ -3891,11 +3891,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1488 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x80a148", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a168", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1489 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x80a188", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a1a8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: result={@return}
@@ -3918,18 +3918,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1504 EventRootType Probe[main.testReturnsAny]
-              InjectionPoints: [{PC: "0x80a538", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a558", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1505 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
-                - PC: "0x80a5c0"
+                - PC: "0x80a5e0"
                   Frameless: false
-                - PC: "0x80a614"
+                - PC: "0x80a634"
                   Frameless: false
-                - PC: "0x80a6cc"
+                - PC: "0x80a6ec"
                   Frameless: false
-                - PC: "0x80a6e0"
+                - PC: "0x80a700"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3957,18 +3957,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 1502 EventRootType Probe[main.testReturnsAnyAndError]
-              InjectionPoints: [{PC: "0x80a3b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a3d8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1503 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
-                - PC: "0x80a40c"
+                - PC: "0x80a42c"
                   Frameless: false
-                - PC: "0x80a468"
+                - PC: "0x80a488"
                   Frameless: false
-                - PC: "0x80a4b0"
+                - PC: "0x80a4d0"
                   Frameless: false
-                - PC: "0x80a4f4"
+                - PC: "0x80a514"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3995,11 +3995,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1547 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0x80b03c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b05c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1548 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0x80b08c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b0ac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -4016,11 +4016,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1549 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0x80b0c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b0e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1550 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0x80b100", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b120", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -4037,11 +4037,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1551 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0x80b138", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b158", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1552 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0x80b16c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b18c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4058,11 +4058,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1555 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0x80b228", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b248", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1556 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0x80b288", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b2a8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4079,11 +4079,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1567 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0x80b588", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b5a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1568 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0x80b5c4", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b5e4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4100,11 +4100,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1543 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0x80aef8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80af18", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1544 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0x80af40", Frameless: false}]
+              InjectionPoints: [{PC: "0x80af60", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4122,14 +4122,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1500 EventRootType Probe[main.testReturnsError]
-              InjectionPoints: [{PC: "0x80a338", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a358", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1501 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
-                - PC: "0x80a36c"
+                - PC: "0x80a38c"
                   Frameless: false
-                - PC: "0x80a380"
+                - PC: "0x80a3a0"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4151,11 +4151,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1490 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x80a148", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a168", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1491 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x80a188", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a1a8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4176,11 +4176,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1498 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x80a268", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a288", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1499 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x80a2f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a318", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4201,11 +4201,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1492 EventRootType Probe[main.testReturnsIntPointer]
-              InjectionPoints: [{PC: "0x80a1c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a1e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1493 EventRootType Probe[main.testReturnsIntPointer]Return
-              InjectionPoints: [{PC: "0x80a224", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a244", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4227,14 +4227,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1506 EventRootType Probe[main.testReturnsInterface]
-              InjectionPoints: [{PC: "0x80a718", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a738", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1507 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
-                - PC: "0x80a7d0"
+                - PC: "0x80a7f0"
                   Frameless: false
-                - PC: "0x80a7e4"
+                - PC: "0x80a804"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4256,11 +4256,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1545 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0x80af80", Frameless: false}]
+              InjectionPoints: [{PC: "0x80afa0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1546 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0x80b000", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b020", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4277,11 +4277,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1541 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0x80ae48", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ae68", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1542 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0x80aec8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80aee8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4298,11 +4298,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1559 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0x80b388", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b3a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1560 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0x80b3dc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b3fc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4319,11 +4319,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1553 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0x80b1a8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b1c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1554 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0x80b1ec", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b20c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4340,11 +4340,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1565 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0x80b518", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b538", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1566 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0x80b558", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b578", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
@@ -4364,7 +4364,7 @@ Probes:
           events:
             - Kind: Line
               Type: 1538 EventRootType Probe[main.testReturnsNamedDeferLine]Line
-              InjectionPoints: [{PC: "0x80ac14", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ac34", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4385,11 +4385,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1563 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0x80b4a8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b4c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1564 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0x80b4e4", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b504", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4406,11 +4406,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1539 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0x80adb8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80add8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1540 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0x80ae0c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ae2c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4427,11 +4427,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1561 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0x80b41c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b43c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1562 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0x80b46c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b48c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4448,11 +4448,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1557 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0x80b2c0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b2e0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1558 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0x80b350", Frameless: false}]
+              InjectionPoints: [{PC: "0x80b370", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4505,11 +4505,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1520 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80a908", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a928", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1521 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80a98c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a9ac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -4784,7 +4784,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1602 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0x80cba0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cbc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4916,7 +4916,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1598 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0x80c5a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c5c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -4938,7 +4938,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1589 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0x80c520", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c540", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -4960,7 +4960,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1450 EventRootType Probe[main.testSmallMap]
-              InjectionPoints: [{PC: "0x808470", Frameless: true}]
+              InjectionPoints: [{PC: "0x808490", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -4981,11 +4981,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1534 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x80a9c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a9e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1535 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x80aa50", Frameless: false}]
+              InjectionPoints: [{PC: "0x80aa70", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -5006,11 +5006,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1579 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0x80be08", Frameless: false}]
+              InjectionPoints: [{PC: "0x80be28", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1580 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0x80be64", Frameless: false}]
+              InjectionPoints: [{PC: "0x80be84", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5054,7 +5054,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1481 EventRootType Probe[main.testStringPointer]
-              InjectionPoints: [{PC: "0x809df0", Frameless: true}]
+              InjectionPoints: [{PC: "0x809e10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}'
@@ -5076,7 +5076,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1593 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0x80c560", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c580", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5142,7 +5142,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1617 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x80ce20", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ce40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5169,7 +5169,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1590 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0x80c530", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c550", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5217,11 +5217,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1583 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0x80bf6c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80bf8c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1584 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0x80bff4", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c014", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5243,7 +5243,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1615 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0x80cd80", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cda0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5264,7 +5264,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1614 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0x80cd70", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cd90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5291,7 +5291,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1445 EventRootType Probe[main.testStructWithMap]
-              InjectionPoints: [{PC: "0x808420", Frameless: true}]
+              InjectionPoints: [{PC: "0x808440", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s} {@duration}'
@@ -5324,7 +5324,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1599 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0x80c5b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c5d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5364,7 +5364,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1613 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0x80cc20", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cc40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5397,11 +5397,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1522 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80a908", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a928", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1523 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80a98c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a9ac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{nonexistentVariable}'
@@ -5422,11 +5422,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1524 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80a908", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a928", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1525 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80a98c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a9ac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{unsupportedExpression}'
@@ -5449,11 +5449,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1526 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80a908", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a928", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1527 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80a98c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a9ac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -5485,7 +5485,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1603 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0x80cbb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cbd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5517,7 +5517,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1604 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x80cbc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cbe0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5547,7 +5547,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1605 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x80cbc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cbe0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5579,7 +5579,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1606 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x80cbd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cbf0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5609,7 +5609,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1607 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x80cbd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cbf0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5773,7 +5773,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1480 EventRootType Probe[main.testUintPointer]
-              InjectionPoints: [{PC: "0x809d80", Frameless: true}]
+              InjectionPoints: [{PC: "0x809da0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5795,7 +5795,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1587 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0x80c500", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c520", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5817,7 +5817,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1611 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0x80cc00", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cc20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5839,7 +5839,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1479 EventRootType Probe[main.testUnsafePointer]
-              InjectionPoints: [{PC: "0x809d60", Frameless: true}]
+              InjectionPoints: [{PC: "0x809d80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5883,7 +5883,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1596 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x80c590", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c5b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5905,7 +5905,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 1597 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x80c590", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c5b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5930,7 +5930,7 @@ Probes:
               InjectionPoints:
                 - PC: "0x807c28"
                   Frameless: false
-                - PC: "0x80ef50"
+                - PC: "0x80ef70"
                   Frameless: false
               Condition: null
             - Kind: Return
@@ -5957,11 +5957,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 1585 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0x80c028", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c048", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1586 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x80c08c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80c0ac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -7030,214 +7030,188 @@ Subprograms:
       DictRegister: null
     - ID: 63
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x808420..0x808430]
+      OutOfLinePCRanges: [0x808440..0x808450]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 176 StructureType main.structWithMap
-          Locations:
-            - Range: 0x808420..0x808430
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 64
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x808430..0x808440]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 182 GoMapType map[string]main.nestedStruct
-          Locations:
-            - Range: 0x808430..0x808440
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 65
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0x808440..0x808450]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 187 GoMapType map[string]int
           Locations:
             - Range: 0x808440..0x808450
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 66
-      Name: main.testMapStringToSlice
+    - ID: 64
+      Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0x808450..0x808460]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 192 GoMapType map[string][]string
+          Type: 182 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0x808450..0x808460
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 67
-      Name: main.testMapArrayToArray
+    - ID: 65
+      Name: main.testMapStringToInt
       OutOfLinePCRanges: [0x808460..0x808470]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 197 GoMapType map[[4]string][2]int
+          Type: 187 GoMapType map[string]int
           Locations:
             - Range: 0x808460..0x808470
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 68
-      Name: main.testSmallMap
+    - ID: 66
+      Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0x808470..0x808480]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 187 GoMapType map[string]int
+          Type: 192 GoMapType map[string][]string
           Locations:
             - Range: 0x808470..0x808480
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 69
-      Name: main.testArrayOfMaps
+    - ID: 67
+      Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0x808480..0x808490]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 202 ArrayType [2]map[string]int
+          Type: 197 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0x808480..0x808490
-              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 70
-      Name: main.testPointerToMap
+    - ID: 68
+      Name: main.testSmallMap
       OutOfLinePCRanges: [0x808490..0x8084a0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 203 PointerType *map[string]int
+          Type: 187 GoMapType map[string]int
           Locations:
             - Range: 0x808490..0x8084a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 71
-      Name: main.testMapIntToInt
+    - ID: 69
+      Name: main.testArrayOfMaps
       OutOfLinePCRanges: [0x8084a0..0x8084b0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 177 GoMapType map[int]int
+          Type: 202 ArrayType [2]map[string]int
           Locations:
             - Range: 0x8084a0..0x8084b0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 72
-      Name: main.testMapMassive
+    - ID: 70
+      Name: main.testPointerToMap
       OutOfLinePCRanges: [0x8084b0..0x8084c0]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 204 GoMapType map[string][]main.structWithMap
+        - Name: m
+          Type: 203 PointerType *map[string]int
           Locations:
             - Range: 0x8084b0..0x8084c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 73
-      Name: main.testMapEmbeddedMaps
+    - ID: 71
+      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0x8084c0..0x8084d0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 204 GoMapType map[string][]main.structWithMap
+          Type: 177 GoMapType map[int]int
           Locations:
             - Range: 0x8084c0..0x8084d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 74
-      Name: main.testMapWithLinkedList
+    - ID: 72
+      Name: main.testMapMassive
       OutOfLinePCRanges: [0x8084d0..0x8084e0]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 209 GoMapType map[bool]main.node
+        - Name: redactMyEntries
+          Type: 204 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x8084d0..0x8084e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 75
-      Name: main.testMapWithSmallValue
+    - ID: 73
+      Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0x8084e0..0x8084f0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 214 GoMapType map[int]uint8
+          Type: 204 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x8084e0..0x8084f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 76
-      Name: main.testMapWithSmallValueMassive
+    - ID: 74
+      Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0x8084f0..0x808500]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 214 GoMapType map[int]uint8
+        - Name: m
+          Type: 209 GoMapType map[bool]main.node
           Locations:
             - Range: 0x8084f0..0x808500
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 77
-      Name: main.testMapWithSmallKeyAndValue
+    - ID: 75
+      Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0x808500..0x808510]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 219 GoMapType map[uint8]uint8
+          Type: 214 GoMapType map[int]uint8
           Locations:
             - Range: 0x808500..0x808510
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 78
-      Name: main.testMapWithSmallKeyAndValueMassive
+    - ID: 76
+      Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0x808510..0x808520]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 219 GoMapType map[uint8]uint8
+        - Name: redactMyEntries
+          Type: 214 GoMapType map[int]uint8
           Locations:
             - Range: 0x808510..0x808520
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 79
-      Name: main.testMapSmallKeySmallValue
+    - ID: 77
+      Name: main.testMapWithSmallKeyAndValue
       OutOfLinePCRanges: [0x808520..0x808530]
       InlinePCRanges: []
       Variables:
@@ -7249,113 +7223,112 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 80
-      Name: main.testMapSmallKeyLargeValue
+    - ID: 78
+      Name: main.testMapWithSmallKeyAndValueMassive
       OutOfLinePCRanges: [0x808530..0x808540]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 224 GoMapType map[uint8][4]int
+          Type: 219 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x808530..0x808540
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 81
-      Name: main.testMapLargeKeySmallValue
+    - ID: 79
+      Name: main.testMapSmallKeySmallValue
       OutOfLinePCRanges: [0x808540..0x808550]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 229 GoMapType map[[4]int]uint8
+          Type: 219 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x808540..0x808550
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 82
-      Name: main.testMapLargeKeyLargeValue
+    - ID: 80
+      Name: main.testMapSmallKeyLargeValue
       OutOfLinePCRanges: [0x808550..0x808560]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 234 GoMapType map[[4]int][4]int
+          Type: 224 GoMapType map[uint8][4]int
           Locations:
             - Range: 0x808550..0x808560
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 83
-      Name: main.testMapEmptyKey
+    - ID: 81
+      Name: main.testMapLargeKeySmallValue
       OutOfLinePCRanges: [0x808560..0x808570]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 239 GoMapType map[struct {}]int
+          Type: 229 GoMapType map[[4]int]uint8
           Locations:
             - Range: 0x808560..0x808570
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 84
-      Name: main.testMapEmptyValue
+    - ID: 82
+      Name: main.testMapLargeKeyLargeValue
       OutOfLinePCRanges: [0x808570..0x808580]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 244 GoMapType map[int]struct {}
+          Type: 234 GoMapType map[[4]int][4]int
           Locations:
             - Range: 0x808570..0x808580
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 85
-      Name: main.testMapEmptyKeyAndValue
+    - ID: 83
+      Name: main.testMapEmptyKey
       OutOfLinePCRanges: [0x808580..0x808590]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 249 GoMapType map[struct {}]struct {}
+          Type: 239 GoMapType map[struct {}]int
           Locations:
             - Range: 0x808580..0x808590
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 86
-      Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x8098f0..0x809900]
+    - ID: 84
+      Name: main.testMapEmptyValue
+      OutOfLinePCRanges: [0x808590..0x8085a0]
       InlinePCRanges: []
       Variables:
-        - Name: w
-          Type: 4 BaseType uint8
+        - Name: m
+          Type: 244 GoMapType map[int]struct {}
           Locations:
-            - Range: 0x8098f0..0x809900
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: x
-          Type: 4 BaseType uint8
-          Locations:
-            - Range: 0x8098f0..0x809900
-              Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: "y"
-          Type: 18 BaseType float32
-          Locations:
-            - Range: 0x8098f0..0x809900
-              Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
+            - Range: 0x808590..0x8085a0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 87
-      Name: main.testCombinedString
+    - ID: 85
+      Name: main.testMapEmptyKeyAndValue
+      OutOfLinePCRanges: [0x8085a0..0x8085b0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 249 GoMapType map[struct {}]struct {}
+          Locations:
+            - Range: 0x8085a0..0x8085b0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 86
+      Name: main.testCombinedByte
       OutOfLinePCRanges: [0x809910..0x809920]
       InlinePCRanges: []
       Variables:
@@ -7367,14 +7340,10 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
         - Name: x
-          Type: 10 GoStringHeaderType string
+          Type: 4 BaseType uint8
           Locations:
             - Range: 0x809910..0x809920
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
+              Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: "y"
@@ -7385,43 +7354,74 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 87
+      Name: main.testCombinedString
+      OutOfLinePCRanges: [0x809930..0x809940]
+      InlinePCRanges: []
+      Variables:
+        - Name: w
+          Type: 4 BaseType uint8
+          Locations:
+            - Range: 0x809930..0x809940
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: x
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0x809930..0x809940
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: "y"
+          Type: 18 BaseType float32
+          Locations:
+            - Range: 0x809930..0x809940
+              Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 88
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x8099d0..0x8099e0]
+      OutOfLinePCRanges: [0x8099f0..0x809a00]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x8099d0..0x8099e0
+            - Range: 0x8099f0..0x809a00
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x8099d0..0x8099e0
+            - Range: 0x8099f0..0x809a00
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x8099d0..0x8099e0
+            - Range: 0x8099f0..0x809a00
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x8099d0..0x8099e0
+            - Range: 0x8099f0..0x809a00
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x8099d0..0x8099e0
+            - Range: 0x8099f0..0x809a00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7432,63 +7432,63 @@ Subprograms:
       DictRegister: null
     - ID: 89
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0x809b70..0x809bb0]
+      OutOfLinePCRanges: [0x809b90..0x809bd0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0x809b70..0x809bac
+            - Range: 0x809b90..0x809bcc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0x809b70..0x809bac
+            - Range: 0x809b90..0x809bcc
               Pieces: []
-            - Range: 0x809bac..0x809bad
+            - Range: 0x809bcc..0x809bcd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x809bad..0x809bb0
+            - Range: 0x809bcd..0x809bd0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 90
       Name: main.testChannel
-      OutOfLinePCRanges: [0x809bb0..0x809bc0]
+      OutOfLinePCRanges: [0x809bd0..0x809be0]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 254 GoChannelType chan bool
           Locations:
-            - Range: 0x809bb0..0x809bc0
+            - Range: 0x809bd0..0x809be0
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 91
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x809d30..0x809d40]
+      OutOfLinePCRanges: [0x809d50..0x809d60]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 255 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x809d30..0x809d40
+            - Range: 0x809d50..0x809d60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 92
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x809d40..0x809d50]
+      OutOfLinePCRanges: [0x809d60..0x809d70]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 257 StructureType main.node
           Locations:
-            - Range: 0x809d40..0x809d50
+            - Range: 0x809d60..0x809d70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7499,267 +7499,267 @@ Subprograms:
       DictRegister: null
     - ID: 93
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x809d50..0x809d60]
+      OutOfLinePCRanges: [0x809d70..0x809d80]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 258 PointerType *main.node
           Locations:
-            - Range: 0x809d50..0x809d60
+            - Range: 0x809d70..0x809d80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 94
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x809d60..0x809d70]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 17 VoidPointerType unsafe.Pointer
-          Locations:
-            - Range: 0x809d60..0x809d70
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 95
-      Name: main.testUintPointer
       OutOfLinePCRanges: [0x809d80..0x809d90]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 113 PointerType *uint
+          Type: 17 VoidPointerType unsafe.Pointer
           Locations:
             - Range: 0x809d80..0x809d90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 95
+      Name: main.testUintPointer
+      OutOfLinePCRanges: [0x809da0..0x809db0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 113 PointerType *uint
+          Locations:
+            - Range: 0x809da0..0x809db0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 96
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x809df0..0x809e00]
+      OutOfLinePCRanges: [0x809e10..0x809e20]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 102 PointerType *string
           Locations:
-            - Range: 0x809df0..0x809e00
+            - Range: 0x809e10..0x809e20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 97
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x809e10..0x809e20]
+      OutOfLinePCRanges: [0x809e30..0x809e40]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 11 PointerType *bool
           Locations:
-            - Range: 0x809e10..0x809e20
+            - Range: 0x809e30..0x809e40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x809e10..0x809e20
+            - Range: 0x809e30..0x809e40
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 98
       Name: main.testCycle
-      OutOfLinePCRanges: [0x809e30..0x809e40]
+      OutOfLinePCRanges: [0x809e50..0x809e60]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 259 PointerType *main.t
           Locations:
-            - Range: 0x809e30..0x809e40
+            - Range: 0x809e50..0x809e60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 99
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0x80a130..0x80a1b0]
+      OutOfLinePCRanges: [0x80a150..0x80a1d0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80a130..0x80a14c
+            - Range: 0x80a150..0x80a16c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80a130..0x80a188
+            - Range: 0x80a150..0x80a1a8
               Pieces: []
-            - Range: 0x80a188..0x80a189
+            - Range: 0x80a1a8..0x80a1a9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a189..0x80a1b0
+            - Range: 0x80a1a9..0x80a1d0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80a14c..0x80a158
+            - Range: 0x80a16c..0x80a178
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a158..0x80a1b0
+            - Range: 0x80a178..0x80a1d0
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 100
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0x80a1b0..0x80a250]
+      OutOfLinePCRanges: [0x80a1d0..0x80a270]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80a1b0..0x80a1d4
+            - Range: 0x80a1d0..0x80a1f4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a1d4..0x80a250
+            - Range: 0x80a1f4..0x80a270
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 106 PointerType *int
           Locations:
-            - Range: 0x80a1b0..0x80a224
+            - Range: 0x80a1d0..0x80a244
               Pieces: []
-            - Range: 0x80a224..0x80a225
+            - Range: 0x80a244..0x80a245
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a225..0x80a250
+            - Range: 0x80a245..0x80a270
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: '&result'
           Type: 106 PointerType *int
           Locations:
-            - Range: 0x80a1d8..0x80a1f0
+            - Range: 0x80a1f8..0x80a210
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a1f0..0x80a250
+            - Range: 0x80a210..0x80a270
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 101
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0x80a250..0x80a320]
+      OutOfLinePCRanges: [0x80a270..0x80a340]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80a250..0x80a2a8
+            - Range: 0x80a270..0x80a2c8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80a250..0x80a2f8
+            - Range: 0x80a270..0x80a318
               Pieces: []
-            - Range: 0x80a2f8..0x80a2f9
+            - Range: 0x80a318..0x80a319
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a2f9..0x80a320
+            - Range: 0x80a319..0x80a340
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80a250..0x80a320, Pieces: []}]
+          Locations: [{Range: 0x80a270..0x80a340, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: resultInt
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80a26c..0x80a2ac
+            - Range: 0x80a28c..0x80a2cc
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80a2ac..0x80a320
+            - Range: 0x80a2cc..0x80a340
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: -1
         - Name: resultFloat
           Type: 15 BaseType float64
           Locations:
-            - Range: 0x80a27c..0x80a2ac
+            - Range: 0x80a29c..0x80a2cc
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-            - Range: 0x80a2ac..0x80a320
+            - Range: 0x80a2cc..0x80a340
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 102
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0x80a320..0x80a3a0]
+      OutOfLinePCRanges: [0x80a340..0x80a3c0]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x80a320..0x80a340
+            - Range: 0x80a340..0x80a360
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 16 GoInterfaceType error
           Locations:
-            - Range: 0x80a320..0x80a36c
+            - Range: 0x80a340..0x80a38c
               Pieces: []
-            - Range: 0x80a36c..0x80a36d
+            - Range: 0x80a38c..0x80a38d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a36d..0x80a380
+            - Range: 0x80a38d..0x80a3a0
               Pieces: []
-            - Range: 0x80a380..0x80a381
+            - Range: 0x80a3a0..0x80a3a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a381..0x80a3a0
+            - Range: 0x80a3a1..0x80a3c0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 103
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0x80a3a0..0x80a520]
+      OutOfLinePCRanges: [0x80a3c0..0x80a540]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 168 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80a3a0..0x80a3f0
+            - Range: 0x80a3c0..0x80a410
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a3f0..0x80a3f4
+            - Range: 0x80a410..0x80a414
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x80a478..0x80a480
+            - Range: 0x80a498..0x80a4a0
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a4c0..0x80a4c8
+            - Range: 0x80a4e0..0x80a4e8
               Pieces:
                 - Size: 8
                   Op: null
@@ -7770,117 +7770,117 @@ Subprograms:
         - Name: failed
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x80a3a0..0x80a3f8
+            - Range: 0x80a3c0..0x80a418
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 168 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80a3a0..0x80a40c
+            - Range: 0x80a3c0..0x80a42c
               Pieces: []
-            - Range: 0x80a40c..0x80a40d
+            - Range: 0x80a42c..0x80a42d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a40d..0x80a468
+            - Range: 0x80a42d..0x80a488
               Pieces: []
-            - Range: 0x80a468..0x80a469
+            - Range: 0x80a488..0x80a489
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a469..0x80a4b0
+            - Range: 0x80a489..0x80a4d0
               Pieces: []
-            - Range: 0x80a4b0..0x80a4b1
+            - Range: 0x80a4d0..0x80a4d1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a4b1..0x80a4f4
+            - Range: 0x80a4d1..0x80a514
               Pieces: []
-            - Range: 0x80a4f4..0x80a4f5
+            - Range: 0x80a514..0x80a515
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a4f5..0x80a520
+            - Range: 0x80a515..0x80a540
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 16 GoInterfaceType error
           Locations:
-            - Range: 0x80a3a0..0x80a40c
+            - Range: 0x80a3c0..0x80a42c
               Pieces: []
-            - Range: 0x80a40c..0x80a40d
+            - Range: 0x80a42c..0x80a42d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80a40d..0x80a468
+            - Range: 0x80a42d..0x80a488
               Pieces: []
-            - Range: 0x80a468..0x80a469
+            - Range: 0x80a488..0x80a489
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80a469..0x80a4b0
+            - Range: 0x80a489..0x80a4d0
               Pieces: []
-            - Range: 0x80a4b0..0x80a4b1
+            - Range: 0x80a4d0..0x80a4d1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80a4b1..0x80a4f4
+            - Range: 0x80a4d1..0x80a514
               Pieces: []
-            - Range: 0x80a4f4..0x80a4f5
+            - Range: 0x80a514..0x80a515
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80a4f5..0x80a520
+            - Range: 0x80a515..0x80a540
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80a3f0..0x80a3f8
+            - Range: 0x80a410..0x80a418
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 104
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0x80a520..0x80a700]
+      OutOfLinePCRanges: [0x80a540..0x80a720]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 168 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80a520..0x80a560
+            - Range: 0x80a540..0x80a580
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a560..0x80a568
+            - Range: 0x80a580..0x80a588
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80a568..0x80a700
+            - Range: 0x80a588..0x80a720
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -7891,549 +7891,549 @@ Subprograms:
         - Name: ~r0
           Type: 168 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80a520..0x80a5c0
+            - Range: 0x80a540..0x80a5e0
               Pieces: []
-            - Range: 0x80a5c0..0x80a5c1
+            - Range: 0x80a5e0..0x80a5e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a5c1..0x80a614
+            - Range: 0x80a5e1..0x80a634
               Pieces: []
-            - Range: 0x80a614..0x80a615
+            - Range: 0x80a634..0x80a635
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a615..0x80a6cc
+            - Range: 0x80a635..0x80a6ec
               Pieces: []
-            - Range: 0x80a6cc..0x80a6cd
+            - Range: 0x80a6ec..0x80a6ed
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a6cd..0x80a6e0
+            - Range: 0x80a6ed..0x80a700
               Pieces: []
-            - Range: 0x80a6e0..0x80a6e1
+            - Range: 0x80a700..0x80a701
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a6e1..0x80a700
+            - Range: 0x80a701..0x80a720
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80a5ac..0x80a5b4
+            - Range: 0x80a5cc..0x80a5d4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: '&result'
           Type: 106 PointerType *int
           Locations:
-            - Range: 0x80a5f8..0x80a614
+            - Range: 0x80a618..0x80a634
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 105
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0x80a700..0x80a850]
+      OutOfLinePCRanges: [0x80a720..0x80a870]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 168 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80a700..0x80a73c
+            - Range: 0x80a720..0x80a75c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a73c..0x80a780
+            - Range: 0x80a75c..0x80a7a0
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x80a780..0x80a7f0
+            - Range: 0x80a7a0..0x80a810
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x80a7f0..0x80a818
+            - Range: 0x80a810..0x80a838
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80a818..0x80a81c
+            - Range: 0x80a838..0x80a83c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80a81c..0x80a850
+            - Range: 0x80a83c..0x80a870
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 173 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x80a700..0x80a7d0
+            - Range: 0x80a720..0x80a7f0
               Pieces: []
-            - Range: 0x80a7d0..0x80a7d1
+            - Range: 0x80a7f0..0x80a7f1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a7d1..0x80a7e4
+            - Range: 0x80a7f1..0x80a804
               Pieces: []
-            - Range: 0x80a7e4..0x80a7e5
+            - Range: 0x80a804..0x80a805
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a7e5..0x80a850
+            - Range: 0x80a805..0x80a870
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 173 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x80a700..0x80a73c
+            - Range: 0x80a720..0x80a75c
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a73c..0x80a780
+            - Range: 0x80a75c..0x80a7a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80a780..0x80a788
+            - Range: 0x80a7a0..0x80a7a8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80a788..0x80a7dc
+            - Range: 0x80a7a8..0x80a7fc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80a7dc..0x80a7e0
+            - Range: 0x80a7fc..0x80a800
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80a7e0..0x80a7e4
+            - Range: 0x80a800..0x80a804
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x80a7e4..0x80a850
+            - Range: 0x80a804..0x80a870
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 106
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0x80a850..0x80a8f0]
+      OutOfLinePCRanges: [0x80a870..0x80a910]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80a850..0x80a86c
+            - Range: 0x80a870..0x80a88c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80a850..0x80a8c4
+            - Range: 0x80a870..0x80a8e4
               Pieces: []
-            - Range: 0x80a8c4..0x80a8c5
+            - Range: 0x80a8e4..0x80a8e5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a8c5..0x80a8f0
+            - Range: 0x80a8e5..0x80a910
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 107
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0x80a8f0..0x80a9b0]
+      OutOfLinePCRanges: [0x80a910..0x80a9d0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80a8f0..0x80a940
+            - Range: 0x80a910..0x80a960
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80a8f0..0x80a98c
+            - Range: 0x80a910..0x80a9ac
               Pieces: []
-            - Range: 0x80a98c..0x80a98d
+            - Range: 0x80a9ac..0x80a9ad
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a98d..0x80a9b0
+            - Range: 0x80a9ad..0x80a9d0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80a8f0..0x80a98c
+            - Range: 0x80a910..0x80a9ac
               Pieces: []
-            - Range: 0x80a98c..0x80a98d
+            - Range: 0x80a9ac..0x80a9ad
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80a98d..0x80a9b0
+            - Range: 0x80a9ad..0x80a9d0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 108
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0x80a9b0..0x80aa70]
+      OutOfLinePCRanges: [0x80a9d0..0x80aa90]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80a9b0..0x80a9f0
+            - Range: 0x80a9d0..0x80aa10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a9f0..0x80aa70
+            - Range: 0x80aa10..0x80aa90
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80a9b0..0x80aa50
+            - Range: 0x80a9d0..0x80aa70
               Pieces: []
-            - Range: 0x80aa50..0x80aa51
+            - Range: 0x80aa70..0x80aa71
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80aa51..0x80aa70
+            - Range: 0x80aa71..0x80aa90
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80a9b0..0x80aa50
+            - Range: 0x80a9d0..0x80aa70
               Pieces: []
-            - Range: 0x80aa50..0x80aa51
+            - Range: 0x80aa70..0x80aa71
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80aa51..0x80aa70
+            - Range: 0x80aa71..0x80aa90
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80a9b0..0x80aa50
+            - Range: 0x80a9d0..0x80aa70
               Pieces: []
-            - Range: 0x80aa50..0x80aa51
+            - Range: 0x80aa70..0x80aa71
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80aa51..0x80aa70
+            - Range: 0x80aa71..0x80aa90
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 109
       Name: main.testConflictingReturn
-      OutOfLinePCRanges: [0x80aa70..0x80ab50]
+      OutOfLinePCRanges: [0x80aa90..0x80ab70]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80aa70..0x80aab0
+            - Range: 0x80aa90..0x80aad0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80aab0..0x80ab50
+            - Range: 0x80aad0..0x80ab70
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80aa70..0x80ab2c
+            - Range: 0x80aa90..0x80ab4c
               Pieces: []
-            - Range: 0x80ab2c..0x80ab2d
+            - Range: 0x80ab4c..0x80ab4d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ab2d..0x80ab50
+            - Range: 0x80ab4d..0x80ab70
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80aa70..0x80ab2c
+            - Range: 0x80aa90..0x80ab4c
               Pieces: []
-            - Range: 0x80ab2c..0x80ab2d
+            - Range: 0x80ab4c..0x80ab4d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80ab2d..0x80ab50
+            - Range: 0x80ab4d..0x80ab70
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 110
       Name: main.testReturnsNamedDeferLine
-      OutOfLinePCRanges: [0x80ab50..0x80ace0]
+      OutOfLinePCRanges: [0x80ab70..0x80ad00]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80ab50..0x80abb0
+            - Range: 0x80ab70..0x80abd0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80abb0..0x80ace0
+            - Range: 0x80abd0..0x80ad00
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80ab7c..0x80ace0
+            - Range: 0x80ab9c..0x80ad00
               Pieces: [{Size: 16, Op: {CfaOffset: -120}}]
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80ab80..0x80ace0
+            - Range: 0x80aba0..0x80ad00
               Pieces: [{Size: 16, Op: {CfaOffset: -136}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 111
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0x80ada0..0x80ae30]
+      OutOfLinePCRanges: [0x80adc0..0x80ae50]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 20 BaseType int8
           Locations:
-            - Range: 0x80ada0..0x80ae0c
+            - Range: 0x80adc0..0x80ae2c
               Pieces: []
-            - Range: 0x80ae0c..0x80ae0d
+            - Range: 0x80ae2c..0x80ae2d
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ae0d..0x80ae30
+            - Range: 0x80ae2d..0x80ae50
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 103 BaseType int16
           Locations:
-            - Range: 0x80ada0..0x80ae0c
+            - Range: 0x80adc0..0x80ae2c
               Pieces: []
-            - Range: 0x80ae0c..0x80ae0d
+            - Range: 0x80ae2c..0x80ae2d
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80ae0d..0x80ae30
+            - Range: 0x80ae2d..0x80ae50
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x80ada0..0x80ae0c
+            - Range: 0x80adc0..0x80ae2c
               Pieces: []
-            - Range: 0x80ae0c..0x80ae0d
+            - Range: 0x80ae2c..0x80ae2d
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80ae0d..0x80ae30
+            - Range: 0x80ae2d..0x80ae50
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 14 BaseType int64
           Locations:
-            - Range: 0x80ada0..0x80ae0c
+            - Range: 0x80adc0..0x80ae2c
               Pieces: []
-            - Range: 0x80ae0c..0x80ae0d
+            - Range: 0x80ae2c..0x80ae2d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80ae0d..0x80ae30
+            - Range: 0x80ae2d..0x80ae50
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x80ada0..0x80ae0c
+            - Range: 0x80adc0..0x80ae2c
               Pieces: []
-            - Range: 0x80ae0c..0x80ae0d
+            - Range: 0x80ae2c..0x80ae2d
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80ae0d..0x80ae30
+            - Range: 0x80ae2d..0x80ae50
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 7 BaseType uint16
           Locations:
-            - Range: 0x80ada0..0x80ae0c
+            - Range: 0x80adc0..0x80ae2c
               Pieces: []
-            - Range: 0x80ae0c..0x80ae0d
+            - Range: 0x80ae2c..0x80ae2d
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80ae0d..0x80ae30
+            - Range: 0x80ae2d..0x80ae50
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 3 BaseType uint32
           Locations:
-            - Range: 0x80ada0..0x80ae0c
+            - Range: 0x80adc0..0x80ae2c
               Pieces: []
-            - Range: 0x80ae0c..0x80ae0d
+            - Range: 0x80ae2c..0x80ae2d
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80ae0d..0x80ae30
+            - Range: 0x80ae2d..0x80ae50
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 9 BaseType uint64
           Locations:
-            - Range: 0x80ada0..0x80ae0c
+            - Range: 0x80adc0..0x80ae2c
               Pieces: []
-            - Range: 0x80ae0c..0x80ae0d
+            - Range: 0x80ae2c..0x80ae2d
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80ae0d..0x80ae30
+            - Range: 0x80ae2d..0x80ae50
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 112
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0x80ae30..0x80aee0]
+      OutOfLinePCRanges: [0x80ae50..0x80af00]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80ae30..0x80aee0, Pieces: []}]
+          Locations: [{Range: 0x80ae50..0x80af00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80ae30..0x80aee0, Pieces: []}]
+          Locations: [{Range: 0x80ae50..0x80af00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80ae30..0x80aee0, Pieces: []}]
+          Locations: [{Range: 0x80ae50..0x80af00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80ae30..0x80aee0, Pieces: []}]
+          Locations: [{Range: 0x80ae50..0x80af00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80ae30..0x80aee0, Pieces: []}]
+          Locations: [{Range: 0x80ae50..0x80af00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80ae30..0x80aee0, Pieces: []}]
+          Locations: [{Range: 0x80ae50..0x80af00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80ae30..0x80aee0, Pieces: []}]
+          Locations: [{Range: 0x80ae50..0x80af00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80ae30..0x80aee0, Pieces: []}]
+          Locations: [{Range: 0x80ae50..0x80af00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80ae30..0x80aee0, Pieces: []}]
+          Locations: [{Range: 0x80ae50..0x80af00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r9
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80ae30..0x80aee0, Pieces: []}]
+          Locations: [{Range: 0x80ae50..0x80af00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r10
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80ae30..0x80aee0, Pieces: []}]
+          Locations: [{Range: 0x80ae50..0x80af00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r11
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80ae30..0x80aee0, Pieces: []}]
+          Locations: [{Range: 0x80ae50..0x80af00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r12
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80ae30..0x80aee0, Pieces: []}]
+          Locations: [{Range: 0x80ae50..0x80af00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r13
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80ae30..0x80aee0, Pieces: []}]
+          Locations: [{Range: 0x80ae50..0x80af00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r14
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80ae30..0x80aee0, Pieces: []}]
+          Locations: [{Range: 0x80ae50..0x80af00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: onlyOnAmd64_16
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80ae30..0x80aee0, Pieces: []}]
+          Locations: [{Range: 0x80ae50..0x80af00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: bothArmAndAmd64
           Type: 15 BaseType float64
           Locations:
-            - Range: 0x80ae30..0x80aec8
+            - Range: 0x80ae50..0x80aee8
               Pieces: []
-            - Range: 0x80aec8..0x80aec9
+            - Range: 0x80aee8..0x80aee9
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x80aec9..0x80aee0
+            - Range: 0x80aee9..0x80af00
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 113
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0x80aee0..0x80af60]
+      OutOfLinePCRanges: [0x80af00..0x80af80]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 104 BaseType complex64
-          Locations: [{Range: 0x80aee0..0x80af60, Pieces: []}]
+          Locations: [{Range: 0x80af00..0x80af80, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 19 BaseType complex128
-          Locations: [{Range: 0x80aee0..0x80af60, Pieces: []}]
+          Locations: [{Range: 0x80af00..0x80af80, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 114
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0x80af60..0x80b020]
+      OutOfLinePCRanges: [0x80af80..0x80b040]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0x80af60..0x80b000
+            - Range: 0x80af80..0x80b020
               Pieces: []
-            - Range: 0x80b000..0x80b001
+            - Range: 0x80b020..0x80b021
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8455,193 +8455,193 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80b001..0x80b020
+            - Range: 0x80b021..0x80b040
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 115
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0x80b020..0x80b0b0]
+      OutOfLinePCRanges: [0x80b040..0x80b0d0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 262 ArrayType [3]int
           Locations:
-            - Range: 0x80b020..0x80b08c
+            - Range: 0x80b040..0x80b0ac
               Pieces: []
-            - Range: 0x80b08c..0x80b08d
+            - Range: 0x80b0ac..0x80b0ad
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x80b08d..0x80b0b0
+            - Range: 0x80b0ad..0x80b0d0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 116
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0x80b0b0..0x80b120]
+      OutOfLinePCRanges: [0x80b0d0..0x80b140]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 263 ArrayType [1]int
           Locations:
-            - Range: 0x80b0b0..0x80b100
+            - Range: 0x80b0d0..0x80b120
               Pieces: []
-            - Range: 0x80b100..0x80b101
+            - Range: 0x80b120..0x80b121
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80b101..0x80b120
+            - Range: 0x80b121..0x80b140
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 117
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0x80b120..0x80b190]
+      OutOfLinePCRanges: [0x80b140..0x80b1b0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 264 ArrayType [0]int
           Locations:
-            - Range: 0x80b120..0x80b16c
+            - Range: 0x80b140..0x80b18c
               Pieces: []
-            - Range: 0x80b16c..0x80b16d
+            - Range: 0x80b18c..0x80b18d
               Pieces: []
-            - Range: 0x80b16d..0x80b190
+            - Range: 0x80b18d..0x80b1b0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 118
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0x80b190..0x80b210]
+      OutOfLinePCRanges: [0x80b1b0..0x80b230]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 265 StructureType main.mixedStruct
-          Locations: [{Range: 0x80b190..0x80b210, Pieces: []}]
+          Locations: [{Range: 0x80b1b0..0x80b230, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 119
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0x80b210..0x80b2a0]
+      OutOfLinePCRanges: [0x80b230..0x80b2c0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80b210..0x80b288
+            - Range: 0x80b230..0x80b2a8
               Pieces: []
-            - Range: 0x80b288..0x80b289
+            - Range: 0x80b2a8..0x80b2a9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80b289..0x80b2a0
+            - Range: 0x80b2a9..0x80b2c0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80b210..0x80b288
+            - Range: 0x80b230..0x80b2a8
               Pieces: []
-            - Range: 0x80b288..0x80b289
+            - Range: 0x80b2a8..0x80b2a9
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80b289..0x80b2a0
+            - Range: 0x80b2a9..0x80b2c0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80b210..0x80b288
+            - Range: 0x80b230..0x80b2a8
               Pieces: []
-            - Range: 0x80b288..0x80b289
+            - Range: 0x80b2a8..0x80b2a9
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80b289..0x80b2a0
+            - Range: 0x80b2a9..0x80b2c0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80b210..0x80b288
+            - Range: 0x80b230..0x80b2a8
               Pieces: []
-            - Range: 0x80b288..0x80b289
+            - Range: 0x80b2a8..0x80b2a9
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80b289..0x80b2a0
+            - Range: 0x80b2a9..0x80b2c0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80b210..0x80b288
+            - Range: 0x80b230..0x80b2a8
               Pieces: []
-            - Range: 0x80b288..0x80b289
+            - Range: 0x80b2a8..0x80b2a9
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80b289..0x80b2a0
+            - Range: 0x80b2a9..0x80b2c0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80b210..0x80b288
+            - Range: 0x80b230..0x80b2a8
               Pieces: []
-            - Range: 0x80b288..0x80b289
+            - Range: 0x80b2a8..0x80b2a9
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80b289..0x80b2a0
+            - Range: 0x80b2a9..0x80b2c0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80b210..0x80b288
+            - Range: 0x80b230..0x80b2a8
               Pieces: []
-            - Range: 0x80b288..0x80b289
+            - Range: 0x80b2a8..0x80b2a9
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80b289..0x80b2a0
+            - Range: 0x80b2a9..0x80b2c0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80b210..0x80b288
+            - Range: 0x80b230..0x80b2a8
               Pieces: []
-            - Range: 0x80b288..0x80b289
+            - Range: 0x80b2a8..0x80b2a9
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80b289..0x80b2a0
+            - Range: 0x80b2a9..0x80b2c0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80b210..0x80b288
+            - Range: 0x80b230..0x80b2a8
               Pieces: []
-            - Range: 0x80b288..0x80b289
+            - Range: 0x80b2a8..0x80b2a9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80b289..0x80b2a0
+            - Range: 0x80b2a9..0x80b2c0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 120
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0x80b2a0..0x80b370]
+      OutOfLinePCRanges: [0x80b2c0..0x80b390]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 266 StructureType main.wideStruct
           Locations:
-            - Range: 0x80b2a0..0x80b350
+            - Range: 0x80b2c0..0x80b370
               Pieces: []
-            - Range: 0x80b350..0x80b351
+            - Range: 0x80b370..0x80b371
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8665,145 +8665,145 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0x80b351..0x80b370
+            - Range: 0x80b371..0x80b390
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 121
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0x80b370..0x80b400]
+      OutOfLinePCRanges: [0x80b390..0x80b420]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80b370..0x80b3dc
+            - Range: 0x80b390..0x80b3fc
               Pieces: []
-            - Range: 0x80b3dc..0x80b3dd
+            - Range: 0x80b3fc..0x80b3fd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80b3dd..0x80b400
+            - Range: 0x80b3fd..0x80b420
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80b370..0x80b400, Pieces: []}]
+          Locations: [{Range: 0x80b390..0x80b420, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80b370..0x80b3dc
+            - Range: 0x80b390..0x80b3fc
               Pieces: []
-            - Range: 0x80b3dc..0x80b3dd
+            - Range: 0x80b3fc..0x80b3fd
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80b3dd..0x80b400
+            - Range: 0x80b3fd..0x80b420
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80b370..0x80b400, Pieces: []}]
+          Locations: [{Range: 0x80b390..0x80b420, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80b370..0x80b3dc
+            - Range: 0x80b390..0x80b3fc
               Pieces: []
-            - Range: 0x80b3dc..0x80b3dd
+            - Range: 0x80b3fc..0x80b3fd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80b3dd..0x80b400
+            - Range: 0x80b3fd..0x80b420
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 122
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0x80b400..0x80b490]
+      OutOfLinePCRanges: [0x80b420..0x80b4b0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 267 StructureType main.structWithArray
           Locations:
-            - Range: 0x80b400..0x80b46c
+            - Range: 0x80b420..0x80b48c
               Pieces: []
-            - Range: 0x80b46c..0x80b46d
+            - Range: 0x80b48c..0x80b48d
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x80b46d..0x80b490
+            - Range: 0x80b48d..0x80b4b0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 123
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0x80b490..0x80b500]
+      OutOfLinePCRanges: [0x80b4b0..0x80b520]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80b490..0x80b500, Pieces: []}]
+          Locations: [{Range: 0x80b4b0..0x80b520, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 124
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0x80b500..0x80b570]
+      OutOfLinePCRanges: [0x80b520..0x80b590]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float32
-          Locations: [{Range: 0x80b500..0x80b570, Pieces: []}]
+          Locations: [{Range: 0x80b520..0x80b590, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 15 BaseType float64
-          Locations: [{Range: 0x80b500..0x80b570, Pieces: []}]
+          Locations: [{Range: 0x80b520..0x80b590, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 125
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0x80b570..0x80b5e0]
+      OutOfLinePCRanges: [0x80b590..0x80b600]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x80b570..0x80b5c4
+            - Range: 0x80b590..0x80b5e4
               Pieces: []
-            - Range: 0x80b5c4..0x80b5c5
+            - Range: 0x80b5e4..0x80b5e5
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80b5c5..0x80b5e0
+            - Range: 0x80b5e5..0x80b600
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 2 BaseType uintptr
           Locations:
-            - Range: 0x80b570..0x80b5c4
+            - Range: 0x80b590..0x80b5e4
               Pieces: []
-            - Range: 0x80b5c4..0x80b5c5
+            - Range: 0x80b5e4..0x80b5e5
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80b5c5..0x80b5e0
+            - Range: 0x80b5e5..0x80b600
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 126
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0x80b5e0..0x80b770]
+      OutOfLinePCRanges: [0x80b600..0x80b790]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0x80b5e0..0x80b614
+            - Range: 0x80b600..0x80b634
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8825,7 +8825,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80b614..0x80b644
+            - Range: 0x80b634..0x80b664
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8847,7 +8847,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80b644..0x80b64c
+            - Range: 0x80b664..0x80b66c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8869,7 +8869,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80b64c..0x80b650
+            - Range: 0x80b66c..0x80b670
               Pieces:
                 - Size: 8
                   Op: null
@@ -8896,9 +8896,9 @@ Subprograms:
         - Name: ~r0
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0x80b5e0..0x80b730
+            - Range: 0x80b600..0x80b750
               Pieces: []
-            - Range: 0x80b730..0x80b731
+            - Range: 0x80b750..0x80b751
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8920,44 +8920,44 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80b731..0x80b770
+            - Range: 0x80b751..0x80b790
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 127
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0x80b770..0x80b840]
+      OutOfLinePCRanges: [0x80b790..0x80b860]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 262 ArrayType [3]int
           Locations:
-            - Range: 0x80b770..0x80b840
+            - Range: 0x80b790..0x80b860
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 262 ArrayType [3]int
           Locations:
-            - Range: 0x80b770..0x80b820
+            - Range: 0x80b790..0x80b840
               Pieces: []
-            - Range: 0x80b820..0x80b821
+            - Range: 0x80b840..0x80b841
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x80b821..0x80b840
+            - Range: 0x80b841..0x80b860
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 128
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0x80b840..0x80ba50]
+      OutOfLinePCRanges: [0x80b860..0x80ba70]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0x80b840..0x80b874
+            - Range: 0x80b860..0x80b894
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8979,7 +8979,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80b874..0x80b8a8
+            - Range: 0x80b894..0x80b8c8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9001,7 +9001,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80b8a8..0x80b8b0
+            - Range: 0x80b8c8..0x80b8d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9023,7 +9023,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80b8b0..0x80b8b4
+            - Range: 0x80b8d0..0x80b8d4
               Pieces:
                 - Size: 8
                   Op: null
@@ -9050,16 +9050,16 @@ Subprograms:
         - Name: s2
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0x80b840..0x80ba50
+            - Range: 0x80b860..0x80ba70
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0x80b840..0x80ba08
+            - Range: 0x80b860..0x80ba28
               Pieces: []
-            - Range: 0x80ba08..0x80ba09
+            - Range: 0x80ba28..0x80ba29
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9081,196 +9081,196 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80ba09..0x80ba50
+            - Range: 0x80ba29..0x80ba70
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 129
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0x80ba50..0x80bc00]
+      OutOfLinePCRanges: [0x80ba70..0x80bc20]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80ba50..0x80bad8
+            - Range: 0x80ba70..0x80baf8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80bad8..0x80bc00
+            - Range: 0x80baf8..0x80bc20
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80ba50..0x80ba98
+            - Range: 0x80ba70..0x80bab8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80ba98..0x80bc00
+            - Range: 0x80bab8..0x80bc20
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80ba50..0x80bad0
+            - Range: 0x80ba70..0x80baf0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80bad0..0x80bc00
+            - Range: 0x80baf0..0x80bc20
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80ba50..0x80bad8
+            - Range: 0x80ba70..0x80baf8
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80bad8..0x80bc00
+            - Range: 0x80baf8..0x80bc20
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80ba50..0x80bad8
+            - Range: 0x80ba70..0x80baf8
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80bad8..0x80bc00
+            - Range: 0x80baf8..0x80bc20
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80ba50..0x80bad8
+            - Range: 0x80ba70..0x80baf8
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80bad8..0x80bc00
+            - Range: 0x80baf8..0x80bc20
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80ba50..0x80bad8
+            - Range: 0x80ba70..0x80baf8
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80bad8..0x80bc00
+            - Range: 0x80baf8..0x80bc20
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80ba50..0x80bad8
+            - Range: 0x80ba70..0x80baf8
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80bad8..0x80bc00
+            - Range: 0x80baf8..0x80bc20
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: i
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80ba50..0x80bad8
+            - Range: 0x80ba70..0x80baf8
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0x80bad8..0x80bc00
+            - Range: 0x80baf8..0x80bc20
               Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 120 ArrayType [2]int
           Locations:
-            - Range: 0x80ba50..0x80bbc0
+            - Range: 0x80ba70..0x80bbe0
               Pieces: []
-            - Range: 0x80bbc0..0x80bbc1
+            - Range: 0x80bbe0..0x80bbe1
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-            - Range: 0x80bbc1..0x80bc00
+            - Range: 0x80bbe1..0x80bc20
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 130
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0x80bc00..0x80bdf0]
+      OutOfLinePCRanges: [0x80bc20..0x80be10]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80bc00..0x80bc88
+            - Range: 0x80bc20..0x80bca8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80bc88..0x80bdf0
+            - Range: 0x80bca8..0x80be10
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80bc00..0x80bc4c
+            - Range: 0x80bc20..0x80bc6c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80bc4c..0x80bdf0
+            - Range: 0x80bc6c..0x80be10
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80bc00..0x80bc80
+            - Range: 0x80bc20..0x80bca0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80bc80..0x80bdf0
+            - Range: 0x80bca0..0x80be10
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80bc00..0x80bc88
+            - Range: 0x80bc20..0x80bca8
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80bc88..0x80bdf0
+            - Range: 0x80bca8..0x80be10
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80bc00..0x80bc88
+            - Range: 0x80bc20..0x80bca8
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80bc88..0x80bdf0
+            - Range: 0x80bca8..0x80be10
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80bc00..0x80bc88
+            - Range: 0x80bc20..0x80bca8
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80bc88..0x80bdf0
+            - Range: 0x80bca8..0x80be10
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80bc00..0x80bc88
+            - Range: 0x80bc20..0x80bca8
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80bc88..0x80bdf0
+            - Range: 0x80bca8..0x80be10
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80bc00..0x80bc88
+            - Range: 0x80bc20..0x80bca8
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80bc88..0x80bdf0
+            - Range: 0x80bca8..0x80be10
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80bc00..0x80bc88
+            - Range: 0x80bc20..0x80bca8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80bc88..0x80bdf0
+            - Range: 0x80bca8..0x80be10
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 72}
@@ -9281,9 +9281,9 @@ Subprograms:
         - Name: ~r0
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0x80bc00..0x80bdac
+            - Range: 0x80bc20..0x80bdcc
               Pieces: []
-            - Range: 0x80bdac..0x80bdad
+            - Range: 0x80bdcc..0x80bdcd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9305,232 +9305,194 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80bdad..0x80bdf0
+            - Range: 0x80bdcd..0x80be10
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 131
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0x80bdf0..0x80be80]
+      OutOfLinePCRanges: [0x80be10..0x80bea0]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 172 ArrayType [5]int
           Locations:
-            - Range: 0x80bdf0..0x80be80
+            - Range: 0x80be10..0x80bea0
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80bdf0..0x80be64
+            - Range: 0x80be10..0x80be84
               Pieces: []
-            - Range: 0x80be64..0x80be65
+            - Range: 0x80be84..0x80be85
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80be65..0x80be80
+            - Range: 0x80be85..0x80bea0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80bdf0..0x80be64
+            - Range: 0x80be10..0x80be84
               Pieces: []
-            - Range: 0x80be64..0x80be65
+            - Range: 0x80be84..0x80be85
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80be65..0x80be80
+            - Range: 0x80be85..0x80bea0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80bdf0..0x80be64
+            - Range: 0x80be10..0x80be84
               Pieces: []
-            - Range: 0x80be64..0x80be65
+            - Range: 0x80be84..0x80be85
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80be65..0x80be80
+            - Range: 0x80be85..0x80bea0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 132
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0x80be80..0x80bf50]
+      OutOfLinePCRanges: [0x80bea0..0x80bf70]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 120 ArrayType [2]int
           Locations:
-            - Range: 0x80be80..0x80bf50
+            - Range: 0x80bea0..0x80bf70
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 262 ArrayType [3]int
           Locations:
-            - Range: 0x80be80..0x80bf50
+            - Range: 0x80bea0..0x80bf70
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80be80..0x80bf38
+            - Range: 0x80bea0..0x80bf58
               Pieces: []
-            - Range: 0x80bf38..0x80bf39
+            - Range: 0x80bf58..0x80bf59
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80bf39..0x80bf50
+            - Range: 0x80bf59..0x80bf70
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 120 ArrayType [2]int
           Locations:
-            - Range: 0x80be80..0x80bf38
+            - Range: 0x80bea0..0x80bf58
               Pieces: []
-            - Range: 0x80bf38..0x80bf39
+            - Range: 0x80bf58..0x80bf59
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
-            - Range: 0x80bf39..0x80bf50
+            - Range: 0x80bf59..0x80bf70
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 133
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0x80bf50..0x80c010]
+      OutOfLinePCRanges: [0x80bf70..0x80c030]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 267 StructureType main.structWithArray
           Locations:
-            - Range: 0x80bf50..0x80c010
+            - Range: 0x80bf70..0x80c030
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80bf50..0x80bff4
+            - Range: 0x80bf70..0x80c014
               Pieces: []
-            - Range: 0x80bff4..0x80bff5
+            - Range: 0x80c014..0x80c015
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80bff5..0x80c010
+            - Range: 0x80c015..0x80c030
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 267 StructureType main.structWithArray
           Locations:
-            - Range: 0x80bf50..0x80bff4
+            - Range: 0x80bf70..0x80c014
               Pieces: []
-            - Range: 0x80bff4..0x80bff5
+            - Range: 0x80c014..0x80c015
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x80bff5..0x80c010
+            - Range: 0x80c015..0x80c030
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80bfd0..0x80c010
+            - Range: 0x80bff0..0x80c030
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 134
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0x80c010..0x80c0b0]
+      OutOfLinePCRanges: [0x80c030..0x80c0d0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 264 ArrayType [0]int
-          Locations: [{Range: 0x80c010..0x80c0b0, Pieces: []}]
+          Locations: [{Range: 0x80c030..0x80c0d0, Pieces: []}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80c010..0x80c050
+            - Range: 0x80c030..0x80c070
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c050..0x80c068
+            - Range: 0x80c070..0x80c088
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x80c068..0x80c070
+            - Range: 0x80c088..0x80c090
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x80c070..0x80c0b0
+            - Range: 0x80c090..0x80c0d0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 8 BaseType int
           Locations:
-            - Range: 0x80c010..0x80c08c
+            - Range: 0x80c030..0x80c0ac
               Pieces: []
-            - Range: 0x80c08c..0x80c08d
+            - Range: 0x80c0ac..0x80c0ad
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c08d..0x80c0b0
+            - Range: 0x80c0ad..0x80c0d0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 264 ArrayType [0]int
           Locations:
-            - Range: 0x80c010..0x80c08c
+            - Range: 0x80c030..0x80c0ac
               Pieces: []
-            - Range: 0x80c08c..0x80c08d
+            - Range: 0x80c0ac..0x80c0ad
               Pieces: []
-            - Range: 0x80c08d..0x80c0b0
+            - Range: 0x80c0ad..0x80c0d0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 135
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0x80c500..0x80c510]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 268 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x80c500..0x80c510
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 136
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x80c510..0x80c520]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 268 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x80c510..0x80c520
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 137
-      Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0x80c520..0x80c530]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 269 GoSliceHeaderType [][]uint
+          Type: 268 GoSliceHeaderType []uint
           Locations:
             - Range: 0x80c520..0x80c530
               Pieces:
@@ -9543,13 +9505,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 138
-      Name: main.testStructSlice
+    - ID: 136
+      Name: main.testEmptySlice
       OutOfLinePCRanges: [0x80c530..0x80c540]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 271 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 268 GoSliceHeaderType []uint
           Locations:
             - Range: 0x80c530..0x80c540
               Pieces:
@@ -9561,21 +9523,14 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
           DictIndex: -1
-        - Name: a
-          Type: 8 BaseType int
-          Locations:
-            - Range: 0x80c530..0x80c540
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
       DictRegister: null
-    - ID: 139
-      Name: main.testEmptySliceOfStructs
+    - ID: 137
+      Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0x80c540..0x80c550]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 271 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 269 GoSliceHeaderType [][]uint
           Locations:
             - Range: 0x80c540..0x80c550
               Pieces:
@@ -9587,16 +9542,9 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
           DictIndex: -1
-        - Name: a
-          Type: 8 BaseType int
-          Locations:
-            - Range: 0x80c540..0x80c550
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
       DictRegister: null
-    - ID: 140
-      Name: main.testNilSliceOfStructs
+    - ID: 138
+      Name: main.testStructSlice
       OutOfLinePCRanges: [0x80c550..0x80c560]
       InlinePCRanges: []
       Variables:
@@ -9621,13 +9569,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 141
-      Name: main.testStringSlice
+    - ID: 139
+      Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0x80c560..0x80c570]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 165 GoSliceHeaderType []string
+        - Name: xs
+          Type: 271 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0x80c560..0x80c570
               Pieces:
@@ -9639,47 +9587,47 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
           DictIndex: -1
+        - Name: a
+          Type: 8 BaseType int
+          Locations:
+            - Range: 0x80c560..0x80c570
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
       DictRegister: null
-    - ID: 142
-      Name: main.testNilSliceWithOtherParams
+    - ID: 140
+      Name: main.testNilSliceOfStructs
       OutOfLinePCRanges: [0x80c570..0x80c580]
       InlinePCRanges: []
       Variables:
-        - Name: a
-          Type: 20 BaseType int8
-          Locations:
-            - Range: 0x80c570..0x80c580
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-        - Name: s
-          Type: 274 GoSliceHeaderType []bool
+        - Name: xs
+          Type: 271 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0x80c570..0x80c580
               Pieces:
                 - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
           Role: Parameter
           DictIndex: -1
-        - Name: x
-          Type: 12 BaseType uint
+        - Name: a
+          Type: 8 BaseType int
           Locations:
             - Range: 0x80c570..0x80c580
-              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 143
-      Name: main.testNilSlice
+    - ID: 141
+      Name: main.testStringSlice
       OutOfLinePCRanges: [0x80c580..0x80c590]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 275 GoSliceHeaderType []uint16
+        - Name: s
+          Type: 165 GoSliceHeaderType []string
           Locations:
             - Range: 0x80c580..0x80c590
               Pieces:
@@ -9692,32 +9640,46 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 144
-      Name: main.testVeryLargeSlice
+    - ID: 142
+      Name: main.testNilSliceWithOtherParams
       OutOfLinePCRanges: [0x80c590..0x80c5a0]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 268 GoSliceHeaderType []uint
+        - Name: a
+          Type: 20 BaseType int8
+          Locations:
+            - Range: 0x80c590..0x80c5a0
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: s
+          Type: 274 GoSliceHeaderType []bool
           Locations:
             - Range: 0x80c590..0x80c5a0
               Pieces:
                 - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: x
+          Type: 12 BaseType uint
+          Locations:
+            - Range: 0x80c590..0x80c5a0
+              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 145
-      Name: main.testSliceEmptyStructs
+    - ID: 143
+      Name: main.testNilSlice
       OutOfLinePCRanges: [0x80c5a0..0x80c5b0]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 276 GoSliceHeaderType []struct {}
+          Type: 275 GoSliceHeaderType []uint16
           Locations:
             - Range: 0x80c5a0..0x80c5b0
               Pieces:
@@ -9730,15 +9692,53 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 144
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0x80c5b0..0x80c5c0]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 268 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0x80c5b0..0x80c5c0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 145
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0x80c5c0..0x80c5d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 276 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0x80c5c0..0x80c5d0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 146
       Name: main.testSubslices
-      OutOfLinePCRanges: [0x80c5b0..0x80c5c0]
+      OutOfLinePCRanges: [0x80c5d0..0x80c5e0]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 268 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80c5b0..0x80c5c0
+            - Range: 0x80c5d0..0x80c5e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9751,7 +9751,7 @@ Subprograms:
         - Name: bs
           Type: 268 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80c5b0..0x80c5c0
+            - Range: 0x80c5d0..0x80c5e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9764,7 +9764,7 @@ Subprograms:
         - Name: cs
           Type: 268 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80c5b0..0x80c5c0
+            - Range: 0x80c5d0..0x80c5e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -9777,34 +9777,34 @@ Subprograms:
       DictRegister: null
     - ID: 147
       Name: main.stackC
-      OutOfLinePCRanges: [0x80cb40..0x80cba0]
+      OutOfLinePCRanges: [0x80cb60..0x80cbc0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80cb40..0x80cb88
+            - Range: 0x80cb60..0x80cba8
               Pieces: []
-            - Range: 0x80cb88..0x80cb89
+            - Range: 0x80cba8..0x80cba9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80cb89..0x80cba0
+            - Range: 0x80cba9..0x80cbc0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 148
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x80cba0..0x80cbb0]
+      OutOfLinePCRanges: [0x80cbc0..0x80cbd0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80cba0..0x80cbb0
+            - Range: 0x80cbc0..0x80cbd0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9815,13 +9815,13 @@ Subprograms:
       DictRegister: null
     - ID: 149
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x80cbb0..0x80cbc0]
+      OutOfLinePCRanges: [0x80cbd0..0x80cbe0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80cbb0..0x80cbc0
+            - Range: 0x80cbd0..0x80cbe0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9832,7 +9832,7 @@ Subprograms:
         - Name: "y"
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80cbb0..0x80cbc0
+            - Range: 0x80cbd0..0x80cbe0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9843,7 +9843,7 @@ Subprograms:
         - Name: z
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80cbb0..0x80cbc0
+            - Range: 0x80cbd0..0x80cbe0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9854,13 +9854,13 @@ Subprograms:
       DictRegister: null
     - ID: 150
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x80cbc0..0x80cbd0]
+      OutOfLinePCRanges: [0x80cbe0..0x80cbf0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 278 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x80cbc0..0x80cbd0
+            - Range: 0x80cbe0..0x80cbf0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9879,66 +9879,32 @@ Subprograms:
       DictRegister: null
     - ID: 151
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x80cbd0..0x80cbe0]
+      OutOfLinePCRanges: [0x80cbf0..0x80cc00]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 279 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x80cbd0..0x80cbe0
+            - Range: 0x80cbf0..0x80cc00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 152
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x80cbe0..0x80cbf0]
+      OutOfLinePCRanges: [0x80cc00..0x80cc10]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 280 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x80cbe0..0x80cbf0
+            - Range: 0x80cc00..0x80cc10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 153
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0x80cbf0..0x80cc00]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 10 GoStringHeaderType string
-          Locations:
-            - Range: 0x80cbf0..0x80cc00
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 154
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x80cc00..0x80cc10]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 10 GoStringHeaderType string
-          Locations:
-            - Range: 0x80cc00..0x80cc10
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 155
-      Name: main.testEmptyString
       OutOfLinePCRanges: [0x80cc10..0x80cc20]
       InlinePCRanges: []
       Variables:
@@ -9954,12 +9920,12 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 156
-      Name: main.testSubstrings
+    - ID: 154
+      Name: main.testUnitializedString
       OutOfLinePCRanges: [0x80cc20..0x80cc30]
       InlinePCRanges: []
       Variables:
-        - Name: a
+        - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
             - Range: 0x80cc20..0x80cc30
@@ -9970,10 +9936,44 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
           DictIndex: -1
+      DictRegister: null
+    - ID: 155
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0x80cc30..0x80cc40]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0x80cc30..0x80cc40
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 156
+      Name: main.testSubstrings
+      OutOfLinePCRanges: [0x80cc40..0x80cc50]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0x80cc40..0x80cc50
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
         - Name: b
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80cc20..0x80cc30
+            - Range: 0x80cc40..0x80cc50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9984,7 +9984,7 @@ Subprograms:
         - Name: c
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80cc20..0x80cc30
+            - Range: 0x80cc40..0x80cc50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9995,26 +9995,26 @@ Subprograms:
       DictRegister: null
     - ID: 157
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x80cd70..0x80cd80]
+      OutOfLinePCRanges: [0x80cd90..0x80cda0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 282 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x80cd70..0x80cd80
+            - Range: 0x80cd90..0x80cda0
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 158
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x80cd80..0x80cd90]
+      OutOfLinePCRanges: [0x80cda0..0x80cdb0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 295 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x80cd80..0x80cd90
+            - Range: 0x80cda0..0x80cdb0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10033,13 +10033,13 @@ Subprograms:
       DictRegister: null
     - ID: 159
       Name: main.testStruct
-      OutOfLinePCRanges: [0x80ce20..0x80ce30]
+      OutOfLinePCRanges: [0x80ce40..0x80ce50]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 326 StructureType main.aStruct
           Locations:
-            - Range: 0x80ce20..0x80ce30
+            - Range: 0x80ce40..0x80ce50
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -10060,130 +10060,68 @@ Subprograms:
       DictRegister: null
     - ID: 160
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0x80ce80..0x80ce90]
+      OutOfLinePCRanges: [0x80cea0..0x80ceb0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 327 PointerType *main.anotherStruct
           Locations:
-            - Range: 0x80ce80..0x80ce90
+            - Range: 0x80cea0..0x80ceb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 161
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0x80ce90..0x80cea0]
+      OutOfLinePCRanges: [0x80ceb0..0x80cec0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 329 StructureType main.tenStrings
           Locations:
-            - Range: 0x80ce90..0x80cea0
+            - Range: 0x80ceb0..0x80cec0
               Pieces: [{Size: 160, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 162
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x80cec0..0x80ced0]
+      OutOfLinePCRanges: [0x80cee0..0x80cef0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 330 StructureType main.emptyStruct
-          Locations: [{Range: 0x80cec0..0x80ced0, Pieces: []}]
+          Locations: [{Range: 0x80cee0..0x80cef0, Pieces: []}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 163
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x80ced0..0x80cee0]
+      OutOfLinePCRanges: [0x80cef0..0x80cf00]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 331 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x80ced0..0x80cee0
+            - Range: 0x80cef0..0x80cf00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 164
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0x80e4d0..0x80e4e0]
+      OutOfLinePCRanges: [0x80e4f0..0x80e500]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 332 BaseType go.shape.int
-          Locations:
-            - Range: 0x80e4d0..0x80e4e0
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
-          Locations:
-            - Range: 0x80e4d0..0x80e4d4
-              Pieces: []
-            - Range: 0x80e4d4..0x80e4d5
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e4d5..0x80e4e0
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 165
-      Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0x80e4e0..0x80e4f0]
-      InlinePCRanges: []
-      Variables:
-        - Name: val
-          Type: 334 GoStringHeaderType go.shape.string
-          Locations:
-            - Range: 0x80e4e0..0x80e4ec
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80e4ec..0x80e4f0
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
-          Locations:
-            - Range: 0x80e4e0..0x80e4ec
-              Pieces: []
-            - Range: 0x80e4ec..0x80e4ed
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80e4ed..0x80e4f0
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 166
-      Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0x80e4f0..0x80e500]
-      InlinePCRanges: []
-      Variables:
-        - Name: box
-          Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
             - Range: 0x80e4f0..0x80e500
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 332 BaseType go.shape.int
+          Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
             - Range: 0x80e4f0..0x80e4f4
               Pieces: []
@@ -10194,13 +10132,13 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 167
-      Name: main.nestedGeneric[go.shape.string]
+    - ID: 165
+      Name: main.wrapBox[go.shape.string]
       OutOfLinePCRanges: [0x80e500..0x80e510]
       InlinePCRanges: []
       Variables:
-        - Name: box
-          Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+        - Name: val
+          Type: 334 GoStringHeaderType go.shape.string
           Locations:
             - Range: 0x80e500..0x80e50c
               Pieces:
@@ -10217,7 +10155,7 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 334 GoStringHeaderType go.shape.string
+          Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
             - Range: 0x80e500..0x80e50c
               Pieces: []
@@ -10232,15 +10170,77 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
+    - ID: 166
+      Name: main.nestedGeneric[go.shape.int]
+      OutOfLinePCRanges: [0x80e510..0x80e520]
+      InlinePCRanges: []
+      Variables:
+        - Name: box
+          Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+          Locations:
+            - Range: 0x80e510..0x80e520
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 332 BaseType go.shape.int
+          Locations:
+            - Range: 0x80e510..0x80e514
+              Pieces: []
+            - Range: 0x80e514..0x80e515
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x80e515..0x80e520
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 167
+      Name: main.nestedGeneric[go.shape.string]
+      OutOfLinePCRanges: [0x80e520..0x80e530]
+      InlinePCRanges: []
+      Variables:
+        - Name: box
+          Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+          Locations:
+            - Range: 0x80e520..0x80e52c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x80e52c..0x80e530
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 334 GoStringHeaderType go.shape.string
+          Locations:
+            - Range: 0x80e520..0x80e52c
+              Pieces: []
+            - Range: 0x80e52c..0x80e52d
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x80e52d..0x80e530
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
     - ID: 168
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0x80e570..0x80e710]
+      OutOfLinePCRanges: [0x80e590..0x80e730]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 336 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x80e570..0x80e5a0
+            - Range: 0x80e590..0x80e5c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10248,7 +10248,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80e5a0..0x80e5b4
+            - Range: 0x80e5c0..0x80e5d4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10256,7 +10256,7 @@ Subprograms:
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: null
-            - Range: 0x80e5b4..0x80e710
+            - Range: 0x80e5d4..0x80e730
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10269,18 +10269,18 @@ Subprograms:
         - Name: pred
           Type: 338 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0x80e570..0x80e5b4
+            - Range: 0x80e590..0x80e5d4
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80e5b4..0x80e710
+            - Range: 0x80e5d4..0x80e730
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 336 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x80e570..0x80e6d8
+            - Range: 0x80e590..0x80e6f8
               Pieces: []
-            - Range: 0x80e6d8..0x80e6d9
+            - Range: 0x80e6f8..0x80e6f9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10288,14 +10288,14 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80e6d9..0x80e710
+            - Range: 0x80e6f9..0x80e730
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
           Type: 336 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x80e5a0..0x80e5b4
+            - Range: 0x80e5c0..0x80e5d4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10303,7 +10303,7 @@ Subprograms:
                   Op: null
                 - Size: 8
                   Op: null
-            - Range: 0x80e5b4..0x80e5d4
+            - Range: 0x80e5d4..0x80e5f4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10311,7 +10311,7 @@ Subprograms:
                   Op: {CfaOffset: -80}
                 - Size: 8
                   Op: {CfaOffset: -72}
-            - Range: 0x80e5d4..0x80e5d8
+            - Range: 0x80e5f4..0x80e5f8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10319,7 +10319,7 @@ Subprograms:
                   Op: {CfaOffset: -80}
                 - Size: 8
                   Op: {CfaOffset: -72}
-            - Range: 0x80e5d8..0x80e5d8
+            - Range: 0x80e5f8..0x80e5f8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10327,7 +10327,7 @@ Subprograms:
                   Op: {CfaOffset: -80}
                 - Size: 8
                   Op: {CfaOffset: -72}
-            - Range: 0x80e5d8..0x80e608
+            - Range: 0x80e5f8..0x80e628
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10335,7 +10335,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 7, Shift: 0}
-            - Range: 0x80e608..0x80e698
+            - Range: 0x80e628..0x80e6b8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10343,7 +10343,7 @@ Subprograms:
                   Op: {CfaOffset: -80}
                 - Size: 8
                   Op: {CfaOffset: -72}
-            - Range: 0x80e698..0x80e6ac
+            - Range: 0x80e6b8..0x80e6cc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10351,7 +10351,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 7, Shift: 0}
-            - Range: 0x80e6ac..0x80e6c0
+            - Range: 0x80e6cc..0x80e6e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10359,7 +10359,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 7, Shift: 0}
-            - Range: 0x80e6c0..0x80e6cc
+            - Range: 0x80e6e0..0x80e6ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10367,7 +10367,7 @@ Subprograms:
                   Op: null
                 - Size: 8
                   Op: null
-            - Range: 0x80e6cc..0x80e710
+            - Range: 0x80e6ec..0x80e730
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10380,110 +10380,62 @@ Subprograms:
         - Name: item
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0x80e5f8..0x80e608
+            - Range: 0x80e618..0x80e628
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e608..0x80e698
+            - Range: 0x80e628..0x80e6b8
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
     - ID: 169
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x80e710..0x80e760]
+      OutOfLinePCRanges: [0x80e730..0x80e780]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x80e710..0x80e738
+            - Range: 0x80e730..0x80e758
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
           Type: 339 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0x80e710..0x80e738
+            - Range: 0x80e730..0x80e758
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x80e710..0x80e738
+            - Range: 0x80e730..0x80e758
               Pieces: []
-            - Range: 0x80e738..0x80e739
+            - Range: 0x80e758..0x80e759
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80e739..0x80e760
+            - Range: 0x80e759..0x80e780
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
     - ID: 170
       Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0x80e950..0x80e960]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 337 PointerType *go.shape.int
-          Locations:
-            - Range: 0x80e950..0x80e960
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 337 PointerType *go.shape.int
-          Locations:
-            - Range: 0x80e950..0x80e954
-              Pieces: []
-            - Range: 0x80e954..0x80e955
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e955..0x80e960
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 171
-      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0x80e960..0x80e970]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 340 PointerType *go.shape.struct { Name string }
-          Locations:
-            - Range: 0x80e960..0x80e970
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 340 PointerType *go.shape.struct { Name string }
-          Locations:
-            - Range: 0x80e960..0x80e964
-              Pieces: []
-            - Range: 0x80e964..0x80e965
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e965..0x80e970
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 172
-      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
       OutOfLinePCRanges: [0x80e970..0x80e980]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 342 PointerType *go.shape.struct { X int; Y int }
+          Type: 337 PointerType *go.shape.int
           Locations:
             - Range: 0x80e970..0x80e980
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 342 PointerType *go.shape.struct { X int; Y int }
+          Type: 337 PointerType *go.shape.int
           Locations:
             - Range: 0x80e970..0x80e974
               Pieces: []
@@ -10494,101 +10446,149 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
+    - ID: 171
+      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
+      OutOfLinePCRanges: [0x80e980..0x80e990]
+      InlinePCRanges: []
+      Variables:
+        - Name: p
+          Type: 340 PointerType *go.shape.struct { Name string }
+          Locations:
+            - Range: 0x80e980..0x80e990
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 340 PointerType *go.shape.struct { Name string }
+          Locations:
+            - Range: 0x80e980..0x80e984
+              Pieces: []
+            - Range: 0x80e984..0x80e985
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x80e985..0x80e990
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 172
+      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
+      OutOfLinePCRanges: [0x80e990..0x80e9a0]
+      InlinePCRanges: []
+      Variables:
+        - Name: p
+          Type: 342 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0x80e990..0x80e9a0
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 342 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0x80e990..0x80e994
+              Pieces: []
+            - Range: 0x80e994..0x80e995
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x80e995..0x80e9a0
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
     - ID: 173
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0x80e980..0x80e990]
+      OutOfLinePCRanges: [0x80e9a0..0x80e9b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 344 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0x80e980..0x80e990
+            - Range: 0x80e9a0..0x80e9b0
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80e980..0x80e984
+            - Range: 0x80e9a0..0x80e9a4
               Pieces: []
-            - Range: 0x80e984..0x80e985
+            - Range: 0x80e9a4..0x80e9a5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80e985..0x80e990
+            - Range: 0x80e9a5..0x80e9b0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 174
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0x80ea00..0x80ea10]
+      OutOfLinePCRanges: [0x80ea20..0x80ea30]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 346 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0x80ea00..0x80ea10
+            - Range: 0x80ea20..0x80ea30
               Pieces: [{Size: 136, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0x80ea00..0x80ea04
+            - Range: 0x80ea20..0x80ea24
               Pieces: []
-            - Range: 0x80ea04..0x80ea05
+            - Range: 0x80ea24..0x80ea25
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ea05..0x80ea10
+            - Range: 0x80ea25..0x80ea30
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 175
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0x80ea80..0x80ea90]
+      OutOfLinePCRanges: [0x80eaa0..0x80eab0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 347 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0x80ea80..0x80ea90
+            - Range: 0x80eaa0..0x80eab0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0x80ea80..0x80ea90
+            - Range: 0x80eaa0..0x80eab0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
           Type: 349 BaseType go.shape.bool
           Locations:
-            - Range: 0x80ea80..0x80ea90
+            - Range: 0x80eaa0..0x80eab0
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
     - ID: 176
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0x80eaf0..0x80eb60]
+      OutOfLinePCRanges: [0x80eb10..0x80eb80]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 350 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0x80eaf0..0x80eb60
+            - Range: 0x80eb10..0x80eb80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80eaf0..0x80eb60
+            - Range: 0x80eb10..0x80eb80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10599,20 +10599,20 @@ Subprograms:
         - Name: v
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0x80eaf0..0x80eb60
+            - Range: 0x80eb10..0x80eb80
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
     - ID: 177
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0x80ebc0..0x80ebd0]
+      OutOfLinePCRanges: [0x80ebe0..0x80ebf0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80ebc0..0x80ebd0
+            - Range: 0x80ebe0..0x80ebf0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10623,59 +10623,59 @@ Subprograms:
         - Name: b
           Type: 349 BaseType go.shape.bool
           Locations:
-            - Range: 0x80ebc0..0x80ebd0
+            - Range: 0x80ebe0..0x80ebf0
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 349 BaseType go.shape.bool
           Locations:
-            - Range: 0x80ebc0..0x80ebc8
+            - Range: 0x80ebe0..0x80ebe8
               Pieces: []
-            - Range: 0x80ebc8..0x80ebc9
+            - Range: 0x80ebe8..0x80ebe9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ebc9..0x80ebd0
+            - Range: 0x80ebe9..0x80ebf0
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80ebc0..0x80ebc8
+            - Range: 0x80ebe0..0x80ebe8
               Pieces: []
-            - Range: 0x80ebc8..0x80ebc9
+            - Range: 0x80ebe8..0x80ebe9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80ebc9..0x80ebd0
+            - Range: 0x80ebe9..0x80ebf0
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 178
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x80ebd0..0x80ebf0]
+      OutOfLinePCRanges: [0x80ebf0..0x80ec10]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0x80ebd0..0x80ebe0
+            - Range: 0x80ebf0..0x80ec00
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80ebd0..0x80ebdc
+            - Range: 0x80ebf0..0x80ebfc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80ebdc..0x80ebf0
+            - Range: 0x80ebfc..0x80ec10
               Pieces:
                 - Size: 8
                   Op: null
@@ -10686,73 +10686,73 @@ Subprograms:
         - Name: ~r0
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80ebd0..0x80ebe0
+            - Range: 0x80ebf0..0x80ec00
               Pieces: []
-            - Range: 0x80ebe0..0x80ebe1
+            - Range: 0x80ec00..0x80ec01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80ebe1..0x80ebf0
+            - Range: 0x80ec01..0x80ec10
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0x80ebd0..0x80ebe0
+            - Range: 0x80ebf0..0x80ec00
               Pieces: []
-            - Range: 0x80ebe0..0x80ebe1
+            - Range: 0x80ec00..0x80ec01
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80ebe1..0x80ebf0
+            - Range: 0x80ec01..0x80ec10
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
     - ID: 179
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0x80ebf0..0x80ec40]
+      OutOfLinePCRanges: [0x80ec10..0x80ec60]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 352 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0x80ebf0..0x80ec18
+            - Range: 0x80ec10..0x80ec38
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80ebf0..0x80ec18
+            - Range: 0x80ec10..0x80ec38
               Pieces: []
-            - Range: 0x80ec18..0x80ec19
+            - Range: 0x80ec38..0x80ec39
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80ec19..0x80ec40
+            - Range: 0x80ec39..0x80ec60
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 180
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0x80ec40..0x80eca0]
+      OutOfLinePCRanges: [0x80ec60..0x80ecc0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 353 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0x80ec40..0x80ec6c
+            - Range: 0x80ec60..0x80ec8c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80ec6c..0x80ec70
+            - Range: 0x80ec8c..0x80ec90
               Pieces:
                 - Size: 8
                   Op: null
@@ -10763,65 +10763,65 @@ Subprograms:
         - Name: ~r0
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x80ec40..0x80ec70
+            - Range: 0x80ec60..0x80ec90
               Pieces: []
-            - Range: 0x80ec70..0x80ec71
+            - Range: 0x80ec90..0x80ec91
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80ec71..0x80eca0
+            - Range: 0x80ec91..0x80ecc0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
     - ID: 181
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0x80eca0..0x80ecb0]
+      OutOfLinePCRanges: [0x80ecc0..0x80ecd0]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 354 PointerType *go.shape.string
           Locations:
-            - Range: 0x80eca0..0x80eca4
+            - Range: 0x80ecc0..0x80ecc4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80eca0..0x80eca4
+            - Range: 0x80ecc0..0x80ecc4
               Pieces: []
-            - Range: 0x80eca4..0x80eca5
+            - Range: 0x80ecc4..0x80ecc5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80eca5..0x80ecb0
+            - Range: 0x80ecc5..0x80ecd0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 182
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0x80ecb0..0x80ed00]
+      OutOfLinePCRanges: [0x80ecd0..0x80ed20]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 355 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x80ecb0..0x80ecf0
+            - Range: 0x80ecd0..0x80ed10
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 356 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x80ecb0..0x80ecf4
+            - Range: 0x80ecd0..0x80ed14
               Pieces: []
-            - Range: 0x80ecf4..0x80ecf5
+            - Range: 0x80ed14..0x80ed15
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10835,20 +10835,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x80ecf5..0x80ed00
+            - Range: 0x80ed15..0x80ed20
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 183
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0x80ed00..0x80ed40]
+      OutOfLinePCRanges: [0x80ed20..0x80ed60]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 336 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x80ed00..0x80ed0c
+            - Range: 0x80ed20..0x80ed2c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10856,7 +10856,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80ed0c..0x80ed40
+            - Range: 0x80ed2c..0x80ed60
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10869,42 +10869,42 @@ Subprograms:
         - Name: needle
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0x80ed00..0x80ed40
+            - Range: 0x80ed20..0x80ed60
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x80ed00..0x80ed28
+            - Range: 0x80ed20..0x80ed48
               Pieces: []
-            - Range: 0x80ed28..0x80ed29
+            - Range: 0x80ed48..0x80ed49
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ed29..0x80ed30
+            - Range: 0x80ed49..0x80ed50
               Pieces: []
-            - Range: 0x80ed30..0x80ed31
+            - Range: 0x80ed50..0x80ed51
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ed31..0x80ed40
+            - Range: 0x80ed51..0x80ed60
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0x80ed1c..0x80ed2c
+            - Range: 0x80ed3c..0x80ed4c
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Local
           DictIndex: 1
       DictRegister: 0
     - ID: 184
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0x80ed40..0x80ee00]
+      OutOfLinePCRanges: [0x80ed60..0x80ee20]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 357 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0x80ed40..0x80ed64
+            - Range: 0x80ed60..0x80ed84
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10912,7 +10912,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80ed64..0x80ed68
+            - Range: 0x80ed84..0x80ed88
               Pieces:
                 - Size: 8
                   Op: null
@@ -10925,13 +10925,13 @@ Subprograms:
         - Name: needle
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80ed40..0x80ed9c
+            - Range: 0x80ed60..0x80edbc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x80ed9c..0x80ee00
+            - Range: 0x80edbc..0x80ee20
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 40}
@@ -10942,22 +10942,22 @@ Subprograms:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x80ed40..0x80edb8
+            - Range: 0x80ed60..0x80edd8
               Pieces: []
-            - Range: 0x80edb8..0x80edb9
+            - Range: 0x80edd8..0x80edd9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80edb9..0x80edc8
+            - Range: 0x80edd9..0x80ede8
               Pieces: []
-            - Range: 0x80edc8..0x80edc9
+            - Range: 0x80ede8..0x80ede9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80edc9..0x80ee00
+            - Range: 0x80ede9..0x80ee20
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80ed84..0x80ed9c
+            - Range: 0x80eda4..0x80edbc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10968,56 +10968,56 @@ Subprograms:
       DictRegister: 0
     - ID: 185
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0x80ee00..0x80ee10]
+      OutOfLinePCRanges: [0x80ee20..0x80ee30]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 358 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0x80ee00..0x80ee08
+            - Range: 0x80ee20..0x80ee28
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
           Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0x80ee00..0x80ee10
+            - Range: 0x80ee20..0x80ee30
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x80ee00..0x80ee08
+            - Range: 0x80ee20..0x80ee28
               Pieces: []
-            - Range: 0x80ee08..0x80ee09
+            - Range: 0x80ee28..0x80ee29
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ee09..0x80ee10
+            - Range: 0x80ee29..0x80ee30
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 1
     - ID: 186
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0x80ee60..0x80eed0]
+      OutOfLinePCRanges: [0x80ee80..0x80eef0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 359 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0x80ee60..0x80ee8c
+            - Range: 0x80ee80..0x80eeac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80ee8c..0x80ee98
+            - Range: 0x80eeac..0x80eeb8
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80ee98..0x80ee9c
+            - Range: 0x80eeb8..0x80eebc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11028,7 +11028,7 @@ Subprograms:
         - Name: value
           Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80ee60..0x80ee9c
+            - Range: 0x80ee80..0x80eebc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -11039,11 +11039,11 @@ Subprograms:
         - Name: ~r0
           Type: 5 BaseType bool
           Locations:
-            - Range: 0x80ee60..0x80ee9c
+            - Range: 0x80ee80..0x80eebc
               Pieces: []
-            - Range: 0x80ee9c..0x80ee9d
+            - Range: 0x80eebc..0x80eebd
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ee9d..0x80eed0
+            - Range: 0x80eebd..0x80eef0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11296,8 +11296,8 @@ Subprograms:
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0x807c10..0x807c70]
       InlinePCRanges:
-        - Ranges: [0x80ef50..0x80ef74]
-          RootRanges: [0x80ef30..0x80efa0]
+        - Ranges: [0x80ef70..0x80ef94]
+          RootRanges: [0x80ef50..0x80efc0]
       Variables:
         - Name: b
           Type: 364 StructureType main.firstBehavior
@@ -11330,8 +11330,8 @@ Subprograms:
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x8083c0..0x8083cc, 0x8083d0..0x8083d8]
-          RootRanges: [0x808330..0x808420]
+        - Ranges: [0x8083e0..0x8083ec, 0x8083f0..0x8083f8]
+          RootRanges: [0x808350..0x808440]
         - Ranges: [0x139638..0x13963c, 0x139640..0x139648]
           RootRanges: [0x139630..0x139650]
       Variables: []

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -260,12 +260,13 @@ Package: main
 	Function: iterExample.rangeOverIterator.Values[...].func1 (main.iterExample.rangeOverIterator.Values[go.shape.[]int,go.shape.int].func1) in slices/iter.go [38:40] injectible: [39-40]
 		Var: v: go.shape.int (declared at line 39, available: [40-40])
 		Arg: yield: func(go.shape.int) bool (declared at line 0, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [21:39] injectible: [21-22], [24-24], [26-29], [33-37], [39-39]
-		Var: ticker: *time.Ticker (declared at line 33, available: [34-34])
-		Scope: 26-34
-			Var: scanner: *bufio.Scanner (declared at line 26, available: )
-		Scope: 34-37
-			Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 35, available: [34-37])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [21:45] injectible: [21-21], [24-25], [28-28], [30-30], [32-35], [39-43], [45-45]
+		Var: ticker: *time.Ticker (declared at line 39, available: [40-40])
+		Var: service: string (declared at line 24, available: [25-28])
+		Scope: 32-40
+			Var: scanner: *bufio.Scanner (declared at line 32, available: )
+		Scope: 40-43
+			Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 41, available: [40-43])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
@@ -290,9 +291,9 @@ Package: main
 		Arg: ~r0: uint64 (declared at line 40, available: )
 		Var: n: uint64 (declared at line 45, available: [44-46])
 		Var: b: []uint8 (declared at line 41, available: [44-45])
-	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [41:73] injectible: [41-54], [56-57], [59-61], [63-64], [67-73]
-		Var: it: main.iterExample (declared at line 58, available: [41-73])
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 55, available: [41-73])
+	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [47:79] injectible: [47-60], [62-63], [65-67], [69-70], [73-79]
+		Var: it: main.iterExample (declared at line 64, available: [47-79])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 61, available: [47-79])
 	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
 		Arg: x: []int (declared at line 16, available: [16-17])
 		Arg: ~r0: string (declared at line 16, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -250,10 +250,11 @@ Package: main
 	Function: iterExample.rangeOverIterator.Values[...].func1 (main.iterExample.rangeOverIterator.Values[go.shape.[]int,go.shape.int].func1) in slices/iter.go [38:40] injectible: [39-40]
 		Var: v: go.shape.int (declared at line 39, available: [40-40])
 		Arg: yield: func(go.shape.int) bool (declared at line 0, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [21:39] injectible: [21-22], [24-24], [26-29], [33-37], [39-39]
-		Var: ticker: *time.Ticker (declared at line 33, available: [34-34])
-		Scope: 34-37
-			Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 35, available: [34-37])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [21:45] injectible: [21-21], [24-25], [28-28], [30-30], [32-35], [39-43], [45-45]
+		Var: ticker: *time.Ticker (declared at line 39, available: [40-40])
+		Var: service: string (declared at line 24, available: [25-28])
+		Scope: 40-43
+			Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 41, available: [40-43])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
@@ -278,9 +279,9 @@ Package: main
 		Arg: ~r0: uint64 (declared at line 40, available: )
 		Var: n: uint64 (declared at line 45, available: [44-46])
 		Var: b: []uint8 (declared at line 41, available: [44-45])
-	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [41:73] injectible: [41-54], [56-57], [59-61], [63-64], [67-73]
-		Var: it: main.iterExample (declared at line 58, available: [41-73])
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 55, available: [41-73])
+	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [47:79] injectible: [47-60], [62-63], [65-67], [69-70], [73-79]
+		Var: it: main.iterExample (declared at line 64, available: [47-79])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 61, available: [47-79])
 	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
 		Arg: x: []int (declared at line 16, available: [16-17])
 		Arg: ~r0: string (declared at line 16, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -247,10 +247,11 @@ Package: main
 	Function: iterExample.rangeOverIterator.Values[...].func1 (main.iterExample.rangeOverIterator.Values[go.shape.[]int,go.shape.int].func1) in slices/iter.go [38:40] injectible: [39-40]
 		Var: v: go.shape.int (declared at line 39, available: [40-40])
 		Arg: yield: func(go.shape.int) bool (declared at line 0, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [21:39] injectible: [21-22], [24-24], [26-29], [33-37], [39-39]
-		Var: ticker: *time.Ticker (declared at line 33, available: [34-34])
-		Scope: 34-37
-			Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 35, available: [34-37])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [21:45] injectible: [21-21], [24-25], [28-28], [30-30], [32-35], [39-43], [45-45]
+		Var: ticker: *time.Ticker (declared at line 39, available: [40-40])
+		Var: service: string (declared at line 24, available: [25-28])
+		Scope: 40-43
+			Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 41, available: [40-43])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
@@ -275,9 +276,9 @@ Package: main
 		Arg: ~r0: uint64 (declared at line 40, available: )
 		Var: n: uint64 (declared at line 45, available: [44-46])
 		Var: b: []uint8 (declared at line 41, available: [42-45])
-	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [41:73] injectible: [41-54], [56-57], [59-61], [63-64], [67-73]
-		Var: it: main.iterExample (declared at line 58, available: [41-73])
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 55, available: [41-73])
+	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [47:79] injectible: [47-60], [62-63], [65-67], [69-70], [73-79]
+		Var: it: main.iterExample (declared at line 64, available: [47-79])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 61, available: [47-79])
 	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
 		Arg: x: []int (declared at line 16, available: [16-17])
 		Arg: ~r0: string (declared at line 16, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.26rc1.out
@@ -247,10 +247,11 @@ Package: main
 	Function: iterExample.rangeOverIterator.Values[...].func1 (main.iterExample.rangeOverIterator.Values[go.shape.[]int,go.shape.int].func1) in slices/iter.go [38:40] injectible: [39-40]
 		Var: v: go.shape.int (declared at line 39, available: [40-40])
 		Arg: yield: func(go.shape.int) bool (declared at line 0, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [21:39] injectible: [21-22], [24-24], [26-29], [33-37], [39-39]
-		Var: ticker: *time.Ticker (declared at line 33, available: [34-34])
-		Scope: 34-37
-			Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 35, available: [34-37])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [21:45] injectible: [21-21], [24-25], [28-28], [30-30], [32-35], [39-43], [45-45]
+		Var: ticker: *time.Ticker (declared at line 39, available: [40-40])
+		Var: service: string (declared at line 24, available: [25-28])
+		Scope: 40-43
+			Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 41, available: [40-43])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
@@ -275,9 +276,9 @@ Package: main
 		Arg: ~r0: uint64 (declared at line 40, available: )
 		Var: n: uint64 (declared at line 45, available: [44-46])
 		Var: b: []uint8 (declared at line 41, available: [42-45])
-	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [41:73] injectible: [41-54], [56-57], [59-61], [63-64], [67-73]
-		Var: it: main.iterExample (declared at line 58, available: [41-73])
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 55, available: [41-73])
+	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [47:79] injectible: [47-60], [62-63], [65-67], [69-70], [73-79]
+		Var: it: main.iterExample (declared at line 64, available: [47-79])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 61, available: [47-79])
 	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
 		Arg: x: []int (declared at line 16, available: [16-17])
 		Arg: ~r0: string (declared at line 16, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -262,12 +262,13 @@ Package: main
 	Function: iterExample.rangeOverIterator.Values[...].func1 (main.iterExample.rangeOverIterator.Values[go.shape.[]int,go.shape.int].func1) in slices/iter.go [38:40] injectible: [39-40]
 		Var: v: go.shape.int (declared at line 39, available: [40-40])
 		Arg: yield: func(go.shape.int) bool (declared at line 0, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [21:39] injectible: [21-22], [24-24], [26-29], [33-37], [39-39]
-		Var: ticker: *time.Ticker (declared at line 33, available: [34-34])
-		Scope: 26-34
-			Var: scanner: *bufio.Scanner (declared at line 26, available: )
-		Scope: 34-37
-			Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 35, available: [34-37])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [21:45] injectible: [21-21], [24-25], [28-28], [30-30], [32-35], [39-43], [45-45]
+		Var: ticker: *time.Ticker (declared at line 39, available: [40-40])
+		Var: service: string (declared at line 24, available: [25-28])
+		Scope: 32-40
+			Var: scanner: *bufio.Scanner (declared at line 32, available: )
+		Scope: 40-43
+			Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 41, available: [40-43])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
@@ -292,9 +293,9 @@ Package: main
 		Arg: ~r0: uint64 (declared at line 40, available: )
 		Var: n: uint64 (declared at line 45, available: [44-46])
 		Var: b: []uint8 (declared at line 41, available: [44-45])
-	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [41:73] injectible: [41-54], [56-57], [59-61], [63-64], [67-73]
-		Var: it: main.iterExample (declared at line 58, available: [41-73])
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 55, available: [41-73])
+	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [47:79] injectible: [47-60], [62-63], [65-67], [69-70], [73-79]
+		Var: it: main.iterExample (declared at line 64, available: [47-79])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 61, available: [47-79])
 	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
 		Arg: x: []int (declared at line 16, available: [16-17])
 		Arg: ~r0: string (declared at line 16, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -252,10 +252,11 @@ Package: main
 	Function: iterExample.rangeOverIterator.Values[...].func1 (main.iterExample.rangeOverIterator.Values[go.shape.[]int,go.shape.int].func1) in slices/iter.go [38:40] injectible: [39-40]
 		Var: v: go.shape.int (declared at line 39, available: [40-40])
 		Arg: yield: func(go.shape.int) bool (declared at line 0, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [21:39] injectible: [21-22], [24-24], [26-29], [33-37], [39-39]
-		Var: ticker: *time.Ticker (declared at line 33, available: [34-34])
-		Scope: 34-37
-			Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 35, available: [34-37])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [21:45] injectible: [21-21], [24-25], [28-28], [30-30], [32-35], [39-43], [45-45]
+		Var: ticker: *time.Ticker (declared at line 39, available: [40-40])
+		Var: service: string (declared at line 24, available: [25-28])
+		Scope: 40-43
+			Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 41, available: [40-43])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
@@ -280,9 +281,9 @@ Package: main
 		Arg: ~r0: uint64 (declared at line 40, available: )
 		Var: n: uint64 (declared at line 45, available: [44-46])
 		Var: b: []uint8 (declared at line 41, available: [44-45])
-	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [41:73] injectible: [41-54], [56-57], [59-61], [63-64], [67-73]
-		Var: it: main.iterExample (declared at line 58, available: [41-73])
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 55, available: [41-73])
+	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [47:79] injectible: [47-60], [62-63], [65-67], [69-70], [73-79]
+		Var: it: main.iterExample (declared at line 64, available: [47-79])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 61, available: [47-79])
 	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
 		Arg: x: []int (declared at line 16, available: [16-17])
 		Arg: ~r0: string (declared at line 16, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -249,10 +249,11 @@ Package: main
 	Function: iterExample.rangeOverIterator.Values[...].func1 (main.iterExample.rangeOverIterator.Values[go.shape.[]int,go.shape.int].func1) in slices/iter.go [38:40] injectible: [39-40]
 		Var: v: go.shape.int (declared at line 39, available: [40-40])
 		Arg: yield: func(go.shape.int) bool (declared at line 0, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [21:39] injectible: [21-22], [24-24], [26-29], [33-37], [39-39]
-		Var: ticker: *time.Ticker (declared at line 33, available: [34-34])
-		Scope: 34-37
-			Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 35, available: [34-37])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [21:45] injectible: [21-21], [24-25], [28-28], [30-30], [32-35], [39-43], [45-45]
+		Var: ticker: *time.Ticker (declared at line 39, available: [40-40])
+		Var: service: string (declared at line 24, available: [25-28])
+		Scope: 40-43
+			Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 41, available: [40-43])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [988-989])
@@ -277,9 +278,9 @@ Package: main
 		Arg: ~r0: uint64 (declared at line 40, available: )
 		Var: n: uint64 (declared at line 45, available: [44-46])
 		Var: b: []uint8 (declared at line 41, available: [42-45])
-	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [41:73] injectible: [41-54], [56-57], [59-61], [63-64], [67-73]
-		Var: it: main.iterExample (declared at line 58, available: [41-73])
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 55, available: [41-73])
+	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [47:79] injectible: [47-60], [62-63], [65-67], [69-70], [73-79]
+		Var: it: main.iterExample (declared at line 64, available: [47-79])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 61, available: [47-79])
 	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
 		Arg: x: []int (declared at line 16, available: [16-17])
 		Arg: ~r0: string (declared at line 16, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.26rc1.out
@@ -249,10 +249,11 @@ Package: main
 	Function: iterExample.rangeOverIterator.Values[...].func1 (main.iterExample.rangeOverIterator.Values[go.shape.[]int,go.shape.int].func1) in slices/iter.go [38:40] injectible: [39-40]
 		Var: v: go.shape.int (declared at line 39, available: [40-40])
 		Arg: yield: func(go.shape.int) bool (declared at line 0, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [21:39] injectible: [21-22], [24-24], [26-29], [33-37], [39-39]
-		Var: ticker: *time.Ticker (declared at line 33, available: [34-34])
-		Scope: 34-37
-			Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 35, available: [34-37])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [21:45] injectible: [21-21], [24-25], [28-28], [30-30], [32-35], [39-43], [45-45]
+		Var: ticker: *time.Ticker (declared at line 39, available: [40-40])
+		Var: service: string (declared at line 24, available: [25-28])
+		Scope: 40-43
+			Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 41, available: [40-43])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [988-989])
@@ -277,9 +278,9 @@ Package: main
 		Arg: ~r0: uint64 (declared at line 40, available: )
 		Var: n: uint64 (declared at line 45, available: [44-46])
 		Var: b: []uint8 (declared at line 41, available: [42-45])
-	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [41:73] injectible: [41-54], [56-57], [59-61], [63-64], [67-73]
-		Var: it: main.iterExample (declared at line 58, available: [41-73])
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 55, available: [41-73])
+	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [47:79] injectible: [47-60], [62-63], [65-67], [69-70], [73-79]
+		Var: it: main.iterExample (declared at line 64, available: [47-79])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 61, available: [47-79])
 	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
 		Arg: x: []int (declared at line 16, available: [16-17])
 		Arg: ~r0: string (declared at line 16, available: )

--- a/pkg/dyninst/testdata/decoded/sample/stackC.json
+++ b/pkg/dyninst/testdata/decoded/sample/stackC.json
@@ -38,12 +38,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 49
+            "lineNumber": 55
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testAny.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 70
+            "lineNumber": 76
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -112,12 +112,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 70
+            "lineNumber": 76
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -196,12 +196,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 70
+            "lineNumber": 76
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -280,12 +280,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 70
+            "lineNumber": 76
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -364,12 +364,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 70
+            "lineNumber": 76
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -448,12 +448,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 70
+            "lineNumber": 76
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -532,12 +532,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 70
+            "lineNumber": 76
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -611,12 +611,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 70
+            "lineNumber": 76
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -695,12 +695,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 70
+            "lineNumber": 76
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -780,12 +780,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 70
+            "lineNumber": 76
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testAnyPtr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testAnyPtr.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 70
+            "lineNumber": 76
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -107,12 +107,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 70
+            "lineNumber": 76
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -187,12 +187,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 70
+            "lineNumber": 76
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -272,12 +272,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 70
+            "lineNumber": 76
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -357,12 +357,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 70
+            "lineNumber": 76
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -448,12 +448,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 70
+            "lineNumber": 76
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayArgAndReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayArgAndReturn.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayEmptyStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayEmptyStructs.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 52
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfArrays.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfArrays.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 52
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfArraysOfArrays.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfArraysOfArrays.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 52
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfMaps.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfMaps.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 69
+            "lineNumber": 75
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfStrings.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfStrings.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 52
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfStructs.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 52
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testAtomicAdd.json
+++ b/pkg/dyninst/testdata/decoded/sample/testAtomicAdd.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 42
+            "lineNumber": 48
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testBigStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testBigStruct.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 58
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testBigStruct_geq_go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testBigStruct_geq_go1.26rc1.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 58
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testBoolArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testBoolArray.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 52
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testByteArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testByteArray.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 52
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testCaptureExprGetmember.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCaptureExprGetmember.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 48
+            "lineNumber": 54
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testCaptureExprGetmember_geq_go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCaptureExprGetmember_geq_go1.26rc1.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 48
+            "lineNumber": 54
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testCaptureExprLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCaptureExprLine.json
@@ -33,12 +33,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 56
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -115,12 +115,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 56
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -197,12 +197,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 56
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -284,12 +284,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 56
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -361,12 +361,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 56
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testCaptureExprLineCond.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCaptureExprLineCond.json
@@ -38,12 +38,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 56
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testCaptureExprLineWithTemplate.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCaptureExprLineWithTemplate.json
@@ -33,12 +33,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 56
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -116,12 +116,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 56
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -199,12 +199,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 56
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -287,12 +287,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 56
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -365,12 +365,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 56
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testCaptureExprSimple.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCaptureExprSimple.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 44
+            "lineNumber": 50
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testCaptureExprWithTemplate.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCaptureExprWithTemplate.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 44
+            "lineNumber": 50
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testChannel.json
+++ b/pkg/dyninst/testdata/decoded/sample/testChannel.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 42
+            "lineNumber": 48
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testCombinedByte.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCombinedByte.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 44
+            "lineNumber": 50
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testConflictingReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testConflictingReturn.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testCycle.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCycle.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 51
+            "lineNumber": 57
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepMap1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepMap1.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 58
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepMap7.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepMap7.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 58
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepPtr1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepPtr1.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 58
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepPtr7.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepPtr7.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 58
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepSlice1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepSlice1.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 58
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepSlice7.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepSlice7.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 58
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testEmptySlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptySlice.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 47
+            "lineNumber": 53
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testEmptySliceOfStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptySliceOfStructs.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 47
+            "lineNumber": 53
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testEmptyString.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptyString.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 45
+            "lineNumber": 51
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -97,12 +97,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 45
+            "lineNumber": 51
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testEmptyStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptyStruct.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 48
+            "lineNumber": 54
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testEmptyStructPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptyStructPointer.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 48
+            "lineNumber": 54
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testError.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 70
+            "lineNumber": 76
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testErrorAtLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testErrorAtLine.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 58
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testErrorAtLine_config_arch=amd64,toolchain=go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testErrorAtLine_config_arch=amd64,toolchain=go1.26rc1.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 58
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testEsotericHeap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEsotericHeap.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 67
+            "lineNumber": 73
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testEsotericStack.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEsotericStack.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 67
+            "lineNumber": 73
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testFrameless.json
+++ b/pkg/dyninst/testdata/decoded/sample/testFrameless.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 56
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testFramelessArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testFramelessArray.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 56
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testFramelessArrayLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testFramelessArrayLine.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 56
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericDeref.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericDeref.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 68
+            "lineNumber": 74
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -134,12 +134,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 68
+            "lineNumber": 74
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericDo.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericDo.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 68
+            "lineNumber": 74
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -112,12 +112,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 68
+            "lineNumber": 74
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericFuncContains.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericFuncContains.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 68
+            "lineNumber": 74
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -125,12 +125,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 68
+            "lineNumber": 74
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -222,12 +222,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 68
+            "lineNumber": 74
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -319,12 +319,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 68
+            "lineNumber": 74
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -416,12 +416,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 68
+            "lineNumber": 74
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericFuncContainsLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericFuncContainsLine.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 68
+            "lineNumber": 74
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -102,12 +102,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 68
+            "lineNumber": 74
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -194,12 +194,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 68
+            "lineNumber": 74
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -286,12 +286,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 68
+            "lineNumber": 74
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -378,12 +378,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 68
+            "lineNumber": 74
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericLargeGet.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericLargeGet.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 68
+            "lineNumber": 74
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -672,12 +672,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 68
+            "lineNumber": 74
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericLibFilter.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericLibFilter.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 61
+            "lineNumber": 67
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -140,12 +140,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 68
+            "lineNumber": 74
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericLibMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericLibMap.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 68
+            "lineNumber": 74
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericMethodGuess.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericMethodGuess.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 68
+            "lineNumber": 74
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -116,12 +116,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 68
+            "lineNumber": 74
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericNested.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericNested.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 68
+            "lineNumber": 74
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -112,12 +112,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 68
+            "lineNumber": 74
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericPairSetValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericPairSetValue.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 68
+            "lineNumber": 74
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -117,12 +117,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 68
+            "lineNumber": 74
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericPtrIdentity.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericPtrIdentity.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 68
+            "lineNumber": 74
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -127,12 +127,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 68
+            "lineNumber": 74
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -218,12 +218,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 68
+            "lineNumber": 74
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericSwap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericSwap.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 68
+            "lineNumber": 74
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -119,12 +119,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 68
+            "lineNumber": 74
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericWrapBox.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericWrapBox.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 68
+            "lineNumber": 74
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -112,12 +112,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 68
+            "lineNumber": 74
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBA.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBA.json
@@ -33,12 +33,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 56
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBB.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBB.json
@@ -33,12 +33,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 56
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBBA.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBBA.json
@@ -38,12 +38,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 56
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBBB.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBBB.json
@@ -38,12 +38,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 56
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBC.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBC.json
@@ -33,12 +33,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 56
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBCA.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBCA.json
@@ -38,12 +38,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 56
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBCALine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBCALine.json
@@ -38,12 +38,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 56
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBCB.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBCB.json
@@ -38,12 +38,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 56
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBCBLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBCBLine.json
@@ -38,12 +38,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 56
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedFuncFromOtherPackage.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedFuncFromOtherPackage.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 53
+            "lineNumber": 59
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedPrint.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedPrint.json
@@ -33,12 +33,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 56
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -113,12 +113,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 56
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -193,12 +193,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 56
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -278,12 +278,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 56
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -353,12 +353,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 56
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedPrintLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedPrintLine.json
@@ -33,12 +33,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 56
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -117,12 +117,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 56
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -201,12 +201,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 56
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -290,12 +290,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 56
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -369,12 +369,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 56
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedSq.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedSq.json
@@ -33,12 +33,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 56
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedSqLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedSqLine.json
@@ -33,12 +33,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 56
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedSumArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedSumArray.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 56
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -125,12 +125,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 50
+            "lineNumber": 56
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInt16Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt16Array.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 52
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInt32Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt32Array.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 52
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInt64Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt64Array.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 52
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInt8Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt8Array.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 52
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testIntArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testIntArray.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 52
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInterface.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInterface.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 70
+            "lineNumber": 76
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -108,12 +108,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 70
+            "lineNumber": 76
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -189,12 +189,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 70
+            "lineNumber": 76
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -269,12 +269,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 70
+            "lineNumber": 76
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -350,12 +350,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 70
+            "lineNumber": 76
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -425,12 +425,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 70
+            "lineNumber": 76
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testLargeArgAndReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLargeArgAndReturn.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testLinkedList.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLinkedList.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 51
+            "lineNumber": 57
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineA.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineA.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 58
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineB.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineB.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 58
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -106,12 +106,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 58
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -184,12 +184,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 58
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -262,12 +262,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 58
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -340,12 +340,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 58
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -418,12 +418,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 58
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -496,12 +496,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 58
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -574,12 +574,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 58
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -652,12 +652,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 58
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -730,12 +730,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 58
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineB_geq_go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineB_geq_go1.26rc1.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 58
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineC.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineC.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 58
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -106,12 +106,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 58
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -184,12 +184,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 58
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -262,12 +262,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 58
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -340,12 +340,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 58
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -418,12 +418,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 58
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -496,12 +496,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 58
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -574,12 +574,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 58
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -652,12 +652,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 58
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -730,12 +730,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 58
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineC_geq_go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineC_geq_go1.26rc1.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 58
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testManyArgsArrayReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testManyArgsArrayReturn.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testManyPointers.json
+++ b/pkg/dyninst/testdata/decoded/sample/testManyPointers.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 63
+            "lineNumber": 69
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testManyStrings.json
+++ b/pkg/dyninst/testdata/decoded/sample/testManyStrings.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 64
+            "lineNumber": 70
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapArrayToArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapArrayToArray.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 69
+            "lineNumber": 75
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmbeddedMaps.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmbeddedMaps.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 69
+            "lineNumber": 75
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmptyKey.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmptyKey.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 69
+            "lineNumber": 75
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmptyKeyAndValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmptyKeyAndValue.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 69
+            "lineNumber": 75
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmptyValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmptyValue.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 69
+            "lineNumber": 75
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapIntToInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapIntToInt.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 69
+            "lineNumber": 75
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapLargeKeyLargeValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapLargeKeyLargeValue.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 69
+            "lineNumber": 75
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapLargeKeySmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapLargeKeySmallValue.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 69
+            "lineNumber": 75
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapMassive.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 69
+            "lineNumber": 75
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapMassiveWithSizeLimit.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapMassiveWithSizeLimit.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 69
+            "lineNumber": 75
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapSmallKeyLargeValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapSmallKeyLargeValue.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 69
+            "lineNumber": 75
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapSmallKeySmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapSmallKeySmallValue.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 69
+            "lineNumber": 75
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapStringToInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapStringToInt.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 69
+            "lineNumber": 75
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapStringToSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapStringToSlice.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 69
+            "lineNumber": 75
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapStringToStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapStringToStruct.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 69
+            "lineNumber": 75
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithLinkedList.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithLinkedList.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 69
+            "lineNumber": 75
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValue.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 69
+            "lineNumber": 75
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValueMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValueMassive.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 69
+            "lineNumber": 75
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValue.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 69
+            "lineNumber": 75
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValueMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValueMassive.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 69
+            "lineNumber": 75
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMassiveString.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMassiveString.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 45
+            "lineNumber": 51
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMassiveStringWithSizeLimit.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMassiveStringWithSizeLimit.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 45
+            "lineNumber": 51
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMixedArgsStackReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMixedArgsStackReturn.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleArrayArgs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleArrayArgs.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleLargeArgs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleLargeArgs.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleNamedReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleNamedReturn.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleSimpleParams.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleSimpleParams.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 44
+            "lineNumber": 50
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturn.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturnByNameCaptureExpr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturnByNameCaptureExpr.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturnByNameMultiCaptureExpr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturnByNameMultiCaptureExpr.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturnByNameTemplate.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturnByNameTemplate.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturnWithTemplate.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturnWithTemplate.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNestedPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNestedPointer.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 48
+            "lineNumber": 54
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNilPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNilPointer.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 51
+            "lineNumber": 57
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNilSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNilSlice.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 47
+            "lineNumber": 53
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNilSliceOfStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNilSliceOfStructs.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 47
+            "lineNumber": 53
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNilSliceWithOtherParams.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNilSliceWithOtherParams.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 47
+            "lineNumber": 53
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testOneStringInStructPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testOneStringInStructPointer.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 45
+            "lineNumber": 51
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testPointerLoop.json
+++ b/pkg/dyninst/testdata/decoded/sample/testPointerLoop.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 51
+            "lineNumber": 57
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testPointerToMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testPointerToMap.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 69
+            "lineNumber": 75
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testPointerToSimpleStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testPointerToSimpleStruct.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 51
+            "lineNumber": 57
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnCaptureExpr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnCaptureExpr.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnCondMulti.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnCondMulti.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnCondMultiFloat.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnCondMultiFloat.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnCondSingle.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnCondSingle.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnCondUnavailableFloat.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnCondUnavailableFloat.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnMultiCaptureExpr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnMultiCaptureExpr.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnMultiTemplate.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnMultiTemplate.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnTemplate.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnTemplate.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsAny.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -107,12 +107,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -196,12 +196,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsAnyAndError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsAnyAndError.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -135,12 +135,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsArray.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsArrayOne.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsArrayOne.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsArrayZero.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsArrayZero.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsBacktrackInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsBacktrackInt.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsBoolAndUintptr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsBoolAndUintptr.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsComplex.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsComplex.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsError.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -118,12 +118,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsInt.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsIntAndFloat.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsIntAndFloat.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsIntPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsIntPointer.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsInterface.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsInterface.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -112,12 +112,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -211,12 +211,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsLargeStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsLargeStruct.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsManyFloats.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsManyFloats.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsMixed.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsMixed.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsMixedStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsMixedStruct.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsMultipleFloats.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsMultipleFloats.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsNamedDeferLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsNamedDeferLine.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsOnlyFloat.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsOnlyFloat.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsPrimitives.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsPrimitives.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsStructWithArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsStructWithArray.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsWideStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsWideStruct.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testRuneArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testRuneArray.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 52
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSegmentsForParamsAndReturnsOutOfOrder.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSegmentsForParamsAndReturnsOutOfOrder.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleBool.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleBool.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 43
+            "lineNumber": 49
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleByte.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleByte.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 43
+            "lineNumber": 49
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleFloat32.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleFloat32.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 43
+            "lineNumber": 49
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleFloat64.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleFloat64.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 43
+            "lineNumber": 49
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 43
+            "lineNumber": 49
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt16.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt16.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 43
+            "lineNumber": 49
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt32.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt32.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 43
+            "lineNumber": 49
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt64.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt64.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 43
+            "lineNumber": 49
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt8.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt8.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 43
+            "lineNumber": 49
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleRune.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleRune.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 43
+            "lineNumber": 49
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleString.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleString.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 45
+            "lineNumber": 51
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 43
+            "lineNumber": 49
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint16.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint16.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 43
+            "lineNumber": 49
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint32.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint32.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 43
+            "lineNumber": 49
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint64.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint64.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 43
+            "lineNumber": 49
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint8.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint8.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 43
+            "lineNumber": 49
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSliceEmptyStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSliceEmptyStructs.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 47
+            "lineNumber": 53
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSliceOfSlices.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSliceOfSlices.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 47
+            "lineNumber": 53
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSmallMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSmallMap.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 69
+            "lineNumber": 75
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSomeNamedReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSomeNamedReturn.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStackArgRegReturns.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStackArgRegReturns.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStringArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringArray.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 52
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStringPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringPointer.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 51
+            "lineNumber": 57
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStringSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringSlice.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 47
+            "lineNumber": 53
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStringType1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringType1.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 58
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStringType2.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringType2.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 52
+            "lineNumber": 58
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStruct.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 48
+            "lineNumber": 54
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStructSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructSlice.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 47
+            "lineNumber": 53
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithAny.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 70
+            "lineNumber": 76
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithArrayArg.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithArrayArg.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicMaps.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicMaps.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 48
+            "lineNumber": 54
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicMaps_geq_go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicMaps_geq_go1.26rc1.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 48
+            "lineNumber": 54
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicSlices.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicSlices.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 48
+            "lineNumber": 54
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithMap.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 69
+            "lineNumber": 75
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStruct_geq_go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStruct_geq_go1.26rc1.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 48
+            "lineNumber": 54
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSubslices.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSubslices.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 47
+            "lineNumber": 53
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSubstrings.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSubstrings.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 45
+            "lineNumber": 51
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testTemplateWithNonexistantVariableName.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTemplateWithNonexistantVariableName.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testTemplateWithUnsupportedExpression.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTemplateWithUnsupportedExpression.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testTemplateWithUnsupportedVariable.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTemplateWithUnsupportedVariable.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testThreeStrings.json
+++ b/pkg/dyninst/testdata/decoded/sample/testThreeStrings.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 45
+            "lineNumber": 51
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStruct.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 45
+            "lineNumber": 51
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStructPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStructPointer.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 45
+            "lineNumber": 51
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStruct_geq_go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStruct_geq_go1.26rc1.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 45
+            "lineNumber": 51
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testTypeAlias.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTypeAlias.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 43
+            "lineNumber": 49
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testUint16Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint16Array.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 52
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testUint32Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint32Array.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 52
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testUint64Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint64Array.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 52
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testUint8Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint8Array.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 52
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testUintArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUintArray.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 52
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testUintPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUintPointer.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 51
+            "lineNumber": 57
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testUintSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUintSlice.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 47
+            "lineNumber": 53
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testUnitializedString.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUnitializedString.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 45
+            "lineNumber": 51
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testUnsafePointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUnsafePointer.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 51
+            "lineNumber": 57
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testVeryLargeArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testVeryLargeArray.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 52
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testVeryLargeSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testVeryLargeSlice.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 47
+            "lineNumber": 53
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testVeryLargeSliceWithSizeLimit.json
+++ b/pkg/dyninst/testdata/decoded/sample/testVeryLargeSliceWithSizeLimit.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 47
+            "lineNumber": 53
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testWhollyInlinedSubroutine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testWhollyInlinedSubroutine.json
@@ -33,12 +33,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 68
+            "lineNumber": 74
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -122,12 +122,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -197,12 +197,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testZeroSizeArgAndReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testZeroSizeArgAndReturn.json
@@ -28,12 +28,12 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 71
+            "lineNumber": 77
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 28
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testprogs/progs/sample/main.go
+++ b/pkg/dyninst/testprogs/progs/sample/main.go
@@ -19,7 +19,13 @@ import (
 )
 
 func main() {
-	tracer.Start(tracer.WithService("sample-service"))
+	// Default to "sample-service" for dyninst tests, but let DD_SERVICE win so
+	// demo deployments can report under their own service name.
+	service := os.Getenv("DD_SERVICE")
+	if service == "" {
+		service = "sample-service"
+	}
+	tracer.Start(tracer.WithService(service))
 
 	if os.Getenv("DD_SAMPLE_LOOP") == "" {
 		// Wait for input before executing functions to allow time for uprobe attachment


### PR DESCRIPTION
### What does this PR do?

Reads `DD_SERVICE` in the dyninst sample's `main.go` and falls back to `"sample-service"` only if it's unset. Previously `tracer.Start(tracer.WithService("sample-service"))` hardcoded the service name and overrode whatever the env passed in.

### Motivation

The dyninst sample is now also built and deployed as the Go debugger demo service. The demo's k8s deployment sets `DD_SERVICE=debugger-demo-go`, but the hardcoded `WithService` made the running binary report as `sample-service` regardless, so it showed up under the wrong service in Datadog and DI probes targeting `debugger-demo-go` didn't match.

### Describe how you validated your changes

Built locally and ran the binary with and without `DD_SERVICE` set to confirm the precedence. unset falls back to `sample-service`, set wins.

### Additional Notes

Dyninst tests are unaffected because they don't set `DD_SERVICE` in their environment, so they continue to get `sample service`.