### PR TITLE
[CONTP-1651] Fix(ncclprofiler): Inject NCCL_INSPECTOR_DUMP_DIR and DUMP_THREAD_INTERVAL_MICROSECONDS in webhook

### DIFF
--- a/pkg/clusteragent/admission/mutate/ncclprofiler/mutator.go
+++ b/pkg/clusteragent/admission/mutate/ncclprofiler/mutator.go
@@ -74,6 +74,21 @@ func mutatePod(pod *corev1.Pod, injectorImage, hostSocketPath, socketPath string
 	envAdded = mutatecommon.InjectEnv(pod, corev1.EnvVar{Name: "NCCL_DD_INSPECTOR_PATH", Value: soMountPath + "/libnccl-profiler-inspector.so"}) || envAdded
 	envAdded = mutatecommon.InjectEnv(pod, corev1.EnvVar{Name: "NCCL_INSPECTOR_ENABLE", Value: "1"}) || envAdded
 
+	// Point NVIDIA Inspector's file-dump at /tmp — writable in virtually
+	// every customer training container. Without this, Inspector's dump
+	// thread tries the default location, and if THAT isn't writable, the
+	// thread breaks before calling our patched inspectorCommInfoDump →
+	// socket delivery silently emits nothing. Customer can override.
+	envAdded = mutatecommon.InjectEnv(pod, corev1.EnvVar{Name: "NCCL_INSPECTOR_DUMP_DIR", Value: "/tmp/nccl-inspector"}) || envAdded
+
+	// Inspector's dump thread sets the needs_writing flag that gates the
+	// .so's socket-delivery hook. Default interval is 0 (thread sits
+	// idle), so without an explicit value the .so emits nothing. Default
+	// to 100 ms; consumers can override (InjectEnv is a no-op if already
+	// set). The Inspector .so also setenv-defaults this at init time as a
+	// belt-and-suspenders for pods loading the .so outside the webhook.
+	envAdded = mutatecommon.InjectEnv(pod, corev1.EnvVar{Name: "NCCL_INSPECTOR_DUMP_THREAD_INTERVAL_MICROSECONDS", Value: "100000"}) || envAdded
+
 	// Prepend init container that copies the Inspector .so from the injector image.
 	// SecurityContext drops all capabilities + disallows privilege escalation so
 	// the container passes the "restricted" PodSecurity standard. Resource


### PR DESCRIPTION
### What does this PR do?
  Adds 2 missing env-var injections to the NCCL profiler webhook:
  - `NCCL_INSPECTOR_DUMP_DIR=/tmp/nccl-inspector`
  - `NCCL_INSPECTOR_DUMP_THREAD_INTERVAL_MICROSECONDS=100000`
  Both are no-ops if the user already sets them in the pod spec.
  
### Motivation
  The webhook today injects 4 of the 6 env vars Inspector needs to deliver events end-to-end. Above two are missing. 

### Describe how you validated your changes
  **1. Minimal opt-in PodSpec** — the webhook only mutates pods that carry the label `admission.datadoghq.com/nccl-profiler.enabled: "true"`. The pod sets no NCCL env vars itself; everything comes from the webhook:

  ```
  metadata:
    labels:
      admission.datadoghq.com/nccl-profiler.enabled: "true"
  spec:
    containers:
      - name: trainer
        image: <training-image>
        resources:
          limits:
            nvidia.com/gpu: 1
  ```

  2. After webhook mutation, the pod has:
  - An init container that copies libnccl-profiler-inspector.so into a shared emptyDir at /datadog-nccl/.
  - 6 injected env vars on the trainer container (
  NCCL_PROFILER_PLUGIN,
  NCCL_DD_SOCKET_PATH, 
  NCCL_DD_INSPECTOR_PATH, 
  NCCL_INSPECTOR_ENABLE,
  NCCL_INSPECTOR_DUMP_DIR, 
  NCCL_INSPECTOR_DUMP_THREAD_INTERVAL_MICROSECONDS)
  — the last two are the ones added by this PR.
```
  NCCL_INSPECTOR_DUMP_DIR=/tmp/nccl-inspector
  NCCL_INSPECTOR_DUMP_THREAD_INTERVAL_MICROSECONDS=100000
```


