### PR TITLE
[anomalydetection] Add reporter

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -44,7 +44,7 @@ import (
 	logssourcefx "github.com/DataDog/datadog-agent/comp/anomalydetection/logssource/fx"
 	observerfx "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/fx"
 	recordernoopfx "github.com/DataDog/datadog-agent/comp/anomalydetection/recorder/fx-noop"
-	reporternoopfx "github.com/DataDog/datadog-agent/comp/anomalydetection/reporter/fx-noop"
+	reporterfx "github.com/DataDog/datadog-agent/comp/anomalydetection/reporter/fx"
 	doqueryactionsfx "github.com/DataDog/datadog-agent/comp/dataobs/queryactions/fx"
 	haagentfx "github.com/DataDog/datadog-agent/comp/haagent/fx"
 	networkconfigmanagement "github.com/DataDog/datadog-agent/comp/networkconfigmanagement/def"
@@ -517,7 +517,7 @@ func getSharedFxOption() fx.Option {
 		logssourcefx.Module(),
 		hfrunnernoopfx.Module(),
 		recordernoopfx.Module(),
-		reporternoopfx.Module(),
+		reporterfx.Module(),
 		langDetectionClimpl.Module(),
 		metadata.Bundle(),
 		orchestratorForwarderImpl.Module(orchestratorForwarderImpl.NewDefaultParams()),

--- a/comp/anomalydetection/observer/impl/events.go
+++ b/comp/anomalydetection/observer/impl/events.go
@@ -76,11 +76,14 @@ func (s *reporterEventSink) onEngineEvent(evt engineEvent) {
 			NewAnomalies:  ac.anomalies,
 		}
 		if s.state != nil {
-			// Use CorrelationHistory (accumulated) rather than ActiveCorrelations
-			// (post-eviction) so that batch detector clusters are visible to
-			// reporters even when their changepoint timestamps are old enough
-			// to be evicted.
-			output.ActiveCorrelations = s.state.CorrelationHistory()
+			// ActiveCorrelations is the live sliding-window set; reporters
+			// use it to detect when a pattern has gone inactive (so it can
+			// fire again on recurrence). CorrelationHistory is the accumulated
+			// set including batch-detector clusters whose changepoint
+			// timestamps may already be evicted from the sliding window;
+			// reporters drive one-shot emission from this set.
+			output.ActiveCorrelations = s.state.ActiveCorrelations()
+			output.CorrelationHistory = s.state.CorrelationHistory()
 		}
 		for _, r := range s.reporters {
 			r.Report(output)

--- a/comp/anomalydetection/reporter/def/component.go
+++ b/comp/anomalydetection/reporter/def/component.go
@@ -34,8 +34,17 @@ type ReportOutput struct {
 	AdvancedToSec int64
 	// NewAnomalies are anomalies detected in this advance cycle.
 	NewAnomalies []observerdef.Anomaly
-	// ActiveCorrelations are the current correlation patterns across all correlators.
+	// ActiveCorrelations are the patterns currently held in each correlator's
+	// sliding window. A pattern leaves this set when it goes inactive
+	// (eviction, timeout) and rejoins if it recurs.
 	ActiveCorrelations []observerdef.ActiveCorrelation
+	// CorrelationHistory is the accumulated set of every correlation pattern
+	// the engine has detected during the current run, including ones whose
+	// changepoint timestamps are already old enough to be evicted from
+	// ActiveCorrelations (e.g. batch detector clusters). Reporters that want
+	// to emit exactly once per pattern should drive emission from this set
+	// and use ActiveCorrelations to decide when a pattern has gone inactive.
+	CorrelationHistory []observerdef.ActiveCorrelation
 }
 
 // StorageConsumer is an optional interface for reporters that need access to
@@ -44,10 +53,4 @@ type ReportOutput struct {
 // the first Report call.
 type StorageConsumer interface {
 	SetStorage(storage observerdef.StorageReader)
-}
-
-// CorrelationSender sends Datadog events for detected anomaly correlations.
-// Obtain one via reporterimpl.NewLiveCorrelationSender.
-type CorrelationSender interface {
-	Send(c observerdef.ActiveCorrelation) error
 }

--- a/comp/anomalydetection/reporter/fx/BUILD.bazel
+++ b/comp/anomalydetection/reporter/fx/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "fx",
+    srcs = ["fx.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/anomalydetection/reporter/fx",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/anomalydetection/reporter/impl",
+        "//pkg/util/fxutil",
+    ],
+)

--- a/comp/anomalydetection/reporter/fx/fx.go
+++ b/comp/anomalydetection/reporter/fx/fx.go
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package fx provides the fx module for the live reporter component.
+// Wire this in agent binaries: it provides the StdoutReporter + optional EventReporter.
+package fx
+
+import (
+	reporterimpl "github.com/DataDog/datadog-agent/comp/anomalydetection/reporter/impl"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Module defines the fx options for the live reporter component.
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fxutil.ProvideComponentConstructor(
+			reporterimpl.NewComponent,
+		),
+	)
+}

--- a/comp/anomalydetection/reporter/impl/BUILD.bazel
+++ b/comp/anomalydetection/reporter/impl/BUILD.bazel
@@ -1,0 +1,35 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "impl",
+    srcs = [
+        "notify.go",
+        "reporter.go",
+        "reporter_event.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/comp/anomalydetection/reporter/impl",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/anomalydetection/observer/def",
+        "//comp/anomalydetection/reporter/def",
+        "//comp/core/config",
+        "//comp/core/log/def",
+        "//comp/forwarder/eventplatform",
+        "//pkg/logs/message",
+        "//pkg/util/strings",
+    ],
+)
+
+go_test(
+    name = "impl_test",
+    srcs = [
+        "notify_test.go",
+        "payload_test.go",
+    ],
+    embed = [":impl"],
+    gotags = ["test"],
+    deps = [
+        "//comp/anomalydetection/observer/def",
+        "@com_github_stretchr_testify//assert",
+    ],
+)

--- a/comp/anomalydetection/reporter/impl/notify.go
+++ b/comp/anomalydetection/reporter/impl/notify.go
@@ -1,0 +1,574 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package reporterimpl
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	observerdef "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	pkgstrings "github.com/DataDog/datadog-agent/pkg/util/strings"
+)
+
+const (
+	// logPatternRateWindowSec is the current-rate averaging window (seconds).
+	logPatternRateWindowSec = 60
+	// logPatternPrevRateWindowSec is the baseline window length: [-6min, -1min].
+	logPatternPrevRateWindowSec = 5 * logPatternRateWindowSec
+
+	// Thresholds for surfacing a rate-change annotation.
+	// Both must be exceeded: relative change guards against noise at low rates,
+	// absolute change guards against large relative swings near zero.
+	logRateChangeRelThreshold = 0.3
+	logRateChangeAbsThreshold = 2
+
+	// Canonical namespace names matching the extractor implementations in observer/impl.
+	logPatternExtractorNamespace = "log_pattern_extractor"
+	logMetricsExtractorNamespace = "log_metrics_extractor"
+
+	// changeEventMessageMaxLen caps the rendered change-event message. The v2
+	// Events API rejects messages larger than 4 KiB.
+	changeEventMessageMaxLen = 4000
+	// impactedResourcesMaxItems caps the number of service entries we attach
+	// to a change event. Matches the v2 API server-side limit.
+	impactedResourcesMaxItems = 100
+	// changedResourceNameMaxLen caps the changed_resource.name length.
+	changedResourceNameMaxLen = 128
+
+	// changeEventIntegrationID identifies the publishing integration. The
+	// `edge-intelligence` integration is registered upstream in
+	// integrations-internal-core#3240 (source_type_id 78252213) and the
+	// event-management intake derives source_type from this value. We also
+	// emit changeEventSourceTypeID explicitly so the intake can validate the
+	// pairing without a registry lookup.
+	changeEventIntegrationID = "edge-intelligence"
+	changeEventSourceTypeID  = 78252213
+
+	// changedResourceType is the resource classification carried in
+	// data.attributes.attributes.changed_resource.type.
+	changedResourceType = "anomaly"
+
+	// Change-event sub-categories carried in change_metadata.sub_category.
+	// The set is intentionally small and extensible.
+	subCategorySpike      = "spike"
+	subCategoryDrop       = "drop"
+	subCategoryNewPattern = "new_pattern"
+)
+
+// splitTagKeyOrder is the canonical ordered list of tag dimensions used to split
+// log series, matching log_tagged_pattern_clusterer in observer/impl.
+var splitTagKeyOrder = []string{"source", "service", "env", "host"}
+
+// eventSender formats and dispatches one Datadog change event per correlation
+// through the event-platform forwarder (event-management intake). Events are
+// sent as raw JSON matching the v2 Events API shape so we don't have to depend
+// on the heavyweight datadog-api-client-go module.
+type eventSender struct {
+	forwarder eventplatform.Forwarder
+	logger    log.Component
+	storage   observerdef.StorageReader
+}
+
+// newEventSender creates an eventSender backed by the given forwarder.
+// storage is used to compute windowed log rates for display in event messages;
+// it may be nil and will be set later via EventReporter.SetStorage.
+func newEventSender(forwarder eventplatform.Forwarder, logger log.Component, storage observerdef.StorageReader) (*eventSender, error) {
+	if forwarder == nil {
+		return nil, errors.New("event-platform forwarder is not available")
+	}
+	return &eventSender{
+		forwarder: forwarder,
+		logger:    logger,
+		storage:   storage,
+	}, nil
+}
+
+// logPatternRate returns the avg log/s over [T-60s, T] when the anomaly points
+// at a storage-backed series.
+func logPatternRate(a observerdef.Anomaly, storage observerdef.StorageReader) (rate float64, ok bool) {
+	if a.SourceRef == nil || storage == nil {
+		return 0, false
+	}
+	total := storage.SumRange(a.SourceRef.Ref, a.Timestamp-logPatternRateWindowSec, a.Timestamp, observerdef.AggregateCount)
+	return total / logPatternRateWindowSec, true
+}
+
+// logPatternPrevRate returns the avg log/s over the baseline window [-6min, -1min].
+// No DebugInfo fallback: CurrentValue is always present-tense.
+func logPatternPrevRate(a observerdef.Anomaly, storage observerdef.StorageReader) (rate float64, ok bool) {
+	if a.SourceRef != nil && storage != nil {
+		start := a.Timestamp - logPatternPrevRateWindowSec - logPatternRateWindowSec
+		total := storage.SumRange(a.SourceRef.Ref, start, a.Timestamp-logPatternRateWindowSec, observerdef.AggregateCount)
+		if total == 0 {
+			return 0, false
+		}
+		return total / logPatternPrevRateWindowSec, true
+	}
+	return 0, false
+}
+
+// isSignificantRateChange reports whether the rate shift from prev to curr
+// exceeds both the absolute and relative thresholds.
+func isSignificantRateChange(prev, curr float64) bool {
+	diff := curr - prev
+	if diff < 0 {
+		diff = -diff
+	}
+	denom := max(prev, curr)
+	return diff >= logRateChangeAbsThreshold && denom > 0 && diff/denom >= logRateChangeRelThreshold
+}
+
+// logRatePart formats the rate annotation for a log-derived anomaly description.
+func logRatePart(a observerdef.Anomaly, storage observerdef.StorageReader) string {
+	curr, ok := logPatternRate(a, storage)
+	if !ok {
+		return ""
+	}
+	if prev, ok := logPatternPrevRate(a, storage); ok && isSignificantRateChange(prev, curr) {
+		return fmt.Sprintf("\n\trate: %.1flog/s (was %.1flog/s last minutes)", curr, prev)
+	}
+	return fmt.Sprintf("\n\trate: %.1flog/s", curr)
+}
+
+func (s *eventSender) send(c observerdef.ActiveCorrelation) error {
+	msg := BuildChangeMessage(c, s.storage)
+	ts := time.Unix(c.FirstSeen, 0).UTC().Format(time.RFC3339)
+	aggKey := "observer:" + c.Pattern
+
+	s.logger.Infof("[observer] sending change event: pattern=%s title=%q aggKey=%s timestamp=%s\n%s\n", c.Pattern, c.Title, aggKey, ts, msg)
+
+	payload := buildChangeEventPayload(c, msg, ts, aggKey)
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal change-event payload: %w", err)
+	}
+
+	epMsg := message.NewMessage(body, nil, "", time.Now().UnixNano())
+	return s.forwarder.SendEventPlatformEventBlocking(epMsg, eventplatform.EventTypeEventManagement)
+}
+
+// buildChangeEventPayload returns the v2 Events API JSON envelope for a
+// correlation. Keys mirror the schema produced by datadog-api-client-go's
+// EventCreateRequestPayload (data.type=event, data.attributes.{title, message,
+// category, integration_id, source_type_id, tags, timestamp, aggregation_key,
+// attributes}). integration_id pins the publisher to the `edge-intelligence`
+// integration so the event-management intake can route and authorize the event.
+func buildChangeEventPayload(c observerdef.ActiveCorrelation, msg, ts, aggKey string) map[string]any {
+	return map[string]any{
+		"data": map[string]any{
+			"type": "event",
+			"attributes": map[string]any{
+				"title":           c.Title,
+				"message":         msg,
+				"category":        "change",
+				"integration_id":  changeEventIntegrationID,
+				"source_type_id":  changeEventSourceTypeID,
+				"tags":            BuildEventTags(c),
+				"timestamp":       ts,
+				"aggregation_key": aggKey,
+				"attributes":      buildChangeAttributes(c),
+			},
+		},
+	}
+}
+
+// BuildEventTags returns the Datadog event tags for a correlation.
+// It always includes "source:edge-intelligence" and "pattern:{pattern}".
+// It adds "anomaly_type:metric" and/or "anomaly_type:log" depending on which
+// anomaly types are present (log-derived metric anomalies count as log).
+// It also propagates "service:", "env:", and "host:" dimensions collected from
+// each anomaly's source tags and from Context.SplitTags (set by the log pattern
+// extractor for sub-clustered log series).
+func BuildEventTags(c observerdef.ActiveCorrelation) []string {
+	hasMetric := false
+	hasLog := false
+	dimensionSet := make(map[string]struct{})
+
+	for _, a := range c.Anomalies {
+		if a.Type == observerdef.AnomalyTypeLog || IsLogDerivedAnomaly(a) {
+			hasLog = true
+		} else {
+			hasMetric = true
+		}
+		// Propagate dimensional tags from the source series.
+		for _, t := range a.Source.Tags {
+			for _, prefix := range []string{"service:", "env:", "host:"} {
+				if strings.HasPrefix(t, prefix) {
+					dimensionSet[t] = struct{}{}
+					break
+				}
+			}
+		}
+		// For log-derived anomalies, dimensional info lives in Context.SplitTags
+		// (set by the log tagged pattern clusterer).
+		if a.Context != nil {
+			for _, k := range []string{"service", "env", "host"} {
+				if v, ok := a.Context.SplitTags[k]; ok {
+					dimensionSet[k+":"+v] = struct{}{}
+				}
+			}
+		}
+	}
+
+	tags := []string{"source:edge-intelligence", "pattern:" + c.Pattern}
+	if hasMetric {
+		tags = append(tags, "anomaly_type:metric")
+	}
+	if hasLog {
+		tags = append(tags, "anomaly_type:log")
+	}
+	for t := range dimensionSet {
+		tags = append(tags, t)
+	}
+	sort.Strings(tags[2:]) // keep source and pattern first; sort the rest for determinism
+	return tags
+}
+
+// buildChangeAttributes constructs the nested change-event attributes block.
+// The shape mirrors the v2 Events API ChangeEventCustomAttributes schema:
+// changed_resource (required), author, impacted_resources, prev_value,
+// new_value, change_metadata.
+func buildChangeAttributes(c observerdef.ActiveCorrelation) map[string]any {
+	name := truncateChars(c.Pattern, changedResourceNameMaxLen)
+	attrs := map[string]any{
+		"changed_resource": map[string]any{
+			"name": name,
+			"type": changedResourceType,
+		},
+		"author": map[string]any{
+			"name": "datadog-agent-observer",
+			"type": "automation",
+		},
+		"prev_value":      buildPrevValue(c),
+		"new_value":       buildNewValue(c),
+		"change_metadata": buildChangeMetadata(c),
+	}
+	if impacted := extractImpactedServices(c); len(impacted) > 0 {
+		attrs["impacted_resources"] = impacted
+	}
+	return attrs
+}
+
+// extractImpactedServices collects unique service names from anomaly and member tags.
+func extractImpactedServices(c observerdef.ActiveCorrelation) []map[string]any {
+	seen := make(map[string]bool)
+	for _, m := range c.Members {
+		for _, tag := range m.Tags {
+			if strings.HasPrefix(tag, "service:") {
+				seen[strings.TrimPrefix(tag, "service:")] = true
+			}
+		}
+	}
+	for _, a := range c.Anomalies {
+		for _, tag := range a.Source.Tags {
+			if strings.HasPrefix(tag, "service:") {
+				seen[strings.TrimPrefix(tag, "service:")] = true
+			}
+		}
+	}
+	names := make([]string, 0, len(seen))
+	for svc := range seen {
+		names = append(names, svc)
+	}
+	sort.Strings(names)
+	if len(names) > impactedResourcesMaxItems {
+		names = names[:impactedResourcesMaxItems]
+	}
+	items := make([]map[string]any, 0, len(names))
+	for _, svc := range names {
+		items = append(items, map[string]any{
+			"name": svc,
+			"type": "service",
+		})
+	}
+	return items
+}
+
+// buildPrevValue creates a per-series baseline snapshot for the change event.
+func buildPrevValue(c observerdef.ActiveCorrelation) map[string]any {
+	prev := make(map[string]any)
+	for _, a := range c.Anomalies {
+		if a.DebugInfo == nil {
+			continue
+		}
+		key := anomalyDisplayKey(a)
+		prev[key] = map[string]any{
+			"mean":   a.DebugInfo.BaselineMean,
+			"median": a.DebugInfo.BaselineMedian,
+			"stddev": a.DebugInfo.BaselineStddev,
+		}
+	}
+	return prev
+}
+
+// buildNewValue creates a per-series current-state snapshot for the change event.
+func buildNewValue(c observerdef.ActiveCorrelation) map[string]any {
+	newVal := make(map[string]any)
+	for _, a := range c.Anomalies {
+		if a.DebugInfo == nil {
+			continue
+		}
+		key := anomalyDisplayKey(a)
+		entry := map[string]any{
+			"value":           a.DebugInfo.CurrentValue,
+			"deviation_sigma": a.DebugInfo.DeviationSigma,
+		}
+		if a.DebugInfo.Threshold != 0 {
+			entry["threshold"] = a.DebugInfo.Threshold
+		}
+		newVal[key] = entry
+	}
+	return newVal
+}
+
+// buildChangeMetadata creates the full structured anomaly inventory.
+func buildChangeMetadata(c observerdef.ActiveCorrelation) map[string]any {
+	var metricAnomalies, logAnomalies []any
+	for _, a := range c.Anomalies {
+		entry := map[string]any{
+			"source":    a.Source.DisplayName(),
+			"detector":  a.DetectorName,
+			"title":     a.Title,
+			"timestamp": a.Timestamp,
+		}
+		if a.Description != "" {
+			entry["description"] = a.Description
+		}
+		if a.Score != nil {
+			entry["score"] = *a.Score
+		}
+		if a.DebugInfo != nil {
+			entry["debug_info"] = map[string]any{
+				"baseline_mean":   a.DebugInfo.BaselineMean,
+				"baseline_stddev": a.DebugInfo.BaselineStddev,
+				"baseline_median": a.DebugInfo.BaselineMedian,
+				"baseline_mad":    a.DebugInfo.BaselineMAD,
+				"threshold":       a.DebugInfo.Threshold,
+				"current_value":   a.DebugInfo.CurrentValue,
+				"deviation_sigma": a.DebugInfo.DeviationSigma,
+			}
+		}
+		if a.Context != nil {
+			ctx := map[string]any{}
+			if a.Context.Pattern != "" {
+				ctx["pattern"] = a.Context.Pattern
+			}
+			if a.Context.Example != "" {
+				ctx["example"] = a.Context.Example
+			}
+			if len(a.Context.SplitTags) > 0 {
+				ctx["split_tags"] = a.Context.SplitTags
+			}
+			if len(ctx) > 0 {
+				entry["context"] = ctx
+			}
+		}
+		if a.Type == observerdef.AnomalyTypeLog || IsLogDerivedAnomaly(a) {
+			logAnomalies = append(logAnomalies, entry)
+		} else {
+			metricAnomalies = append(metricAnomalies, entry)
+		}
+	}
+
+	// Always emit both arrays (possibly empty) so the wire payload's shape
+	// matches the spec's ChangeEvent entity: metric_anomalies and log_anomalies
+	// are List<AnomalyInventoryEntry>, not optional.
+	if metricAnomalies == nil {
+		metricAnomalies = []any{}
+	}
+	if logAnomalies == nil {
+		logAnomalies = []any{}
+	}
+
+	meta := map[string]any{
+		"anomaly_count":    len(c.Anomalies),
+		"first_seen":       time.Unix(c.FirstSeen, 0).UTC().Format(time.RFC3339),
+		"last_updated":     time.Unix(c.LastUpdated, 0).UTC().Format(time.RFC3339),
+		"sub_category":     classifyCorrelationSubCategory(c),
+		"metric_anomalies": metricAnomalies,
+		"log_anomalies":    logAnomalies,
+	}
+	if len(c.Members) > 0 {
+		members := make([]string, len(c.Members))
+		for i, m := range c.Members {
+			members[i] = m.DisplayName()
+		}
+		meta["member_series"] = members
+	}
+	return meta
+}
+
+// BuildChangeMessage creates a compact human-readable summary for a correlation
+// (Datadog change events, testbench JSON output, and replay-reported events).
+// storage may be nil; when it is, log-rate annotations are omitted.
+func BuildChangeMessage(c observerdef.ActiveCorrelation, storage observerdef.StorageReader) string {
+	anomalyLines := []string{}
+	for _, a := range c.Anomalies {
+		if IsLogDerivedAnomaly(a) {
+			anomalyLines = append(anomalyLines, "- "+logDerivedDescription(a, storage))
+		} else if a.DebugInfo != nil {
+			display := anomalyDisplayKey(a)
+			anomalyLines = append(anomalyLines, fmt.Sprintf("- %s: %.2f (baseline mean: %.2f, %.1f sigma)", display, a.DebugInfo.CurrentValue, a.DebugInfo.BaselineMean, a.DebugInfo.DeviationSigma))
+		} else if a.Description != "" {
+			anomalyLines = append(anomalyLines, "- "+a.Description)
+		} else {
+			anomalyLines = append(anomalyLines, "- "+anomalyDisplayKey(a))
+		}
+	}
+
+	// Ensure anomaly bullets are unique and sorted (two anomalies on the
+	// same series at a similar timestamp render to the same bullet). The
+	// header reports the deduplicated count so it matches the rendered list.
+	slices.Sort(anomalyLines)
+	anomalyLines = slices.Compact(anomalyLines)
+
+	var lines []string
+	lines = append(lines, fmt.Sprintf("Correlated behavior change detected: %d anomalies in pattern %q", len(anomalyLines), c.Pattern))
+	lines = append(lines, "")
+	lines = append(lines, anomalyLines...)
+	text := strings.Join(lines, "\n")
+	return truncateBytesValidUTF8(text, changeEventMessageMaxLen)
+}
+
+// truncateChars returns s unchanged when it is at most maxChars runes long.
+// Otherwise it returns the first (maxChars-1) runes of s followed by an
+// ellipsis rune, so the result is exactly maxChars characters and remains
+// valid UTF-8. maxChars must be at least 1.
+func truncateChars(s string, maxChars int) string {
+	if utf8.RuneCountInString(s) <= maxChars {
+		return s
+	}
+	runes := []rune(s)
+	return string(runes[:maxChars-1]) + "…"
+}
+
+// truncateBytesValidUTF8 returns s unchanged when its byte length does not
+// exceed maxBytes. Otherwise it delegates rune-boundary truncation to
+// pkg/util/strings.TruncateUTF8, then appends a 3-byte ASCII ellipsis ("...")
+// so the result is at most maxBytes bytes and remains valid UTF-8. maxBytes
+// must be at least 4.
+func truncateBytesValidUTF8(s string, maxBytes int) string {
+	if len(s) <= maxBytes {
+		return s
+	}
+	const ellipsis = "..."
+	return pkgstrings.TruncateUTF8(s, maxBytes-len(ellipsis)) + ellipsis
+}
+
+// anomalyDisplayKey returns a human-readable key for an anomaly's source series.
+func anomalyDisplayKey(a observerdef.Anomaly) string {
+	if key := a.Source.DisplayName(); key != "" {
+		return key
+	}
+	return a.Source.String()
+}
+
+// classifyCorrelationSubCategory chooses one of subCategorySpike,
+// subCategoryDrop, or subCategoryNewPattern for a correlation. Event Management
+// uses this to label the change event without parsing the message body.
+//
+// Rules, in priority order:
+//  1. If any anomaly is a log-pattern detection without a meaningful baseline
+//     (no DebugInfo, or DebugInfo.BaselineMean == 0), classify the whole
+//     correlation as "new_pattern" — these represent novel signals that didn't
+//     exist before.
+//  2. Otherwise, if every anomaly with DebugInfo has CurrentValue <=
+//     BaselineMean, the signal dropped — "drop".
+//  3. Otherwise "spike".
+func classifyCorrelationSubCategory(c observerdef.ActiveCorrelation) string {
+	if len(c.Anomalies) == 0 {
+		return subCategorySpike
+	}
+	for _, a := range c.Anomalies {
+		if !(a.Type == observerdef.AnomalyTypeLog || IsLogDerivedAnomaly(a)) {
+			continue
+		}
+		if a.DebugInfo == nil || a.DebugInfo.BaselineMean == 0 {
+			return subCategoryNewPattern
+		}
+	}
+	sawDebug := false
+	allDrops := true
+	for _, a := range c.Anomalies {
+		if a.DebugInfo == nil {
+			continue
+		}
+		sawDebug = true
+		if a.DebugInfo.CurrentValue > a.DebugInfo.BaselineMean {
+			allDrops = false
+			break
+		}
+	}
+	if sawDebug && allDrops {
+		return subCategoryDrop
+	}
+	return subCategorySpike
+}
+
+// IsLogDerivedAnomaly returns true for metric anomalies that originate from
+// log pattern extraction. These should be presented as log anomalies with
+// pattern/example/rate context rather than raw metric descriptions.
+func IsLogDerivedAnomaly(a observerdef.Anomaly) bool {
+	if a.Type == observerdef.AnomalyTypeLog || a.Context == nil {
+		return false
+	}
+	switch a.Source.Namespace {
+	case logPatternExtractorNamespace:
+		return strings.TrimSpace(a.Context.Pattern) != ""
+	case logMetricsExtractorNamespace:
+		return strings.TrimSpace(a.Context.Pattern) != "" || strings.TrimSpace(a.Context.Example) != ""
+	}
+	return false
+}
+
+// logDerivedDescription builds a human-readable description for a log-derived
+// metric anomaly, including pattern, example, and windowed average rate.
+func logDerivedDescription(a observerdef.Anomaly, storage observerdef.StorageReader) string {
+	if a.Source.Namespace == logMetricsExtractorNamespace {
+		return logFrequencyDerivedDescription(a, storage)
+	}
+	pattern := strings.TrimSpace(a.Context.Pattern)
+	var example string
+	// Don't display example if it's the same as the pattern
+	if a.Context.Example != "" && strings.TrimSpace(a.Context.Example) != pattern {
+		example = "\n\texample: " + strings.TrimSpace(a.Context.Example)
+	}
+	ratePart := logRatePart(a, storage)
+	var tagsPart string
+	if len(a.Context.SplitTags) > 0 {
+		var parts []string
+		for _, k := range splitTagKeyOrder {
+			if v, ok := a.Context.SplitTags[k]; ok {
+				parts = append(parts, k+"="+v)
+			}
+		}
+		if len(parts) > 0 {
+			tagsPart = "\n\ttags: " + strings.Join(parts, ", ")
+		}
+	}
+	return fmt.Sprintf("Log pattern change rate detected:\n\tpattern: %s%s%s%s", pattern, example, ratePart, tagsPart)
+}
+
+// logFrequencyDerivedDescription builds a human-readable description for
+// log.pattern.* anomalies from LogMetricsExtractor. The stored pattern is an
+// internal tokenized structural signature (not human-readable), so the example
+// log line is used as the primary identifier instead.
+func logFrequencyDerivedDescription(a observerdef.Anomaly, storage observerdef.StorageReader) string {
+	example := strings.TrimSpace(a.Context.Example)
+	if example == "" {
+		example = strings.TrimSpace(a.Context.Pattern)
+	}
+	return fmt.Sprintf("Log frequency change detected:\n\texample: %s%s", example, logRatePart(a, storage))
+}

