### PR TITLE
[AGENTCFG-780] Gate FX construction on first configstream snapshot

### DIFF
--- a/comp/core/configstreamconsumer/impl/consumer.go
+++ b/comp/core/configstreamconsumer/impl/consumer.go
@@ -109,19 +109,25 @@ func NewComponent(reqs Requires) (Provides, error) {
 
 	c.initMetrics()
 
-	// Register lifecycle hooks
+	// Block FX construction on the first snapshot so any component constructed
+	// after this one (including providers that read config eagerly, e.g.
+	// comp/trace/config.NewComponent or pkg/security/agent.StartRuntimeSecurity)
+	// sees the streamed values. The remoteagent RAR loop runs concurrently
+	// because it is also started during construction; see helper.Start.
+	if err := c.start(context.Background()); err != nil {
+		return Provides{}, err
+	}
+
 	reqs.Lifecycle.Append(compdef.Hook{
-		OnStart: c.start,
-		OnStop:  c.stop,
+		OnStop: c.stop,
 	})
 
 	return Provides{Comp: c}, nil
 }
 
 // start initiates the config stream connection and blocks until the first config snapshot is
-// received. Blocking here ensures all components initialized after this one (and the binary's
-// run function) see a fully-populated config. Returns an error if the snapshot is not received
-// within ReadyTimeout (default 60s), which aborts FX startup.
+// received. Returns an error if the snapshot is not received within ReadyTimeout (default 60s),
+// which aborts FX startup.
 func (c *consumer) start(_ context.Context) error {
 	// Use context.Background() so the stream lifetime is not bounded by the
 	// Fx startup context, which expires after app.StartTimeout (~5 minutes).

--- a/comp/core/remoteagent/helper/serverhelper.go
+++ b/comp/core/remoteagent/helper/serverhelper.go
@@ -129,12 +129,10 @@ func NewUnimplementedRemoteAgentServer(ipcComp ipc.Component, log log.Component,
 
 	remoteAgentServer.grpcServer = grpc.NewServer(serverOpts...)
 
-	// Setup lifecycle
+	// Each impl must call Start() after registering its gRPC services so the
+	// service list reported to the core agent is complete and the gRPC server
+	// is not accepting RPCs before they are wired.
 	lc.Append(compdef.Hook{
-		OnStart: func(_ context.Context) error {
-			remoteAgentServer.start()
-			return nil
-		},
 		OnStop: func(_ context.Context) error {
 			remoteAgentServer.stop()
 			return nil
@@ -144,8 +142,9 @@ func NewUnimplementedRemoteAgentServer(ipcComp ipc.Component, log log.Component,
 	return remoteAgentServer, nil
 }
 
-// Start the unimplemented remote agent server
-func (s *UnimplementedRemoteAgentServer) start() {
+// Start begins serving gRPC and starts the RAR registration loop. Impls must
+// call this after registering services on GetGRPCServer().
+func (s *UnimplementedRemoteAgentServer) Start() {
 	s.ctx, s.cancel = context.WithCancel(context.Background())
 
 	// Get the services from the gRPC server

--- a/comp/core/remoteagent/helper/serverhelper_test.go
+++ b/comp/core/remoteagent/helper/serverhelper_test.go
@@ -61,9 +61,8 @@ func TestNoSessionIDReturnsError(t *testing.T) {
 	// Register a test service
 	pbcore.RegisterStatusProviderServer(server.GetGRPCServer(), &mockStatusProvider{})
 
-	// Start the server
-	err = lc.Start(context.Background())
-	require.NoError(t, err)
+	// Start the server (impls call this explicitly after registering services).
+	server.Start()
 	defer lc.Stop(context.Background())
 
 	// Create a client to the remote agent server
@@ -118,9 +117,8 @@ func TestAuthTokenIsChecked(t *testing.T) {
 	// Register a test service
 	pbcore.RegisterStatusProviderServer(server.GetGRPCServer(), &mockStatusProvider{})
 
-	// Start the server
-	err = lc.Start(context.Background())
-	require.NoError(t, err)
+	// Start the server (impls call this explicitly after registering services).
+	server.Start()
 	defer lc.Stop(context.Background())
 
 	tests := []struct {
@@ -206,12 +204,11 @@ func TestServerLifecycle(t *testing.T) {
 	// Register a test service
 	pbcore.RegisterStatusProviderServer(server.GetGRPCServer(), &mockStatusProvider{})
 
-	// Verify lifecycle hooks were registered
+	// Verify lifecycle hooks were registered (OnStop only; Start is called explicitly).
 	lc.AssertHooksNumber(1)
 
-	// Start the server
-	err = lc.Start(context.Background())
-	require.NoError(t, err)
+	// Start the server (impls call this explicitly after registering services).
+	server.Start()
 
 	// Verify the server is running by checking if we can connect
 	conn, err := grpc.NewClient(
@@ -274,9 +271,8 @@ func TestRegisteredServicesReported(t *testing.T) {
 	pbcore.RegisterFlareProviderServer(server.GetGRPCServer(), &mockFlareProvider{})
 	pbcore.RegisterTelemetryProviderServer(server.GetGRPCServer(), &mockTelemetryProvider{})
 
-	// Start the server
-	err = lc.Start(context.Background())
-	require.NoError(t, err)
+	// Start the server (impls call this explicitly after registering services).
+	server.Start()
 	defer lc.Stop(context.Background())
 
 	// Wait for registration to complete
@@ -336,7 +332,7 @@ func TestRegistrationRefreshContention(t *testing.T) {
 	defer mockCoreAgent.stop()
 
 	// Create the remote agent server
-	_, err := NewUnimplementedRemoteAgentServer(
+	server, err := NewUnimplementedRemoteAgentServer(
 		ipcComp,
 		logComp,
 		configComp,
@@ -347,9 +343,8 @@ func TestRegistrationRefreshContention(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	// Start the server
-	err = lc.Start(context.Background())
-	require.NoError(t, err)
+	// Start the server (impls call this explicitly after registering services).
+	server.Start()
 	defer lc.Stop(context.Background())
 
 	// Wait for multiple registration attempts
@@ -408,9 +403,8 @@ func TestSessionIDInResponseMetadata(t *testing.T) {
 	// Register a test service
 	pbcore.RegisterStatusProviderServer(server.GetGRPCServer(), &mockStatusProvider{})
 
-	// Start the server
-	err = lc.Start(context.Background())
-	require.NoError(t, err)
+	// Start the server (impls call this explicitly after registering services).
+	server.Start()
 	defer lc.Stop(context.Background())
 
 	// Create a client and make a request

--- a/comp/core/remoteagent/impl-process/remoteagent.go
+++ b/comp/core/remoteagent/impl-process/remoteagent.go
@@ -61,6 +61,8 @@ func NewComponent(reqs Requires) (Provides, error) {
 	// Add your gRPC services implementations here:
 	pbcore.RegisterTelemetryProviderServer(remoteAgentServer.GetGRPCServer(), remoteagentImpl)
 
+	remoteAgentServer.Start()
+
 	provides := Provides{
 		Comp: remoteagentImpl,
 	}

--- a/comp/core/remoteagent/impl-securityagent/remoteagent.go
+++ b/comp/core/remoteagent/impl-securityagent/remoteagent.go
@@ -54,6 +54,8 @@ func NewComponent(reqs Requires) (Provides, error) {
 		remoteAgentServer: remoteAgentServer,
 	}
 
+	remoteAgentServer.Start()
+
 	provides := Provides{
 		Comp: remoteagentImpl,
 	}

--- a/comp/core/remoteagent/impl-systemprobe/remoteagent.go
+++ b/comp/core/remoteagent/impl-systemprobe/remoteagent.go
@@ -68,6 +68,8 @@ func NewComponent(reqs Requires) (Provides, error) {
 	pbcore.RegisterTelemetryProviderServer(remoteAgentServer.GetGRPCServer(), remoteagentImpl)
 	pbcore.RegisterStatusProviderServer(remoteAgentServer.GetGRPCServer(), remoteagentImpl)
 
+	remoteAgentServer.Start()
+
 	provides := Provides{
 		Comp: remoteagentImpl,
 	}

--- a/comp/core/remoteagent/impl-template/remoteagent.go
+++ b/comp/core/remoteagent/impl-template/remoteagent.go
@@ -57,6 +57,9 @@ func NewComponent(reqs Requires) (Provides, error) {
 	// Add your gRPC services implementations here: e.g.
 	// pbcore.RegisterStatusProviderServer(remoteAgentServer.GetGRPCServer(), remoteagentImpl)
 
+	// Call Start() after registering all gRPC services on the server.
+	remoteAgentServer.Start()
+
 	provides := Provides{
 		Comp: remoteagentImpl,
 	}

--- a/comp/core/remoteagent/impl-trace/remoteagent.go
+++ b/comp/core/remoteagent/impl-trace/remoteagent.go
@@ -54,6 +54,8 @@ func NewComponent(reqs Requires) (Provides, error) {
 		remoteAgentServer: remoteAgentServer,
 	}
 
+	remoteAgentServer.Start()
+
 	provides := Provides{
 		Comp: remoteagentImpl,
 	}


### PR DESCRIPTION
### What does this PR do?
This PR moves the `configstreamconsumer`'s blocking wait for the first snapshot from its Lifecycle `OnStart` hook into `NewComponent`. To make that possible without deadlocking on the RAR `session_id`, it also splits `remoteagent`'s Lifecycle: the helper no longer auto-starts on `OnStart`; each remote-agent impl explicitly calls `remoteAgentServer.Start()` after registering its gRPC services.

Net result: every component constructed *after* the consumer (in fx option-list order) sees the streamed values in `config.Component`, including providers that read config eagerly in their `NewComponent` (e.g. `comp/trace/config`) or in provider-constructor `fx.Provide` functions (e.g. `pkg/security/agent.StartRuntimeSecurity`, `pkg/compliance.StartCompliance`).

### Motivation
Codex review threads on #50626 (trace-agent) and #50628 (security-agent) called out that with the previous `OnStart`-based wait, fx still runs all `NewComponent` constructors before any lifecycle hook fires. Subsystems that build their config eagerly during construction — such as the trace-agent's `AgentConfig` and the security-agent's CWS/compliance workload starts — therefore see the pre-stream local YAML, defeating the intended "block until streamed config" gate for those settings.

A naive fix (just block in `consumer.NewComponent`) deadlocks: the consumer's `streamLoop` needs the RAR `session_id` from `remoteagent`, but `remoteagent`'s registration loop is started in *its* `OnStart` — which never fires while the consumer holds up FX construction. Splitting `remoteagent`'s start out of `OnStart` (and having each impl call it explicitly after registering services) lets the gRPC server + registration loop start concurrently during the FX construction phase, so the consumer's wait can resolve.

### Describe how you validated your changes
- `dda inv linter.go --targets=./comp/core/configstreamconsumer/impl` — clean
- `dda inv linter.go --targets=./comp/core/remoteagent/helper` — clean
- `dda inv test --targets=./comp/core/configstreamconsumer/impl` — all 7 tests pass
- `dda inv agent.build --build-exclude=systemd` — ok
- `dda inv trace-agent.build` — ok
- `dda inv process-agent.build` — ok
- `dda inv security-agent.build` — ok
- streamed config from the core agent to system probe (which already has config streaming enabled via config option).

End-to-end validation against a running core agent on macOS is bundled in the three downstream PRs that wire `configstreamconsumer` into trace-agent (#50626), process-agent (#50627), and security-agent (#50628). Once those PRs are rebased onto this refactor, the codex review threads about pre-stream config in cached `AgentConfig` / pre-stream workload constructors are resolved.

system-probe (already wired via #46281) keeps the same observable behavior: startup still blocks on the snapshot; the wait now happens during FX construction instead of during `OnStart`.

### Additional Notes