### PR TITLE
[ABLD-387] `bazel`ify proto generation: rest of `core`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -622,8 +622,6 @@ exports_files(glob(
 # gazelle:exclude pkg/process/util/containers
 # gazelle:exclude pkg/process/util/status
 # gazelle:exclude pkg/procmgr
-# gazelle:exclude pkg/proto/datadog/api
-# gazelle:exclude pkg/proto/datadog/remoteagent
 # gazelle:exclude pkg/proto/protodep
 # gazelle:exclude pkg/remoteflags
 # gazelle:exclude pkg/sbom/collectors/docker
@@ -850,13 +848,6 @@ exports_files(glob(
 # gazelle:exclude tools/host-profiler
 # gazelle:exclude tools/retry_file_dump
 # gazelle:exclude tools/windows
-# Proto definitions under pkg/proto/datadog/ use pre-generated Go code checked
-# into pkg/proto/pbgo/. Gazelle's proto mode is disabled because multiple proto
-# directories share the same go_package ("pkg/proto/pbgo/core"), making
-# per-directory go_proto_library targets impossible. Additionally, some directories
-# (remoteagent, privateactionrunner) contain multiple proto packages which
-# gazelle cannot handle at all.
-# Vendored proto definitions used only for protoc code-gen, not Bazel builds.
 
 # All custom build tags from tasks/build_tags.py ALL_TAGS, plus "test".
 # "test" is included so Gazelle analyzes test-only sources and generates their

--- a/bazel/rules/write_pb_go/_gazelle_extension.go
+++ b/bazel/rules/write_pb_go/_gazelle_extension.go
@@ -93,11 +93,21 @@ func goProtoLibraries(args language.GenerateArgs) map[string][]goProtoLibrary {
 		if pc := proto.GetProtoConfig(args.Config); pc != nil && !strings.HasPrefix(importPath, pc.GoPrefix) {
 			importPath = fmt.Sprintf("%s/%s", pc.GoPrefix, importPath)
 		}
-		protoLabel, err := label.Parse(r.AttrString("proto"))
-		if err != nil {
-			continue
+		protoLabels := r.AttrStrings("protos")   // plural: `gazelle:proto file`
+		if s := r.AttrString("proto"); s != "" { // singular: `gazelle:proto default|package`
+			protoLabels = append(protoLabels, s)
 		}
-		if protoInfos, ok := protoLibrarySrcs[protoLabel.Name]; ok {
+		var protoInfos []proto.FileInfo
+		for _, s := range protoLabels {
+			protoLabel, err := label.Parse(s)
+			if err != nil {
+				continue
+			}
+			if infos, ok := protoLibrarySrcs[protoLabel.Name]; ok {
+				protoInfos = append(protoInfos, infos...)
+			}
+		}
+		if len(protoInfos) > 0 {
 			result[importPath] = append(result[importPath], goProtoLibrary{
 				label:         label.New("", args.Rel, r.Name()),
 				generatedSrcs: generatedSrcs(r, protoInfos),

--- a/pkg/proto/datadog/api/v1/BUILD.bazel
+++ b/pkg/proto/datadog/api/v1/BUILD.bazel
@@ -1,0 +1,40 @@
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
+load("@rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "v1_proto",
+    srcs = ["api.proto"],
+    strip_import_prefix = "/pkg/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/proto/datadog/autodiscovery:autodiscovery_proto",
+        "//pkg/proto/datadog/kubemetadata:kubemetadata_proto",
+        "//pkg/proto/datadog/model/v1:v1_proto",
+        "//pkg/proto/datadog/remoteagent:remoteagent_proto",
+        "//pkg/proto/datadog/remoteconfig:config_proto",
+        "//pkg/proto/datadog/workloadfilter:workloadfilter_proto",
+        "//pkg/proto/datadog/workloadmeta:workloadmeta_proto",
+        "@protobuf//:empty_proto",
+    ],
+)
+
+go_proto_library(
+    name = "v1_go_proto",
+    compilers = [
+        "@rules_go//proto:go_proto",
+        "//bazel/rules/go_proto_compiler:go_grpc_futureproof",
+    ],
+    importpath = "pkg/proto/pbgo/core",
+    proto = ":v1_proto",
+    tags = ["manual"],  # only for .pb.go files (target wouldn't compile due to sibling deps in the same Go package)
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/proto/datadog/autodiscovery:autodiscovery_go_proto",
+        "//pkg/proto/datadog/kubemetadata:kubemetadata_go_proto",
+        "//pkg/proto/datadog/model/v1:v1_go_proto",
+        "//pkg/proto/datadog/remoteagent:core_go_proto",
+        "//pkg/proto/datadog/remoteconfig:config_go_proto",
+        "//pkg/proto/datadog/workloadfilter:workloadfilter_go_proto",
+        "//pkg/proto/datadog/workloadmeta:workloadmeta_go_proto",
+    ],
+)

--- a/pkg/proto/datadog/remoteagent/BUILD.bazel
+++ b/pkg/proto/datadog/remoteagent/BUILD.bazel
@@ -1,0 +1,47 @@
+# gazelle:proto file
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
+load("@rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "flare_proto",
+    srcs = ["flare.proto"],
+    strip_import_prefix = "/pkg/proto",
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "remoteagent_proto",
+    srcs = ["remoteagent.proto"],
+    strip_import_prefix = "/pkg/proto",
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "status_proto",
+    srcs = ["status.proto"],
+    strip_import_prefix = "/pkg/proto",
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "telemetry_proto",
+    srcs = ["telemetry.proto"],
+    strip_import_prefix = "/pkg/proto",
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "core_go_proto",
+    compilers = [
+        "@rules_go//proto:go_proto",
+        "//bazel/rules/go_proto_compiler:go_grpc_futureproof",
+    ],
+    importpath = "pkg/proto/pbgo/core",
+    protos = [
+        ":flare_proto",
+        ":remoteagent_proto",
+        ":status_proto",
+        ":telemetry_proto",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/proto/pbgo/core/BUILD.bazel
+++ b/pkg/proto/pbgo/core/BUILD.bazel
@@ -4,6 +4,10 @@ load("//bazel/rules/write_pb_go:defs.bzl", "write_pb_go")
 write_pb_go(
     name = "write_pb_go",
     srcs = {
+        "//pkg/proto/datadog/api/v1:v1_go_proto": [
+            "api.pb.go",
+            "api_grpc.pb.go",
+        ],
         "//pkg/proto/datadog/autodiscovery:autodiscovery_go_proto": [
             "autodiscovery.pb.go",
         ],
@@ -12,6 +16,15 @@ write_pb_go(
         ],
         "//pkg/proto/datadog/model/v1:v1_go_proto": [
             "model.pb.go",
+        ],
+        "//pkg/proto/datadog/remoteagent:core_go_proto": [
+            "flare.pb.go",
+            "flare_grpc.pb.go",
+            "remoteagent.pb.go",
+            "status.pb.go",
+            "status_grpc.pb.go",
+            "telemetry.pb.go",
+            "telemetry_grpc.pb.go",
         ],
         "//pkg/proto/datadog/remoteconfig:config_go_proto": [
             "echo.pb.go",

--- a/tasks/protobuf.py
+++ b/tasks/protobuf.py
@@ -10,9 +10,7 @@ from tasks.libs.common.color import Color, color_message
 from tasks.libs.common.git import get_unstaged_files, get_untracked_files
 
 PROTO_PKGS = {
-    'api/v1': False,
     'trace': True,
-    'remoteagent': False,
 }
 
 # maybe put this in a separate function


### PR DESCRIPTION
### What does this PR do?
- bring `pkg/proto/datadog/{remoteagent,api/v1}` under `gazelle` control:
  - drop their matching `gazelle:exclude` lines from the root `BUILD.bazel`,
  - `# gazelle:proto file` in `remoteagent/BUILD.bazel` so `gazelle` generates one `proto_library` per `.proto`; the inherited `proto package` mode would otherwise emit colliding rule names from the 4 `.proto`s' shared `...v1` package-name suffix,
  - `proto_library` + `go_proto_library` (gRPC compiler inherited) in each: `remoteagent`'s aggregates 4 `proto_library`s via `protos = [...]` (plural),
  - `write_pb_go` in `pkg/proto/pbgo/core/BUILD.bazel` keeps the new `flare.pb.go`, `flare_grpc.pb.go`, `remoteagent.pb.go`, `status.pb.go`, `status_grpc.pb.go`, `telemetry.pb.go`, `telemetry_grpc.pb.go`, `api.pb.go` and `api_grpc.pb.go` in sync,
- extend the `write_pb_go` Gazelle extension to recognize `protos` (plural) on `go_proto_library` in addition to `proto` (singular): required so `# gazelle:proto file` mode actually produces a `write_pb_go` rule,
- delete the now-stale paragraph in the root `BUILD.bazel` claiming "Gazelle's proto mode is disabled" and naming `remoteagent`/ `privateactionrunner` as gazelle-unmanageable,
- drop `'remoteagent': False` and `'api/v1': False` from `PROTO_PKGS` in `tasks/protobuf.py` (only `'trace': True` remains on the remaining code path to migrate).

### Motivation
Last `pbgo/core` contributors migrating from `dda inv protobuf.generate` to pure `bazel`, both deferred from #50560:
- `remoteagent` because its 4 `.proto`s declare distinct `...v1`-suffixed proto packages in the same directory (now unblocked by `protos`-plural support in the `write_pb_go` extension, which makes `# gazelle:proto file` viable),
- `api/v1` because it imports from every other `pbgo/core` contributor (now all bazel-managed).

The `manual` tag is obviously  a workaround: every per-dir `go_proto_library` in this cluster claims `importpath = "pkg/proto/pbgo/core"`, so each lives in its own bazel archive: `api_grpc.pb.go` references sibling-archive types, leaving the standalone Go compile broken.
A future architectural cleanup (e.g. canonicalizing to one `default`-mode `proto_library` across the cluster) would lift it.

### Describe how you validated your changes
- `bazel run //:gazelle` is stable,
- `bazel build //...` succeeds (`v1_go_proto` excluded by `manual`),
- `bazel test //pkg/proto/pbgo/core:write_pb_go_tests` passes (17 sub-tests; 9 new across `remoteagent` and `api/v1`),
- previously migrated `write_pb_go` tests still pass (`process`, `sbom`, `dogstatsdhttp`, `languagedetection`, `privateactionrunner`, `trace/idx`),
- `dda inv protobuf.generate` succeeds and is a no-op on `remoteagent` and `api/v1`.