--- a/comp/anomalydetection/reporter/impl/notify_test.go
+++ b/comp/anomalydetection/reporter/impl/notify_test.go
@@ -1,0 +1,414 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package reporterimpl
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+
+	observerdef "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
+)
+
+// sumRangeStorage is a minimal StorageReader that answers SumRange calls via a
+// user-supplied function and panics on all other methods (they are unused here).
+type sumRangeStorage struct {
+	fn func(handle observerdef.SeriesRef, start, end int64, agg observerdef.Aggregate) float64
+}
+
+func (s *sumRangeStorage) SumRange(handle observerdef.SeriesRef, start, end int64, agg observerdef.Aggregate) float64 {
+	return s.fn(handle, start, end, agg)
+}
+func (s *sumRangeStorage) ListSeries(_ observerdef.SeriesFilter) []observerdef.SeriesMeta {
+	panic("not implemented")
+}
+func (s *sumRangeStorage) GetSeriesRange(_ observerdef.SeriesRef, _, _ int64, _ observerdef.Aggregate) *observerdef.Series {
+	panic("not implemented")
+}
+func (s *sumRangeStorage) ForEachPoint(_ observerdef.SeriesRef, _, _ int64, _ observerdef.Aggregate, _ func(*observerdef.Series, observerdef.Point)) bool {
+	panic("not implemented")
+}
+func (s *sumRangeStorage) PointCount(_ observerdef.SeriesRef) int { panic("not implemented") }
+func (s *sumRangeStorage) PointCountUpTo(_ observerdef.SeriesRef, _ int64) int {
+	panic("not implemented")
+}
+func (s *sumRangeStorage) WriteGeneration(_ observerdef.SeriesRef) int64 { panic("not implemented") }
+func (s *sumRangeStorage) SeriesGeneration() uint64                      { panic("not implemented") }
+
+func TestIsLogDerivedAnomaly_LogMetricsExtractorWithPattern(t *testing.T) {
+	a := observerdef.Anomaly{
+		Type:   observerdef.AnomalyTypeMetric,
+		Source: observerdef.SeriesDescriptor{Namespace: logMetricsExtractorNamespace},
+		Context: &observerdef.MetricContext{
+			Pattern: "C3:C8_C1",
+			Example: "ERROR: connection refused to db.prod:5432",
+		},
+	}
+	assert.True(t, IsLogDerivedAnomaly(a))
+}
+
+func TestIsLogDerivedAnomaly_LogMetricsExtractorExampleOnlyNoPattern(t *testing.T) {
+	// Even with an empty pattern, a non-empty example qualifies.
+	a := observerdef.Anomaly{
+		Type:   observerdef.AnomalyTypeMetric,
+		Source: observerdef.SeriesDescriptor{Namespace: logMetricsExtractorNamespace},
+		Context: &observerdef.MetricContext{
+			Pattern: "",
+			Example: "some log line",
+		},
+	}
+	assert.True(t, IsLogDerivedAnomaly(a))
+}
+
+func TestIsLogDerivedAnomaly_LogMetricsExtractorNoContext(t *testing.T) {
+	a := observerdef.Anomaly{
+		Type:    observerdef.AnomalyTypeMetric,
+		Source:  observerdef.SeriesDescriptor{Namespace: logMetricsExtractorNamespace},
+		Context: nil,
+	}
+	assert.False(t, IsLogDerivedAnomaly(a))
+}
+
+func TestBuildChangeMessage_LogMetricsExtractorUsesExample(t *testing.T) {
+	c := observerdef.ActiveCorrelation{
+		Pattern: "p",
+		Anomalies: []observerdef.Anomaly{
+			{
+				Type:   observerdef.AnomalyTypeMetric,
+				Source: observerdef.SeriesDescriptor{Namespace: logMetricsExtractorNamespace},
+				Context: &observerdef.MetricContext{
+					Pattern: "C3:C8_C1",
+					Example: "ERROR: connection refused to db.prod:5432",
+				},
+			},
+		},
+	}
+	msg := BuildChangeMessage(c, nil)
+	assert.Contains(t, msg, "Log frequency change detected")
+	assert.Contains(t, msg, "ERROR: connection refused to db.prod:5432")
+	assert.NotContains(t, msg, "C3:C8_C1") // tokenized signature should not appear
+}
+
+func TestBuildChangeMessage_LogMetricsExtractorFallsBackToPatternWhenNoExample(t *testing.T) {
+	c := observerdef.ActiveCorrelation{
+		Pattern: "p",
+		Anomalies: []observerdef.Anomaly{
+			{
+				Type:   observerdef.AnomalyTypeMetric,
+				Source: observerdef.SeriesDescriptor{Namespace: logMetricsExtractorNamespace},
+				Context: &observerdef.MetricContext{
+					Pattern: "C3:C8_C1",
+					Example: "",
+				},
+			},
+		},
+	}
+	msg := BuildChangeMessage(c, nil)
+	assert.Contains(t, msg, "Log frequency change detected")
+	assert.Contains(t, msg, "C3:C8_C1")
+}
+
+func TestBuildEventTags_LogMetricsExtractorTreatedAsLog(t *testing.T) {
+	c := observerdef.ActiveCorrelation{
+		Pattern: "p",
+		Anomalies: []observerdef.Anomaly{
+			{
+				Type:   observerdef.AnomalyTypeMetric,
+				Source: observerdef.SeriesDescriptor{Namespace: logMetricsExtractorNamespace},
+				Context: &observerdef.MetricContext{
+					Pattern: "C3:C8_C1",
+					Example: "some log line",
+				},
+			},
+		},
+	}
+	tags := BuildEventTags(c)
+	assert.Contains(t, tags, "anomaly_type:log")
+	assert.NotContains(t, tags, "anomaly_type:metric")
+}
+
+func TestBuildEventTags_BaseTagsAlwaysPresent(t *testing.T) {
+	c := observerdef.ActiveCorrelation{Pattern: "kernel_bottleneck"}
+	tags := BuildEventTags(c)
+	assert.Contains(t, tags, "source:edge-intelligence")
+	assert.Contains(t, tags, "pattern:kernel_bottleneck")
+}
+
+func TestBuildEventTags_MetricAnomalyType(t *testing.T) {
+	c := observerdef.ActiveCorrelation{
+		Pattern: "p",
+		Anomalies: []observerdef.Anomaly{
+			{Type: observerdef.AnomalyTypeMetric, Source: observerdef.SeriesDescriptor{Namespace: "dogstatsd"}},
+		},
+	}
+	tags := BuildEventTags(c)
+	assert.Contains(t, tags, "anomaly_type:metric")
+	assert.NotContains(t, tags, "anomaly_type:log")
+}
+
+func TestBuildEventTags_LogAnomalyType(t *testing.T) {
+	c := observerdef.ActiveCorrelation{
+		Pattern: "p",
+		Anomalies: []observerdef.Anomaly{
+			{Type: observerdef.AnomalyTypeLog, Source: observerdef.SeriesDescriptor{Namespace: "log_detector"}},
+		},
+	}
+	tags := BuildEventTags(c)
+	assert.Contains(t, tags, "anomaly_type:log")
+	assert.NotContains(t, tags, "anomaly_type:metric")
+}
+
+func TestBuildEventTags_LogDerivedMetricAnomaly(t *testing.T) {
+	// A metric anomaly originating from log_pattern_extractor with a pattern
+	// context is treated as a log anomaly.
+	c := observerdef.ActiveCorrelation{
+		Pattern: "p",
+		Anomalies: []observerdef.Anomaly{
+			{
+				Type: observerdef.AnomalyTypeMetric,
+				Source: observerdef.SeriesDescriptor{
+					Namespace: logPatternExtractorNamespace,
+				},
+				Context: &observerdef.MetricContext{
+					Pattern: "some log pattern",
+				},
+			},
+		},
+	}
+	tags := BuildEventTags(c)
+	assert.Contains(t, tags, "anomaly_type:log")
+	assert.NotContains(t, tags, "anomaly_type:metric")
+}
+
+func TestBuildEventTags_BothTypes(t *testing.T) {
+	c := observerdef.ActiveCorrelation{
+		Pattern: "p",
+		Anomalies: []observerdef.Anomaly{
+			{Type: observerdef.AnomalyTypeMetric, Source: observerdef.SeriesDescriptor{Namespace: "dogstatsd"}},
+			{Type: observerdef.AnomalyTypeLog, Source: observerdef.SeriesDescriptor{Namespace: "log_detector"}},
+		},
+	}
+	tags := BuildEventTags(c)
+	assert.Contains(t, tags, "anomaly_type:metric")
+	assert.Contains(t, tags, "anomaly_type:log")
+}
+
+func TestBuildEventTags_DimensionalTagsFromSourceTags(t *testing.T) {
+	c := observerdef.ActiveCorrelation{
+		Pattern: "p",
+		Anomalies: []observerdef.Anomaly{
+			{
+				Type: observerdef.AnomalyTypeMetric,
+				Source: observerdef.SeriesDescriptor{
+					Namespace: "dogstatsd",
+					Tags:      []string{"service:web", "env:prod", "host:h1", "version:1.0"},
+				},
+			},
+		},
+	}
+	tags := BuildEventTags(c)
+	assert.Contains(t, tags, "service:web")
+	assert.Contains(t, tags, "env:prod")
+	assert.Contains(t, tags, "host:h1")
+	assert.NotContains(t, tags, "version:1.0") // non-dimensional tags not propagated
+}
+
+func TestBuildEventTags_DimensionalTagsFromSplitTags(t *testing.T) {
+	// Log-derived anomalies carry dimensional info in Context.SplitTags.
+	c := observerdef.ActiveCorrelation{
+		Pattern: "p",
+		Anomalies: []observerdef.Anomaly{
+			{
+				Type:   observerdef.AnomalyTypeMetric,
+				Source: observerdef.SeriesDescriptor{Namespace: logPatternExtractorNamespace},
+				Context: &observerdef.MetricContext{
+					Pattern: "some log pattern",
+					SplitTags: map[string]string{
+						"service": "api",
+						"env":     "staging",
+						"host":    "h2",
+					},
+				},
+			},
+		},
+	}
+	tags := BuildEventTags(c)
+	assert.Contains(t, tags, "service:api")
+	assert.Contains(t, tags, "env:staging")
+	assert.Contains(t, tags, "host:h2")
+}
+
+func TestBuildEventTags_DeduplicatesDimensions(t *testing.T) {
+	c := observerdef.ActiveCorrelation{
+		Pattern: "p",
+		Anomalies: []observerdef.Anomaly{
+			{
+				Type:   observerdef.AnomalyTypeMetric,
+				Source: observerdef.SeriesDescriptor{Namespace: "ns", Tags: []string{"service:web"}},
+			},
+			{
+				Type:   observerdef.AnomalyTypeMetric,
+				Source: observerdef.SeriesDescriptor{Namespace: "ns", Tags: []string{"service:web"}},
+			},
+		},
+	}
+	tags := BuildEventTags(c)
+	count := 0
+	for _, t := range tags {
+		if t == "service:web" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "service:web should appear exactly once")
+}
+
+func TestBuildEventTags_SourceAndPatternAreFirstTwo(t *testing.T) {
+	c := observerdef.ActiveCorrelation{
+		Pattern: "mypat",
+		Anomalies: []observerdef.Anomaly{
+			{
+				Type:   observerdef.AnomalyTypeMetric,
+				Source: observerdef.SeriesDescriptor{Namespace: "ns", Tags: []string{"service:svc"}},
+			},
+		},
+	}
+	tags := BuildEventTags(c)
+	assert.Equal(t, "source:edge-intelligence", tags[0])
+	assert.Equal(t, "pattern:mypat", tags[1])
+	// Remaining tags are sorted
+	rest := tags[2:]
+	sorted := make([]string, len(rest))
+	copy(sorted, rest)
+	sort.Strings(sorted)
+	assert.Equal(t, sorted, rest)
+}
+
+// --- isSignificantRateChange ---
+
+func TestIsSignificantRateChange_BothAboveThresholds(t *testing.T) {
+	// curr is 3× prev → relative change = 2/3 > 0.5, absolute > 0.1
+	assert.True(t, isSignificantRateChange(1.0, 3.0))
+}
+
+func TestIsSignificantRateChange_RelativeBelowThreshold(t *testing.T) {
+	// 10 → 13: relative change = 3/13 ≈ 0.23 < 0.5
+	assert.False(t, isSignificantRateChange(10.0, 13.0))
+}
+
+func TestIsSignificantRateChange_AbsoluteBelowThreshold(t *testing.T) {
+	// 0.01 → 0.05: absolute change = 0.04 < 0.1, even though relative is large
+	assert.False(t, isSignificantRateChange(0.01, 0.05))
+}
+
+func TestIsSignificantRateChange_BothZero(t *testing.T) {
+	assert.False(t, isSignificantRateChange(0.0, 0.0))
+}
+
+func TestIsSignificantRateChange_RateDrops(t *testing.T) {
+	// 5 → 1: large drop, should be significant
+	assert.True(t, isSignificantRateChange(5.0, 1.0))
+}
+
+// --- rate display in BuildChangeMessage ---
+
+// makeStorageWithRates returns a sumRangeStorage whose SumRange returns
+// prevTotal for the earlier window and currTotal for the current window,
+// identified by the end timestamp.
+func makeStorageWithRates(ts int64, prevTotal, currTotal float64) *sumRangeStorage {
+	return &sumRangeStorage{
+		fn: func(_ observerdef.SeriesRef, _ int64, end int64, _ observerdef.Aggregate) float64 {
+			if end == ts-logPatternRateWindowSec {
+				return prevTotal
+			}
+			return currTotal
+		},
+	}
+}
+
+func makeLogPatternAnomaly(ts int64) observerdef.Anomaly {
+	return observerdef.Anomaly{
+		Type:      observerdef.AnomalyTypeMetric,
+		Timestamp: ts,
+		Source:    observerdef.SeriesDescriptor{Namespace: logPatternExtractorNamespace},
+		SourceRef: &observerdef.QueryHandle{Ref: observerdef.SeriesRef(42)},
+		Context: &observerdef.MetricContext{
+			Pattern: "connection refused",
+			Example: "ERROR: connection refused to db:5432",
+		},
+	}
+}
+
+func TestBuildChangeMessage_RateChangedDisplay(t *testing.T) {
+	const ts = int64(10000)
+	// prev window: 6 logs/s, curr window: 0.5 log/s — large drop, should show "changed from"
+	storage := makeStorageWithRates(ts, 6.0*logPatternPrevRateWindowSec, 0.5*logPatternRateWindowSec)
+	c := observerdef.ActiveCorrelation{
+		Pattern:   "p",
+		Anomalies: []observerdef.Anomaly{makeLogPatternAnomaly(ts)},
+	}
+	msg := BuildChangeMessage(c, storage)
+	assert.Contains(t, msg, fmt.Sprintf("rate: %.1flog/s (was %.1flog/s last minutes)", 0.5, 6.0))
+}
+
+func TestBuildChangeMessage_RateUnchanged_ShowsPlainRate(t *testing.T) {
+	const ts = int64(10000)
+	// Both windows return the same rate → not significant, plain display
+	storage := makeStorageWithRates(ts, 3.0*logPatternPrevRateWindowSec, 3.0*logPatternRateWindowSec)
+	c := observerdef.ActiveCorrelation{
+		Pattern:   "p",
+		Anomalies: []observerdef.Anomaly{makeLogPatternAnomaly(ts)},
+	}
+	msg := BuildChangeMessage(c, storage)
+	assert.Contains(t, msg, fmt.Sprintf("\n\trate: %.1flog/s", 3.0))
+	// No previous rate display
+	assert.NotContains(t, msg, "was")
+	assert.NotContains(t, msg, "last minutes")
+}
+
+func TestBuildChangeMessage_LogFrequency_RateChangedDisplay(t *testing.T) {
+	const ts = int64(10000)
+	// prev window: 0.2 log/s, curr window: 5.0 log/s — large jump
+	storage := makeStorageWithRates(ts, 0.2*logPatternPrevRateWindowSec, 5.0*logPatternRateWindowSec)
+	a := observerdef.Anomaly{
+		Type:      observerdef.AnomalyTypeMetric,
+		Timestamp: ts,
+		Source:    observerdef.SeriesDescriptor{Namespace: logMetricsExtractorNamespace},
+		SourceRef: &observerdef.QueryHandle{Ref: observerdef.SeriesRef(7)},
+		Context: &observerdef.MetricContext{
+			Example: "panic: runtime error",
+		},
+	}
+	c := observerdef.ActiveCorrelation{Pattern: "p", Anomalies: []observerdef.Anomaly{a}}
+	msg := BuildChangeMessage(c, storage)
+	assert.Contains(t, msg, fmt.Sprintf("rate: %.1flog/s (was %.1flog/s last minutes)", 5.0, 0.2))
+}
+
+func TestBuildChangeMessage_LogFrequencyWithoutStorageOmitsRate(t *testing.T) {
+	a := observerdef.Anomaly{
+		Type:   observerdef.AnomalyTypeMetric,
+		Source: observerdef.SeriesDescriptor{Namespace: logMetricsExtractorNamespace},
+		Context: &observerdef.MetricContext{
+			Example: "panic: runtime error",
+		},
+		DebugInfo: &observerdef.AnomalyDebugInfo{CurrentValue: 5},
+	}
+	c := observerdef.ActiveCorrelation{Pattern: "p", Anomalies: []observerdef.Anomaly{a}}
+	msg := BuildChangeMessage(c, nil)
+	assert.Contains(t, msg, "panic: runtime error")
+	assert.NotContains(t, msg, "rate:")
+}
+
+func TestTruncateBytesValidUTF8_AppendsEllipsisAtRuneBoundary(t *testing.T) {
+	s := strings.Repeat("☃", 10)
+	got := truncateBytesValidUTF8(s, 10)
+	assert.Equal(t, "☃☃...", got)
+	assert.LessOrEqual(t, len(got), 10)
+	assert.True(t, utf8.ValidString(got))
+}

