### PR TITLE
[noisy_neighbor] add per-cgroup PMU and tracepoint signals

### DIFF
--- a/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern-user.h
+++ b/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern-user.h
@@ -8,6 +8,9 @@ typedef struct {
     __u64 event_count;
     __u64 preemption_count;
     __u64 pid_count;
+    __u64 wakeup_count;
+    __u64 sum_softirq_ns;
+    __u64 block_io_requests;
 } cgroup_agg_stats_t;
 
 #endif

--- a/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern.c
+++ b/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern.c
@@ -14,6 +14,10 @@ BPF_TASK_STORAGE_MAP(runq_enqueued, u64)
 
 BPF_PERCPU_HASH_MAP(cgroup_agg_stats, __u64, cgroup_agg_stats_t, MAX_TASK_ENTRIES)
 
+// Per-CPU softirq entry timestamp. Single-slot percpu array; softirq runs in
+// non-preemptible context so per-CPU storage is sufficient.
+BPF_PERCPU_ARRAY_MAP(softirq_start_ns, __u64, 1)
+
 void bpf_rcu_read_lock(void) __ksym;
 void bpf_rcu_read_unlock(void) __ksym;
 extern void *bpf_rdonly_cast(const void *obj, __u32 btf_id) __ksym __weak;
@@ -71,15 +75,28 @@ static __always_inline cgroup_agg_stats_t *get_or_create_cgroup_stats(u64 cgroup
     return stats;
 }
 
+// count_wakeup increments the per-cgroup wakeup counter for the given task.
+// Called from the wakeup tracepoints only; the sched_switch re-enqueue path is
+// a preemption-driven re-enqueue, not a wakeup, so it must not call this.
+static __always_inline void count_wakeup(struct task_struct *task) {
+    u64 cgroup_id = get_task_cgroup_id(task);
+    cgroup_agg_stats_t *stats = get_or_create_cgroup_stats(cgroup_id);
+    if (stats) {
+        stats->wakeup_count += 1;
+    }
+}
+
 SEC("tp_btf/sched_wakeup")
 int tp_sched_wakeup(u64 *ctx) {
     struct task_struct *task = (void *)ctx[0];
+    count_wakeup(task);
     return enqueue_timestamp(task);
 }
 
 SEC("tp_btf/sched_wakeup_new")
 int tp_sched_wakeup_new(u64 *ctx) {
     struct task_struct *task = (void *)ctx[0];
+    count_wakeup(task);
     return enqueue_timestamp(task);
 }
 
@@ -123,6 +140,61 @@ int tp_sched_switch(u64 *ctx) {
         stats->pid_count = get_cgroup_pids_count(next);
     }
 
+    return 0;
+}
+
+// Softirq accounting: stamp entry timestamp per CPU; on exit, attribute the
+// elapsed nanoseconds to the cgroup of whatever task was running on this CPU
+// when the softirq fired. For irq-tail softirq processing this charges back
+// to the interrupted task's cgroup (the victim — what we want). For
+// ksoftirqd-driven softirqs it charges to ksoftirqd (typically root); a
+// known limitation.
+SEC("tp_btf/softirq_entry")
+int tp_softirq_entry(u64 *ctx) {
+    u32 zero = 0;
+    u64 *slot = bpf_map_lookup_elem(&softirq_start_ns, &zero);
+    if (slot) {
+        *slot = bpf_ktime_get_ns();
+    }
+    return 0;
+}
+
+SEC("tp_btf/softirq_exit")
+int tp_softirq_exit(u64 *ctx) {
+    u32 zero = 0;
+    u64 *slot = bpf_map_lookup_elem(&softirq_start_ns, &zero);
+    if (!slot || *slot == 0) {
+        return 0;
+    }
+    u64 delta = bpf_ktime_get_ns() - *slot;
+    *slot = 0;
+
+    struct task_struct *task = bpf_get_current_task_btf();
+    if (!task) {
+        return 0;
+    }
+    u64 cgroup_id = get_task_cgroup_id(task);
+    cgroup_agg_stats_t *stats = get_or_create_cgroup_stats(cgroup_id);
+    if (stats) {
+        stats->sum_softirq_ns += delta;
+    }
+    return 0;
+}
+
+// Block-I/O issue tracking: count requests issued from each cgroup, using the
+// task that issued the I/O (current task) rather than the bio's owning cgroup.
+// Simple and matches what cgroup CPU accounting attributes elsewhere.
+SEC("tp_btf/block_rq_issue")
+int tp_block_rq_issue(u64 *ctx) {
+    struct task_struct *task = bpf_get_current_task_btf();
+    if (!task) {
+        return 0;
+    }
+    u64 cgroup_id = get_task_cgroup_id(task);
+    cgroup_agg_stats_t *stats = get_or_create_cgroup_stats(cgroup_id);
+    if (stats) {
+        stats->block_io_requests += 1;
+    }
     return 0;
 }
 