--- a/comp/anomalydetection/reporter/impl/payload_test.go
+++ b/comp/anomalydetection/reporter/impl/payload_test.go
@@ -1,0 +1,279 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package reporterimpl
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+
+	observerdef "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
+)
+
+// TestBuildChangeEventPayload_WireShape asserts the JSON envelope produced for
+// the event-management intake matches the v2 Events API ChangeEvent schema we
+// used to obtain via datadog-api-client-go, including the edge-intelligence
+// routing metadata (integration_id, source_type_id) and the anomaly resource
+// type. The contract here is the wire format, not the helper functions: if the
+// intake changes field names or the SME-agreed values shift, we want this test
+// to fail loudly.
+func TestBuildChangeEventPayload_WireShape(t *testing.T) {
+	c := observerdef.ActiveCorrelation{
+		Pattern: "kernel_bottleneck",
+		Title:   "kernel bottleneck detected",
+		Anomalies: []observerdef.Anomaly{
+			{
+				Type:   observerdef.AnomalyTypeMetric,
+				Source: observerdef.SeriesDescriptor{Namespace: "dogstatsd", Tags: []string{"service:web", "env:prod"}},
+				DebugInfo: &observerdef.AnomalyDebugInfo{
+					CurrentValue: 10,
+					BaselineMean: 1,
+				},
+			},
+		},
+	}
+
+	payload := buildChangeEventPayload(c, "hello", "2024-01-01T00:00:00Z", "observer:kernel_bottleneck")
+
+	// Round-trip through JSON so we exercise the same marshalling path as send().
+	blob, err := json.Marshal(payload)
+	assert.NoError(t, err)
+
+	var decoded map[string]any
+	assert.NoError(t, json.Unmarshal(blob, &decoded))
+
+	data, ok := decoded["data"].(map[string]any)
+	assert.True(t, ok, "missing data envelope")
+	assert.Equal(t, "event", data["type"])
+
+	attrs, ok := data["attributes"].(map[string]any)
+	assert.True(t, ok, "missing data.attributes")
+	assert.Equal(t, "kernel bottleneck detected", attrs["title"])
+	assert.Equal(t, "hello", attrs["message"])
+	assert.Equal(t, "change", attrs["category"])
+	assert.Equal(t, "2024-01-01T00:00:00Z", attrs["timestamp"])
+	assert.Equal(t, "observer:kernel_bottleneck", attrs["aggregation_key"])
+
+	// edge-intelligence routing: must be present and locked to the registered
+	// values from integrations-internal-core#3240.
+	assert.Equal(t, "edge-intelligence", attrs["integration_id"])
+	assert.EqualValues(t, 78252213, attrs["source_type_id"])
+
+	tags, ok := attrs["tags"].([]any)
+	assert.True(t, ok, "tags must be a JSON array")
+	assert.NotEmpty(t, tags)
+
+	inner, ok := attrs["attributes"].(map[string]any)
+	assert.True(t, ok, "missing nested change-event attributes")
+
+	changed, ok := inner["changed_resource"].(map[string]any)
+	assert.True(t, ok, "missing changed_resource")
+	assert.Equal(t, "kernel_bottleneck", changed["name"])
+	// Resource type is `anomaly` (Event Management validation was updated to
+	// accept this value); the previous `configuration` value would be rejected.
+	assert.Equal(t, "anomaly", changed["type"])
+
+	author, ok := inner["author"].(map[string]any)
+	assert.True(t, ok, "missing author")
+	assert.Equal(t, "datadog-agent-observer", author["name"])
+	assert.Equal(t, "automation", author["type"])
+
+	impacted, ok := inner["impacted_resources"].([]any)
+	assert.True(t, ok, "missing impacted_resources")
+	assert.Len(t, impacted, 1)
+	item := impacted[0].(map[string]any)
+	assert.Equal(t, "web", item["name"])
+	assert.Equal(t, "service", item["type"])
+
+	assert.Contains(t, inner, "prev_value")
+	assert.Contains(t, inner, "new_value")
+
+	meta, ok := inner["change_metadata"].(map[string]any)
+	assert.True(t, ok, "missing change_metadata")
+	assert.Equal(t, "spike", meta["sub_category"], "current > baseline should classify as spike")
+}
+
+// TestBuildChangeEventPayload_TruncatesChangedResourceName ensures we don't
+// emit a name longer than the v2 API accepts (128 chars), that truncated
+// names end with an ellipsis to signal the cut, and that the result remains
+// valid UTF-8 even when the cut would land mid-rune.
+func TestBuildChangeEventPayload_TruncatesChangedResourceName(t *testing.T) {
+	long := make([]byte, 200)
+	for i := range long {
+		long[i] = 'x'
+	}
+	c := observerdef.ActiveCorrelation{Pattern: string(long), Title: "t"}
+
+	payload := buildChangeEventPayload(c, "m", "2024-01-01T00:00:00Z", "k")
+
+	inner := payload["data"].(map[string]any)["attributes"].(map[string]any)["attributes"].(map[string]any)
+	changed := inner["changed_resource"].(map[string]any)
+	name := changed["name"].(string)
+	assert.Equal(t, changedResourceNameMaxLen, utf8.RuneCountInString(name), "truncated name should be exactly maxChars runes long")
+	assert.True(t, strings.HasSuffix(name, "\u2026"), "truncated name should end with an ellipsis")
+}
+
+// TestBuildChangeEventPayload_TruncatesAtRuneBoundary checks that a pattern
+// whose final rune (before maxChars) is multi-byte is not cut mid-codepoint:
+// the resulting name must stay valid UTF-8 and contain exactly maxChars runes.
+func TestBuildChangeEventPayload_TruncatesAtRuneBoundary(t *testing.T) {
+	// Build a pattern of 200 three-byte runes; any byte-indexed truncation at
+	// changedResourceNameMaxLen would land inside a rune.
+	var b strings.Builder
+	for i := 0; i < 200; i++ {
+		b.WriteRune('☃') // U+2603, 3 bytes
+	}
+	c := observerdef.ActiveCorrelation{Pattern: b.String(), Title: "t"}
+
+	payload := buildChangeEventPayload(c, "m", "2024-01-01T00:00:00Z", "k")
+
+	inner := payload["data"].(map[string]any)["attributes"].(map[string]any)["attributes"].(map[string]any)
+	name := inner["changed_resource"].(map[string]any)["name"].(string)
+	assert.True(t, utf8.ValidString(name), "truncated name must remain valid UTF-8")
+	assert.Equal(t, changedResourceNameMaxLen, utf8.RuneCountInString(name), "truncated name should be exactly maxChars runes long")
+	assert.True(t, strings.HasSuffix(name, "\u2026"), "truncated name should end with an ellipsis")
+}
+
+// TestBuildChangeEventPayload_AnomalyInventoryAlwaysPresent asserts that both
+// metric_anomalies and log_anomalies are present in change_metadata regardless
+// of which categories the correlation contains. The spec's ChangeEvent entity
+// declares both as List<AnomalyInventoryEntry> (always-present, possibly
+// empty); intake consumers should not need to handle field absence.
+func TestBuildChangeEventPayload_AnomalyInventoryAlwaysPresent(t *testing.T) {
+	cases := map[string]observerdef.ActiveCorrelation{
+		"metric only": {
+			Pattern: "p",
+			Anomalies: []observerdef.Anomaly{{
+				Type:      observerdef.AnomalyTypeMetric,
+				Source:    observerdef.SeriesDescriptor{Namespace: "dogstatsd"},
+				DebugInfo: &observerdef.AnomalyDebugInfo{CurrentValue: 5, BaselineMean: 1},
+			}},
+		},
+		"log only": {
+			Pattern: "p",
+			Anomalies: []observerdef.Anomaly{{
+				Type:   observerdef.AnomalyTypeLog,
+				Source: observerdef.SeriesDescriptor{Namespace: "log_detector"},
+			}},
+		},
+		"empty": {Pattern: "p"},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			payload := buildChangeEventPayload(c, "m", "2024-01-01T00:00:00Z", "k")
+			inner := payload["data"].(map[string]any)["attributes"].(map[string]any)["attributes"].(map[string]any)
+			meta := inner["change_metadata"].(map[string]any)
+			assert.Contains(t, meta, "metric_anomalies", "metric_anomalies must be present")
+			assert.Contains(t, meta, "log_anomalies", "log_anomalies must be present")
+			// Round-trip through JSON to confirm both arrays serialise as [] rather
+			// than being elided or marshalled to null when empty.
+			blob, err := json.Marshal(payload)
+			assert.NoError(t, err)
+			var decoded map[string]any
+			assert.NoError(t, json.Unmarshal(blob, &decoded))
+			rtMeta := decoded["data"].(map[string]any)["attributes"].(map[string]any)["attributes"].(map[string]any)["change_metadata"].(map[string]any)
+			assert.NotNil(t, rtMeta["metric_anomalies"], "metric_anomalies must serialise as an array, not null")
+			assert.NotNil(t, rtMeta["log_anomalies"], "log_anomalies must serialise as an array, not null")
+		})
+	}
+}
+
+// TestBuildChangeEventPayload_NoImpactedResourcesWhenEmpty makes sure we omit
+// the impacted_resources key entirely (rather than emitting an empty array)
+// when no service tags are present, matching the upstream omitempty behaviour.
+func TestBuildChangeEventPayload_NoImpactedResourcesWhenEmpty(t *testing.T) {
+	c := observerdef.ActiveCorrelation{Pattern: "p", Title: "t"}
+
+	payload := buildChangeEventPayload(c, "m", "2024-01-01T00:00:00Z", "k")
+
+	inner := payload["data"].(map[string]any)["attributes"].(map[string]any)["attributes"].(map[string]any)
+	_, present := inner["impacted_resources"]
+	assert.False(t, present, "impacted_resources should be omitted when no services are impacted")
+}
+
+// --- classifyCorrelationSubCategory ---
+
+func TestClassifySubCategory_SpikeOnIncrease(t *testing.T) {
+	c := observerdef.ActiveCorrelation{Anomalies: []observerdef.Anomaly{{
+		Type:      observerdef.AnomalyTypeMetric,
+		DebugInfo: &observerdef.AnomalyDebugInfo{CurrentValue: 10, BaselineMean: 2},
+	}}}
+	assert.Equal(t, subCategorySpike, classifyCorrelationSubCategory(c))
+}
+
+func TestClassifySubCategory_DropWhenAllBelowBaseline(t *testing.T) {
+	c := observerdef.ActiveCorrelation{Anomalies: []observerdef.Anomaly{
+		{
+			Type:      observerdef.AnomalyTypeMetric,
+			DebugInfo: &observerdef.AnomalyDebugInfo{CurrentValue: 1, BaselineMean: 5},
+		},
+		{
+			Type:      observerdef.AnomalyTypeMetric,
+			DebugInfo: &observerdef.AnomalyDebugInfo{CurrentValue: 0.5, BaselineMean: 3},
+		},
+	}}
+	assert.Equal(t, subCategoryDrop, classifyCorrelationSubCategory(c))
+}
+
+func TestClassifySubCategory_SpikeWhenMixedDirections(t *testing.T) {
+	// One spike, one drop — not a uniform drop, so we default to spike
+	// (the more eye-catching framing for a heterogeneous correlation).
+	c := observerdef.ActiveCorrelation{Anomalies: []observerdef.Anomaly{
+		{
+			Type:      observerdef.AnomalyTypeMetric,
+			DebugInfo: &observerdef.AnomalyDebugInfo{CurrentValue: 1, BaselineMean: 5},
+		},
+		{
+			Type:      observerdef.AnomalyTypeMetric,
+			DebugInfo: &observerdef.AnomalyDebugInfo{CurrentValue: 10, BaselineMean: 2},
+		},
+	}}
+	assert.Equal(t, subCategorySpike, classifyCorrelationSubCategory(c))
+}
+
+func TestClassifySubCategory_NewPatternForLogWithoutBaseline(t *testing.T) {
+	c := observerdef.ActiveCorrelation{Anomalies: []observerdef.Anomaly{{
+		Type:   observerdef.AnomalyTypeLog,
+		Source: observerdef.SeriesDescriptor{Namespace: "log_detector"},
+	}}}
+	assert.Equal(t, subCategoryNewPattern, classifyCorrelationSubCategory(c))
+}
+
+func TestClassifySubCategory_NewPatternForLogDerivedZeroBaseline(t *testing.T) {
+	// A log-pattern metric anomaly with BaselineMean=0 means the pattern
+	// didn't exist before — classify as new_pattern, not spike.
+	c := observerdef.ActiveCorrelation{Anomalies: []observerdef.Anomaly{{
+		Type:   observerdef.AnomalyTypeMetric,
+		Source: observerdef.SeriesDescriptor{Namespace: logPatternExtractorNamespace},
+		Context: &observerdef.MetricContext{
+			Pattern: "connection refused",
+		},
+		DebugInfo: &observerdef.AnomalyDebugInfo{CurrentValue: 5, BaselineMean: 0},
+	}}}
+	assert.Equal(t, subCategoryNewPattern, classifyCorrelationSubCategory(c))
+}
+
+func TestClassifySubCategory_LogDerivedWithBaselineStaysAsSpikeOrDrop(t *testing.T) {
+	// Log-pattern metric anomaly with a real baseline behaves like a normal
+	// rate change: classified by direction, not as new_pattern.
+	c := observerdef.ActiveCorrelation{Anomalies: []observerdef.Anomaly{{
+		Type:   observerdef.AnomalyTypeMetric,
+		Source: observerdef.SeriesDescriptor{Namespace: logPatternExtractorNamespace},
+		Context: &observerdef.MetricContext{
+			Pattern: "connection refused",
+		},
+		DebugInfo: &observerdef.AnomalyDebugInfo{CurrentValue: 50, BaselineMean: 5},
+	}}}
+	assert.Equal(t, subCategorySpike, classifyCorrelationSubCategory(c))
+}
+
+func TestClassifySubCategory_EmptyCorrelationDefaultsToSpike(t *testing.T) {
+	assert.Equal(t, subCategorySpike, classifyCorrelationSubCategory(observerdef.ActiveCorrelation{}))
+}

--- a/comp/anomalydetection/reporter/impl/reporter.go
+++ b/comp/anomalydetection/reporter/impl/reporter.go
@@ -1,0 +1,83 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package reporterimpl provides the live reporter implementations:
+// a stdout reporter (always active) and an optional Datadog event reporter
+// (active when anomaly_detection.reporting.enabled=true).
+package reporterimpl
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	reporterdef "github.com/DataDog/datadog-agent/comp/anomalydetection/reporter/def"
+	config "github.com/DataDog/datadog-agent/comp/core/config"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
+)
+
+// Requires defines the dependencies for the live reporter component.
+type Requires struct {
+	Config        config.Component
+	Log           log.Component
+	EventPlatform eventplatform.Component
+}
+
+// Provides defines the output of the live reporter component.
+// Reporters are provided via the anomalydetection_reporters Fx group so the
+// observer can subscribe multiple reporters independently.
+type Provides struct {
+	Reporters []reporterdef.Reporter `group:"anomalydetection_reporters,flatten"`
+}
+
+// NewComponent creates the live reporter component. It always provides a
+// stdoutReporter and, when anomaly_detection.reporting.enabled=true and the
+// event-platform forwarder is available, also provides an EventReporter that
+// posts Datadog change events through the event-management intake pipeline.
+func NewComponent(req Requires) (Provides, error) {
+	reporters := []reporterdef.Reporter{&stdoutReporter{}}
+
+	if req.Config.GetBool("anomaly_detection.reporting.enabled") {
+		forwarder, ok := req.EventPlatform.Get()
+		if !ok {
+			req.Log.Warnf("[reporter] event_reporter disabled: event-platform forwarder is not running")
+		} else {
+			sender, err := newEventSender(forwarder, req.Log, nil)
+			if err != nil {
+				req.Log.Warnf("[reporter] event_reporter disabled: %v", err)
+			} else {
+				reporters = append(reporters, &EventReporter{sender: sender, logger: req.Log})
+			}
+		}
+	}
+
+	return Provides{Reporters: reporters}, nil
+}
+
+type stdoutReporter struct{}
+
+func (r *stdoutReporter) Name() string { return "stdout_reporter" }
+
+func (r *stdoutReporter) Report(output reporterdef.ReportOutput) {
+	if len(output.ActiveCorrelations) == 0 {
+		return
+	}
+	for _, ac := range output.ActiveCorrelations {
+		fmt.Printf("[observer] report: pattern=%s — %s (%d series)\n",
+			ac.Pattern, ac.Title, len(ac.Members))
+		for _, a := range ac.Anomalies {
+			ts := time.Unix(a.Timestamp, 0).UTC().Format(time.RFC3339)
+			fmt.Printf("  - %s [%s] at %s\n", a.Source.DisplayName(), a.DetectorName, ts)
+		}
+	}
+	if len(output.NewAnomalies) > 0 {
+		names := make([]string, 0, len(output.NewAnomalies))
+		for _, a := range output.NewAnomalies {
+			names = append(names, a.DetectorName+":"+a.Source.Name)
+		}
+		fmt.Printf("[observer] new anomalies: %s\n", strings.Join(names, ", "))
+	}
+}