--- a/pkg/collector/corechecks/ebpf/noisyneighbor/noisy_neighbor.go
+++ b/pkg/collector/corechecks/ebpf/noisyneighbor/noisy_neighbor.go
@@ -137,6 +137,9 @@ func (n *NoisyNeighborCheck) submitPrimaryMetrics(sender sender.Sender, stat mod
 func (n *NoisyNeighborCheck) submitRawCounters(sender sender.Sender, stat model.NoisyNeighborStats, tags []string) {
 	sender.Count("noisy_neighbor.events.total", float64(stat.EventCount), "", tags)
 	sender.Gauge("noisy_neighbor.unique_processes", float64(stat.UniquePidCount), "", tags)
+	sender.Count("noisy_neighbor.wakeups.total", float64(stat.WakeupCount), "", tags)
+	sender.Count("noisy_neighbor.softirq_ns.total", float64(stat.SumSoftirqNs), "", tags)
+	sender.Count("noisy_neighbor.block_io_requests.total", float64(stat.BlockIORequests), "", tags)
 }
 
 // submitPMUMetrics emits per-cgroup hardware/software perf counters. Values

--- a/pkg/collector/corechecks/ebpf/noisyneighbor/noisy_neighbor.go
+++ b/pkg/collector/corechecks/ebpf/noisyneighbor/noisy_neighbor.go
@@ -62,12 +62,13 @@ func (n *NoisyNeighborCheck) Configure(senderManager sender.SenderManager, _ uin
 		return err
 	}
 	if err := n.config.Parse(config); err != nil {
-		return fmt.Errorf("noisy_neighbor check config: %s", err)
+		return fmt.Errorf("noisy_neighbor check config: %w", err)
 	}
-	n.sysProbeClient = sysprobeclient.GetCheckClient(sysprobeclient.WithSocketPath(pkgconfigsetup.SystemProbe().GetString("system_probe_config.sysprobe_socket")))
+	socketPath := pkgconfigsetup.SystemProbe().GetString("system_probe_config.sysprobe_socket")
+	n.sysProbeClient = sysprobeclient.GetCheckClient(sysprobeclient.WithSocketPath(socketPath))
 	reader, err := cgroups.NewReader(cgroups.WithReaderFilter(cgroups.ContainerFilter))
 	if err != nil {
-		return fmt.Errorf("noisy_neighbor: cgroup reader init failed: %s", err)
+		return fmt.Errorf("noisy_neighbor: cgroup reader init failed: %w", err)
 	}
 	n.cgroupReader = reader
 	return nil
@@ -76,17 +77,17 @@ func (n *NoisyNeighborCheck) Configure(senderManager sender.SenderManager, _ uin
 func (n *NoisyNeighborCheck) Run() error {
 	stats, err := sysprobeclient.GetCheck[[]model.NoisyNeighborStats](n.sysProbeClient, sysconfig.NoisyNeighborModule)
 	if err != nil {
-		return fmt.Errorf("get noisy neighbor check: %s", err)
+		return fmt.Errorf("get noisy neighbor check: %w", err)
 	}
 
 	sender, err := n.GetSender()
 	if err != nil {
-		return fmt.Errorf("get metric sender: %s", err)
+		return fmt.Errorf("get metric sender: %w", err)
 	}
 
 	err = n.cgroupReader.RefreshCgroups(0)
 	if err != nil {
-		return fmt.Errorf("unable to refresh cgroups: %s", err)
+		return fmt.Errorf("unable to refresh cgroups: %w", err)
 	}
 
 	var totalCgroups uint64

--- a/pkg/collector/corechecks/ebpf/noisyneighbor/noisy_neighbor.go
+++ b/pkg/collector/corechecks/ebpf/noisyneighbor/noisy_neighbor.go
@@ -95,6 +95,7 @@ func (n *NoisyNeighborCheck) Run() error {
 		tags := n.getContainerTags(stat)
 		n.submitPrimaryMetrics(sender, stat, tags)
 		n.submitRawCounters(sender, stat, tags)
+		n.submitPMUMetrics(sender, stat, tags)
 	}
 	sender.Gauge("noisy_neighbor.system.cgroups_tracked", float64(totalCgroups), "", nil)
 	sender.Commit()
@@ -136,4 +137,23 @@ func (n *NoisyNeighborCheck) submitPrimaryMetrics(sender sender.Sender, stat mod
 func (n *NoisyNeighborCheck) submitRawCounters(sender sender.Sender, stat model.NoisyNeighborStats, tags []string) {
 	sender.Count("noisy_neighbor.events.total", float64(stat.EventCount), "", tags)
 	sender.Gauge("noisy_neighbor.unique_processes", float64(stat.UniquePidCount), "", tags)
+}
+
+// submitPMUMetrics emits per-cgroup hardware/software perf counters. Values
+// arrive pre-scaled by the manager (counter * enabled / running) so we just
+// pass them through as Count() samples — the consumer divides by interval to
+// recover a rate. EnabledNs == 0 means the system-probe could not open any
+// PMU events on this cgroup so we skip emission rather than reporting zeros.
+func (n *NoisyNeighborCheck) submitPMUMetrics(sender sender.Sender, stat model.NoisyNeighborStats, tags []string) {
+	p := stat.PMU
+	if p.EnabledNs == 0 {
+		return
+	}
+	sender.Count("noisy_neighbor.pmu.cycles", float64(p.Cycles), "", tags)
+	sender.Count("noisy_neighbor.pmu.instructions", float64(p.Instructions), "", tags)
+	sender.Count("noisy_neighbor.pmu.llc_misses", float64(p.LLCMisses), "", tags)
+	sender.Count("noisy_neighbor.pmu.branch_misses", float64(p.BranchMisses), "", tags)
+	sender.Count("noisy_neighbor.pmu.cache_references", float64(p.CacheReferences), "", tags)
+	sender.Count("noisy_neighbor.pmu.itlb_misses", float64(p.ITLBMisses), "", tags)
+	sender.Count("noisy_neighbor.pmu.cpu_migrations", float64(p.CPUMigrations), "", tags)
 }

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/cgroup_pmu.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/cgroup_pmu.go
@@ -8,6 +8,7 @@
 package noisyneighbor
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"path/filepath"
@@ -37,23 +38,36 @@ type pmuEvent struct {
 	config uint64
 }
 
+// PMU event indices. The const block is the canonical ordering: pmuEvents
+// initialises slots by name (idxCycles: {…}) and ReadAll's struct literal
+// reads them back the same way, so reordering this list is a compile error
+// rather than a silent metric mislabel.
+const (
+	idxCycles = iota
+	idxInstructions
+	idxLLCMisses
+	idxBranchMisses
+	idxCacheReferences
+	idxITLBMisses
+	idxCPUMigrations
+	numPMUEvents
+)
+
 // pmuEvents is the fixed set of counters we attempt to sample per cgroup. An
 // event whose perf_event_open returns EINVAL/ENOTSUP on probe is recorded as
 // unsupported and skipped for all subsequent cgroup opens.
-var pmuEvents = [...]pmuEvent{
-	{name: "cycles", typ: unix.PERF_TYPE_HARDWARE, config: unix.PERF_COUNT_HW_CPU_CYCLES},
-	{name: "instructions", typ: unix.PERF_TYPE_HARDWARE, config: unix.PERF_COUNT_HW_INSTRUCTIONS},
-	{name: "llc_misses", typ: unix.PERF_TYPE_HARDWARE, config: unix.PERF_COUNT_HW_CACHE_MISSES},
-	{name: "branch_misses", typ: unix.PERF_TYPE_HARDWARE, config: unix.PERF_COUNT_HW_BRANCH_MISSES},
-	{name: "cache_references", typ: unix.PERF_TYPE_HARDWARE, config: unix.PERF_COUNT_HW_CACHE_REFERENCES},
-	{name: "itlb_misses", typ: unix.PERF_TYPE_HW_CACHE,
+var pmuEvents = [numPMUEvents]pmuEvent{
+	idxCycles:          {name: "cycles", typ: unix.PERF_TYPE_HARDWARE, config: unix.PERF_COUNT_HW_CPU_CYCLES},
+	idxInstructions:    {name: "instructions", typ: unix.PERF_TYPE_HARDWARE, config: unix.PERF_COUNT_HW_INSTRUCTIONS},
+	idxLLCMisses:       {name: "llc_misses", typ: unix.PERF_TYPE_HARDWARE, config: unix.PERF_COUNT_HW_CACHE_MISSES},
+	idxBranchMisses:    {name: "branch_misses", typ: unix.PERF_TYPE_HARDWARE, config: unix.PERF_COUNT_HW_BRANCH_MISSES},
+	idxCacheReferences: {name: "cache_references", typ: unix.PERF_TYPE_HARDWARE, config: unix.PERF_COUNT_HW_CACHE_REFERENCES},
+	idxITLBMisses: {name: "itlb_misses", typ: unix.PERF_TYPE_HW_CACHE,
 		config: uint64(unix.PERF_COUNT_HW_CACHE_ITLB) |
 			(uint64(unix.PERF_COUNT_HW_CACHE_OP_READ) << 8) |
 			(uint64(unix.PERF_COUNT_HW_CACHE_RESULT_MISS) << 16)},
-	{name: "cpu_migrations", typ: unix.PERF_TYPE_SOFTWARE, config: unix.PERF_COUNT_SW_CPU_MIGRATIONS},
+	idxCPUMigrations: {name: "cpu_migrations", typ: unix.PERF_TYPE_SOFTWARE, config: unix.PERF_COUNT_SW_CPU_MIGRATIONS},
 }
-
-const numPMUEvents = len(pmuEvents)
 
 // perfReadValue is the layout returned by read(fd) when read_format is
 // PERF_FORMAT_TOTAL_TIME_ENABLED | PERF_FORMAT_TOTAL_TIME_RUNNING — exactly
@@ -178,9 +192,19 @@ func walkContainerCgroups(cgroupRoot string) (map[uint64]string, error) {
 	seen := make(map[uint64]string)
 	walkErr := filepath.WalkDir(cgroupRoot, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			// Don't bail the whole walk on a permission denied or transient
-			// ENOENT (cgroups disappear under us all the time). Skip the
-			// offending directory but keep walking siblings.
+			// ENOENT is expected — cgroups vanish under us all the time as
+			// containers exit between WalkDir's readdir and stat. Anything
+			// else (EACCES on a permission-denied mount, EIO on a wedged
+			// fs) is worth surfacing at debug level so operators can
+			// diagnose a misconfigured /host/proc/1/root mount without it
+			// looking identical to "no containers ran during this window".
+			// d == nil happens when WalkDir cannot stat the root itself;
+			// callers of walkContainerCgroups depend on that path returning
+			// an empty result so the probe doesn't crash at startup if the
+			// cgroupRoot mount hasn't materialised yet.
+			if !errors.Is(err, fs.ErrNotExist) {
+				log.Debugf("noisy_neighbor: walk %s: %v", path, err)
+			}
 			if d != nil && d.IsDir() {
 				return fs.SkipDir
 			}
@@ -195,6 +219,7 @@ func walkContainerCgroups(cgroupRoot string) (map[uint64]string, error) {
 		case cgroupContainer:
 			inode, err := statInode(path)
 			if err != nil {
+				log.Debugf("noisy_neighbor: stat %s: %v", path, err)
 				return nil
 			}
 			seen[inode] = path
@@ -249,13 +274,13 @@ func (m *cgroupPMUManager) ReadAll() map[uint64]model.CgroupPMUStats {
 			entry.last[i] = cur
 		}
 		stats[inode] = model.CgroupPMUStats{
-			Cycles:          scaled[0],
-			Instructions:    scaled[1],
-			LLCMisses:       scaled[2],
-			BranchMisses:    scaled[3],
-			CacheReferences: scaled[4],
-			ITLBMisses:      scaled[5],
-			CPUMigrations:   scaled[6],
+			Cycles:          scaled[idxCycles],
+			Instructions:    scaled[idxInstructions],
+			LLCMisses:       scaled[idxLLCMisses],
+			BranchMisses:    scaled[idxBranchMisses],
+			CacheReferences: scaled[idxCacheReferences],
+			ITLBMisses:      scaled[idxITLBMisses],
+			CPUMigrations:   scaled[idxCPUMigrations],
 			EnabledNs:       enabledNs,
 			RunningNs:       runningNs,
 		}
@@ -297,10 +322,39 @@ func (m *cgroupPMUManager) Close() {
 // cgroup directory at path. If a single (event, CPU) open fails after the
 // startup probe accepted that event, we record the slot as -1 and continue —
 // the read path skips negative fds.
+//
+// Two correctness checks happen here that aren't obvious from a glance:
+//
+//  1. After opening cgroupFD, we fstat it and bail if the inode no longer
+//     matches the one walkContainerCgroups recorded for this path. On busy
+//     hosts a container can exit and a new container can be created with the
+//     same path between the walk and the open; without this check we'd open
+//     perf events against the new cgroup but key the entry under the old
+//     inode, silently miscounting until the next refresh.
+//
+//  2. After all fds are opened, we do an initial readEvent for each supported
+//     event and stash the result as entry.last. Without this, the first
+//     ReadAll's delta is current_counter - 0, i.e. everything that
+//     accumulated between perf_event_open and the first /check — over-reports
+//     the first window for any long-lived cgroup tracked from probe init.
 func (m *cgroupPMUManager) openCgroupEvents(inode uint64, path string) (*cgroupPMUEntry, error) {
 	cgroupFD, err := unix.Open(path, unix.O_RDONLY|unix.O_CLOEXEC, 0)
 	if err != nil {
 		return nil, fmt.Errorf("open cgroup dir %q: %w", path, err)
+	}
+
+	var st syscall.Stat_t
+	if err := syscall.Fstat(cgroupFD, &st); err != nil {
+		unix.Close(cgroupFD)
+		return nil, fmt.Errorf("fstat cgroup dir %q: %w", path, err)
+	}
+	if st.Ino != inode {
+		// A different cgroup now lives at this path; the inode we walked is
+		// gone. Refusing to register this entry leaves it as a candidate
+		// for the next refresh, where walkContainerCgroups will pick up the
+		// new inode.
+		unix.Close(cgroupFD)
+		return nil, fmt.Errorf("cgroup inode changed under us: walked=%d open=%d at %q", inode, st.Ino, path)
 	}
 
 	entry := &cgroupPMUEntry{
@@ -317,12 +371,10 @@ func (m *cgroupPMUManager) openCgroupEvents(inode uint64, path string) (*cgroupP
 		}
 		fds := make([]int, m.numCPU)
 		for cpu := range fds {
-			fds[cpu] = -1
-		}
-		for cpu := 0; cpu < m.numCPU; cpu++ {
 			fd, err := openPerfEvent(cgroupFD, cpu, pmuEvents[i])
 			if err != nil {
 				log.Debugf("noisy_neighbor: open %s on cgroup %s cpu=%d: %v", pmuEvents[i].name, path, cpu, err)
+				fds[cpu] = -1
 				continue
 			}
 			fds[cpu] = fd
@@ -334,6 +386,18 @@ func (m *cgroupPMUManager) openCgroupEvents(inode uint64, path string) (*cgroupP
 		entry.close()
 		return nil, fmt.Errorf("no PMU events opened for %q", path)
 	}
+
+	// Prime entry.last with the current counter value so the first ReadAll
+	// returns a delta-since-open rather than the full accumulated counter.
+	for i := range pmuEvents {
+		if !m.supported[i] {
+			continue
+		}
+		if cur, ok := entry.readEvent(i); ok {
+			entry.last[i] = cur
+		}
+	}
+
 	return entry, nil
 }
 

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/cgroup_pmu.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/cgroup_pmu.go
@@ -143,44 +143,21 @@ func (m *cgroupPMUManager) Refresh() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	seen := make(map[uint64]struct{})
-	walkErr := filepath.WalkDir(m.cgroupRoot, func(path string, d fs.DirEntry, err error) error {
+	seen, err := walkContainerCgroups(m.cgroupRoot)
+	if err != nil {
+		return fmt.Errorf("walking cgroup tree %q: %w", m.cgroupRoot, err)
+	}
+
+	for inode, path := range seen {
+		if _, ok := m.entries[inode]; ok {
+			continue
+		}
+		entry, err := m.openCgroupEvents(inode, path)
 		if err != nil {
-			// Don't bail the whole walk on a permission denied or transient
-			// ENOENT (cgroups disappear under us all the time). Skip the
-			// offending directory but keep walking siblings.
-			if d != nil && d.IsDir() {
-				return fs.SkipDir
-			}
-			return nil
+			log.Debugf("noisy_neighbor: open perf events for cgroup %s (inode %d): %v", path, inode, err)
+			continue
 		}
-		if !d.IsDir() || path == m.cgroupRoot {
-			return nil
-		}
-		name := d.Name()
-		switch classifyCgroupName(name) {
-		case cgroupSkip:
-			return fs.SkipDir
-		case cgroupContainer:
-			inode, err := statInode(path)
-			if err != nil {
-				return nil
-			}
-			seen[inode] = struct{}{}
-			if _, ok := m.entries[inode]; ok {
-				return nil
-			}
-			entry, err := m.openCgroupEvents(inode, path)
-			if err != nil {
-				log.Debugf("noisy_neighbor: open perf events for cgroup %s (inode %d): %v", path, inode, err)
-				return nil
-			}
-			m.entries[inode] = entry
-		}
-		return nil
-	})
-	if walkErr != nil {
-		return fmt.Errorf("walking cgroup tree %q: %w", m.cgroupRoot, walkErr)
+		m.entries[inode] = entry
 	}
 
 	for inode, entry := range m.entries {
@@ -191,6 +168,40 @@ func (m *cgroupPMUManager) Refresh() error {
 		delete(m.entries, inode)
 	}
 	return nil
+}
+
+// walkContainerCgroups walks cgroupRoot and returns a {inode → path} map for
+// every directory whose basename classifies as a container scope. Pure
+// filesystem operation — no perf_event_open, no privileged syscalls — so it's
+// the natural seam for unit-testing cgroup discovery without root.
+func walkContainerCgroups(cgroupRoot string) (map[uint64]string, error) {
+	seen := make(map[uint64]string)
+	walkErr := filepath.WalkDir(cgroupRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// Don't bail the whole walk on a permission denied or transient
+			// ENOENT (cgroups disappear under us all the time). Skip the
+			// offending directory but keep walking siblings.
+			if d != nil && d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !d.IsDir() || path == cgroupRoot {
+			return nil
+		}
+		switch classifyCgroupName(d.Name()) {
+		case cgroupSkip:
+			return fs.SkipDir
+		case cgroupContainer:
+			inode, err := statInode(path)
+			if err != nil {
+				return nil
+			}
+			seen[inode] = path
+		}
+		return nil
+	})
+	return seen, walkErr
 }
 
 // ReadAll snapshots every tracked cgroup's counters, computes a delta against

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/cgroup_pmu.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/cgroup_pmu.go
@@ -1,0 +1,410 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package noisyneighbor
+
+import (
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe/noisyneighbor/model"
+	"github.com/DataDog/datadog-agent/pkg/util/cgroups"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// pmuEvent describes one hardware/software PMU counter we sample. Each event
+// is opened in its own perf-event group (group_fd=-1) rather than as a member
+// of a shared group: on heterogeneous PMU hardware (e.g. ARM Neoverse, where
+// cache events live on a different physical PMU than CPU-pipeline events) the
+// kernel refuses to schedule a group whose members come from different PMUs.
+// Per-event opens cost one extra syscall per (event, CPU) at read time but
+// work uniformly across architectures.
+type pmuEvent struct {
+	name   string
+	typ    uint32
+	config uint64
+}
+
+// pmuEvents is the fixed set of counters we attempt to sample per cgroup. An
+// event whose perf_event_open returns EINVAL/ENOTSUP on probe is recorded as
+// unsupported and skipped for all subsequent cgroup opens.
+var pmuEvents = [...]pmuEvent{
+	{name: "cycles", typ: unix.PERF_TYPE_HARDWARE, config: unix.PERF_COUNT_HW_CPU_CYCLES},
+	{name: "instructions", typ: unix.PERF_TYPE_HARDWARE, config: unix.PERF_COUNT_HW_INSTRUCTIONS},
+	{name: "llc_misses", typ: unix.PERF_TYPE_HARDWARE, config: unix.PERF_COUNT_HW_CACHE_MISSES},
+	{name: "branch_misses", typ: unix.PERF_TYPE_HARDWARE, config: unix.PERF_COUNT_HW_BRANCH_MISSES},
+	{name: "cache_references", typ: unix.PERF_TYPE_HARDWARE, config: unix.PERF_COUNT_HW_CACHE_REFERENCES},
+	{name: "itlb_misses", typ: unix.PERF_TYPE_HW_CACHE,
+		config: uint64(unix.PERF_COUNT_HW_CACHE_ITLB) |
+			(uint64(unix.PERF_COUNT_HW_CACHE_OP_READ) << 8) |
+			(uint64(unix.PERF_COUNT_HW_CACHE_RESULT_MISS) << 16)},
+	{name: "cpu_migrations", typ: unix.PERF_TYPE_SOFTWARE, config: unix.PERF_COUNT_SW_CPU_MIGRATIONS},
+}
+
+const numPMUEvents = len(pmuEvents)
+
+// perfReadValue is the layout returned by read(fd) when read_format is
+// PERF_FORMAT_TOTAL_TIME_ENABLED | PERF_FORMAT_TOTAL_TIME_RUNNING — exactly
+// 24 bytes (one counter + scaling-time pair). We never use PERF_FORMAT_GROUP.
+type perfReadValue struct {
+	Counter uint64
+	Enabled uint64
+	Running uint64
+}
+
+const perfReadValueSize = int(unsafe.Sizeof(perfReadValue{}))
+
+// cgroupPMUEntry holds the open perf fds for one tracked cgroup and the
+// last-read counter values used for delta computation across check intervals.
+type cgroupPMUEntry struct {
+	cgroupID uint64
+	path     string
+	cgroupFD int
+	// eventFDs[i][cpu] is the fd for event i on CPU cpu, or -1 if the event
+	// is unsupported on this host. We pre-size to [numPMUEvents][numCPU] and
+	// leave unsupported entries as -1 instead of using a ragged slice.
+	eventFDs [numPMUEvents][]int
+	last     [numPMUEvents]perfReadValue
+}
+
+// cgroupPMUManager owns user-space perf-event-open fds scoped to container
+// cgroups via PERF_FLAG_PID_CGROUP. It is created once per Probe lifetime, and
+// Refresh()/ReadAll() are called on each /check invocation.
+type cgroupPMUManager struct {
+	cgroupRoot string
+	numCPU     int
+	// supported[i] is true when pmuEvents[i] succeeded on the startup probe;
+	// false events are skipped on every subsequent open.
+	supported [numPMUEvents]bool
+
+	mu      sync.Mutex
+	entries map[uint64]*cgroupPMUEntry
+}
+
+// newCgroupPMUManager creates a manager rooted at cgroupRoot. cgroupRoot is
+// where the host's cgroup v2 hierarchy is visible from inside the running
+// process (system-probe sees the host view via /host/proc/1/root/sys/fs/cgroup).
+// The manager probes each event against cgroupRoot to learn which counters
+// this kernel/PMU combination accepts.
+func newCgroupPMUManager(cgroupRoot string) *cgroupPMUManager {
+	m := &cgroupPMUManager{
+		cgroupRoot: cgroupRoot,
+		numCPU:     runtime.NumCPU(),
+		entries:    make(map[uint64]*cgroupPMUEntry),
+	}
+	m.probeSupported()
+	return m
+}
+
+// probeSupported attempts to open each pmuEvent against the cgroup tree root
+// on CPU 0 and records which events the kernel accepts. We don't read these
+// probe events — just opening them confirms the (type, config) combination
+// is valid and the calling process has the right capability set.
+func (m *cgroupPMUManager) probeSupported() {
+	cgroupFD, err := unix.Open(m.cgroupRoot, unix.O_RDONLY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		log.Warnf("noisy_neighbor: probe open cgroup root %q: %v (PMU events disabled)", m.cgroupRoot, err)
+		return
+	}
+	defer unix.Close(cgroupFD)
+
+	supportedNames := make([]string, 0, numPMUEvents)
+	skippedNames := make([]string, 0)
+	for i := range pmuEvents {
+		fd, err := openPerfEvent(cgroupFD, 0, pmuEvents[i])
+		if err != nil {
+			m.supported[i] = false
+			skippedNames = append(skippedNames, fmt.Sprintf("%s(%v)", pmuEvents[i].name, err))
+			continue
+		}
+		unix.Close(fd)
+		m.supported[i] = true
+		supportedNames = append(supportedNames, pmuEvents[i].name)
+	}
+	log.Infof("noisy_neighbor: PMU events supported=%v unsupported=%v", supportedNames, skippedNames)
+}
+
+// Refresh walks the cgroup tree looking for container cgroups and opens perf
+// events on any new ones. Cgroups that disappeared since the last refresh have
+// their fds closed and entries removed.
+func (m *cgroupPMUManager) Refresh() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	seen := make(map[uint64]struct{})
+	walkErr := filepath.WalkDir(m.cgroupRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// Don't bail the whole walk on a permission denied or transient
+			// ENOENT (cgroups disappear under us all the time). Skip the
+			// offending directory but keep walking siblings.
+			if d != nil && d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !d.IsDir() || path == m.cgroupRoot {
+			return nil
+		}
+		name := d.Name()
+		switch classifyCgroupName(name) {
+		case cgroupSkip:
+			return fs.SkipDir
+		case cgroupContainer:
+			inode, err := statInode(path)
+			if err != nil {
+				return nil
+			}
+			seen[inode] = struct{}{}
+			if _, ok := m.entries[inode]; ok {
+				return nil
+			}
+			entry, err := m.openCgroupEvents(inode, path)
+			if err != nil {
+				log.Debugf("noisy_neighbor: open perf events for cgroup %s (inode %d): %v", path, inode, err)
+				return nil
+			}
+			m.entries[inode] = entry
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return fmt.Errorf("walking cgroup tree %q: %w", m.cgroupRoot, walkErr)
+	}
+
+	for inode, entry := range m.entries {
+		if _, ok := seen[inode]; ok {
+			continue
+		}
+		entry.close()
+		delete(m.entries, inode)
+	}
+	return nil
+}
+
+// ReadAll snapshots every tracked cgroup's counters, computes a delta against
+// the previously stored value, and returns one CgroupPMUStats keyed by cgroup
+// inode. The stored "last" value is updated in place so subsequent calls
+// return the delta since this call returned.
+//
+// Each event's value is scaled by its own enabled/running ratio inside this
+// function: when an event was multiplexed (running < enabled), the kernel
+// only counted for the running fraction, so we extrapolate to the value the
+// counter would have shown at 100% allocation. Events on different physical
+// PMUs can multiplex independently, so per-event scaling is required for
+// correctness — using one shared ratio would systematically misreport events
+// that got a different schedule than the reference event.
+//
+// EnabledNs/RunningNs in the returned struct are the ratio of the first
+// supported event, kept only as a coarse "PMU saturation" signal for metric
+// consumers — the counter values themselves are already scaled.
+func (m *cgroupPMUManager) ReadAll() map[uint64]model.CgroupPMUStats {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	stats := make(map[uint64]model.CgroupPMUStats, len(m.entries))
+	for inode, entry := range m.entries {
+		var scaled [numPMUEvents]uint64
+		var enabledNs, runningNs uint64
+		var primaryRead bool
+		for i := range pmuEvents {
+			if !m.supported[i] {
+				continue
+			}
+			cur, ok := entry.readEvent(i)
+			if !ok {
+				continue
+			}
+			dCounter := cur.Counter - entry.last[i].Counter
+			dEnabled := cur.Enabled - entry.last[i].Enabled
+			dRunning := cur.Running - entry.last[i].Running
+			scaled[i] = scalePMUDelta(dCounter, dEnabled, dRunning)
+			if !primaryRead {
+				enabledNs = dEnabled
+				runningNs = dRunning
+				primaryRead = true
+			}
+			entry.last[i] = cur
+		}
+		stats[inode] = model.CgroupPMUStats{
+			Cycles:          scaled[0],
+			Instructions:    scaled[1],
+			LLCMisses:       scaled[2],
+			BranchMisses:    scaled[3],
+			CacheReferences: scaled[4],
+			ITLBMisses:      scaled[5],
+			CPUMigrations:   scaled[6],
+			EnabledNs:       enabledNs,
+			RunningNs:       runningNs,
+		}
+	}
+	return stats
+}
+
+// scalePMUDelta extrapolates a raw counter delta back to what it would have
+// shown at 100% allocation using the standard counter*enabled/running formula.
+// When enabled == running (no multiplexing) the result equals the raw delta.
+// When running == 0 the event was paused for the entire window so the result
+// is 0 — the sample carries no usable information.
+func scalePMUDelta(counter, enabled, running uint64) uint64 {
+	if running == 0 {
+		return 0
+	}
+	if enabled == running {
+		return counter
+	}
+	// Compute as counter + counter*(enabled-running)/running rather than
+	// counter*enabled/running to keep the multiplication operands small in
+	// the common case (small multiplexing slice). Reduces — but does not
+	// eliminate — u64 overflow risk on very long check intervals.
+	missing := enabled - running
+	return counter + (counter*missing)/running
+}
+
+// Close releases every fd this manager opened.
+func (m *cgroupPMUManager) Close() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for inode, entry := range m.entries {
+		entry.close()
+		delete(m.entries, inode)
+	}
+}
+
+// openCgroupEvents opens every supported event on every CPU, scoped to the
+// cgroup directory at path. If a single (event, CPU) open fails after the
+// startup probe accepted that event, we record the slot as -1 and continue —
+// the read path skips negative fds.
+func (m *cgroupPMUManager) openCgroupEvents(inode uint64, path string) (*cgroupPMUEntry, error) {
+	cgroupFD, err := unix.Open(path, unix.O_RDONLY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open cgroup dir %q: %w", path, err)
+	}
+
+	entry := &cgroupPMUEntry{
+		cgroupID: inode,
+		path:     path,
+		cgroupFD: cgroupFD,
+	}
+
+	anyOpened := false
+	for i := range pmuEvents {
+		if !m.supported[i] {
+			entry.eventFDs[i] = nil
+			continue
+		}
+		fds := make([]int, m.numCPU)
+		for cpu := range fds {
+			fds[cpu] = -1
+		}
+		for cpu := 0; cpu < m.numCPU; cpu++ {
+			fd, err := openPerfEvent(cgroupFD, cpu, pmuEvents[i])
+			if err != nil {
+				log.Debugf("noisy_neighbor: open %s on cgroup %s cpu=%d: %v", pmuEvents[i].name, path, cpu, err)
+				continue
+			}
+			fds[cpu] = fd
+			anyOpened = true
+		}
+		entry.eventFDs[i] = fds
+	}
+	if !anyOpened {
+		entry.close()
+		return nil, fmt.Errorf("no PMU events opened for %q", path)
+	}
+	return entry, nil
+}
+
+// openPerfEvent opens a single perf event with group_fd=-1 (its own group).
+// read_format gets TOTAL_TIME_ENABLED|TOTAL_TIME_RUNNING so each read also
+// returns the kernel's scaling-time bookkeeping for the event.
+func openPerfEvent(cgroupFD int, cpu int, ev pmuEvent) (int, error) {
+	attr := unix.PerfEventAttr{
+		Type:        ev.typ,
+		Config:      ev.config,
+		Size:        uint32(unsafe.Sizeof(unix.PerfEventAttr{})),
+		Read_format: unix.PERF_FORMAT_TOTAL_TIME_ENABLED | unix.PERF_FORMAT_TOTAL_TIME_RUNNING,
+	}
+	return unix.PerfEventOpen(&attr, cgroupFD, cpu, -1,
+		unix.PERF_FLAG_PID_CGROUP|unix.PERF_FLAG_FD_CLOEXEC)
+}
+
+func (e *cgroupPMUEntry) close() {
+	for i := range e.eventFDs {
+		for _, fd := range e.eventFDs[i] {
+			if fd >= 0 {
+				unix.Close(fd)
+			}
+		}
+		e.eventFDs[i] = nil
+	}
+	if e.cgroupFD >= 0 {
+		unix.Close(e.cgroupFD)
+		e.cgroupFD = -1
+	}
+}
+
+// readEvent reads one event across every CPU fd and returns the sum. Returns
+// ok=false only if zero CPUs returned a successful read.
+func (e *cgroupPMUEntry) readEvent(eventIdx int) (perfReadValue, bool) {
+	var sum perfReadValue
+	var v perfReadValue
+	bufSlice := (*[perfReadValueSize]byte)(unsafe.Pointer(&v))[:]
+	any := false
+	for _, fd := range e.eventFDs[eventIdx] {
+		if fd < 0 {
+			continue
+		}
+		n, err := unix.Read(fd, bufSlice)
+		if err != nil || n != perfReadValueSize {
+			continue
+		}
+		sum.Counter += v.Counter
+		sum.Enabled += v.Enabled
+		sum.Running += v.Running
+		any = true
+	}
+	return sum, any
+}
+
+type cgroupKind int
+
+const (
+	cgroupOther     cgroupKind = iota // not a container, but recurse into it
+	cgroupContainer                   // a container cgroup, register it
+	cgroupSkip                        // skip this subtree entirely
+)
+
+// classifyCgroupName decides what to do with a cgroup folder by name. Folder
+// names matching ContainerRegexp are container scopes; systemd `.mount` aliases
+// and conmon monitor cgroups hold no relevant processes so we skip them.
+func classifyCgroupName(name string) cgroupKind {
+	if cgroups.ContainerRegexp.FindString(name) == "" {
+		return cgroupOther
+	}
+	if strings.HasSuffix(name, ".mount") ||
+		strings.HasPrefix(name, "crio-conmon-") ||
+		strings.HasPrefix(name, "libpod-conmon-") {
+		return cgroupSkip
+	}
+	return cgroupContainer
+}
+
+func statInode(path string) (uint64, error) {
+	var st syscall.Stat_t
+	if err := syscall.Stat(path, &st); err != nil {
+		return 0, err
+	}
+	return st.Ino, nil
+}

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/cgroup_pmu_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/cgroup_pmu_test.go
@@ -1,0 +1,338 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package noisyneighbor
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestScalePMUDelta_overflowProtection separately asserts the function
+// doesn't panic on adversarial inputs, including running > enabled (which
+// causes the subtraction inside scalePMUDelta to wrap under uint64) — we
+// only require the function to return without panicking, since the result
+// is mathematically meaningless when the kernel violates the invariant.
+func TestScalePMUDelta_overflowProtection(t *testing.T) {
+	cases := []struct{ counter, enabled, running uint64 }{
+		{100, 100, 200},         // running > enabled
+		{1<<63 - 1, 1 << 63, 1}, // counter near uint64 limit
+		{1, 1<<63 + 1, 1 << 62}, // large enabled & running spread
+	}
+	for _, c := range cases {
+		assert.NotPanics(t, func() {
+			_ = scalePMUDelta(c.counter, c.enabled, c.running)
+		})
+	}
+}
+
+// TestScalePMUDelta exercises every branch of the multiplexing-scaling
+// arithmetic. The scaling formula is counter + counter*(enabled-running)/running,
+// chosen instead of counter*enabled/running to keep the multiplication operands
+// small in the common multiplexing case. The fast-path returns counter
+// untouched when enabled == running.
+func TestScalePMUDelta(t *testing.T) {
+	tests := []struct {
+		name    string
+		counter uint64
+		enabled uint64
+		running uint64
+		want    uint64
+	}{
+		{
+			name:    "running=0 returns 0 even with non-zero counter",
+			counter: 12345,
+			enabled: 1_000_000,
+			running: 0,
+			want:    0,
+		},
+		{
+			name:    "no multiplexing (enabled == running) returns raw counter",
+			counter: 1_000_000,
+			enabled: 5_000_000,
+			running: 5_000_000,
+			want:    1_000_000,
+		},
+		{
+			name:    "no multiplexing with zero counter returns zero",
+			counter: 0,
+			enabled: 5_000_000,
+			running: 5_000_000,
+			want:    0,
+		},
+		{
+			name:    "exact half multiplexing doubles the counter",
+			counter: 1_000_000,
+			enabled: 2_000_000,
+			running: 1_000_000,
+			want:    2_000_000,
+		},
+		{
+			name:    "quarter multiplexing multiplies counter by 4x",
+			counter: 1_000_000,
+			enabled: 4_000_000,
+			running: 1_000_000,
+			want:    4_000_000,
+		},
+		{
+			name:    "small multiplexing slice (1% missing)",
+			counter: 990_000,
+			enabled: 1_000_000,
+			running: 990_000,
+			want:    990_000 + (990_000*10_000)/990_000,
+		},
+		{
+			name:    "zero counter returns 0 even when multiplexed",
+			counter: 0,
+			enabled: 4_000_000,
+			running: 1_000_000,
+			want:    0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := scalePMUDelta(tt.counter, tt.enabled, tt.running)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestClassifyCgroupName covers every input shape walkContainerCgroups can
+// encounter on cgroup v2 hierarchies in the wild: container scopes named with
+// the standard 64-char hex id, AWS ECS hex-with-suffix, Garden UUIDs, systemd
+// `.mount` aliases that share a container id with the real scope, and the
+// crio-conmon / libpod-conmon monitor cgroups that hold no relevant procs.
+func TestClassifyCgroupName(t *testing.T) {
+	const hex64 = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+	const ecs = "abcdef0123456789abcdef0123456789-1234"
+	// Garden uses 8-4-4-4-4 hex groups (NOT the standard 8-4-4-4-12 UUID).
+	const garden = "12345678-aaaa-bbbb-cccc-dddd"
+
+	tests := []struct {
+		name string
+		in   string
+		want cgroupKind
+	}{
+		{"empty", "", cgroupOther},
+		{"plain slice", "kubelet.slice", cgroupOther},
+		{"system slice", "system.slice", cgroupOther},
+		{"user slice", "user.slice", cgroupOther},
+		{"besteffort pod slice", "kubelet-kubepods-besteffort-pod1234abcd.slice", cgroupOther},
+		{"hex64 container id", hex64, cgroupContainer},
+		{"docker scope", "docker-" + hex64 + ".scope", cgroupContainer},
+		{"cri-containerd scope", "cri-containerd-" + hex64 + ".scope", cgroupContainer},
+		{"ECS hex-with-suffix", ecs, cgroupContainer},
+		{"Garden UUID", garden, cgroupContainer},
+		{"systemd .mount alias", hex64 + ".mount", cgroupSkip},
+		{"docker .mount alias", "docker-" + hex64 + ".mount", cgroupSkip},
+		{"crio-conmon monitor", "crio-conmon-" + hex64, cgroupSkip},
+		{"libpod-conmon monitor", "libpod-conmon-" + hex64, cgroupSkip},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, classifyCgroupName(tt.in))
+		})
+	}
+}
+
+// TestStatInode validates the syscall.Stat → inode plumbing against a real
+// tempdir. Existence-positive and ENOENT-negative cases — the function is a
+// thin wrapper but it's the only place we inject a non-mock inode into the
+// PMU manager, so a regression here would silently break cgroup-id matching
+// with what BPF reports.
+func TestStatInode(t *testing.T) {
+	t.Run("existing directory returns non-zero inode matching os.Stat", func(t *testing.T) {
+		dir := t.TempDir()
+		got, err := statInode(dir)
+		require.NoError(t, err)
+		assert.NotZero(t, got)
+
+		// Cross-check against os.Stat's view of the same path.
+		fi, err := os.Stat(dir)
+		require.NoError(t, err)
+		osInode := fi.Sys().(*syscall.Stat_t).Ino
+		assert.Equal(t, osInode, got)
+	})
+
+	t.Run("missing path returns error", func(t *testing.T) {
+		_, err := statInode("/this/path/should/never/exist/abc123")
+		assert.Error(t, err)
+	})
+}
+
+// TestWalkContainerCgroups builds a synthetic cgroup tree that mirrors the
+// kubelet.slice / containerd / Garden layouts seen in production and verifies
+// only container scopes are returned, while .mount aliases and conmon monitor
+// cgroups are skipped (and skipped means we don't descend either — a nested
+// container under a conmon dir should not appear).
+func TestWalkContainerCgroups(t *testing.T) {
+	const (
+		hex1   = "1111111111111111111111111111111111111111111111111111111111111111"
+		hex2   = "2222222222222222222222222222222222222222222222222222222222222222"
+		hex3   = "3333333333333333333333333333333333333333333333333333333333333333"
+		hex4   = "4444444444444444444444444444444444444444444444444444444444444444"
+		hex5   = "5555555555555555555555555555555555555555555555555555555555555555"
+		hex6   = "6666666666666666666666666666666666666666666666666666666666666666"
+		garden = "12345678-aaaa-bbbb-cccc-dddd"
+	)
+
+	root := t.TempDir()
+
+	// k8s + containerd: deep nesting under kubelet.slice
+	makeDirs := []string{
+		"kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-besteffort.slice/" +
+			"kubelet-kubepods-besteffort-podabc.slice/cri-containerd-" + hex1 + ".scope",
+		"kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-burstable.slice/" +
+			"kubelet-kubepods-burstable-poddef.slice/cri-containerd-" + hex2 + ".scope",
+		// Standalone Docker scope
+		"system.slice/docker-" + hex3 + ".scope",
+		// systemd .mount alias — must be classified Skip
+		"system.slice/docker-" + hex4 + ".scope.mount",
+		// crio-conmon — must Skip and not descend
+		"system.slice/crio-conmon-" + hex5 + "/nested-fake-" + hex6 + ".scope",
+		// Garden / Cloud Foundry layout
+		"garden/" + garden,
+		// Non-container directories that should NOT be picked up
+		"user.slice/user-1000.slice",
+		"init.scope",
+	}
+	for _, rel := range makeDirs {
+		require.NoError(t, os.MkdirAll(filepath.Join(root, rel), 0o755))
+	}
+
+	seen, err := walkContainerCgroups(root)
+	require.NoError(t, err)
+
+	// Build the expected set of paths and verify by absolute path, not by
+	// inode (inodes are filesystem-specific and unstable across reruns).
+	gotPaths := make(map[string]struct{}, len(seen))
+	for _, p := range seen {
+		gotPaths[p] = struct{}{}
+	}
+
+	wantPaths := []string{
+		filepath.Join(root, "kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-besteffort.slice/"+
+			"kubelet-kubepods-besteffort-podabc.slice/cri-containerd-"+hex1+".scope"),
+		filepath.Join(root, "kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-burstable.slice/"+
+			"kubelet-kubepods-burstable-poddef.slice/cri-containerd-"+hex2+".scope"),
+		filepath.Join(root, "system.slice/docker-"+hex3+".scope"),
+		filepath.Join(root, "garden/"+garden),
+	}
+	for _, p := range wantPaths {
+		assert.Contains(t, gotPaths, p, "expected container scope %s", p)
+	}
+	assert.Len(t, gotPaths, len(wantPaths), "got unexpected entries: %v", gotPaths)
+
+	// Affirmative skip: the nested fake scope under crio-conmon must NOT be
+	// returned even though its name matches the container regex — SkipDir
+	// must short-circuit the descent.
+	for p := range gotPaths {
+		assert.NotContains(t, p, "crio-conmon-", "must not descend into conmon: %s", p)
+		assert.NotContains(t, p, ".scope.mount", "must skip .mount aliases: %s", p)
+	}
+
+	// Sanity: every returned inode is a real kernfs inode and matches what
+	// stat() reports on the returned path. This is what BPF's
+	// bpf_get_current_cgroup_id matches against.
+	for inode, path := range seen {
+		got, err := statInode(path)
+		require.NoError(t, err)
+		assert.Equal(t, inode, got, "map key inode must equal statInode(path)")
+	}
+}
+
+// TestWalkContainerCgroups_NonexistentRoot verifies the walk doesn't panic
+// when the cgroup root is missing (e.g., the system-probe ran outside its
+// usual container or /host/proc wasn't mounted yet at startup). The walker
+// swallows per-entry stat errors and just returns an empty result — this
+// matches the behaviour Refresh() expects so a missing tree doesn't crash
+// the probe at startup.
+func TestWalkContainerCgroups_NonexistentRoot(t *testing.T) {
+	seen, _ := walkContainerCgroups("/this/path/should/never/exist/cgrp")
+	assert.Empty(t, seen)
+}
+
+// TestCgroupPMUEntry_close_idempotent asserts close() does not panic when
+// called on a zero-value entry or twice in a row. cgroupFD is -1 in the zero
+// value, which the close() guard catches; subsequent calls must remain safe.
+func TestCgroupPMUEntry_close_idempotent(t *testing.T) {
+	e := &cgroupPMUEntry{cgroupFD: -1}
+	assert.NotPanics(t, e.close)
+	assert.NotPanics(t, e.close)
+}
+
+// TestNewCgroupPMUManager checks construction sets the expected initial state.
+// probeSupported() is called inside the constructor; when the root path
+// doesn't exist (or is unprivileged), it logs and returns without populating
+// `supported`, which leaves every event marked false. This is the desired
+// behavior so the manager can be safely constructed on non-Linux test hosts.
+func TestNewCgroupPMUManager(t *testing.T) {
+	// Use a tempdir so probeSupported's unix.Open succeeds without surprising
+	// the test environment, but the per-event opens will fail (the tempdir
+	// isn't a real cgroup directory).
+	mgr := newCgroupPMUManager(t.TempDir())
+	require.NotNil(t, mgr)
+	assert.NotNil(t, mgr.entries)
+	assert.Empty(t, mgr.entries)
+	assert.Greater(t, mgr.numCPU, 0)
+	// `supported` should be all-false since perf_event_open against a normal
+	// directory (not a cgroup) returns EBADF/EINVAL.
+	for i, ok := range mgr.supported {
+		assert.False(t, ok, "event %d (%s) unexpectedly marked supported", i, pmuEvents[i].name)
+	}
+}
+
+// TestCgroupPMUManager_Close_empty checks Close() is safe on a freshly-built
+// manager with no entries (the typical early-exit path when probeSupported
+// rejected every event).
+func TestCgroupPMUManager_Close_empty(t *testing.T) {
+	mgr := newCgroupPMUManager(t.TempDir())
+	assert.NotPanics(t, mgr.Close)
+}
+
+// TestCgroupPMUManager_ReadAll_emptyEntries verifies ReadAll returns an empty
+// map (not nil) when nothing is tracked yet, since callers iterate over the
+// return value without a nil-check.
+func TestCgroupPMUManager_ReadAll_emptyEntries(t *testing.T) {
+	mgr := newCgroupPMUManager(t.TempDir())
+	got := mgr.ReadAll()
+	require.NotNil(t, got)
+	assert.Empty(t, got)
+}
+
+// TestPMUEvents_stable freezes the supported event set's order and identity.
+// The order is load-bearing — ReadAll indexes into pmuEvents via the same
+// integer that ends up as a struct field, so a reorder would silently
+// misattribute metric values.
+func TestPMUEvents_stable(t *testing.T) {
+	require.Equal(t, 7, numPMUEvents, "numPMUEvents must match the array length")
+	expectedOrder := []string{
+		"cycles",
+		"instructions",
+		"llc_misses",
+		"branch_misses",
+		"cache_references",
+		"itlb_misses",
+		"cpu_migrations",
+	}
+	require.Len(t, pmuEvents, len(expectedOrder))
+	for i, want := range expectedOrder {
+		assert.Equal(t, want, pmuEvents[i].name, "event index %d", i)
+	}
+}
+
+// TestPerfReadValueSize freezes the read-buffer layout. The kernel writes
+// exactly 24 bytes when read_format is TOTAL_TIME_ENABLED|TOTAL_TIME_RUNNING;
+// a struct that doesn't match would corrupt every read.
+func TestPerfReadValueSize(t *testing.T) {
+	assert.Equal(t, 24, perfReadValueSize, "perfReadValue must be exactly 24 bytes (3 × u64)")
+}

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/cgroup_pmu_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/cgroup_pmu_test.go
@@ -101,7 +101,9 @@ func TestScalePMUDelta(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := scalePMUDelta(tt.counter, tt.enabled, tt.running)
-			assert.Equal(t, tt.want, got)
+			assert.Equalf(t, tt.want, got,
+				"scalePMUDelta(counter=%d, enabled=%d, running=%d)",
+				tt.counter, tt.enabled, tt.running)
 		})
 	}
 }
@@ -139,7 +141,8 @@ func TestClassifyCgroupName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, classifyCgroupName(tt.in))
+			assert.Equalf(t, tt.want, classifyCgroupName(tt.in),
+				"classifyCgroupName(%q)", tt.in)
 		})
 	}
 }
@@ -255,9 +258,11 @@ func TestWalkContainerCgroups(t *testing.T) {
 // usual container or /host/proc wasn't mounted yet at startup). The walker
 // swallows per-entry stat errors and just returns an empty result — this
 // matches the behaviour Refresh() expects so a missing tree doesn't crash
-// the probe at startup.
+// the probe at startup. The nil-error part of the contract is what makes
+// Refresh() safe to call before any cgroups appear; lock it down.
 func TestWalkContainerCgroups_NonexistentRoot(t *testing.T) {
-	seen, _ := walkContainerCgroups("/this/path/should/never/exist/cgrp")
+	seen, err := walkContainerCgroups("/this/path/should/never/exist/cgrp")
+	require.NoError(t, err, "missing root must surface as empty result, not error (so Refresh is safe at startup)")
 	assert.Empty(t, seen)
 }
 

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/ebpf_types_linux.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/ebpf_types_linux.go
@@ -4,8 +4,11 @@
 package noisyneighbor
 
 type ebpfCgroupAggStats struct {
-	Sum_latencies_ns uint64
-	Event_count      uint64
-	Preemption_count uint64
-	Pid_count        uint64
+	Sum_latencies_ns  uint64
+	Event_count       uint64
+	Preemption_count  uint64
+	Pid_count         uint64
+	Wakeup_count      uint64
+	Sum_softirq_ns    uint64
+	Block_io_requests uint64
 }

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/model/types.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/model/types.go
@@ -8,15 +8,19 @@ package model
 
 // NoisyNeighborStats is one row of per-cgroup statistics returned by the
 // system-probe /check endpoint. The BPF-side counters (latencies, events,
-// preemptions, pids) come from the cgroup_agg_stats map; the PMU-side counters
-// come from user-space perf-event reads. Any field may be zero when the
-// corresponding source had no data for this cgroup in the interval.
+// preemptions, pids, wakeups, softirq ns, block-io issues) come from the
+// cgroup_agg_stats map; the PMU-side counters come from user-space
+// perf-event reads. Any field may be zero when the corresponding source had
+// no data for this cgroup in the interval.
 type NoisyNeighborStats struct {
 	CgroupID        uint64
 	SumLatenciesNs  uint64
 	EventCount      uint64
 	PreemptionCount uint64
 	UniquePidCount  uint64 // kernel task_struct->pid (TID) count
+	WakeupCount     uint64
+	SumSoftirqNs    uint64
+	BlockIORequests uint64
 
 	// PMU is the delta-since-last-read for the seven hardware/software perf
 	// counters opened per cgroup. EnabledNs and RunningNs let the consumer

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/model/types.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/model/types.go
@@ -6,11 +6,37 @@
 // Package model contains the model for the noisy neighbor check
 package model
 
-// NoisyNeighborStats contains the statistics from the noisy neighbor check
+// NoisyNeighborStats is one row of per-cgroup statistics returned by the
+// system-probe /check endpoint. The BPF-side counters (latencies, events,
+// preemptions, pids) come from the cgroup_agg_stats map; the PMU-side counters
+// come from user-space perf-event reads. Any field may be zero when the
+// corresponding source had no data for this cgroup in the interval.
 type NoisyNeighborStats struct {
 	CgroupID        uint64
 	SumLatenciesNs  uint64
 	EventCount      uint64
 	PreemptionCount uint64
 	UniquePidCount  uint64 // kernel task_struct->pid (TID) count
+
+	// PMU is the delta-since-last-read for the seven hardware/software perf
+	// counters opened per cgroup. EnabledNs and RunningNs let the consumer
+	// scale counters when the PMU is multiplexed.
+	PMU CgroupPMUStats
+}
+
+// CgroupPMUStats is the per-cgroup PMU sample. Counters are summed across
+// CPUs; EnabledNs and RunningNs are the matching scaling-time totals (each in
+// nanoseconds). When the PMU is multiplexed, RunningNs < EnabledNs and the
+// consumer scales counters by EnabledNs/RunningNs to estimate the value at
+// 100% allocation.
+type CgroupPMUStats struct {
+	Cycles          uint64
+	Instructions    uint64
+	LLCMisses       uint64
+	BranchMisses    uint64
+	CacheReferences uint64
+	ITLBMisses      uint64
+	CPUMigrations   uint64
+	EnabledNs       uint64
+	RunningNs       uint64
 }

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
@@ -24,12 +24,17 @@ import (
 // 5.13 for kfuncs, 6.2 for bpf_rcu_read_lock kfunc
 var minimumKernelVersion = kernel.VersionCode(6, 2, 0)
 
-// defaultCgroupRoot is where the host's cgroup v2 hierarchy is visible from
-// inside the system-probe container. The system-probe container itself only
-// has a cgroup-namespaced view of /sys/fs/cgroup (rooted at its own cgroup);
-// the host's full tree is reachable through /host/proc/1/root because the
-// /host/proc mount is the host proc filesystem.
-const defaultCgroupRoot = "/host/proc/1/root/sys/fs/cgroup"
+// hostCgroupRoot returns the path under which the host's cgroup v2 hierarchy
+// is reachable from inside the system-probe process. The system-probe
+// container has a cgroup-namespaced view of /sys/fs/cgroup (rooted at its own
+// cgroup with no siblings visible), so we resolve the host tree through
+// procfs: /<host_proc>/1/root/sys/fs/cgroup is PID 1's filesystem-root view
+// of the cgroup mount, which on a normal host is the unconstrained tree.
+// kernel.HostProc() respects the HOST_PROC env var and DOCKER_DD_AGENT
+// detection that the rest of system-probe uses for procfs access.
+func hostCgroupRoot() string {
+	return kernel.HostProc("1", "root", "sys", "fs", "cgroup")
+}
 
 // Probe is the eBPF side of the noisy neighbor check
 type Probe struct {
@@ -84,7 +89,7 @@ func NewProbe(cfg *ddebpf.Config) (*Probe, error) {
 	}
 	ddebpf.AddNameMappings(p.mgr.Manager, "noisy_neighbor")
 
-	p.pmuMgr = newCgroupPMUManager(defaultCgroupRoot)
+	p.pmuMgr = newCgroupPMUManager(hostCgroupRoot())
 	if err := p.pmuMgr.Refresh(); err != nil {
 		// A failure here is informational — perf_event_open may be denied on
 		// some hosts (paranoid kernel.perf_event_paranoid, missing

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
@@ -24,9 +24,17 @@ import (
 // 5.13 for kfuncs, 6.2 for bpf_rcu_read_lock kfunc
 var minimumKernelVersion = kernel.VersionCode(6, 2, 0)
 
+// defaultCgroupRoot is where the host's cgroup v2 hierarchy is visible from
+// inside the system-probe container. The system-probe container itself only
+// has a cgroup-namespaced view of /sys/fs/cgroup (rooted at its own cgroup);
+// the host's full tree is reachable through /host/proc/1/root because the
+// /host/proc mount is the host proc filesystem.
+const defaultCgroupRoot = "/host/proc/1/root/sys/fs/cgroup"
+
 // Probe is the eBPF side of the noisy neighbor check
 type Probe struct {
-	mgr *ddebpf.Manager
+	mgr    *ddebpf.Manager
+	pmuMgr *cgroupPMUManager
 }
 
 // NewProbe creates a [Probe]
@@ -71,11 +79,22 @@ func NewProbe(cfg *ddebpf.Config) (*Probe, error) {
 		return nil, err
 	}
 	ddebpf.AddNameMappings(p.mgr.Manager, "noisy_neighbor")
+
+	p.pmuMgr = newCgroupPMUManager(defaultCgroupRoot)
+	if err := p.pmuMgr.Refresh(); err != nil {
+		// A failure here is informational — perf_event_open may be denied on
+		// some hosts (paranoid kernel.perf_event_paranoid, missing
+		// CAP_PERF_MON) but BPF-side metrics still work.
+		log.Warnf("noisy_neighbor: initial cgroup PMU refresh failed: %v", err)
+	}
 	return p, nil
 }
 
 // Close releases all associated resources
 func (p *Probe) Close() {
+	if p.pmuMgr != nil {
+		p.pmuMgr.Close()
+	}
 	if p.mgr != nil {
 		ddebpf.RemoveNameMappings(p.mgr.Manager)
 		if err := p.mgr.Stop(manager.CleanAll); err != nil {
@@ -84,63 +103,83 @@ func (p *Probe) Close() {
 	}
 }
 
-// GetAndFlush gets the stats
+// GetAndFlush refreshes the user-space PMU fd set against the current cgroup
+// tree, reads counters, drains the BPF cgroup_agg_stats map, and returns the
+// merged per-cgroup statistics. A row is returned whenever either source has
+// non-empty data for that cgroup; missing fields are zero. The BPF map is
+// reset after every read; PMU counters are u64-monotonic and tracked
+// per-cgroup as deltas internally.
 func (p *Probe) GetAndFlush() []model.NoisyNeighborStats {
-	var nnstats []model.NoisyNeighborStats
+	if p.pmuMgr != nil {
+		if err := p.pmuMgr.Refresh(); err != nil {
+			log.Debugf("noisy_neighbor: cgroup PMU refresh: %v", err)
+		}
+	}
+
+	merged := make(map[uint64]*model.NoisyNeighborStats)
+	if p.pmuMgr != nil {
+		for cgID, ps := range p.pmuMgr.ReadAll() {
+			merged[cgID] = &model.NoisyNeighborStats{
+				CgroupID: cgID,
+				PMU:      ps,
+			}
+		}
+	}
 
 	aggMap, found, err := p.mgr.GetMap("cgroup_agg_stats")
 	if err != nil {
 		log.Errorf("failed to get cgroup_agg_stats map: %v", err)
-		return nnstats
-	}
-	if !found {
+	} else if !found {
 		log.Warn("cgroup_agg_stats map not found")
-		return nnstats
-	}
+	} else {
+		iter := aggMap.Iterate()
+		var cgroupID uint64
+		var perCPUStats []ebpfCgroupAggStats
+		var cgroupsToDelete []uint64
 
-	iter := aggMap.Iterate()
-	var cgroupID uint64
-	var perCPUStats []ebpfCgroupAggStats
-	var cgroupsToDelete []uint64
+		for iter.Next(&cgroupID, &perCPUStats) {
+			var cgroupLatencies, cgroupEvents, cgroupPreemptions, pidCount uint64
+			for _, cpuStat := range perCPUStats {
+				cgroupLatencies += cpuStat.Sum_latencies_ns
+				cgroupEvents += cpuStat.Event_count
+				cgroupPreemptions += cpuStat.Preemption_count
+				// pid_count is a global cgroup value (not per-CPU), so take the max rather than summing
+				if cpuStat.Pid_count > pidCount {
+					pidCount = cpuStat.Pid_count
+				}
+			}
 
-	for iter.Next(&cgroupID, &perCPUStats) {
-		var cgroupLatencies, cgroupEvents, cgroupPreemptions, pidCount uint64
-		for _, cpuStat := range perCPUStats {
-			cgroupLatencies += cpuStat.Sum_latencies_ns
-			cgroupEvents += cpuStat.Event_count
-			cgroupPreemptions += cpuStat.Preemption_count
-			// pid_count is a global cgroup value (not per-CPU), so take the max rather than summing
-			if cpuStat.Pid_count > pidCount {
-				pidCount = cpuStat.Pid_count
+			cgroupsToDelete = append(cgroupsToDelete, cgroupID)
+
+			if cgroupEvents == 0 {
+				continue
+			}
+
+			entry, ok := merged[cgroupID]
+			if !ok {
+				entry = &model.NoisyNeighborStats{CgroupID: cgroupID}
+				merged[cgroupID] = entry
+			}
+			entry.SumLatenciesNs = cgroupLatencies
+			entry.EventCount = cgroupEvents
+			entry.PreemptionCount = cgroupPreemptions
+			entry.UniquePidCount = pidCount
+		}
+
+		if err := iter.Err(); err != nil {
+			log.Errorf("error iterating cgroup_agg_stats map: %v", err)
+		}
+
+		for _, cgID := range cgroupsToDelete {
+			if err := aggMap.Delete(&cgID); err != nil {
+				log.Errorf("failed to delete cgroup %d from agg map: %v", cgID, err)
 			}
 		}
-
-		cgroupsToDelete = append(cgroupsToDelete, cgroupID)
-
-		if cgroupEvents == 0 {
-			continue
-		}
-
-		stat := model.NoisyNeighborStats{
-			CgroupID:        cgroupID,
-			SumLatenciesNs:  cgroupLatencies,
-			EventCount:      cgroupEvents,
-			PreemptionCount: cgroupPreemptions,
-			UniquePidCount:  pidCount,
-		}
-
-		nnstats = append(nnstats, stat)
 	}
 
-	if err := iter.Err(); err != nil {
-		log.Errorf("error iterating cgroup_agg_stats map: %v", err)
+	nnstats := make([]model.NoisyNeighborStats, 0, len(merged))
+	for _, s := range merged {
+		nnstats = append(nnstats, *s)
 	}
-
-	for _, cgID := range cgroupsToDelete {
-		if err := aggMap.Delete(&cgID); err != nil {
-			log.Errorf("failed to delete cgroup %d from agg map: %v", cgID, err)
-		}
-	}
-
 	return nnstats
 }

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
@@ -10,6 +10,7 @@ package noisyneighbor
 
 import (
 	"fmt"
+	"sync"
 
 	manager "github.com/DataDog/ebpf-manager"
 
@@ -36,17 +37,27 @@ func hostCgroupRoot() string {
 	return kernel.HostProc("1", "root", "sys", "fs", "cgroup")
 }
 
-// Probe is the eBPF side of the noisy neighbor check
+// Probe is the eBPF side of the noisy neighbor check.
+//
+// The closeMu RWMutex coordinates Close with concurrent GetAndFlush calls:
+// readers (GetAndFlush) take the read lock and refuse to run when closed is
+// set, and Close takes the write lock so it can only proceed once every
+// in-flight reader has returned. Without this, system-probe shutdown (or
+// module restart) can race a /check that's mid-iteration of the BPF map and
+// trigger use-after-free of the map handle once mgr.Stop(CleanAll) runs.
 type Probe struct {
 	mgr    *ddebpf.Manager
 	pmuMgr *cgroupPMUManager
+
+	closeMu sync.RWMutex
+	closed  bool
 }
 
-// NewProbe creates a [Probe]
+// NewProbe creates a [Probe].
 func NewProbe(cfg *ddebpf.Config) (*Probe, error) {
 	kv, err := kernel.HostVersion()
 	if err != nil {
-		return nil, fmt.Errorf("kernel version: %s", err)
+		return nil, fmt.Errorf("kernel version: %w", err)
 	}
 	if kv < minimumKernelVersion {
 		return nil, fmt.Errorf("minimum kernel version %s not met, read %s", minimumKernelVersion, kv)
@@ -99,15 +110,21 @@ func NewProbe(cfg *ddebpf.Config) (*Probe, error) {
 	return p, nil
 }
 
-// Close releases all associated resources
+// Close releases all associated resources. Blocks until any in-flight
+// GetAndFlush returns; subsequent GetAndFlush calls return errProbeClosed
+// without touching teardown-in-progress resources.
 func (p *Probe) Close() {
+	p.closeMu.Lock()
+	p.closed = true
+	p.closeMu.Unlock()
+
 	if p.pmuMgr != nil {
 		p.pmuMgr.Close()
 	}
 	if p.mgr != nil {
 		ddebpf.RemoveNameMappings(p.mgr.Manager)
 		if err := p.mgr.Stop(manager.CleanAll); err != nil {
-			log.Warnf("error stopping ebpf manager: %s", err)
+			log.Warnf("noisy_neighbor: error stopping ebpf manager: %v", err)
 		}
 	}
 }
@@ -118,7 +135,16 @@ func (p *Probe) Close() {
 // non-empty data for that cgroup; missing fields are zero. The BPF map is
 // reset after every read; PMU counters are u64-monotonic and tracked
 // per-cgroup as deltas internally.
+//
+// Returns an empty slice (no error path on this signature) when Close has
+// been called — system-probe's HTTP handler treats nil/empty results as
+// "no data this interval", which is the right behaviour during shutdown.
 func (p *Probe) GetAndFlush() []model.NoisyNeighborStats {
+	p.closeMu.RLock()
+	defer p.closeMu.RUnlock()
+	if p.closed {
+		return nil
+	}
 	if p.pmuMgr != nil {
 		if err := p.pmuMgr.Refresh(); err != nil {
 			log.Debugf("noisy_neighbor: cgroup PMU refresh: %v", err)

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
@@ -60,10 +60,14 @@ func NewProbe(cfg *ddebpf.Config) (*Probe, error) {
 			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "tp_sched_wakeup", UID: uid}},
 			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "tp_sched_wakeup_new", UID: uid}},
 			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "tp_sched_switch", UID: uid}},
+			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "tp_softirq_entry", UID: uid}},
+			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "tp_softirq_exit", UID: uid}},
+			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "tp_block_rq_issue", UID: uid}},
 		}
 		p.mgr.Maps = []*manager.Map{
 			{Name: "runq_enqueued"},
 			{Name: "cgroup_agg_stats"},
+			{Name: "softirq_start_ns"},
 		}
 		if err := p.mgr.InitWithOptions(buf, &opts); err != nil {
 			return fmt.Errorf("failed to init ebpf manager: %w", err)
@@ -138,11 +142,15 @@ func (p *Probe) GetAndFlush() []model.NoisyNeighborStats {
 		var cgroupsToDelete []uint64
 
 		for iter.Next(&cgroupID, &perCPUStats) {
-			var cgroupLatencies, cgroupEvents, cgroupPreemptions, pidCount uint64
+			var sumLatencies, eventCount, preemptionCount, pidCount uint64
+			var wakeupCount, sumSoftirqNs, blockIORequests uint64
 			for _, cpuStat := range perCPUStats {
-				cgroupLatencies += cpuStat.Sum_latencies_ns
-				cgroupEvents += cpuStat.Event_count
-				cgroupPreemptions += cpuStat.Preemption_count
+				sumLatencies += cpuStat.Sum_latencies_ns
+				eventCount += cpuStat.Event_count
+				preemptionCount += cpuStat.Preemption_count
+				wakeupCount += cpuStat.Wakeup_count
+				sumSoftirqNs += cpuStat.Sum_softirq_ns
+				blockIORequests += cpuStat.Block_io_requests
 				// pid_count is a global cgroup value (not per-CPU), so take the max rather than summing
 				if cpuStat.Pid_count > pidCount {
 					pidCount = cpuStat.Pid_count
@@ -151,7 +159,11 @@ func (p *Probe) GetAndFlush() []model.NoisyNeighborStats {
 
 			cgroupsToDelete = append(cgroupsToDelete, cgroupID)
 
-			if cgroupEvents == 0 {
+			// Skip cgroups with no scheduling activity AND no other counters
+			// to keep the metric stream from emitting rows for cgroups the
+			// kernel never scheduled in the interval. PMU-only rows are kept
+			// because the PMU manager populated them already.
+			if eventCount == 0 && wakeupCount == 0 && sumSoftirqNs == 0 && blockIORequests == 0 {
 				continue
 			}
 
@@ -160,10 +172,13 @@ func (p *Probe) GetAndFlush() []model.NoisyNeighborStats {
 				entry = &model.NoisyNeighborStats{CgroupID: cgroupID}
 				merged[cgroupID] = entry
 			}
-			entry.SumLatenciesNs = cgroupLatencies
-			entry.EventCount = cgroupEvents
-			entry.PreemptionCount = cgroupPreemptions
+			entry.SumLatenciesNs = sumLatencies
+			entry.EventCount = eventCount
+			entry.PreemptionCount = preemptionCount
 			entry.UniquePidCount = pidCount
+			entry.WakeupCount = wakeupCount
+			entry.SumSoftirqNs = sumSoftirqNs
+			entry.BlockIORequests = blockIORequests
 		}
 
 		if err := iter.Err(); err != nil {


### PR DESCRIPTION
### What does this PR do?

Adds richer per-cgroup signals to the experimental `noisy_neighbor` system-probe check. On main the check emits `process_scheduling_latency.per_process`, `process_scheduler_preemptions.per_process`, `events.total`, and `unique_processes`, all derived from a single BPF `sched_switch` program. This PR adds:

- **Seven PMU counters per container cgroup**, sampled from user-space at the check interval (every 10 s) via per-cgroup `perf_event_open` calls: `noisy_neighbor.pmu.{cycles, instructions, llc_misses, branch_misses, cache_references, itlb_misses, cpu_migrations}`. The BPF program stays at main's complexity — no PMU work on the `sched_switch` hot path.
- **Three new BPF tracepoint programs** that fold into the existing `cgroup_agg_stats` map: `tp_sched_wakeup`/`wakeup_new` increment a per-cgroup `wakeup_count`, `tp_softirq_entry`/`exit` charge softirq nanoseconds to the cgroup of the interrupted task, and `tp_block_rq_issue` counts block-I/O requests by issuer cgroup. Three new metrics: `noisy_neighbor.{wakeups, softirq_ns, block_io_requests}.total`.

All ten new metrics are tagged through the existing tagger pipeline (`container_id`, `container_name`, `kube_*`).

### Motivation

The natural BPF-side approach for PMU sampling is calling `bpf_perf_event_read_value` from `sched_switch` to charge counter deltas to the previous task's cgroup — that's the standard pattern for per-cgroup performance attribution. Prototyped that way, on a 16-core ARM Neoverse N1 dev box `tp_sched_switch` went from main's 724 ns/call to 4587 ns/call — a 6.3× regression. An attribution experiment (stubbing the seven `bpf_perf_event_read_value` calls plus their downstream stamp/scale/store bookkeeping to a no-op) showed that PMU pipeline accounted for **3893 ns/call, 84.9%** of the cost. The check interval is 10 s, so the per-`sched_switch` resolution that in-BPF reads produce isn't consumed by any downstream pipeline.

This PR's design moves PMU sampling out of the hot path: the system-probe opens a `perf_event_open` fd per `(cgroup × CPU × event)` via `PERF_FLAG_PID_CGROUP`, and reads the counters from user-space once per `/check` invocation. The kernel's perf subsystem already accumulates cgroup-wide counts on context-switch transitions; we read what it would have computed anyway. The three BPF tracepoints added on top are independently cheap (one cgroup-id RCU walk + one map update each, bounded by tracepoint rate) and belong in BPF because they record events the user-space reader cannot synthesize from anywhere else.

Container cgroups are discovered by walking the host cgroup tree visible at `/host/proc/1/root/sys/fs/cgroup` and filtered through the already-exported `cgroups.ContainerRegexp` — no `pkg/util/cgroups` changes, no extra CODEOWNERS surface.

### Describe how you validated your changes

Built via `dda inv agent.hacky-dev-image-build` and deployed to a `kind` cluster with three stress-ng pods (CPU-bound, STREAM victim, quiet baseline) plus the standard control-plane containers.

**Performance** — `bpftool prog show` deltas under `stress-ng --switch 4` for 60 s, paired runs:

| measurement              | tp_sched_switch ns/call |
|---|---|
| main + WIP load fix      | 724.3 (724.3 ± 4.9 ns)  |
| **this PR — V1 only**    | **727.8** (723.3, 732.3) |
| **this PR — V1 + V2**    | **701.7** (702.6, 700.7) |

Net delta vs main: **−22.6 ns/call (within noise).** New V2 tracepoint costs:

- `tp_sched_wakeup`: 832.5 ns/call (+115 ns vs main, from the added `count_wakeup` RCU walk)
- `tp_softirq_entry`: 201.8 ns/call
- `tp_softirq_exit`: 358.2 ns/call
- `tp_block_rq_issue`: 264.5 ns/call

**Signal validation** — single 30 s `agent check noisy_neighbor` run, values are per-cgroup deltas:

| container | cycles | instructions | llc_misses | branch_misses | wakeups |
|---|---|---|---|---|---|
| noisy (--cpu 16)   | 39 B   | 83 B  | 282 M     | 365 M | 0     |
| victim (--stream)  | 21 B   | 29 B  | **925 M** |   2 M | 0     |
| quiet (--cpu 1)    | 10 B   | 13 B  |  36 M     |  38 M | 0     |
| agent (idle)       |  7 B   | 13 B  |  35 M     |  35 M | 10k   |
| kube-apiserver     |  0.3 B |  0.7 B|   3 M     |  —    |  3.4k |

Victim shows 3.3× more LLC misses than noisy at half the cycles — the cache-pressure signature the new signals are designed to surface. Wakeups correctly show zero for the spinning stress-ng workloads and high values for event-driven services.

**Build artifacts:** `bazel test //pkg/ebpf:verify_generated_files` passes; godefs was regenerated cleanly via `bazel run //pkg/collector/corechecks/ebpf/probe/noisyneighbor:ebpf_types_godefs`.

### Additional Notes

**FD scaling.** Each tracked container cgroup allocates `1 + N_cpus × N_supported_events` fds (113 on a 16-CPU host with all 7 events accepted). The system-probe pod runs with `RLIMIT_NOFILE` of 1M, comfortable through several thousand containers. At very high densities the kernel-side `perf_event` accounting (per-CPU buffers, event structs) becomes the actual cost, not the file-descriptor count itself.

**Cgroup discovery.** Container scopes are matched via `cgroups.ContainerRegexp` on each `/check` (every 10 s); empty parent slices and `crio-conmon-*` / `libpod-conmon-*` aliases are skipped. The walk took ~30 ms with ~120 cgroup dirs visible in the kind cluster.

**PMU multiplexing.** When the host has more events than physical counters, the kernel time-multiplexes events onto counters. The manager records each event's `enabled/running` time per read and scales counters back to the implied 100%-allocation value, so consumers see extrapolated event totals.

**Cross-PMU events.** On ARM (and on x86 with split L1/L2/LLC PMUs), events from different physical PMUs cannot share a `perf_event` group. The manager opens each event in its own group rather than grouping them under a single leader — same fd count, one extra `read()` syscall per CPU at check time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)