--- a/comp/anomalydetection/reporter/impl/reporter_event.go
+++ b/comp/anomalydetection/reporter/impl/reporter_event.go
@@ -1,0 +1,99 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package reporterimpl
+
+import (
+	observerdef "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
+	reporterdef "github.com/DataDog/datadog-agent/comp/anomalydetection/reporter/def"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+)
+
+// EventReporter sends Datadog events for new correlations via eventSender.
+// It tracks seen correlations and only fires when a correlation first appears
+// or reappears after going inactive.
+// It implements reporterdef.StorageConsumer so the observer can inject engine
+// storage post-construction for windowed log-rate annotations in change messages.
+type EventReporter struct {
+	sender           *eventSender
+	logger           log.Component
+	seenCorrelations map[string]bool // pattern -> reported
+	// activeBefore tracks patterns observed in ActiveCorrelations on a prior
+	// advance. Only entries marked here are eligible for recurrence cleanup;
+	// patterns that only ever appear via CorrelationHistory (e.g. batch
+	// detector clusters) are emitted once and never deleted.
+	activeBefore map[string]bool
+}
+
+// Ensure EventReporter satisfies both interfaces at compile time.
+var _ reporterdef.Reporter = (*EventReporter)(nil)
+var _ reporterdef.StorageConsumer = (*EventReporter)(nil)
+
+// Name returns the reporter name.
+func (r *EventReporter) Name() string {
+	return "event_reporter"
+}
+
+// SetStorage implements reporterdef.StorageConsumer.
+// Called by the observer after engine construction to enable windowed log-rate
+// annotations in change-event messages.
+func (r *EventReporter) SetStorage(storage observerdef.StorageReader) {
+	r.sender.storage = storage
+}
+
+// Report checks for new correlations and sends a Datadog change event for each one.
+//
+// Emission is driven by output.CorrelationHistory so that batch-detector
+// clusters — whose changepoint timestamps may already be evicted from the
+// sliding window — still fire. Recurrence cleanup is driven by
+// output.ActiveCorrelations: a streaming pattern that leaves the active set
+// is removed from seenCorrelations so it fires again on the next activation.
+// Patterns that only ever appear via CorrelationHistory (no active phase) are
+// emitted once and stay seen for the lifetime of the agent.
+func (r *EventReporter) Report(output reporterdef.ReportOutput) {
+	if r.seenCorrelations == nil {
+		r.seenCorrelations = make(map[string]bool)
+	}
+	if r.activeBefore == nil {
+		r.activeBefore = make(map[string]bool)
+	}
+
+	// Build the set of currently active patterns.
+	currentlyActive := make(map[string]bool, len(output.ActiveCorrelations))
+	for _, ac := range output.ActiveCorrelations {
+		currentlyActive[ac.Pattern] = true
+	}
+
+	// Send an event for each newly-seen correlation. Mark the pattern as
+	// seen only after a successful send: a transient forwarder error leaves
+	// the pattern unmarked so the next advance retries publication. A
+	// persistent failure will keep producing one error log per advance until
+	// either the forwarder recovers or the correlation goes inactive.
+	for _, ac := range output.CorrelationHistory {
+		if !r.seenCorrelations[ac.Pattern] {
+			if err := r.sender.send(ac); err != nil {
+				r.logger.Errorf("[observer] failed to send event for pattern %s: %v", ac.Pattern, err)
+				continue
+			}
+			r.seenCorrelations[ac.Pattern] = true
+		}
+	}
+
+	// Recurrence cleanup: remove seenCorrelations entries for patterns that
+	// were previously active and are no longer active. This lets streaming
+	// patterns re-fire when they come back. Patterns that have never been in
+	// ActiveCorrelations (batch-only) are left alone — they fire once and
+	// stay marked.
+	for pattern := range r.activeBefore {
+		if !currentlyActive[pattern] {
+			delete(r.seenCorrelations, pattern)
+			delete(r.activeBefore, pattern)
+		}
+	}
+	// Carry the current active set forward for the next advance.
+	for pattern := range currentlyActive {
+		r.activeBefore[pattern] = true
+	}
+}

--- a/comp/anomalydetection/reporter/mock/BUILD.bazel
+++ b/comp/anomalydetection/reporter/mock/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "mock",
+    srcs = ["mock.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/anomalydetection/reporter/mock",
+    visibility = ["//visibility:public"],
+    deps = ["//comp/anomalydetection/reporter/def"],
+)

--- a/comp/anomalydetection/reporter/mock/mock.go
+++ b/comp/anomalydetection/reporter/mock/mock.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+// Package mock provides a mock for the reporter component.
+package mock
+
+import (
+	"testing"
+
+	reporter "github.com/DataDog/datadog-agent/comp/anomalydetection/reporter/def"
+)
+
+type noopReporter struct{}
+
+func (r *noopReporter) Name() string                   { return "mock_reporter" }
+func (r *noopReporter) Report(_ reporter.ReportOutput) {}
+
+// Mock returns a no-op reporter for use in tests.
+func Mock(_ *testing.T) reporter.Reporter {
+	return &noopReporter{}
+}

--- a/comp/anomalydetection/reporter/reporter.allium
+++ b/comp/anomalydetection/reporter/reporter.allium
@@ -1,0 +1,628 @@
+-- allium: 3
+
+-- Scope: Anomaly detection reporter component and its boundary with the
+--   observer that feeds it. Defines what triggers a report, how new
+--   correlations are turned into Datadog change events, and the locked
+--   routing identity of those events.
+--
+-- Includes:
+--   - Observer→Reporter trigger semantics (one Report per advance cycle)
+--   - Reporter variants: StdoutReporter (always-on developer trace) and
+--     EventReporter (conditional change-event publisher)
+--   - Per-pattern deduplication: an EventReporter publishes a correlation
+--     at most once per active episode
+--   - Change-event payload shape: title, message, tags, change attributes
+--     block (changed_resource, author, prev_value, new_value, impacted
+--     resources, change_metadata)
+--   - Sub-category classification (spike, drop, new_pattern) recorded in
+--     change_metadata.sub_category
+--   - Routing identity for edge-intelligence (integration_id,
+--     source_type_id, changed_resource.type), locked by invariant
+--   - Payload size caps imposed by the v2 Events API
+--
+-- Excludes:
+--   - How correlations are detected (observer internals: extractors,
+--     detectors, correlators, scheduler, storage engine)
+--   - The shape of upstream signals (metric series, log streams, RRCF) and
+--     how they become Anomaly values
+--   - Event-platform forwarder transport (HTTP delivery, retry, backpressure,
+--     domain selection); the forwarder is treated as an external service
+--   - Event Management intake-side validation, persistence and UI behaviour
+--   - Stdout reporter's exact textual format
+--   - Windowed log-rate annotations and the storage queries that produce
+--     them; these are display enrichment inside the change message
+
+------------------------------------------------------------
+-- External Entities
+------------------------------------------------------------
+
+-- A Correlation is a group of related Anomalies that the observer's
+-- correlators have identified as a single behavioural pattern. The reporter
+-- consumes Correlations; it never creates or mutates them. Pattern is the
+-- correlator's stable identifier for the kind of behaviour observed (e.g.
+-- "kernel_bottleneck"); two Correlations with the same Pattern in the same
+-- active episode are the same event.
+external entity Correlation {
+    pattern: String
+    title: String
+    anomalies: List<Anomaly>
+    member_series: List<String>
+    first_seen: Timestamp
+    last_updated: Timestamp
+}
+
+-- An Anomaly is one point-in-time deviation reported by a detector. Multiple
+-- anomalies on related series are grouped into a Correlation upstream.
+external entity Anomaly {
+    type: AnomalyType
+    detector_name: String
+    title: String
+    description: String
+    source_namespace: String
+    source_display_name: String
+    source_tags: Set<String>
+    timestamp: Timestamp
+    score: Decimal?
+    debug_info: AnomalyDebugInfo?
+    context: AnomalyContext?
+
+    -- Derived: a metric-typed anomaly produced by extracting structure from
+    -- log lines. These are presented as log anomalies even though they flow
+    -- through the metric pipeline. The classification depends on the
+    -- extractor that produced the source series.
+    is_log_derived:
+        if type = log: false
+        else if context = nil: false
+        else if source_namespace = `log_pattern_extractor`:
+            context.pattern != ""
+        else if source_namespace = `log_metrics_extractor`:
+            context.pattern != "" or context.example != ""
+        else: false
+
+    -- Derived: a single classification for tagging and rendering. Log-derived
+    -- metric anomalies are reported as logs.
+    effective_type:
+        if type = log or is_log_derived: log
+        else: metric
+}
+
+-- The event-platform forwarder is the agent's outbound channel for typed
+-- payloads bound for various Datadog intakes. The reporter publishes change
+-- events through it; it does not own delivery semantics.
+external entity Forwarder {
+    -- Derived from forwarder lifecycle. When false, the reporter must skip
+    -- event publishing without erroring.
+    available: Boolean
+}
+
+-- A ChangeEvent is the v2 Events API payload submitted to the Event
+-- Management intake. Field types here are the subset whose values the
+-- reporter chooses; intake-side validation and persistence are out of
+-- scope.
+external entity ChangeEvent {
+    title: String
+    message: String
+    category: EventCategory
+    integration_id: String
+    source_type_id: Integer
+    tags: Set<String>
+    timestamp: Timestamp
+    aggregation_key: String
+    changed_resource_name: String
+    changed_resource_type: String
+    author_name: String
+    author_type: String
+    impacted_resources: List<ImpactedResource>
+    sub_category: SubCategory
+    prev_value: PerSeriesBaseline
+    new_value: PerSeriesCurrent
+    metric_anomalies: List<AnomalyInventoryEntry>
+    log_anomalies: List<AnomalyInventoryEntry>
+    member_series: List<String>
+    first_seen: Timestamp
+    last_updated: Timestamp
+    anomaly_count: Integer
+}
+
+-- The observer engine that calls Report on each subscribed reporter. Its
+-- internals are owned by comp/anomalydetection/observer; here it is only
+-- the party on the far side of ObserverReportBoundary.
+external entity ObserverEngine {}
+
+------------------------------------------------------------
+-- Value Types
+------------------------------------------------------------
+
+-- Detector-supplied baseline and current-state numbers for one anomaly.
+-- Absent for log anomalies that lack a numeric baseline.
+value AnomalyDebugInfo {
+    baseline_mean: Decimal
+    baseline_median: Decimal
+    baseline_stddev: Decimal
+    threshold: Decimal
+    current_value: Decimal
+    deviation_sigma: Decimal
+}
+
+-- Optional enrichment attached to an Anomaly by the extractor that produced
+-- its source series.
+value AnomalyContext {
+    pattern: String
+    example: String
+    split_tags: Map<String, String>
+}
+
+-- An entry in the Event Management impacted-resources list. Today the only
+-- impacted resource kind we emit is the service.
+value ImpactedResource {
+    name: String
+    type: String
+}
+
+-- Per-series numeric snapshot carried in prev_value / new_value. Keyed by
+-- the anomaly's display name. Entries for anomalies without DebugInfo are
+-- omitted; the map may be empty. Display names are assumed unique within a
+-- Correlation (the upstream contract from comp/anomalydetection/observer);
+-- if two anomalies in the same Correlation collide, only the later one's
+-- snapshot is retained.
+value PerSeriesBaseline {
+    -- Map<display_name, { mean, median, stddev }>
+    entries: Map<String, Map<String, Decimal>>
+}
+
+value PerSeriesCurrent {
+    -- Map<display_name, { value, deviation_sigma, threshold? }>
+    entries: Map<String, Map<String, Decimal>>
+}
+
+value AnomalyInventoryEntry {
+    source: String
+    detector: String
+    title: String
+    timestamp: Timestamp
+    description: String?
+    score: Decimal?
+    debug_info: AnomalyDebugInfo?
+    context: AnomalyContext?
+}
+
+------------------------------------------------------------
+-- Enumerations
+------------------------------------------------------------
+
+enum AnomalyType { metric | log }
+
+-- Event Management's category enum; reporter always emits `change`.
+enum EventCategory { change | alert | story }
+
+-- Sub-category recorded in change_metadata.sub_category for downstream
+-- grouping. The enum is closed; new sub-categories require a spec change.
+enum SubCategory { spike | drop | new_pattern }
+
+------------------------------------------------------------
+-- Entities
+------------------------------------------------------------
+
+-- A Reporter is an observer-subscribed sink that turns each detection-cycle
+-- output into outbound effects. Two variants ship in this component:
+-- StdoutReporter is the always-on developer trace; EventReporter publishes
+-- change events to the Event Management intake.
+entity Reporter {
+    kind: StdoutReporter | EventReporter
+}
+
+-- The always-on developer trace. Emits a human-readable summary of active
+-- correlations and new anomalies on every advance cycle. Its exact textual
+-- format is not a contract.
+variant StdoutReporter : Reporter {
+}
+
+-- Publishes change events to the Event Management intake. Tracks which
+-- correlations have already been published in the current active episode
+-- so it fires at most once per pattern until the pattern goes inactive
+-- and reappears. Patterns delivered only via correlation_history (e.g.
+-- batch-detector clusters whose changepoint timestamps are already
+-- evicted from the active set) are published exactly once for the run.
+variant EventReporter : Reporter {
+    seen_patterns: Set<String>
+    -- previously_active tracks patterns observed in active_correlations on
+    -- a prior advance. Only entries marked here are eligible for recurrence
+    -- cleanup; batch-only patterns never enter this set and therefore
+    -- remain in seen_patterns for the lifetime of the agent.
+    previously_active: Set<String>
+}
+
+------------------------------------------------------------
+-- Config
+------------------------------------------------------------
+
+config {
+    -- Gates the EventReporter. When false the reporter component still
+    -- runs (StdoutReporter is always wired) but no change events are
+    -- published. Default is false: opt-in is explicit.
+    reporting_enabled: Boolean = false
+
+    -- Caps imposed by the v2 Events API on outbound payloads. Enforced by
+    -- the PayloadCapsRespected invariant.
+    message_max_bytes: Integer = 4000
+    changed_resource_name_max_chars: Integer = 128
+    impacted_resources_max_items: Integer = 100
+}
+
+------------------------------------------------------------
+-- Routing Identity
+------------------------------------------------------------
+
+-- The Event Management intake routes a change event by the publisher's
+-- (integration_id, source_type_id) pair. These values are constants of
+-- the `edge-intelligence` integration; they are not configurable and are
+-- enforced on every emitted ChangeEvent by the RoutingIdentityLocked
+-- invariant.
+--
+-- changed_resource.type is `anomaly`. The intake rejects the
+-- previously-emitted `configuration` value.
+--
+--   integration_id        = "edge-intelligence"
+--   source_type_id        = 78252213
+--   changed_resource_type = "anomaly"
+--   author_name           = "datadog-agent-observer"
+--   author_type           = "automation"
+--   category              = change
+
+------------------------------------------------------------
+-- Rules
+------------------------------------------------------------
+
+-- Reporter wiring at agent startup. StdoutReporter is unconditional;
+-- EventReporter joins the reporter group only when reporting is enabled
+-- AND the event-platform forwarder is available. A missing or unavailable
+-- forwarder downgrades gracefully to stdout-only with a warning, rather
+-- than failing the agent.
+
+rule WireReportersOnStartup {
+    when: ReporterComponentStarts()
+
+    ensures: StdoutReporter.created()
+
+    ensures:
+        if config.reporting_enabled and Forwarder.available:
+            EventReporter.created(seen_patterns: {})
+
+    @guidance
+        -- ReporterComponentStarts fires once per agent lifetime, at the Fx
+        -- Start hook of comp/anomalydetection/reporter. StdoutReporter is
+        -- unconditional. EventReporter is created only when reporting is
+        -- enabled in config AND the event-platform forwarder is available;
+        -- otherwise the component runs stdout-only with a warning, which is
+        -- the graceful-degradation invariant below.
+}
+
+-- Each advance cycle the observer emits one Report call per subscribed
+-- reporter. The StdoutReporter renders the active correlations and new
+-- anomalies as a developer trace. The exact rendering is not a contract;
+-- the StdoutTraceWritten emission below names the effect at spec level
+-- without prescribing format.
+
+rule ReportCorrelationsToStdout {
+    when: ObserverAdvanced(active_correlations, _correlation_history, new_anomalies)
+
+    for reporter in StdoutReporters:
+        ensures: StdoutTraceWritten(
+            reporter: reporter,
+            correlations: active_correlations,
+            new_anomalies: new_anomalies
+        )
+
+    @guidance
+        -- StdoutReporter never publishes externally and never deduplicates;
+        -- it is a tracing aid for local development and replay. The
+        -- StdoutTraceWritten event is the observable boundary; its textual
+        -- form is unspecified.
+}
+
+-- A correlation that the EventReporter has not yet published is published
+-- exactly once and recorded as seen. Emission iterates correlation_history
+-- (which is a superset of active_correlations) so that batch-detector
+-- clusters whose changepoint timestamps are already old enough to be
+-- evicted from active_correlations still fire. This is the only path that
+-- produces a ChangeEvent. Iterating over EventReporters (a 0-or-1 element
+-- collection) makes the rule a no-op when reporting is not enabled, without
+-- an explicit guard.
+
+rule PublishNewCorrelation {
+    when: ObserverAdvanced(_active_correlations, correlation_history, _new_anomalies)
+
+    for reporter in EventReporters:
+        for c in correlation_history:
+            if c.pattern not in reporter.seen_patterns:
+                ensures: ChangeEvent.created(
+                    title: c.title,
+                    message: render_change_message(c),
+                    category: change,
+                    integration_id: "edge-intelligence",
+                    source_type_id: 78252213,
+                    tags: derive_event_tags(c),
+                    timestamp: c.first_seen,
+                    aggregation_key: "observer:" + c.pattern,
+                    changed_resource_name: truncate(c.pattern, config.changed_resource_name_max_chars),
+                    changed_resource_type: "anomaly",
+                    author_name: "datadog-agent-observer",
+                    author_type: "automation",
+                    impacted_resources: derive_impacted_services(c),
+                    sub_category: classify_sub_category(c),
+                    prev_value: derive_prev_value(c),
+                    new_value: derive_new_value(c),
+                    metric_anomalies: metric_inventory(c),
+                    log_anomalies: log_inventory(c),
+                    member_series: c.member_series,
+                    first_seen: c.first_seen,
+                    last_updated: c.last_updated,
+                    anomaly_count: c.anomalies.count
+                )
+                ensures: reporter.seen_patterns = reporter.seen_patterns + {c.pattern}
+
+    @guidance
+        -- The EventReporter publishes one ChangeEvent per newly-seen
+        -- pattern in one advance cycle. Patterns that recur within the
+        -- same active episode are not republished; see
+        -- DropExpiredSeenPatterns for re-arming semantics.
+        --
+        -- A pattern is marked seen only after a successful publish. A
+        -- forwarder error is logged and the pattern is left unmarked, so
+        -- the next advance retries publication for the same pattern. A
+        -- persistent forwarder failure therefore produces one error log
+        -- per advance until either the forwarder recovers or the
+        -- correlation goes inactive.
+}
+
+-- When a previously-active pattern is absent from the active set, the
+-- EventReporter forgets it so that a fresh occurrence (after the episode
+-- ends) is treated as a new event and republished. Patterns that have
+-- never been in active_correlations (batch-only history entries) are not
+-- eligible for cleanup and remain in seen_patterns for the run.
+
+rule DropExpiredSeenPatterns {
+    when: ObserverAdvanced(active_correlations, _correlation_history, _new_anomalies)
+
+    for reporter in EventReporters:
+        let active_patterns = map_to_pattern_set(active_correlations)
+        -- Streaming patterns that have left the active set are dropped from
+        -- both seen_patterns and previously_active so the next reappearance
+        -- triggers fresh emission.
+        ensures: reporter.seen_patterns =
+            reporter.seen_patterns.filter(p =>
+                p in active_patterns or p not in reporter.previously_active
+            )
+        ensures: reporter.previously_active =
+            reporter.previously_active.filter(p => p in active_patterns)
+            ∪ active_patterns
+}
+
+------------------------------------------------------------
+-- Derivations (black-box functions)
+------------------------------------------------------------
+
+-- The functions called from PublishNewCorrelation's ensures clause are
+-- pure black-box functions of Correlation. Their outputs are part of
+-- the event-payload contract; their internal representation is left as
+-- prose so that string-formatting and iteration-order choices are not
+-- promoted to machine-checkable obligations.
+
+-- classify_sub_category(c: Correlation) -> SubCategory
+--
+-- Returns one of spike | drop | new_pattern, in priority order:
+--   1. If any log-effective anomaly lacks a meaningful baseline (no
+--      debug_info, or debug_info.baseline_mean = 0), the whole
+--      correlation is `new_pattern`. These are novel signals that did
+--      not exist before.
+--   2. Otherwise, if every anomaly with debug_info has
+--      current_value <= baseline_mean, classify as `drop`.
+--   3. Otherwise classify as `spike`.
+--   A Correlation with no anomalies classifies as `spike`.
+
+-- derive_event_tags(c: Correlation) -> Set<String>
+--
+-- Every change event is tagged with a fixed source tag and the
+-- originating pattern, then enriched with the dimensions that identify
+-- which workload the anomalies belong to.
+--
+--   Always present:
+--     source:edge-intelligence
+--     pattern:{c.pattern}
+--
+--   Anomaly-type tags (zero, one, or both):
+--     anomaly_type:metric  if any anomaly has effective_type = metric
+--     anomaly_type:log     if any anomaly has effective_type = log
+--
+--   Dimensional tags: the union of service:, env:, host: tags found on
+--     each anomaly's source_tags, plus the same keys lifted from
+--     context.split_tags (set by the log-pattern clusterer). Tags are
+--     deduplicated.
+--
+-- The leading two tags (source and pattern) are kept in that order;
+-- all remaining tags are sorted for stable output.
+
+-- derive_impacted_services(c: Correlation) -> List<ImpactedResource>
+--
+-- The unique set of services found on member-series tags and anomaly
+-- source tags, emitted as { name, type=service } entries. Sorted
+-- alphabetically before capping at config.impacted_resources_max_items
+-- so the cap is deterministic. When the set is empty, the field is
+-- omitted from the wire payload rather than emitted as [].
+
+-- derive_prev_value(c: Correlation) -> PerSeriesBaseline
+-- derive_new_value(c: Correlation)  -> PerSeriesCurrent
+--
+-- Per-anomaly numeric snapshots keyed by anomaly display name.
+-- prev_value records the baseline at detection time (mean, median,
+-- stddev). new_value records the current value, deviation_sigma and,
+-- when set, the detector threshold. Anomalies without debug_info are
+-- omitted from both maps.
+
+-- metric_inventory(c: Correlation) -> List<AnomalyInventoryEntry>
+-- log_inventory(c: Correlation)    -> List<AnomalyInventoryEntry>
+--
+-- Partition c.anomalies by effective_type into two inventory lists.
+-- Each entry carries the originating anomaly's identifying fields
+-- (source, detector, title, timestamp, description, score, debug_info,
+-- context). Every anomaly appears in exactly one of the two lists;
+-- see AnomaliesPartitionedByEffectiveType.
+
+-- render_change_message(c: Correlation) -> String
+--
+-- A compact human-readable summary listing the correlation header and
+-- one bullet per anomaly. Log-derived anomalies render with
+-- pattern/example/rate annotations; numeric anomalies render with
+-- current value vs baseline mean and sigma. Anomaly bullets are
+-- deduplicated and sorted so two cycles that observe the same anomalies
+-- produce byte-identical messages; the header reports the deduplicated
+-- bullet count, not the raw anomaly count. The resulting string is
+-- truncated to at most config.message_max_bytes bytes; truncation
+-- happens on a rune boundary so the result remains valid UTF-8, and a
+-- three-byte "..." suffix is appended to signal that the message was
+-- cut.
+
+-- truncate(s: String, max_chars: Integer) -> String
+--   Returns s when it is at most max_chars characters long. Otherwise
+--   returns the first (max_chars - 1) characters of s followed by an
+--   ellipsis character (U+2026), so the result is exactly max_chars
+--   characters and remains valid UTF-8. max_chars must be at least 1.
+
+-- map_to_pattern_set(cs: List<Correlation>) -> Set<String>
+--   The set of c.pattern values from cs.
+
+------------------------------------------------------------
+-- Invariants
+------------------------------------------------------------
+
+invariant SubCategoryCoversAll {
+    -- classify_sub_category is total: every Correlation maps to exactly
+    -- one SubCategory value.
+    for c in Correlations:
+        classify_sub_category(c) in {spike, drop, new_pattern}
+}
+
+invariant RoutingIdentityLocked {
+    -- Every emitted ChangeEvent uses the locked routing identity.
+    -- changed_resource.type is `anomaly`; the previously-emitted
+    -- `configuration` value is rejected by the intake.
+    for e in ChangeEvents:
+        e.integration_id = "edge-intelligence"
+        and e.source_type_id = 78252213
+        and e.changed_resource_type = "anomaly"
+        and e.author_name = "datadog-agent-observer"
+        and e.author_type = "automation"
+        and e.category = change
+}
+
+invariant PayloadCapsRespected {
+    -- Caps imposed by the v2 Events API. Encoded here because they shape
+    -- what reaches the user, not just the wire payload.
+    for e in ChangeEvents:
+        byte_length(e.message) <= config.message_max_bytes
+        and char_length(e.changed_resource_name) <= config.changed_resource_name_max_chars
+        and e.impacted_resources.count <= config.impacted_resources_max_items
+}
+
+invariant AnomaliesPartitionedByEffectiveType {
+    -- Every anomaly in a Correlation appears in exactly one of
+    -- metric_anomalies or log_anomalies, never both, never neither.
+    for e in ChangeEvents:
+        e.metric_anomalies.count + e.log_anomalies.count = e.anomaly_count
+}
+
+invariant GracefulDegradationWithoutForwarder {
+    -- If reporting is enabled but the forwarder is unavailable at startup,
+    -- the agent runs normally with StdoutReporter only; no ChangeEvent is
+    -- ever emitted, and no error is propagated to the caller.
+    not (config.reporting_enabled and not Forwarder.available)
+    or (EventReporters.count = 0 and ChangeEvents.count = 0)
+}
+
+-- Two further behavioural properties hold but are not expressible as
+-- single-point-in-time invariants; they constrain how state evolves
+-- across advance cycles.
+--
+-- SeenPatternsBoundedByHistory: after every advance cycle, each
+-- EventReporter's seen_patterns is a subset of the correlation_history
+-- delivered by that cycle (or any prior cycle). Cardinality is bounded by
+-- the cumulative history, not by the live active set.
+--
+-- PublishAtMostOncePerEpisode: within a single contiguous active episode
+-- for a pattern, the EventReporter emits exactly one ChangeEvent. A new
+-- episode begins after the pattern leaves the active set and reappears.
+-- Batch-only patterns (never in active_correlations) constitute a single
+-- episode that lasts for the lifetime of the agent.
+
+------------------------------------------------------------
+-- Surfaces
+------------------------------------------------------------
+
+-- The boundary between the observer's engine and any Reporter. The observer
+-- calls Report once per advance cycle on every subscribed reporter,
+-- carrying the active correlation set, the cumulative correlation history
+-- (a superset including batch-detector clusters whose changepoints may
+-- already be evicted from the active set), and the new anomalies from this
+-- cycle. Reporters must not block the calling goroutine.
+surface ObserverReportBoundary {
+    facing _: ObserverEngine
+
+    exposes:
+        Report(active_correlations: List<Correlation>, correlation_history: List<Correlation>, new_anomalies: List<Anomaly>)
+
+    provides:
+        ObserverAdvanced(active_correlations: List<Correlation>, correlation_history: List<Correlation>, new_anomalies: List<Anomaly>)
+
+    @guarantee SingleAdvancePerCall
+        -- Report is invoked exactly once per advance cycle per subscribed
+        -- reporter; calls are serialised within a reporter (the observer
+        -- does not interleave Report invocations on the same reporter).
+
+    @guarantee ActiveSetIsAuthoritative
+        -- active_correlations is the complete current active set; reporters
+        -- use it to detect when a streaming pattern has gone inactive.
+        -- correlation_history is the cumulative set of every pattern the
+        -- engine has ever detected during the current run and is a superset
+        -- of active_correlations. The EventReporter derives "new" patterns
+        -- by comparing correlation_history against its own seen_patterns
+        -- set, and uses active_correlations to detect when a previously
+        -- emitted pattern has gone inactive (re-arming it for recurrence).
+
+    @guarantee CorrelationsAreOpaque
+        -- The reporter treats Correlation and Anomaly as read-only data
+        -- carriers. It never mutates them, never persists them beyond the
+        -- pattern-tracking state needed for deduplication, and never queries
+        -- observer internals.
+
+    @guidance
+        -- An optional companion handshake exists for reporters that want
+        -- windowed rate annotations in their rendered messages: the
+        -- observer calls SetStorage(storage) exactly once after engine
+        -- construction, before the first Report call. Reporters that do
+        -- not need historical rates ignore this handshake.
+}
+
+------------------------------------------------------------
+-- Deferred Specifications
+------------------------------------------------------------
+
+deferred ForwarderTransport -- see: comp/forwarder/eventplatform
+    -- Event-platform forwarder delivery semantics (HTTP intake selection,
+    -- retry policy, backpressure, payload draining at shutdown) are owned
+    -- by comp/forwarder/eventplatform and not specified here. The reporter
+    -- requires only that SendEventPlatformEventBlocking returns an error
+    -- when delivery fails synchronously; asynchronous failures are not
+    -- surfaced.
+
+deferred AnomalyProduction -- see: comp/anomalydetection/observer
+    -- How Anomaly and Correlation values are produced (extractors,
+    -- detectors, correlators, scheduling, retention) is owned by
+    -- comp/anomalydetection/observer. This spec treats them as inputs.
+
+------------------------------------------------------------
+-- Open Questions
+------------------------------------------------------------
+
+open question "RicherEvidenceBlock: change_metadata currently carries summary statistics (mean, sigma, sub_category) and the anomaly inventory. Should change_metadata also carry structured evidence — which detectors fired, with what scores, on what windows, and links back into source signals — and if so in what shape? Today this is implementation-private; promoting it to the spec would commit the reporter to a stable evidence schema."
+
+open question "LogRateAnnotationContract: rendered messages may include log-rate annotations of the form 'rate: X.Xlog/s (was Y.Ylog/s last minutes)'. The 60-second current window, 5-minute baseline window, 0.3 relative threshold and 2.0 absolute threshold currently live in the implementation. Are these part of the user-visible contract (and therefore spec-level constants in config) or display-only enrichment that the spec leaves unspecified?"


### PR DESCRIPTION
### What does this PR do?

This adds the reporter used to report anomaly events to the backend.

Basically:
1. We detect an anomaly
2. A report is created
3. A report is sent to the backend

### Motivation

### Describe how you validated your changes

1. Enabled anomaly detection + reporting
2. When there is an anomaly, we see a log (stdoutreporter -> this is enabled even if reporting is disabled, only anomaly detection needs to be enabeld) or an event on the backend

### Additional Notes

---

# Claude Recap

### What does this PR do?

Adds production reporter implementation: stdoutReporter (always active) and EventReporter (gated on anomaly_detection.reporting.enabled, default false) that posts Datadog v2 Change Events.

Adds:
- impl/: reporter.go (NewComponent), notify.go (event builder + log-rate annotations), reporter_event.go (correlation dedup), notify_test.go (unit tests)
- fx/: production Fx wiring (replaces fx-noop in cmd/agent/subcommands/run/command.go)
- mock/: //go:build test noop reporter for downstream consumer tests

### Motivation

Wave 3 of the observer→main merge. The observer engine already consumes reporters via the anomalydetection_reporters Fx group but was wired with fx-noop. This PR activates the production reporters (stdout + optional Datadog events) so detected anomalies surface.

### Describe how you validated your changes

- `bazel build //comp/anomalydetection/reporter/...` ✅
- `bazel test //comp/anomalydetection/reporter/...` ✅ (notify_test.go: 1 test passes)
- `dda inv linter.go --targets=./comp/anomalydetection/reporter/...` ✅ (no errors)

### Additional Notes

Config key: `anomaly_detection.reporting.enabled` (default false, not registered in pkg/config/setup — reads via cfg.GetBool).
Base: celian/observer-logic (stacks on #50599 observer engine PR).